### PR TITLE
test: Adjust method name in #18355 message ignoring

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1857,7 +1857,7 @@ class MachineCase(unittest.TestCase):
             "Traceback .*most recent call last.*",
             "File .*",
             "async with self.watch_processing_lock:",
-            "self.send_message.*",
+            "self.send_.*",
             "self.release.*",
             "self._wake_up_first.*",
             "fut.set_result.*",


### PR DESCRIPTION
Commit 747e7c23b713 renamed send_message() to send_json(). Relax the pattern to get along with either (so that this also works for older cockpit versions in e.g. cockpit-machines tests).

----

This is one of our top flakes right now, e.g. https://cockpit-logs.us-east-1.linodeobjects.com/pull-1342-20231207-082302-4456d97b-rhel-9-4/log.html or https://cockpit-logs.us-east-1.linodeobjects.com/pull-1341-20231207-054951-a901376e-rhel-9-4/log.html#38

This mostly seems to affect c-machines these days, so after this lands I'll update test/common there to haul in the fix.