### PR TITLE
Btrfs introduction PR

### DIFF
--- a/pkg/storaged/block/format-dialog.jsx
+++ b/pkg/storaged/block/format-dialog.jsx
@@ -258,7 +258,8 @@ function format_dialog_internal(client, path, start, size, enable_dos_extended, 
     if (old_dir === false)
         return Promise.reject(_("This device can not be used for the installation target."));
 
-    const split_options = parse_options(old_opts);
+    // Strip out btrfs subvolume mount options
+    const split_options = parse_options(old_opts).filter(opt => !(opt.startsWith('subvol=') || opt.startsWith('subvolid=')));
     extract_option(split_options, "noauto");
     const opt_ro = extract_option(split_options, "ro");
     const opt_never_auto = extract_option(split_options, "x-cockpit-never-auto");

--- a/pkg/storaged/btrfs/device.jsx
+++ b/pkg/storaged/btrfs/device.jsx
@@ -1,0 +1,90 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from "cockpit";
+import React from "react";
+import client from "../client";
+
+import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
+import { CardBody } from "@patternfly/react-core/dist/esm/components/Card/index.js";
+import { DescriptionList } from "@patternfly/react-core/dist/esm/components/DescriptionList/index.js";
+
+import { StorageCard, StorageDescription, new_card, register_crossref } from "../pages.jsx";
+import { StorageUsageBar } from "../storage-controls.jsx";
+import { std_lock_action } from "../crypto/actions.jsx";
+import { format_dialog } from "../block/format-dialog.jsx";
+import { btrfs_device_usage } from "./utils.jsx";
+
+const _ = cockpit.gettext;
+
+export function make_btrfs_device_card(next, backing_block, content_block, block_btrfs) {
+    const label = block_btrfs && block_btrfs.data.label;
+    const uuid = block_btrfs && block_btrfs.data.uuid;
+    const use = btrfs_device_usage(client, uuid, block_btrfs.path);
+
+    const btrfs_card = new_card({
+        title: _("btrfs device"),
+        location: label || uuid,
+        next,
+        component: BtrfsDeviceCard,
+        props: { backing_block, content_block },
+        actions: [
+            std_lock_action(backing_block, content_block),
+            { title: _("Format"), action: () => format_dialog(client, backing_block.path), danger: true },
+        ],
+    });
+
+    register_crossref({
+        key: uuid,
+        card: btrfs_card,
+        size: <StorageUsageBar stats={use} short />,
+    });
+
+    return btrfs_card;
+}
+
+export const BtrfsDeviceCard = ({ card, backing_block, content_block }) => {
+    const block_btrfs = client.blocks_fsys_btrfs[content_block.path];
+    const uuid = block_btrfs && block_btrfs.data.uuid;
+    const label = block_btrfs && block_btrfs.data.label;
+    const use = btrfs_device_usage(client, uuid, block_btrfs.path);
+
+    return (
+        <StorageCard card={card}>
+            <CardBody>
+                <DescriptionList className="pf-m-horizontal-on-sm">
+                    <StorageDescription title={_("btrfs volume")}>
+                        {uuid
+                            ? <Button variant="link" isInline role="link"
+                                   onClick={() => cockpit.location.go(["btrfs-volume", uuid])}>
+                                {label || uuid}
+                            </Button>
+                            : "-"
+                        }
+                    </StorageDescription>
+                    <StorageDescription title={_("UUID")} value={content_block.IdUUID} />
+                    { block_btrfs &&
+                    <StorageDescription title={_("Usage")}>
+                        <StorageUsageBar key="s" stats={use} />
+                    </StorageDescription>
+                    }
+                </DescriptionList>
+            </CardBody>
+        </StorageCard>);
+};

--- a/pkg/storaged/btrfs/subvolume.jsx
+++ b/pkg/storaged/btrfs/subvolume.jsx
@@ -1,0 +1,106 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from "cockpit";
+import React from "react";
+
+import { CardBody } from "@patternfly/react-core/dist/esm/components/Card/index.js";
+import { DescriptionList } from "@patternfly/react-core/dist/esm/components/DescriptionList/index.js";
+
+import { StorageCard, StorageDescription, new_card, new_page } from "../pages.jsx";
+import { StorageUsageBar } from "../storage-controls.jsx";
+import { get_fstab_config_with_client } from "../utils.js";
+import { btrfs_usage } from "./utils.jsx";
+import { mounting_dialog } from "../filesystem/mounting-dialog.jsx";
+import { check_mismounted_fsys, MismountAlert } from "../filesystem/mismounting.jsx";
+import { is_mounted, mount_point_text, MountPoint } from "../filesystem/utils.jsx";
+import client from "../client.js";
+
+const _ = cockpit.gettext;
+
+function subvolume_unmount(volume, subvol, forced_options) {
+    const block = client.blocks[volume.path];
+    mounting_dialog(client, block, "unmount", forced_options, subvol);
+}
+
+function subvolume_mount(volume, subvol, forced_options) {
+    const block = client.blocks[volume.path];
+    mounting_dialog(client, block, "mount", forced_options, subvol);
+}
+
+export function make_btrfs_subvolume_page(parent, volume, subvol) {
+    const actions = [];
+
+    const use = btrfs_usage(client, volume);
+    const block = client.blocks[volume.path];
+    const fstab_config = get_fstab_config_with_client(client, block, false, subvol);
+    const [, mount_point] = fstab_config;
+    const mismount_warning = check_mismounted_fsys(block, block, fstab_config, subvol);
+    const mounted = is_mounted(client, block, subvol);
+    const mp_text = mount_point_text(mount_point, mounted);
+    if (mp_text == null)
+        return null;
+    const forced_options = [`subvol=${subvol.pathname}`];
+
+    if (mounted) {
+        actions.push({
+            title: _("Unmount"),
+            action: () => subvolume_unmount(volume, subvol, forced_options),
+        });
+    } else {
+        actions.push({
+            title: _("Mount"),
+            action: () => subvolume_mount(volume, subvol, forced_options),
+        });
+    }
+
+    const card = new_card({
+        title: _("btrfs subvolume"),
+        next: null,
+        page_location: ["btrfs", volume.data.uuid, subvol.pathname],
+        page_name: subvol.pathname,
+        page_size: is_mounted && <StorageUsageBar stats={use} short />,
+        location: mp_text,
+        component: BtrfsSubvolumeCard,
+        has_warning: !!mismount_warning,
+        props: { subvol, mount_point, mismount_warning, block, fstab_config, forced_options },
+        actions,
+    });
+    new_page(parent, card);
+}
+
+const BtrfsSubvolumeCard = ({ card, subvol, mismount_warning, block, fstab_config, forced_options }) => {
+    return (
+        <StorageCard card={card} alert={mismount_warning &&
+        <MismountAlert warning={mismount_warning}
+                                    fstab_config={fstab_config}
+                                    backing_block={block} content_block={block} subvol={subvol} />}>
+            <CardBody>
+                <DescriptionList className="pf-m-horizontal-on-sm">
+                    <StorageDescription title={_("Name")} value={subvol.pathname} />
+                    <StorageDescription title={_("ID")} value={subvol.id} />
+                    <StorageDescription title={_("Mount point")}>
+                        <MountPoint fstab_config={fstab_config}
+                                    backing_block={block} content_block={block}
+                                    forced_options={forced_options} subvol={subvol} />
+                    </StorageDescription>
+                </DescriptionList>
+            </CardBody>
+        </StorageCard>);
+};

--- a/pkg/storaged/btrfs/utils.jsx
+++ b/pkg/storaged/btrfs/utils.jsx
@@ -1,0 +1,77 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+import { decode_filename } from "../utils.js";
+
+/*
+ * Calculate the usage based on the data from `btrfs filesystem show` which has
+ * been made available to client.uuids_btrfs_usage. The size/usage is provided
+ * per block device.
+ */
+export function btrfs_device_usage(client, uuid, path) {
+    const block = client.blocks[path];
+    const device = block && block.Device;
+    const uuid_usage = client.uuids_btrfs_usage[uuid];
+    if (uuid_usage && device) {
+        const usage = uuid_usage[decode_filename(device)];
+        if (usage) {
+            return [usage, block.Size];
+        }
+    }
+    return [0, block.Size];
+}
+
+/**
+ * Calculate the overal btrfs "volume" usage. UDisks only knows the usage per block.
+ */
+export function btrfs_usage(client, volume) {
+    const block_fsys = client.blocks_fsys[volume.path];
+    const mount_point = block_fsys && block_fsys.MountPoints[0];
+    let use = mount_point && client.fsys_sizes.data[decode_filename(mount_point)];
+    if (!use)
+        use = [volume.data.used, client.uuids_btrfs_blocks[volume.data.uuid].reduce((sum, b) => sum + b.Size, 0)];
+    return use;
+}
+
+/**
+ * Is the btrfs volume mounted anywhere
+ */
+export function btrfs_is_volume_mounted(client, block_devices) {
+    for (const block_device of block_devices) {
+        const block_fs = client.blocks_fsys[block_device.path];
+        if (block_fs && block_fs.MountPoints.length > 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+export function parse_subvol_from_options(options) {
+    const subvol = { };
+    const subvolid_match = options.match(/subvolid=(?<subvolid>\d+)/);
+    const subvol_match = options.match(/subvol=(?<subvol>[\w\\/]+)/);
+    if (subvolid_match)
+        subvol.id = subvolid_match.groups.subvolid;
+    if (subvol_match)
+        subvol.pathname = subvol_match.groups.subvol;
+
+    if (subvolid_match || subvol_match)
+        return subvol;
+    else
+        return null;
+}

--- a/pkg/storaged/btrfs/volume.jsx
+++ b/pkg/storaged/btrfs/volume.jsx
@@ -1,0 +1,202 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hopeg that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from "cockpit";
+import React from "react";
+import client from "../client";
+
+import { CardHeader, CardBody } from "@patternfly/react-core/dist/esm/components/Card/index.js";
+import { DescriptionList } from "@patternfly/react-core/dist/esm/components/DescriptionList/index.js";
+import { VolumeIcon } from "../icons/gnome-icons.jsx";
+
+import {
+    new_card, new_page, PAGE_CATEGORY_VIRTUAL,
+    get_crossrefs, ChildrenTable, PageTable, StorageCard, StorageDescription
+} from "../pages.jsx";
+import { StorageUsageBar, StorageLink } from "../storage-controls.jsx";
+import { fmt_size_long, validate_fsys_label, decode_filename, should_ignore } from "../utils.js";
+import { btrfs_usage, btrfs_is_volume_mounted, parse_subvol_from_options } from "./utils.jsx";
+import { dialog_open, TextInput } from "../dialog.jsx";
+import { make_btrfs_subvolume_page } from "./subvolume.jsx";
+
+const _ = cockpit.gettext;
+
+/*
+ * Udisks is a disk/block library so it manages that, btrfs turns this a bit
+ * around and has one "volume" which can have multiple blocks by a unique uuid.
+ *
+ * Cockpit shows Btrfs as following:
+ *
+ * -> btrfs subvolume
+ *    -> btrfs volume
+ *        -> btrfs device
+ *            -> block device
+ */
+export function make_btrfs_volume_page(parent, uuid) {
+    const block_devices = client.uuids_btrfs_blocks[uuid];
+    const block_btrfs = client.blocks_fsys_btrfs[block_devices[0].path];
+    const volume = client.uuids_btrfs_volume[uuid];
+    const use = btrfs_usage(client, volume);
+
+    if (block_devices.some(blk => should_ignore(client, blk.path)))
+        return;
+
+    const name = block_btrfs.data.label || uuid;
+    const btrfs_volume_card = new_card({
+        title: _("btrfs volume"),
+        next: null,
+        page_location: ["btrfs-volume", uuid],
+        page_name: name,
+        page_icon: VolumeIcon,
+        page_category: PAGE_CATEGORY_VIRTUAL,
+        page_size: use[1],
+        component: BtrfsVolumeCard,
+        props: { block_devices, uuid, use },
+    });
+
+    const subvolumes_card = new_card({
+        title: _("btrfs subvolumes"),
+        next: btrfs_volume_card,
+        component: BtrfsSubVolumesCard,
+        props: { volume },
+    });
+
+    const subvolumes_page = new_page(parent, subvolumes_card);
+    make_btrfs_subvolume_pages(subvolumes_page, volume);
+}
+
+const BtrfsVolumeCard = ({ card, block_devices, uuid, use }) => {
+    const block_btrfs = client.blocks_fsys_btrfs[block_devices[0].path];
+    const label = block_btrfs.data.label || "-";
+
+    // Changing the label is only supported when the device is not mounted
+    // otherwise we will get btrfs filesystem error ERROR: device /dev/vda5 is
+    // mounted, use mount point. This is a libblockdev/udisks limitation as it
+    // only passes the device and not the mountpoint when the device is mounted.
+    // https://github.com/storaged-project/libblockdev/issues/966
+    const is_mounted = btrfs_is_volume_mounted(client, block_devices);
+
+    function rename_dialog() {
+        dialog_open({
+            Title: _("Change label"),
+            Fields: [
+                TextInput("name", _("Name"),
+                          {
+                              validate: name => validate_fsys_label(name, "btrfs"),
+                              value: label
+                          })
+            ],
+            Action: {
+                Title: _("Save"),
+                action: function (vals) {
+                    return block_btrfs.SetLabel(vals.name, {});
+                }
+            }
+        });
+    }
+
+    return (
+        <StorageCard card={card}>
+            <CardBody>
+                <DescriptionList className="pf-m-horizontal-on-sm">
+                    <StorageDescription title={_("Label")}
+                                                value={label}
+                                                action={
+                                                    <StorageLink onClick={rename_dialog}
+                                                               excuse={is_mounted ? _("Btrfs volume is mounted") : null}>
+                                                        {_("edit")}
+                                                    </StorageLink>}
+                    />
+                    <StorageDescription title={_("UUID")} value={uuid} />
+                    <StorageDescription title={_("Capacity")} value={fmt_size_long(use[1])} />
+                    <StorageDescription title={_("Usage")}>
+                        <StorageUsageBar key="s" stats={use} />
+                    </StorageDescription>
+                </DescriptionList>
+            </CardBody>
+            <CardHeader><strong>{_("btrfs devices")}</strong></CardHeader>
+            <CardBody className="contains-list">
+                <PageTable emptyCaption={_("No devices found")}
+                                   aria-label={_("btrfs device")}
+                                   crossrefs={get_crossrefs(uuid)} />
+            </CardBody>
+        </StorageCard>
+    );
+};
+
+const BtrfsSubVolumesCard = ({ card, volume }) => {
+    return (
+        <StorageCard card={card}>
+            <CardBody className="contains-list">
+                <ChildrenTable emptyCaption={_("No subvolumes")}
+                               aria-label={_("btrfs subvolumes")}
+                               page={card.page} />
+            </CardBody>
+        </StorageCard>
+    );
+};
+
+function make_btrfs_subvolume_pages(parent, volume) {
+    const subvols = client.uuids_btrfs_subvols[volume.data.uuid];
+    if (subvols) {
+        for (const subvol of subvols) {
+            make_btrfs_subvolume_page(parent, volume, subvol);
+        }
+    } else {
+        const block = client.blocks[volume.path];
+        /*
+         * Try to show subvolumes based on fstab entries, this is a bit tricky
+         * as mounts where subvolid cannot be shown userfriendly.
+         */
+        let has_root = false;
+        for (const config of block.Configuration) {
+            if (config[0] == "fstab") {
+                const fstab_subvol = {};
+                let opts = config[1].opts;
+                if (!opts)
+                    continue;
+
+                opts = decode_filename(opts.v).split(",");
+                for (const opt of opts) {
+                    const fstab_subvol = parse_subvol_from_options(opt);
+
+                    if (!fstab_subvol)
+                        continue;
+
+                    if (fstab_subvol.id && fstab_subvol.pathname) {
+                        break;
+                    }
+                }
+
+                if (fstab_subvol && fstab_subvol.pathname === "/") {
+                    has_root = true;
+                }
+
+                if (fstab_subvol.pathname) {
+                    make_btrfs_subvolume_page(parent, volume, fstab_subvol);
+                }
+            }
+        }
+
+        if (!has_root) {
+            // Always show the root subvolume even when the volume is not mounted.
+            make_btrfs_subvolume_page(parent, volume, { pathname: "/", id: 5 });
+        }
+    }
+}

--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -41,6 +41,11 @@ import deep_equal from "deep-equal";
 /* STORAGED CLIENT
  */
 
+function debug() {
+    if (window.debugging == "all" || window.debugging?.includes("storaged")) // not-covered: debugging
+        console.debug.apply(console, arguments); // not-covered: debugging
+}
+
 const client = {
     busy: 0
 };
@@ -251,7 +256,7 @@ export function btrfs_poll() {
     }))
             .then(() => {
                 if (!deep_equal(client.uuids_btrfs_subvols, uuids_subvols)) {
-                    console.log("SUBVOLS", uuids_subvols);
+                    debug("btrfs_pol new subvols:", uuids_subvols);
                     client.uuids_btrfs_subvols = uuids_subvols;
                     client.update();
                 }

--- a/pkg/storaged/dialog.jsx
+++ b/pkg/storaged/dialog.jsx
@@ -1112,6 +1112,7 @@ export const BlockingMessage = (usage) => {
         vdo: _("backing device for VDO device"),
         "stratis-pool-member": _("member of Stratis pool"),
         mounted: _("Filesystem outside the target"),
+        "btrfs-device": _("device of btrfs volume"),
     };
 
     const rows = [];

--- a/pkg/storaged/overview/overview.jsx
+++ b/pkg/storaged/overview/overview.jsx
@@ -47,6 +47,7 @@ import { make_stratis_stopped_pool_page } from "../stratis/stopped-pool.jsx";
 import { make_nfs_page, nfs_fstab_dialog } from "../nfs/nfs.jsx";
 import { make_iscsi_session_page } from "../iscsi/session.jsx";
 import { make_other_page } from "../block/other.jsx";
+import { make_btrfs_volume_page } from "../btrfs/volume.jsx";
 
 const _ = cockpit.gettext;
 
@@ -71,6 +72,7 @@ export function make_overview_page() {
     Object.keys(client.stratis_manager.StoppedPools).map(uuid => make_stratis_stopped_pool_page(overview_page, uuid));
     client.nfs.entries.forEach(e => make_nfs_page(overview_page, e));
     get_other_devices(client).map(p => make_other_page(overview_page, client.blocks[p]));
+    Object.keys(client.uuids_btrfs_volume).forEach(uuid => make_btrfs_volume_page(overview_page, uuid));
 }
 
 const OverviewCard = ({ card, plot_state }) => {

--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -41,6 +41,8 @@ if grep -q 'ID=.*fedora' /etc/os-release && [ "$PLAN" = "basic" ]; then
     dnf install -y tcsh
     # required by TestJournal.testAbrt*
     dnf install -y abrt abrt-addon-ccpp reportd libreport-plugin-bugzilla libreport-fedora
+    # required by TestStorageBtrfs*
+    dnf install -y udisks2-btrfs
 fi
 
 # dnf installs "missing" weak dependencies, but we don't want them for plans other than "optional"

--- a/test/common/storagelib.py
+++ b/test/common/storagelib.py
@@ -137,6 +137,9 @@ class StorageHelpers:
     def dialog_wait_alert(self, text):
         self.browser.wait_in_text('#dialog .pf-v5-c-alert__title', text)
 
+    def dialog_wait_title(self, text):
+        self.browser.wait_in_text('#dialog .pf-v5-c-modal-box__title', text)
+
     def dialog_field(self, field):
         return f'#dialog [data-field="{field}"]'
 

--- a/test/verify/check-storage-basic
+++ b/test/verify/check-storage-basic
@@ -29,6 +29,7 @@ class TestStorageBasic(storagelib.StorageCase):
         b = self.browser
 
         self.login_and_go("/storage", superuser=False)
+        self.allow_browser_errors("error: findmnt.*")
 
         create_dropdown = self.dropdown_toggle(self.card_header("Storage"))
 

--- a/test/verify/check-storage-btrfs
+++ b/test/verify/check-storage-btrfs
@@ -1,0 +1,469 @@
+#!/usr/bin/python3 -cimport os, sys; os.execv(os.path.dirname(sys.argv[1]) + "/../common/pywrap", sys.argv)
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2023 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import os.path
+
+import storagelib
+import testlib
+
+
+@testlib.nondestructive
+@testlib.skipImage('no btrfs support', 'rhel-*', 'centos-*')
+class TestStorageBtrfs(storagelib.StorageCase):
+    def setUp(self):
+        super().setUp()
+        self.allow_browser_errors("unable to obtain subvolumes for mount point.*")
+        self.allow_browser_errors("unable to obtain default subvolume for mount point.*")
+        self.allow_browser_errors("error: unable to run findmnt.*")
+        self.allow_browser_errors("error: findmnt.*")
+
+    def testBasic(self):
+        m = self.machine
+        b = self.browser
+
+        mount_point = "/run/butter"
+        # btrfs requires a 128 MB
+        dev_1 = self.add_ram_disk(size=128)
+        uuid = "a32d61d6-9d75-4327-9bb9-3fa3627300ae"
+        m.execute(f"mkfs.btrfs -U {uuid} {dev_1}")
+
+        self.login_and_go("/storage")
+        # creation of btrfs partition can take a while on TF.
+        with b.wait_timeout(30):
+            b.wait_visible(self.card_row("Storage", name=uuid))
+        b.wait_in_text(self.card_row("Storage", name="sda"), "btrfs device")
+        self.click_card_row("Storage", name=uuid)
+
+        b.wait_text(self.card_desc("btrfs volume", "UUID"), uuid)
+        # disk(s) are part of the volume card
+        b.wait_visible(self.card_row("btrfs volume", name=dev_1))
+
+        label = "butter"
+        b.click(self.card_desc_action("btrfs volume", "Label"))
+        self.dialog({"name": label})
+        b.wait_text(self.card_desc("btrfs volume", "Label"), label)
+
+        self.click_dropdown(self.card_row("btrfs subvolumes", name="/"), "Mount")
+        self.dialog({"mount_point": mount_point})
+        b.wait_visible(self.card_row("btrfs subvolumes", location=mount_point))
+        # UDisks does not allow us to change the label of a mounted FS
+        b.wait_visible(self.card_desc_action("btrfs volume", "Label") + ":disabled")
+
+        # detect new subvolume
+        subvol = "/run/butter/cake"
+        m.execute(f"btrfs subvolume create {subvol}")
+        b.wait_visible(self.card_row("btrfs subvolumes", name=os.path.basename(subvol)))
+
+        self.click_dropdown(self.card_row("btrfs subvolumes", location=mount_point), "Unmount")
+        self.confirm()
+
+        b.wait_visible(self.card_row("btrfs subvolumes", location=f"{mount_point} (not mounted)"))
+        self.click_dropdown(self.card_row("btrfs subvolumes", name="/"), "Mount")
+        self.confirm()
+
+        b.wait_visible(self.card_row("btrfs subvolumes", location=mount_point))
+        # try to mount a subvol
+        subvol_mount_point = "/run/kitchen"
+        self.click_dropdown(self.card_row("btrfs subvolumes", name=os.path.basename(subvol)), "Mount")
+        self.dialog({"mount_point": subvol_mount_point})
+
+        b.wait_in_text(self.card_row("btrfs subvolumes", location=subvol_mount_point), "cake")
+        b.wait_visible(self.card_row("btrfs subvolumes", location=mount_point))
+
+        b.go("#/")
+        b.wait_visible(self.card("Storage"))
+
+        # btrfs device page
+        self.click_card_row("Storage", name="sda")
+        b.wait_text(self.card_desc("btrfs device", "btrfs volume"), label)
+        b.wait_in_text(self.card_desc("Solid State Drive", "Device file"), dev_1)
+
+        # test link to volume
+        b.click(self.card_button("btrfs device", label))
+        b.wait_text(self.card_desc("btrfs volume", "Label"), label)
+
+        # Format the btrfs device
+        b.go("#/")
+        b.wait_visible(self.card("Storage"))
+        self.click_dropdown(self.card_row("Storage", name="sda"), "Format")
+        self.dialog_wait_open()
+        self.dialog_wait_title(f"{dev_1} is in use")
+        self.dialog_cancel()
+        self.dialog_wait_close()
+
+        self.click_dropdown(self.card_row("Storage", location=subvol_mount_point), "Unmount")
+        self.confirm()
+
+        self.click_dropdown(self.card_row("Storage", location=mount_point), "Unmount")
+        self.confirm()
+        b.wait_visible(self.card_row("Storage", location=f"{mount_point} (not mounted)"))
+
+        # Also when not mounted
+        self.click_dropdown(self.card_row("Storage", name="sda"), "Format")
+        self.dialog_wait_open()
+        self.dialog_wait_title(f"{dev_1} is in use")
+        self.dialog_cancel()
+        self.dialog_wait_close()
+
+    def testMultiDevice(self):
+        m = self.machine
+        b = self.browser
+
+        self.login_and_go("/storage")
+
+        disk1 = self.add_ram_disk(size=140)
+        disk2 = self.add_loopback_disk(size=140)
+        label = "raid1"
+        mount_point = "/run/butter"
+        subvol_mount_point = "/run/cake"
+        subvol = "/run/butter/cake"
+        subvol2 = "/run/butter/bread"
+        subvol_name = os.path.basename(subvol)
+
+        m.execute(f"mkfs.btrfs -L {label} -d raid1 {disk1} {disk2}")
+        self.login_and_go("/storage")
+
+        # creation of btrfs partition can take a while on TF.
+        with b.wait_timeout(30):
+            b.wait_visible(self.card_row("Storage", name=label))
+
+        b.wait_in_text(self.card_row("Storage", name=os.path.basename(disk1)), "btrfs device")
+        b.wait_in_text(self.card_row("Storage", name=os.path.basename(disk2)), "btrfs device")
+
+        # mount /
+        self.click_dropdown(self.card_row("Storage", name=label) + " + tr", "Mount")
+        self.dialog({"mount_point": mount_point})
+        b.wait_visible(self.card_row("Storage", location=mount_point))
+
+        # create subvolume
+        m.execute(f"""
+            btrfs subvolume create {subvol}
+            btrfs subvolume create {subvol2}
+        """)
+        b.wait_visible(self.card_row("Storage", name=os.path.basename(subvol)))
+
+        self.click_dropdown(self.card_row("Storage", name=os.path.basename(subvol)), "Mount")
+        self.dialog({"mount_point": subvol_mount_point})
+        b.wait_visible(self.card_row("Storage", location=subvol_mount_point))
+
+        # devices overview
+        self.click_card_row("Storage", name=label)
+        b.wait_visible(self.card_row("btrfs volume", name=disk1))
+        b.wait_visible(self.card_row("btrfs volume", name=disk2))
+
+        # unmount via main page
+        b.go("#/")
+        b.wait_visible(self.card("Storage"))
+
+        self.click_dropdown(self.card_row("Storage", location=subvol_mount_point), "Unmount")
+        self.confirm()
+        b.wait_visible(self.card_row("Storage", location=f"{subvol_mount_point} (not mounted)"))
+
+        self.click_dropdown(self.card_row("Storage", name=os.path.basename(subvol)), "Mount")
+        self.dialog({"mount_point": subvol_mount_point})
+        b.wait_visible(self.card_row("Storage", location=subvol_mount_point))
+
+        mount_options = m.execute(f"findmnt --fstab -n -o OPTIONS {subvol_mount_point}").strip()
+        self.assertIn(f"subvol={subvol_name}", mount_options)
+        self.assertEqual(mount_options.count(subvol_name), 1)
+
+        self.click_dropdown(self.card_row("Storage", name=os.path.basename(subvol2)), "Mount")
+        self.dialog_wait_open()
+        self.dialog_set_val("mount_point", subvol_mount_point)
+        self.dialog_apply()
+        self.dialog_wait_error("mount_point", f"Mount point is already used for btrfs subvolume {os.path.basename(subvol)} of raid1")
+        self.dialog_cancel()
+
+        self.click_dropdown(self.card_row("Storage", location=subvol_mount_point), "Unmount")
+        self.confirm()
+        b.wait_visible(self.card_row("Storage", location=f"{subvol_mount_point} (not mounted)"))
+
+    def testDefaultSubvolume(self):
+        m = self.machine
+        b = self.browser
+
+        disk1 = self.add_ram_disk(size=140)
+        label = "test_subvol"
+        mount_point = "/run/butter"
+        subvol = "cake"
+        subvol_path = f"{mount_point}/{subvol}"
+
+        m.execute(f"mkfs.btrfs -L {label} {disk1}")
+        self.login_and_go("/storage")
+
+        # creation of btrfs partition can take a while on TF.
+        with b.wait_timeout(30):
+            b.wait_visible(self.card_row("Storage", name=label))
+
+        b.wait_in_text(self.card_row("Storage", name=os.path.basename(disk1)), "btrfs device")
+
+        # Create a new btrfs subvolume and set it as default and mount it.
+        m.execute(f"""
+            mkdir -p {mount_point}
+            mount {disk1} {mount_point}
+            btrfs subvolume create {subvol_path}
+            btrfs subvolume set-default {subvol_path}
+            umount {mount_point}
+            mount {disk1} {mount_point}
+        """)
+
+        # Show a warning for mismounting in details.
+        b.wait_visible(self.card_row("Storage", name=subvol))
+        b.wait_visible(self.card_row("Storage", name=subvol) + ' .ct-icon-exclamation-triangle')
+        self.click_card_row("Storage", name=subvol)
+        b.wait_text(self.card_desc("btrfs subvolume", "Name"), subvol)
+
+        # Mount automatically on /run/butter on boot
+        b.click(self.card_button("btrfs subvolume", f"Mount automatically on {mount_point} on boot"))
+        b.wait_not_present(self.card_button("btrfs subvolume", f"Mount automatically on {mount_point} on boot"))
+
+        # No warnings on main page for either subvolumes
+        b.go("#/")
+        b.wait_visible(self.card("Storage"))
+        b.wait_not_present(self.card_row("Storage", name=subvol) + ' .ct-icon-exclamation-triangle')
+        b.wait_not_present(self.card_row("Storage", name="/") + ' .ct-icon-exclamation-triangle')
+
+    def testMountingHelp(self):
+        m = self.machine
+        b = self.browser
+
+        self.login_and_go("/storage")
+
+        disk = self.add_ram_disk(size=128)
+        uuid = "a32d61d6-9d75-4327-9bb9-3fa3627300ae"
+        mount_point = "/run/butter"
+
+        m.execute(f"mkfs.btrfs -U {uuid} {disk}")
+
+        # creation of btrfs partition can take a while on TF.
+        with b.wait_timeout(30):
+            b.wait_visible(self.card_row("Storage", name=uuid))
+        self.click_card_row("Storage", name=uuid)
+
+        self.click_dropdown(self.card_row("btrfs subvolumes", name="/"), "Mount")
+        self.dialog({"mount_point": mount_point})
+        b.wait_visible(self.card_row("btrfs subvolumes", location=mount_point))
+        self.click_card_row("btrfs subvolumes", location=mount_point)
+
+        filesystem = "btrfs subvolume"
+
+        # Unmount externally, remount with Cockpit
+        m.execute(f"umount {mount_point}")
+        b.click(self.card_button(filesystem, "Mount now"))
+        b.wait_not_present(self.card_button(filesystem, "Mount now"))
+        b.wait_not_in_text(self.card_desc(filesystem, "Mount point"), "The filesystem is not mounted")
+
+        # Unmount externally, adjust fstab with Cockpit
+
+        m.execute(f"umount {mount_point}")
+        b.click(self.card_button(filesystem, "Do not mount automatically on boot"))
+        b.wait_not_present(self.card_button(filesystem, "Do not mount automatically on boot"))
+
+        # Mount somewhere else externally while "noauto", unmount with Cockpit
+
+        m.execute(f"mkdir -p /run/bar; mount {disk} /run/bar")
+        b.click(self.card_button(filesystem, "Unmount now"))
+        b.wait_not_present(self.card_button(filesystem, "Unmount now"))
+
+        # Mount externally, unmount with Cockpit
+
+        m.execute(f"mount {mount_point}")
+        b.click(self.card_button(filesystem, "Unmount now"))
+        b.wait_not_present(self.card_button(filesystem, "Unmount now"))
+
+        # Mount externally, adjust fstab with Cockpit
+
+        m.execute(f"mount {mount_point}")
+        b.click(self.card_button(filesystem, "Mount also automatically on boot"))
+        b.wait_not_present(self.card_button(filesystem, "Mount also automatically on boot"))
+
+        # Move mount point externally, move back with Cockpit
+
+        m.execute(f"umount {mount_point}")
+        m.execute(f"mkdir -p /run/bar; mount {disk} /run/bar")
+        b.click(self.card_button(filesystem, f"Mount on {mount_point} now"))
+        b.wait_not_present(self.card_button(filesystem, f"Mount on {mount_point} now"))
+
+        # Move mount point externally, adjust fstab with Cockpit
+
+        m.execute(f"umount {mount_point}")
+        m.execute(f"mkdir -p /run/bar; mount {disk} /run/bar")
+        b.click(self.card_button(filesystem, "Mount automatically on /run/bar on boot"))
+        b.wait_not_present(self.card_button(filesystem, "Mount automatically on /run/bar on boot"))
+
+        # Using noauto,x-systemd.automount should not show a warning
+        m.execute("sed -i -e 's/auto nofail/auto nofail,noauto/' /etc/fstab")
+        b.wait_visible(self.card_button(filesystem, "Mount also automatically on boot"))
+        m.execute("sed -i -e 's/noauto/noauto,x-systemd.automount/' /etc/fstab")
+        b.wait_not_present(self.card_button(filesystem, "Mount also automatically on boot"))
+
+        # Without fstab entry, mount and try to unmount
+        m.execute("sed -i '/run\\/bar/d' /etc/fstab")
+        b.wait_visible(self.card_button(filesystem, "Mount automatically on /run/bar on boot"))
+        b.click(self.card_button(filesystem, "Unmount now"))
+        b.wait_not_present(self.card_button(filesystem, "Mount automatically on /run/bar on boot"))
+
+    def _create_btrfs_device(self, disk, label):
+        m = self.machine
+
+        self.click_card_row("Storage", name=disk)
+        m.execute(f"mkfs.btrfs -L {label} {disk}")
+
+    def _navigate_root_subvolume(self, label):
+        b = self.browser
+
+        b.wait_visible(self.card("btrfs device"))
+        b.click(self.card_button("btrfs device", label))
+        b.wait_visible(self.card("btrfs volume"))
+        self.click_card_row("btrfs subvolumes", name="/")
+        b.wait_visible(self.card("btrfs subvolume"))
+
+    def testMounting(self):
+        m = self.machine
+        b = self.browser
+        label = "butter"
+        mount_point_foo = "/run/foo"
+        mount_point_bar = "/run/bar"
+        filesystem = "btrfs subvolume"
+
+        self.login_and_go("/storage")
+        disk = self.add_ram_disk(size=128)
+        self._create_btrfs_device(disk, label)
+        self._navigate_root_subvolume(label)
+
+        m.execute(f"""
+            echo 'LABEL={label} {mount_point_foo} btrfs subvol=/ 0 0\n' >> /etc/fstab
+            mkdir -p {mount_point_foo}
+            mount {mount_point_foo}
+        """)
+        self.addCleanup(m.execute, f"umount {mount_point_foo} || true")
+
+        b.wait_in_text(self.card_desc("btrfs subvolume", "Mount point"), f"{mount_point_foo} (stop boot on failure)")
+
+        # Keep the mount point busy
+        sleep_pid = m.spawn(f"cd {mount_point_foo}; sleep infinity", "sleep")
+        self.write_file("/etc/systemd/system/keep-mnt-busy.service",
+                        f"""
+[Unit]
+Description=Test Service
+
+[Service]
+WorkingDirectory={mount_point_foo}
+ExecStart=/usr/bin/sleep infinity
+""")
+        m.execute("systemctl start keep-mnt-busy")
+        m.execute("until systemctl is-active keep-mnt-busy; do sleep 1; done")
+
+        # import time
+        # time.sleep(3)
+        b.click(self.card_button(filesystem, "Unmount"))
+        b.wait_in_text("#dialog", str(sleep_pid))
+        b.wait_in_text("#dialog", "sleep infinity")
+        b.wait_in_text("#dialog", "keep-mnt-busy")
+        b.wait_in_text("#dialog", "Test Service")
+        b.wait_in_text("#dialog", "/usr/bin/sleep infinity")
+        b.wait_in_text("#dialog", "The listed processes and services will be forcefully stopped.")
+        b.assert_pixels("#dialog", "busy-unmount", mock={"td[data-label='PID']": "1234",
+                                                         "td[data-label='Runtime']": "a little while"})
+        self.confirm()
+        b.wait_in_text(self.card_desc(filesystem, "Mount point"), "The filesystem is not mounted")
+
+        m.execute("! systemctl --quiet is-active keep-mnt-busy")
+
+        b.click(self.card_desc(filesystem, "Mount point") + " button")
+        self.dialog(expect={"mount_point": mount_point_foo},
+                    values={"mount_point": mount_point_bar})
+        self.assert_in_configuration("/dev/sda", "fstab", "dir", mount_point_bar)
+        b.wait_in_text(self.card_desc(filesystem, "Mount point"), mount_point_bar)
+
+        b.click(self.card_button(filesystem, "Mount"))
+        self.confirm()
+        b.wait_not_in_text(self.card_desc(filesystem, "Mount point"), "The filesystem is not mounted")
+
+        # Set the "Never unlock at boot option"
+        b.click(self.card_desc(filesystem, "Mount point") + " button")
+        self.dialog({"at_boot": "never"})
+        self.assertIn("noauto", m.execute(f"findmnt -s -n -o OPTIONS {mount_point_bar}"))
+        self.assertIn("x-cockpit-never-auto", m.execute(f"findmnt -s -n -o OPTIONS {mount_point_bar}"))
+        m.execute(f"umount {mount_point_bar} || true")
+
+    def testFstabOption(self):
+        m = self.machine
+        b = self.browser
+        label = "butter"
+
+        self.login_and_go("/storage")
+        disk = self.add_ram_disk(size=128)
+        self._create_btrfs_device(disk, label)
+        self._navigate_root_subvolume(label)
+
+        m.execute("! grep /run/data /etc/fstab")
+        b.click(self.card_button("btrfs subvolume", "Mount"))
+        self.dialog({"mount_point": "/run/data",
+                     "mount_options.extra": "x-foo"})
+        m.execute("grep /run/data /etc/fstab")
+        m.execute("grep 'x-foo' /etc/fstab")
+
+        b.wait_in_text(self.card_desc("btrfs subvolume", "Mount point"), "/run/data (ignore failure, x-foo)")
+
+        # absent mntopts and fsck columns implies "defaults"
+
+        m.execute(r"sed -i '/run\/data/ s/auto.*$/auto subvol=\//' /etc/fstab")
+        b.wait_in_text(self.card_desc("btrfs subvolume", "Mount point"), "/run/data (stop boot on failure)")
+
+    def testLuksEncrypted(self):
+        m = self.machine
+        b = self.browser
+
+        disk = self.add_ram_disk(size=128)
+        label = "butter"
+        mount_point = "/run/butter"
+        passphrase = "einszweidrei"
+
+        m.execute(f"""
+            echo {passphrase} | cryptsetup luksFormat --pbkdf-memory 32768 {disk}
+            echo {passphrase} | cryptsetup luksOpen {disk} btrfs-test
+            mkfs.btrfs -L {label} /dev/mapper/btrfs-test
+        """)
+
+        self.login_and_go("/storage")
+        # creation of btrfs partition can take a while on TF.
+        with b.wait_timeout(30):
+            b.wait_visible(self.card_row("Storage", name=label))
+        b.wait_in_text(self.card_row("Storage", name="sda"), "btrfs device (encrypted)")
+        self.click_dropdown(self.card_row("Storage", name=label) + " + tr", "Mount")
+        self.dialog({"mount_point": mount_point})
+
+        m.execute(f"""
+            umount {mount_point}
+            cryptsetup luksClose /dev/mapper/btrfs-test
+        """)
+        b.wait_in_text(self.card_row("Storage", name="sda"), "Locked data (encrypted)")
+        self.click_dropdown(self.card_row("Storage", name="sda"), "Unlock")
+        self.dialog({"passphrase": "einszweidrei"})
+        b.wait_in_text(self.card_row("Storage", name="sda"), "btrfs device (encrypted)")
+
+        self.click_dropdown(self.card_row("Storage", name=label) + " + tr", "Mount")
+        self.confirm()
+        b.wait_in_text(self.card_row("Storage", location=mount_point), "btrfs subvolume")
+
+
+if __name__ == '__main__':
+    testlib.test_main()

--- a/test/verify/check-storage-scaling
+++ b/test/verify/check-storage-scaling
@@ -33,6 +33,11 @@ class TestStorageScaling(storagelib.StorageCase):
             return b.call_js_func('ph_count', self.card("Storage") + " tbody tr")
 
         b.wait_visible(self.card_row("Storage", name="/dev/vda"))
+        # Wait on btrfs subvolumes on OS'es with the install on btrfs
+        if m.image.startswith('fedora'):
+            b.wait_in_text(self.card_row("Storage", name="root/var/lib/machines"), "btrfs subvolume")
+        elif m.image == "arch":
+            b.wait_in_text(self.card_row("Storage", name="swap"), "btrfs subvolume")
         n_rows = count_rows()
 
         m.execute("modprobe scsi_debug num_tgts=200")

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -657,6 +657,9 @@ Requires: cockpit-shell >= %{required_base}
 Requires: udisks2 >= 2.9
 Recommends: udisks2-lvm2 >= 2.9
 Recommends: udisks2-iscsi >= 2.9
+%if ! 0%{?rhel}
+Recommends: udisks2-btrfs >= 2.9
+%endif
 Recommends: device-mapper-multipath
 Recommends: clevis-luks
 Requires: %{__python3}

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -123,7 +123,8 @@ Depends: ${misc:Depends},
          cockpit-bridge (>= ${source:Version}),
          python3,
          python3-dbus
-Suggests: udisks2-lvm2,
+Suggests: udisks2-btrfs,
+          udisks2-lvm2, 
           mdadm,
 Description: Cockpit user interface for storage
  The Cockpit components for interacting with storage.


### PR DESCRIPTION
This PR introduces the viewing of a btrfs "volume" with devices and subvolumes. To deliver a small initial version this is basically a readonly implementation except for mounting/unmounting subvolumes and setting the volume label.

The design is based upon LVM so what ever show is:

```
-> btrfs subvolume
    -> btrfs volume (the filesystem)
        -> btrfs device (backing storage)
	   -> block device
```

Multi device btrfs volumes should be shown as well but they lack information on the type of configuration RAID1, JBOD, whatever btrfs supports.

## Required changes

* [x] refresh debian/ubuntu images to have btrfs-progs https://github.com/cockpit-project/bots/pull/5640
* [x] change packaging to recommends `udisks2-btrfs` on Fedora for cockpit-storaged
* [x] investigate packaging changes for Debian based distros
* [x] for warnings https://github.com/cockpit-project/cockpit/pull/19697

## Demo

Quick demo https://youtu.be/x0kLxTyUXok

## Screenshots

Overview:

![image](https://github.com/cockpit-project/cockpit/assets/67428/3c2f867d-4785-40f7-b3a2-603b04761973)

Volume detail page;

![image](https://github.com/cockpit-project/cockpit/assets/67428/c0d1f3b2-aa25-43ec-8ddf-9dd578d4a0ab)

Subvolume page:

![image](https://github.com/cockpit-project/cockpit/assets/67428/207aacd0-c778-4deb-961a-85f159c9eb2f)

## To Do

* [ ] tests, extensive tests! Multi device tests. etc.
* [x] warnings? Or do we leave this for a follow up
* [ ] @garrett requested the subvolumes to be indented one level under `/` 

## Technical improvements

We still have to shell out for a few operations instead of using UDisks notable ones are:

* [ ] detection default subvolume ( https://github.com/storaged-project/udisks/commit/c1c6adb8dc3b1fc2fb034afc930ba4f7aa012932 )
* [ ] listing subvolumes the way we want too, now we use cockpit.spawn
* [ ] Should we even set a default subvol when mounting btrfs for the first time? Now it is set to `subvol=/` but that is rather explicit and does not honour `get-default`. But it seems we cannot get the default subvolume before mounting? UDisks can maybe by temporary mounting? Needs validation?
* [ ] UDisks knows what blocks are mounted but does not know which subvolume this belongs too. Example: /tmp/foo is mounted to subvol=blah, MountPoints will have /tmp/foo but won't know what subvolume it belongs too

## Missing features for follow up

Not in order of importance!

* [ ] warnings
	* [x] fstab related
		* [x] wrongly mounted
		* [x] not mounted
	* [ ] multi device warnings
		* [ ] missing device
		* [ ] raid1?
		* [ ] raid5?
* [ ] subvolume deletion
* [ ] subvolume creation
* [ ] creating a btrfs filesystem
* [ ] snapshots
	* [ ] showing them
	* [ ] create
	* [ ] delete
	* [ ] mount/unmount
	* [ ] send?!
* [ ] get/set default subvolume
       Comments from @garrett  show a label that says "default" inside, with some info as a tooltip like "This subvolume will be mounted by default when no subvolume is specified"

* [ ] multi device support
	* [ ] showing RAID 1, RAID X
	* [ ] adding device to volume
	* [ ] remove device to volume
	* [ ] balancing
	* [ ] converting to RAID 1
* [ ] proper UDisks API for volume based filesystems based upon existing LVM API 
 	* [ ] Propose an API in an UDisks issue
	* [ ] write some code
	* [ ] extend libblockdev where required
	* [ ] make libblockdev use libbtrfsutil
	* [ ] extend libbtrfsutil
