### PR TITLE
bridge: Add back support for x.min.js files

### DIFF
--- a/src/cockpit/packages.py
+++ b/src/cockpit/packages.py
@@ -265,10 +265,21 @@ class Package:
                 # Accept-Language is case-insensitive and uses '-' to separate variants
                 lower_locale = locale.lower().replace('_', '-')
 
+                logger.debug('Adding translation %r %r -> %r', basename, lower_locale, name)
                 self.translations[f'{basename}.js'][lower_locale] = name
             else:
-                basename = name[:-3] if name.endswith('.gz') else name
+                # strip out trailing '.gz' components
+                basename = re.sub('.gz$', '', name)
+                logger.debug('Adding content %r -> %r', basename, name)
                 self.files[basename] = name
+
+                # If we see a filename like `x.min.js` we want to also offer it
+                # at `x.js`, but only if `x.js(.gz)` itself is not present.
+                # Note: this works for both the case where we found the `x.js`
+                # first (it's already in the map) and also if we find it second
+                # (it will be replaced in the map by the line just above).
+                # See https://github.com/cockpit-project/cockpit/pull/19716
+                self.files.setdefault(basename.replace('.min.', '.'), name)
 
         # support old cockpit-po-plugin which didn't write po.manifest.??.js
         if not self.translations['po.manifest.js']:


### PR DESCRIPTION
We removed support for `.min.` filenames because we thought that nobody was using it anymore, but there are still external packages that make use of it.

Add it back again, by replacing our `.gz` stripping with a more general-purpose regular expression.

Add a bit of debugging output and a test case to make sure we handle the combinations properly.

Fixes https://issues.redhat.com/browse/RHEL-18861