### PR TITLE
storaged: set a dark hover background on mobile

### DIFF
--- a/pkg/storaged/storage.scss
+++ b/pkg/storaged/storage.scss
@@ -331,7 +331,7 @@ a.disabled {
 }
 
 .ct-clickable-card:hover {
-    background: var(--pf-v5-global--palette--black-150);
+    background: var(--pf-v5-global--BackgroundColor--150);
     box-shadow: var(--pf-v5-global--BoxShadow--md);
     cursor: pointer;
 }


### PR DESCRIPTION
The palette black color is grey and causes a white flash when hovering over the storage devices in dark theme.

Closes #19706

![Screenshot from 2023-12-08 18-42-57](https://github.com/cockpit-project/cockpit/assets/67428/95da7ac2-fe54-4303-b4fb-ddd9cc901745)
