### PR TITLE
systemd: Fix spinner gap

### DIFF
--- a/pkg/systemd/reporting.jsx
+++ b/pkg/systemd/reporting.jsx
@@ -117,6 +117,7 @@ const FAFWorkflowRow = ({ problem }) => {
     const onCancelButtonClick = _event => process.close("canceled");
 
     const onReportButtonClick = _event => {
+        setMessage(_("Waiting to start…"));
         setProblemState(ProblemState.UNREPORTABLE);
         const process = cockpit.spawn(["reporter-ureport", "-d", problem.ID],
                                       {
@@ -396,10 +397,12 @@ const WorkflowRow = ({ message, problemState, reportLinks, label, onReportButton
     return (
         <Split hasGutter>
             <SplitItem>{label}</SplitItem>
-            <SplitItem isFilled>
-                {problemState === ProblemState.REPORTING && <Spinner size="md" /> }
-                {status}
-            </SplitItem>
+            {problemState === ProblemState.REPORTING && (
+                <SplitItem>
+                    <Spinner size="md" />
+                </SplitItem>
+            )}
+            <SplitItem isFilled>{status}</SplitItem>
             <SplitItem>{button}</SplitItem>
         </Split>
     );


### PR DESCRIPTION
1. a flex-gap of 0.5 rem added between the spinner and text
2. fixed the error not clearing when the report button is re-clicked, now it first becomes "Waiting to start" same as the other options before cycling through the other checks for errors.

Fixes #19059