### PR TITLE
test: Wait for real usage, not just a element with a ".usage-bar" class

### DIFF
--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -261,7 +261,7 @@ class TestStorageLvm2(storagelib.StorageCase):
         b.wait_text(self.card_row_col("LVM2 logical volumes", 1, 2), "ext4 filesystem")
         b.wait_text(self.card_row_col("LVM2 logical volumes", 1, 3), mount_point_one)
 
-        b.wait_visible(self.card_row_col("LVM2 logical volumes", 1, 4) + " .usage-bar")
+        b.wait_visible(self.card_row_col("LVM2 logical volumes", 1, 4) + " .usage-bar[role=progressbar]")
         b.assert_pixels('body', "page",
                         # Usage numbers are not stable and also cause
                         # the table columns to shift. The usage bars

--- a/test/verify/check-storage-nfs
+++ b/test/verify/check-storage-nfs
@@ -53,7 +53,7 @@ class TestStorageNfs(storagelib.StorageCase):
 
         b.wait_visible(self.card_row("Storage", name="127.0.0.1:/home/foo"))
         b.wait_visible(self.card_row("Storage", location="/mnt/test"))
-        b.wait_visible(self.card_row("Storage", location="/mnt/test") + " .usage-bar")
+        b.wait_visible(self.card_row("Storage", location="/mnt/test") + " .usage-bar[role=progressbar]")
 
         # Should be saved to fstab
         self.assertEqual(m.execute("cat /etc/fstab"), orig_fstab +
@@ -82,7 +82,7 @@ class TestStorageNfs(storagelib.StorageCase):
 
         b.wait_visible(self.card_row("Storage", name="127.0.0.1:/home/bar"))
         b.wait_visible(self.card_row("Storage", location="/mounts/bar"))
-        b.wait_visible(self.card_row("Storage", location="/mounts/bar") + " .usage-bar")
+        b.wait_visible(self.card_row("Storage", location="/mounts/bar") + " .usage-bar[role=progressbar]")
         m.execute("test -d /mounts/bar")
 
         # Go to details of /home/bar
@@ -217,7 +217,7 @@ class TestStorageNfs(storagelib.StorageCase):
 
         b.wait_visible(self.card_row("Storage", name="127.0.0.1:/home/foo"))
         b.wait_visible(self.card_row("Storage", location="/mnt"))
-        b.wait_visible(self.card_row("Storage", location="/mnt") + " .usage-bar")
+        b.wait_visible(self.card_row("Storage", location="/mnt") + " .usage-bar[role=progressbar]")
 
     def testNfsBusy(self):
         m = self.machine
@@ -242,7 +242,7 @@ class TestStorageNfs(storagelib.StorageCase):
 
         b.wait_visible(self.card_row("Storage", name="127.0.0.1:/home/foo"))
         b.wait_visible(self.card_row("Storage", location="/mounts/foo"))
-        b.wait_visible(self.card_row("Storage", location="/mounts/foo") + " .usage-bar")
+        b.wait_visible(self.card_row("Storage", location="/mounts/foo") + " .usage-bar[role=progressbar]")
 
         # Go to details of /home/foo
         self.click_card_row("Storage", name="127.0.0.1:/home/foo")


### PR DESCRIPTION
The latter is always present, even for rows that have no real usage displayed, just to get the spacing right.

Closes #19705