### PR TITLE
test: Fix "busy CPU" pixel flake on overview page

### DIFF
--- a/containers/flatpak/test/test-browser
+++ b/containers/flatpak/test/test-browser
@@ -59,7 +59,7 @@ class BrowserTest(unittest.TestCase):
 
     def tearDown(self):
         if shutil.which("import"):
-            subprocess.call(["import", "-window", "root", f"test-browser-{ self.id().split('.')[-1] }.png"])
+            subprocess.call(["import", "-window", "root", f"test-browser-{self.id().split('.')[-1]}.png"])
         self.app_actions.activate_action("quit")
         self.assertEqual(self.p_client.wait(), 0)
 

--- a/test/common/lcov.py
+++ b/test/common/lcov.py
@@ -221,7 +221,7 @@ def print_file_coverage(path, line_hits, out):
     for i in range(len(line_hits)):
         if line_hits[i] is not None:
             lines_found += 1
-            out.write(f"DA:{i+1},{line_hits[i]}\n")
+            out.write(f"DA:{i + 1},{line_hits[i]}\n")
             if line_hits[i] > 0:
                 lines_hit += 1
     out.write(f"LH:{lines_hit}\n")

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -912,6 +912,15 @@ class Browser:
             # strip off parameters after hash
             self.enter_page(path.split('#')[0].rstrip('/'))
 
+    def get_pf_progress_value(self, progress_bar_sel):
+        """Get numeric value of a PatternFly <ProgressBar> component"""
+        sel = progress_bar_sel + " .pf-v5-c-progress__indicator"
+        self.wait_visible(sel)
+        self.wait_attr_contains(sel, "style", "width:")
+        style = self.attr(sel, "style")
+        m = re.search(r"width: (\d+)%;", style)
+        return int(m.group(1))
+
     def ignore_ssl_certificate_errors(self, ignore: bool):
         action = ignore and "continue" or "cancel"
         if opts.trace:

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -37,15 +37,6 @@ def getCompressedMinuteValue(test, g_type, saturation, hour, minute):
     return float(m.group(1))
 
 
-def progressValue(test, progress_bar_sel):
-    sel = progress_bar_sel + " .pf-v5-c-progress__indicator"
-    test.browser.wait_visible(sel)
-    test.browser.wait_attr_contains(sel, "style", "width:")
-    style = test.browser.attr(sel, "style")
-    m = re.search(r"width: (\d+)%;", style)
-    return int(m.group(1))
-
-
 def topServiceValue(test, aria_label, col_label, row):
     sel = "table[aria-label='%s'] tbody tr:nth-of-type(%d) td[data-label='%s']" % (aria_label, row, col_label)
     # split off unit, like "12 MB"
@@ -789,10 +780,10 @@ class TestCurrentMetrics(testlib.MachineCase):
             b.wait_visible("#current-top-cpu-usage")
 
         # wait until system settles down
-        b.wait(lambda: progressValue(self, "#current-cpu-usage") < 20)
+        b.wait(lambda: b.get_pf_progress_value("#current-cpu-usage") < 20)
         m.execute("systemd-run --collect --slice cockpittest -p CPUQuota=60% --unit cpu-hog dd if=/dev/urandom of=/dev/null")
         m.execute("systemd-run --collect --slice cockpittest -p CPUQuota=30% --unit cpu-piglet dd if=/dev/urandom of=/dev/null")
-        b.wait(lambda: progressValue(self, "#current-cpu-usage") > 75)
+        b.wait(lambda: b.get_pf_progress_value("#current-cpu-usage") > 75)
         # no other process in the test VM should take > 30% CPU, by the "settles down" assertion above
         b.wait_text("table[aria-label='Top 5 CPU services'] tbody tr:nth-of-type(1) td[data-label='Service']", "cpu-hog")
         b.wait_text("table[aria-label='Top 5 CPU services'] tbody tr:nth-of-type(2) td[data-label='Service']", "cpu-piglet")
@@ -810,7 +801,7 @@ class TestCurrentMetrics(testlib.MachineCase):
 
         m.execute("systemctl stop cpu-hog cpu-piglet")
         # should go back to idle usage
-        b.wait(lambda: progressValue(self, "#current-cpu-usage") < 20)
+        b.wait(lambda: b.get_pf_progress_value("#current-cpu-usage") < 20)
         # it could be that the table disappears completely if no service has a noticeable CPU usage;
         # so don't assume the table exists
         b.wait_not_in_text("#current-metrics-card-cpu", "cpu-hog")
@@ -1002,10 +993,10 @@ class TestCurrentMetrics(testlib.MachineCase):
         # only some images have swap
         have_swap = m.execute("swapon --show").strip()
         # wait until RAM usage is initialized
-        b.wait(lambda: progressValue(self, "#current-memory-usage") > 10)
+        b.wait(lambda: b.get_pf_progress_value("#current-memory-usage") > 10)
 
         # our test machines should use a reasonable chunk of available memory
-        initial_usage = progressValue(self, "#current-memory-usage")
+        initial_usage = b.get_pf_progress_value("#current-memory-usage")
         self.assertGreater(initial_usage, 10)
         self.assertLess(initial_usage, 80)
         # allocate a chunk of memory; this may cause other stuff to get unmapped,
@@ -1021,7 +1012,7 @@ BEGIN {{
         m.execute("while [ ! -e /tmp/hogged ]; do sleep 1; done")
         # bars update every 3s
         time.sleep(8)
-        hog_usage = progressValue(self, "#current-memory-usage")
+        hog_usage = b.get_pf_progress_value("#current-memory-usage")
         self.assertGreater(hog_usage, initial_usage + 8)
 
         b.wait_text("table[aria-label='Top 5 memory services'] tbody tr:nth-of-type(1) td[data-label='Service']", "mem-hog")
@@ -1044,18 +1035,18 @@ BEGIN {{
         b.wait_visible("table[aria-label='Top 5 memory services']")
 
         if have_swap:
-            usage_hog1 = progressValue(self, "#current-memory-usage")
+            usage_hog1 = b.get_pf_progress_value("#current-memory-usage")
 
             # use even more memory to trigger swap
             m.execute("systemd-run --collect --slice cockpittest --unit mem-hog2 awk "
                       """'BEGIN { x = sprintf("%700000000s",""); system("sleep infinity") }'""")
-            b.wait(lambda: progressValue(self, "#current-swap-usage") > 0)
+            b.wait(lambda: b.get_pf_progress_value("#current-swap-usage") > 0)
 
             m.execute("systemctl stop mem-hog mem-hog2")
 
             # after stopping both hogs, usage should go down
-            b.wait(lambda: progressValue(self, "#current-memory-usage") < usage_hog1)
-            self.assertGreater(progressValue(self, "#current-memory-usage"), 10)
+            b.wait(lambda: b.get_pf_progress_value("#current-memory-usage") < usage_hog1)
+            self.assertGreater(b.get_pf_progress_value("#current-memory-usage"), 10)
             b.wait_not_in_text("table[aria-label='Top 5 memory services'] tbody", "mem-hog")
 
             # total swap is shown as tooltip
@@ -1190,7 +1181,7 @@ BEGIN {{
             rm $F""")
         self.addCleanup(m.execute, "umount /var/cockpittest /var/cockpit-ro-test")
 
-        self.assertLess(progressValue(self, ".pf-v5-c-progress[data-disk-usage-target='/var/cockpittest']"), 5)
+        self.assertLess(b.get_pf_progress_value(".pf-v5-c-progress[data-disk-usage-target='/var/cockpittest']"), 5)
         progress_sel = ".pf-v5-c-progress[data-disk-usage-target='/var/cockpittest'] .pf-v5-c-progress__status"
         # free size is anything between 40 and 50 MB
         self.assertRegex(b.text(progress_sel), r"^4\d\.\d MB free$")
@@ -1204,7 +1195,7 @@ BEGIN {{
         self.assertFalse(b.is_present(".pf-v5-c-progress[data-disk-usage-target='/var/cockpit-ro-test']"))
 
         m.execute("dd if=/dev/zero of=/var/cockpittest/blob bs=1M count=40")
-        b.wait(lambda: progressValue(self, ".pf-v5-c-progress[data-disk-usage-target='/var/cockpittest']") >= 90)
+        b.wait(lambda: b.get_pf_progress_value(".pf-v5-c-progress[data-disk-usage-target='/var/cockpittest']") >= 90)
 
         # clicking on progress leads to the storage page
         if not m.ostree_image:
@@ -1422,7 +1413,7 @@ class TestMultiCPU(testlib.MachineCase):
 
         # Test current usage of cores
         b.wait_text("#current-cpu-usage-description", "2 CPUs")
-        b.wait(lambda: progressValue(self, "#current-cpu-usage") < 20)
+        b.wait(lambda: b.get_pf_progress_value("#current-cpu-usage") < 20)
         m.execute("systemd-run --collect --slice cockpittest -p CPUQuota=50% --unit cpu-hog dd if=/dev/urandom of=/dev/null")
         m.execute("systemd-run --collect --slice cockpittest -p CPUQuota=20% --unit cpu-piglet dd if=/dev/urandom of=/dev/null")
         # View all CPUs
@@ -1433,9 +1424,9 @@ class TestMultiCPU(testlib.MachineCase):
         b.wait_not_present(".pf-v5-c-popover")
 
         # the top CPU core runs cpu-hog
-        b.wait(lambda: progressValue(self, "#current-top-cpu-usage") >= 38)
+        b.wait(lambda: b.get_pf_progress_value("#current-top-cpu-usage") >= 38)
         # the hoglet gets scheduled between core 1 and 2
-        b.wait(lambda: progressValue(self, "#current-top-cpu-usage") <= 80)
+        b.wait(lambda: b.get_pf_progress_value("#current-top-cpu-usage") <= 80)
         # looks like "average: 45% max: 60%"
         b.wait(lambda: int(b.text("#current-cpu-usage .pf-v5-c-progress__status").split()[-1].rstrip('%')) >= 38)
         b.wait(lambda: int(b.text("#current-cpu-usage .pf-v5-c-progress__status").split()[-1].rstrip('%')) <= 80)

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -18,7 +18,6 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import re
 import time
 
 import packagelib
@@ -1166,9 +1165,7 @@ class TestWsUpdate(NoSubManCase):
 
         b.wait_in_text("#app div.progress-description", "slow 1-2")
         # progress bar has some reasonable value
-        b.wait_attr_contains(".progress-main-view .pf-v5-c-progress__indicator", "style", "width:")
-        rm = re.search(r"width: (\d+)%;", b.attr(".progress-main-view .pf-v5-c-progress__indicator", "style"))
-        progress = int(rm.group(1))
+        progress = b.get_pf_progress_value(".progress-main-view")
         self.assertGreater(progress, 20)
         self.assertLess(progress, 80)
 

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -648,7 +648,7 @@ OnCalendar=daily
         b.click("div#demo-file-ac-preselected input")
         paths = ["/home/admin/newdir", "/home/admin/newdir/dir1", "/home/admin/newdir/dir2", "/home/admin/newdir/file1", "/home/admin/newdir/file2"]
         for i in range(5):
-            b.wait_in_text(f"#file-autocomplete-widget-preselected li:nth-of-type({i+1}) button", paths[i])
+            b.wait_in_text(f"#file-autocomplete-widget-preselected li:nth-of-type({i + 1}) button", paths[i])
 
     @testlib.skipOstree("No PCP available")
     def testPlots(self):

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
-import re
 import time
 
 import packagelib
@@ -690,12 +689,7 @@ password=foobar
         m.execute("systemctl mask packagekit")
 
         def progressValue(number):
-            sel = ".system-usage tr:nth-child(%i) .pf-v5-c-progress__indicator" % number
-            b.wait_visible(sel)
-            b.wait_attr_contains(sel, "style", "width:")
-            style = b.attr(sel, "style")
-            m = re.search(r"width: (\d+)%;", style)
-            return int(m.group(1))
+            return b.get_pf_progress_value(f".system-usage tr:nth-child({number})")
 
         self.login_and_go("/system")
 

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -96,6 +96,9 @@ class TestSystemInfo(testlib.MachineCase):
         b.wait_not_present("#page_status_notification_system_services")
 
         # ensure general page/card layout without the changing specifics
+        # need to wait until CPU usage settles down, to avoid a layout-shifting error/warning icon
+        b.wait_not_present("#system-usage-cpu-progress + td .pf-v5-c-progress__status-icon")
+        testlib.wait(lambda: b.get_pf_progress_value("#system-usage-cpu-progress + td") < 30)
         b.assert_pixels("#overview", "overview", ignore=[
             ".system-health .pf-v5-c-card__body",
             "#system_machine_id",


### PR DESCRIPTION
When the CPU is busy, the "Usage" card shows a warning icon next to the
progress bar meter, which shifts the layout.

Fixes #19614

---

Addresses [this pixel flake](https://cockpit-logs.us-east-1.linodeobjects.com/pull-0-20231116-012752-9da92292-fedora-39-updates-testing/pixeldiff.html#TestSystemInfo-testBasic-overview), plus some more cleanups.