### PR TITLE
bridge: Add back menu/tool names to `cockpit-bridge --packages`

### DIFF
--- a/src/cockpit/packages.py
+++ b/src/cockpit/packages.py
@@ -20,6 +20,7 @@ import contextlib
 import functools
 import gzip
 import io
+import itertools
 import json
 import logging
 import mimetypes
@@ -490,8 +491,13 @@ class Packages(bus.Object, interface='cockpit.Packages'):
     def show(self):
         for name in sorted(self.packages):
             package = self.packages[name]
-            menuitems = ''
-            print(f'{name:20} {menuitems:40} {package.path}')
+            menuitems = []
+            for entry in itertools.chain(
+                    package.manifest.get('menu', {}).values(),
+                    package.manifest.get('tools', {}).values()):
+                with contextlib.suppress(KeyError):
+                    menuitems.append(entry['label'])
+            print(f'{name:20} {", ".join(menuitems):40} {package.path}')
 
     def get_bridge_configs(self) -> Sequence[BridgeConfig]:
         def yield_configs():

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -1204,7 +1204,8 @@ UnixPath=/run/cockpit/session
 
         packages = m.execute("cockpit-bridge --packages")
         self.assertRegex(packages, r"(^|\n)base1\s+.*/usr/share/cockpit/base1")
-        self.assertRegex(packages, r"(^|\n)system\s+.*/usr/share/cockpit/systemd")
+        # also includes menu and tools entries
+        self.assertRegex(packages, r"(^|\n)system\s.*Services.*Terminal.*\s/usr/share/cockpit/systemd")
 
         if self.is_pybridge():
             bridges = json.loads(m.execute("cockpit-bridge --bridges").strip())


### PR DESCRIPTION
https://issues.redhat.com/browse/RHEL-18520

---

Now it looks pretty much like the old one:

```
❱❱❱ cpy --packages
apps                 Applications                             /var/home/martin/.local/share/cockpit/apps
base1                                                         /var/home/martin/.local/share/cockpit/base1
metrics                                                       /var/home/martin/.local/share/cockpit/metrics
playground           Development                              /var/home/martin/.local/share/cockpit/playground
selinux              SELinux                                  /var/home/martin/.local/share/cockpit/selinux
shell                                                         /var/home/martin/.local/share/cockpit/shell
sosreport            Diagnostic reports                       /var/home/martin/.local/share/cockpit/sosreport
static                                                        /var/home/martin/.local/share/cockpit/static
storage              Storage                                  /var/home/martin/.local/share/cockpit/storaged
system               Overview, Services, Logs, Terminal       /var/home/martin/.local/share/cockpit/systemd
users                Accounts                                 /var/home/martin/.local/share/cockpit/users
```