### PR TITLE
bridge: try harder to ensure Endpoints exited

### DIFF
--- a/src/cockpit/protocol.py
+++ b/src/cockpit/protocol.py
@@ -60,7 +60,6 @@ class CockpitProtocol(asyncio.Protocol):
     transport: Optional[asyncio.Transport] = None
     buffer = b''
     _closed: bool = False
-    _communication_done: Optional[asyncio.Future] = None
 
     def do_ready(self) -> None:
         pass
@@ -173,12 +172,6 @@ class CockpitProtocol(asyncio.Protocol):
 
         self.do_closed(exc)
 
-        if self._communication_done is not None:
-            if exc is None:
-                self._communication_done.set_result(None)
-            else:
-                self._communication_done.set_exception(exc)
-
     def write_channel_data(self, channel, payload):
         """Send a given payload (bytes) on channel (string)"""
         # Channel is certainly ascii (as enforced by .encode() below)
@@ -209,13 +202,6 @@ class CockpitProtocol(asyncio.Protocol):
 
     def eof_received(self) -> Optional[bool]:
         return False
-
-    async def communicate(self) -> None:
-        """Wait until communication is complete on this protocol."""
-        assert self._communication_done is None
-        self._communication_done = asyncio.get_running_loop().create_future()
-        await self._communication_done
-        self._communication_done = None
 
 
 # Helpful functionality for "server"-side protocol implementations

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1851,21 +1851,6 @@ class MachineCase(unittest.TestCase):
         # happens fairly reliably with TestKeys.testAuthorizedKeys, TestConnection.testTls and TestHistoryMetrics.testEvents
         self.allowed_messages.append('cockpit.router-ERROR: trying to drop non-existent channel .* from .*')
 
-        # https://github.com/cockpit-project/cockpit/issues/18355
-        self.allowed_messages += [
-            "[eE]xception ignored in:.*DBusChannel.setup_path_watch.*",
-            "Traceback .*most recent call last.*",
-            "File .*",
-            "async with self.watch_processing_lock:",
-            "self.send_.*",
-            "self.release.*",
-            "self._wake_up_first.*",
-            "fut.set_result.*",
-            "self._check_closed.*",
-            "raise RuntimeError.*",
-            "RuntimeError: Event loop is closed",
-        ]
-
         messages = machine.journal_messages(matches, 6, cursor=cursor)
 
         if "TEST_AUDIT_NO_SELINUX" not in os.environ:

--- a/test/pytest/mockpeer.py
+++ b/test/pytest/mockpeer.py
@@ -3,11 +3,11 @@ import os
 import sys
 
 from cockpit._vendor import systemd_ctypes
-from cockpit.protocol import CockpitProtocolServer
+from cockpit.router import Router
 from cockpit.transports import StdioTransport
 
 
-class MockPeer(CockpitProtocolServer):
+class MockPeer(Router):
     def do_send_init(self):
         init_type = os.environ.get('INIT_TYPE', None)
         if init_type == 'wrong-command':
@@ -37,7 +37,7 @@ class MockPeer(CockpitProtocolServer):
 
 
 async def run():
-    protocol = MockPeer()
+    protocol = MockPeer([])
     StdioTransport(asyncio.get_running_loop(), protocol)
     await protocol.communicate()
 


### PR DESCRIPTION
When the bridge shuts down in an orderly fashion from an EOF on stdin, we signal the endpoints to exit, wait for them to do so, and only close the connection after that's done.

When the connection closes suddenly, such as from a BrokenPipeError, we don't do this waiting around.  The result is that the endpoints are never signalled to clean themselves up, and (crucially) we don't wait for them to do so.

Let's move the communicate() method from the protocol level to the router so that we can make it aware of endpoints.  Then we make two changes:

 - if we didn't already call eof_received() then make sure it happens on disconnect of the transport.  This is what is responsible for asking the endpoints to close.

 - from the end of communicate(), unconditionally wait for all endpoints to have closed down.  This way we'll never get endpoints still running after the event loop has closed.

We accomplish that by adding a bit of redundant state: an asyncio.Event which can be awaited, and tracks if we have no endpoints left.

We also drop calling .shutdown() on all of the routing rules.  This is no longer necessary, as we're signalling all of the endpoints directly.

A minor tweak is needed to a test which was using communicate() on a subclass of CockpitProtocolServer — it can derive from Router now.

This should remove all of the warnings we've been seeing about "Event loop is closed" and "Task was destroyed but it is pending".

Closes #18355