### PR TITLE
networking: Disable interface On/off and MAC editing when unprivileged, fix network test failures on ubuntu-stable

### DIFF
--- a/pkg/networkmanager/network-interface.jsx
+++ b/pkg/networkmanager/network-interface.jsx
@@ -27,6 +27,8 @@ import { Gallery } from "@patternfly/react-core/dist/esm/layouts/Gallery/index.j
 import { Page, PageBreadcrumb, PageSection, PageSectionVariants } from "@patternfly/react-core/dist/esm/components/Page/index.js";
 import { Switch } from "@patternfly/react-core/dist/esm/components/Switch/index.js";
 
+import { Privileged } from "cockpit-components-privileged.jsx";
+
 import { ModelContext } from './model-context.jsx';
 import { NetworkInterfaceMembers } from "./network-interface-members.jsx";
 import { NetworkAction } from './dialogs-common.jsx';
@@ -214,7 +216,7 @@ export const NetworkInterfacePage = ({
             mac = iface.MainConnection.Settings.ethernet.assigned_mac_address;
         }
 
-        const can_edit_mac = (iface && iface.MainConnection &&
+        const can_edit_mac = (privileged && iface && iface.MainConnection &&
                               (connection_settings(iface.MainConnection).type == "802-3-ethernet" ||
                                connection_settings(iface.MainConnection).type == "bond"));
 
@@ -673,10 +675,15 @@ export const NetworkInterfacePage = ({
     let onoff;
     if (isManaged) {
         onoff = (
-            <Switch isChecked={!!(dev && dev.ActiveConnection)}
-                    isDisabled={!iface || (dev && dev.State == 20)}
-                    onChange={(_event, enable) => enable ? connect() : disconnect()}
-                    aria-label={_("Enable or disable the device")} />
+            <Privileged allowed={privileged}
+                        tooltipId="interface-switch"
+                        excuse={ _("Not permitted to configure network devices") }>
+                <Switch id="interface-switch"
+                        isChecked={!!(dev && dev.ActiveConnection)}
+                        isDisabled={!iface || (dev && dev.State == 20) || !privileged}
+                        onChange={(_event, enable) => enable ? connect() : disconnect()}
+                        aria-label={_("Enable or disable the device")} />
+            </Privileged>
         );
     }
 

--- a/test/common/netlib.py
+++ b/test/common/netlib.py
@@ -86,6 +86,8 @@ class NetworkCase(MachineCase, NetworkHelpers):
             self.orig_devs = devs()
             self.restore_dir("/etc/NetworkManager", restart_unit="NetworkManager")
             self.restore_dir("/etc/sysconfig/network-scripts")
+            self.restore_dir("/etc/netplan")
+            self.restore_dir("/run/NetworkManager/system-connections")
             self.addCleanup(cleanupDevs)
 
         m.execute("systemctl start NetworkManager")

--- a/test/verify/check-networkmanager-basic
+++ b/test/verify/check-networkmanager-basic
@@ -285,6 +285,48 @@ class TestNetworkingBasic(netlib.NetworkCase):
         # Killing NM affects realmd as well
         self.allow_journal_messages(".*org.freedesktop.realmd.Service.*")
 
+    def testUnprivileged(self):
+        b = self.browser
+        m = self.machine
+
+        self.login_and_go("/network", superuser=False)
+        b.wait_visible("#networking")
+
+        iface = 'cockpit1'
+        self.add_veth(iface, dhcp_cidr="10.111.113.2/20")
+        self.nm_activate_eth(iface)
+        self.wait_for_iface(iface)
+        con_id = testlib.wait(lambda: self.iface_con_id(iface))
+        mac = m.execute(f"cat /sys/class/net/{iface}/address").strip()
+
+        self.select_iface(iface)
+        b.wait_visible("#network-interface")
+        # On/Off button is disabled, but shows the correct value
+        b.wait_visible(f".pf-v5-c-card__header:contains('{iface}') .pf-v5-c-switch input:disabled")
+        self.wait_onoff(f".pf-v5-c-card__header:contains('{iface}')", val=True)
+
+        # not editable
+        b.wait_visible('#autoreconnect:disabled')
+        b.wait_not_present("#networking-edit-ipv4")
+        b.wait_not_present("#networking-edit-mac")
+        b.wait_text("#network-interface-mac", mac.upper())
+
+        # unpriv UI reacts to system change
+        m.execute(f"nmcli device disconnect {iface}")
+        self.wait_onoff(f".pf-v5-c-card__header:contains('{iface}')", val=False)
+        m.execute(f"nmcli connection up '{con_id}'")
+        self.wait_onoff(f".pf-v5-c-card__header:contains('{iface}')", val=True)
+
+        # UI becomes editable when gaining privileges
+        b.become_superuser()
+        b.wait_visible('#autoreconnect:not(disabled)')
+        b.wait_visible("#networking-edit-ipv4")
+        b.wait_visible("#networking-edit-mac")
+        b.wait_visible(f".pf-v5-c-card__header:contains('{iface}') .pf-v5-c-switch input:not(disabled)")
+
+        # FIXME: if pcp is running, cockpit-pcp throws this warning
+        self.allow_journal_messages('received invalid "host" field in kill command')
+
 
 if __name__ == '__main__':
     testlib.test_main()


### PR DESCRIPTION
Most UI elements are already disabled/not editable, just these two were left.

Thanks to @g-pape for the initial patch!

Fixes #19242