### PR TITLE
client: Provide fallback for GLib.get_user_state_dir()

### DIFF
--- a/src/client/cockpit-client
+++ b/src/client/cockpit-client
@@ -55,6 +55,17 @@ def prctl(*args):
         raise Exception('prctl() failed')
 
 
+def get_user_state_dir():
+    try:
+        # GLib ≥ 2.72
+        return GLib.get_user_state_dir()
+    except AttributeError:
+        try:
+            return os.environ["XDG_STATE_HOME"]
+        except KeyError:
+            return os.path.expanduser("~/.local/share")
+
+
 SET_PDEATHSIG = 1
 
 
@@ -222,7 +233,7 @@ class CockpitClient(Gtk.Application):
         context.set_sandbox_enabled(enabled=True)
         context.set_cache_model(WebKit2.CacheModel.DOCUMENT_VIEWER)
 
-        cookiesFile = os.path.join(GLib.get_user_state_dir(), "cockpit-client", "cookies.txt")
+        cookiesFile = os.path.join(get_user_state_dir(), "cockpit-client", "cookies.txt")
         cookies = context.get_cookie_manager()
         cookies.set_persistent_storage(cookiesFile, WebKit2.CookiePersistentStorage.TEXT)
 


### PR DESCRIPTION
This call was introduced in commit 483027a55, but this API only exists since glib 2.72, while current RHEL 9.3 still has
2.68. This causes client to crash with an AttributeError.

Provide a fallback implementation.

https://issues.redhat.com/browse/RHEL-15020

---

I reproduced that on a fresh RHEL 9.3 workstation installation and validated the fix. The subscription cockpit UI starts correctly now.