### PR TITLE
users: Avoid reading /etc/shadow

### DIFF
--- a/pkg/lib/hooks.js
+++ b/pkg/lib/hooks.js
@@ -190,12 +190,10 @@ export function useFileWithError(path, options, hook_options) {
         const handle = cockpit.file(path, memo_options);
         handle.watch((data, tag, error) => {
             setContentAndError([data || false, error || false]);
-            if (!data && memo_hook_options && memo_hook_options.log_errors)
+            if (!data && memo_hook_options?.log_errors)
                 console.warn("Can't read " + path + ": " + (error ? error.toString() : "not found"));
         });
-        return function () {
-            handle.close();
-        };
+        return handle.close;
     }, [path, memo_options, memo_hook_options]);
 
     return content_and_error;

--- a/pkg/users/account-details.js
+++ b/pkg/users/account-details.js
@@ -103,7 +103,7 @@ function get_expire(name) {
             .then(parse_expire);
 }
 
-export function AccountDetails({ accounts, groups, shadow, current_user, user, shells }) {
+export function AccountDetails({ accounts, groups, current_user, user, shells }) {
     const [expiration, setExpiration] = useState(null);
     useEffect(() => {
         get_expire(user).then(setExpiration);
@@ -114,7 +114,7 @@ export function AccountDetails({ accounts, groups, shadow, current_user, user, s
             get_expire(user).then(setExpiration);
         });
         return handle.close;
-    }, [user, accounts, shadow]);
+    }, [user, accounts]);
 
     const [edited_real_name, set_edited_real_name] = useState(null);
     const [committing_real_name, set_committing_real_name] = useState(false);

--- a/pkg/users/account-details.js
+++ b/pkg/users/account-details.js
@@ -153,7 +153,6 @@ export function AccountDetails({ accounts, groups, current_user, user, shells })
                                this is a workaround for different ways of handling a locked account
                                https://github.com/cockpit-project/cockpit/issues/1216
                                https://bugzilla.redhat.com/show_bug.cgi?id=853153
-                               This seems to be fixed in fedora 23 (usermod catches the different locking behavior)
                             */
                                 if (locked != value && !dont_retry_if_stuck) {
                                     console.log("Account locked state doesn't match desired value, trying again.");

--- a/pkg/users/account-details.js
+++ b/pkg/users/account-details.js
@@ -17,10 +17,7 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-import cockpit from 'cockpit';
 import React, { useState, useEffect, useRef } from 'react';
-import { superuser } from "superuser";
-import { apply_modal_dialog } from "cockpit-components-dialog.jsx";
 
 import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
 import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox/index.js";
@@ -38,6 +35,12 @@ import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput/
 import { Spinner } from "@patternfly/react-core/dist/esm/components/Spinner/index.js";
 import { Popover } from "@patternfly/react-core/dist/esm/components/Popover/index.js";
 import { ExclamationCircleIcon, HelpIcon, UndoIcon } from '@patternfly/react-icons';
+
+import cockpit from 'cockpit';
+import { superuser } from "superuser";
+import * as timeformat from "timeformat.js";
+import { apply_modal_dialog } from "cockpit-components-dialog.jsx";
+
 import { show_unexpected_error } from "./dialog-utils.js";
 import { delete_account_dialog } from "./delete-account-dialog.js";
 import { account_expiration_dialog, password_expiration_dialog } from "./expiration-dialogs.js";
@@ -45,7 +48,6 @@ import { account_shell_dialog } from "./shell-dialog.js";
 import { set_password_dialog, reset_password_dialog } from "./password-dialogs.js";
 import { AccountLogs } from "./account-logs-panel.jsx";
 import { AuthorizedKeys } from "./authorized-keys-panel.js";
-import * as timeformat from "timeformat.js";
 
 const _ = cockpit.gettext;
 

--- a/pkg/users/account-details.js
+++ b/pkg/users/account-details.js
@@ -48,18 +48,9 @@ import { account_shell_dialog } from "./shell-dialog.js";
 import { set_password_dialog, reset_password_dialog } from "./password-dialogs.js";
 import { AccountLogs } from "./account-logs-panel.jsx";
 import { AuthorizedKeys } from "./authorized-keys-panel.js";
+import { get_locked } from "./utils.js";
 
 const _ = cockpit.gettext;
-
-function get_locked(name) {
-    return cockpit.spawn(["passwd", "-S", name], { environ: ["LC_ALL=C"], superuser: "require" })
-            .catch(() => "")
-            .then(content => {
-                const status = content.split(" ")[1];
-                // libuser uses "LK", shadow-utils use "L".
-                return status && (status == "LK" || status == "L");
-            });
-}
 
 function get_expire(name) {
     function parse_expire(data) {

--- a/pkg/users/users.js
+++ b/pkg/users/users.js
@@ -140,7 +140,7 @@ function AccountsPage() {
         );
     } else if (path.length === 1) {
         return (
-            <AccountDetails accounts={accountsInfo} groups={groupsExtraInfo} shadow={shadow || []}
+            <AccountDetails accounts={accountsInfo} groups={groupsExtraInfo}
                             current_user={current_user_info?.name} user={path[0]} shells={shells} />
         );
     } else return null;

--- a/pkg/users/users.js
+++ b/pkg/users/users.js
@@ -20,16 +20,17 @@ import '../lib/patternfly/patternfly-5-cockpit.scss';
 import 'polyfills'; // once per application
 import 'cockpit-dark-theme'; // once per page
 
-import cockpit from 'cockpit';
 import React, { useMemo, useState, useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
-import { superuser } from "superuser";
 
+import cockpit from 'cockpit';
+import { superuser } from "superuser";
 import { usePageLocation, useLoggedInUser, useFile, useInit } from "hooks.js";
 import { etc_passwd_syntax, etc_group_syntax, etc_shells_syntax } from "pam_user_parser.js";
+import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
+
 import { AccountsMain } from "./accounts-list.js";
 import { AccountDetails } from "./account-details.js";
-import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
 
 import "./users.scss";
 

--- a/pkg/users/utils.js
+++ b/pkg/users/utils.js
@@ -1,0 +1,10 @@
+import cockpit from 'cockpit';
+
+export const get_locked = name =>
+    cockpit.spawn(["passwd", "-S", name], { environ: ["LC_ALL=C"], superuser: "require" })
+            .then(content => {
+                const status = content.split(" ")[1];
+                // libuser uses "LK", shadow-utils use "L".
+                return status == "LK" || status == "L";
+            })
+            .catch(() => null);

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -317,6 +317,9 @@ OnCalendar=daily
             })""", language)
             b.wait_attr(".index-page", "lang", language)
 
+        # the quick iteration starts/stops tracer in quick succession, before it can finish
+        self.allow_browser_errors("Tracer failed:.*internal-error")
+
     def testPtBRLocale(self):
         m = self.machine
         b = self.browser


### PR DESCRIPTION
The hashed passwords is sensitive data, and it gets copied around in the
browser a lot. This isn't a data leak or security issue, as a malicious
page already has the privilege to read it by itself at any time, and
browsers isolate websites pretty well. However, let's be careful.

We only need /etc/shadow for two reasons:

 - Determine if an account is locked. Let's drop the file format
   assumption and use `passwd -S`, just as the details page already
   does. Use `get_locked()` from utils.js, and rework the code to get
   along with it being async.

 - Watch the file to get notified about account changes (locked, expiry,
   etc.). But we only need the event, not the actual data. So install a
   simple no-read file watch for this.

Also avoid reading utmp, as we don't look at its contents.

Thanks to @jeepingben for the suggestion!
