### PR TITLE
fmf: Skip TestStorageLvm2.testRaidRepair on Rawhide

### DIFF
--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -80,6 +80,11 @@ if [ "$PLAN" = "optional" ]; then
     # FIXME: creation dialog hangs forever
     EXCLUDES="$EXCLUDES TestStorageISCSI.testISCSI"
 
+    # FIXME: started to fail in rawhide and mess up the VM; see https://github.com/fedora-selinux/selinux-policy/pull/1962
+    if [ "$TEST_OS" = "fedora-40" ]; then
+        EXCLUDES="$EXCLUDES TestStorageLvm2.testRaidRepair"
+    fi
+
     # These don't test more external APIs
     EXCLUDES="$EXCLUDES
               TestAutoUpdates.testBasic


### PR DESCRIPTION
This test started to fail yesterday and corrupt the VM. The dialog fails (for an unknown reason), `vgroup0` stays busy and becomes unremovable.

This doesn't happen in a local `tmt` run, in TF runs against cockpit itself (just in cross-project tests), nor in our fedora-rawhide CI image, and we currently don't get enough debug/journal information to say what's going on.

Skip the test on rawhide for the time being, so that we can improve our test machinery and investigate this without causing failure and noise to stratis, selinux, and udisks.