### PR TITLE
tests: Fix check-users races

### DIFF
--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -25,20 +25,12 @@ import testlib
 good_password = "tqymuVh.ZfZnP§9Wr=LM3JyG5yx"
 
 
-useradd_defaults = {}
-
-
 def getUserAddDetails(machine):
-    global useradd_defaults
-
-    if not useradd_defaults:  # dictionary is empty
-        useradd_defaults_str = machine.execute("useradd -D")
-        lines = useradd_defaults_str.split("\n")
-
-        for line in lines:
-            if line:
-                key, value = line.split("=")
-                useradd_defaults[key] = value
+    useradd_defaults = {}
+    for line in machine.execute("useradd -D").splitlines():
+        if line:
+            key, value = line.split("=")
+            useradd_defaults[key] = value
 
     return useradd_defaults
 

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -406,6 +406,9 @@ class TestAccounts(testlib.MachineCase):
         b = self.browser
         m = self.machine
 
+        # Clean out the relevant logfiles
+        m.execute("truncate -s0 /var/log/{[bw]tmp,lastlog} /var/run/utmp")
+
         self.login_and_go("/users")
         # Create a locked user with weak password
         self.sed_file('s/^SHELL=.*$/SHELL=/', '/etc/default/useradd')


### PR DESCRIPTION
First commit fixes the [TestAccounts.testUserPasswords](https://ci-weather-cockpit.apps.ocp.cloud.ci.centos.org/tests.html?days=7&test=test%2Fverify%2Fcheck-users+TestAccounts.testUserPasswords) that I've seen fail in #19751 a lot [like this](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19751-20231218-082519-95729ab6-arch-other/log.html#171-2).

The second commit fixes this failure, which I've seen somewhere on CI, but I didn't keep the URL. But I do get it locally rather easily:
```
Traceback (most recent call last):
  File "/var/home/martin/upstream/cockpit/main/test/verify/check-users", line 419, in testUserPasswords
    createUser(
  File "/var/home/martin/upstream/cockpit/main/test/verify/check-users", line 106, in createUser
    browser.wait_visible(f"#accounts-create-user-shell[data-selected='{default_shell}']")
[...]
testlib.Error: timeout
wait_js_cond(ph_is_present("#accounts-create-user-shell[data-selected='/usr/bin/bash']")): Uncaught (in promise) Error: condition did not become true
```
The screenshot shows that the dialog actually shows "/bin/bash", which is the correct expectation. The above assertion is wrong.

The third flake that I didn't yet track down is this:
```
Traceback (most recent call last):
  File "/var/home/martin/upstream/cockpit/main/test/verify/check-users", line 544, in testUserPasswords
    b.wait_visible("#account-groups-helper")
[...]
testlib.Error: timeout
wait_js_cond(ph_is_present("#account-groups-helper")): Uncaught (in promise) Error: condition did not become true
```
This is harder to fix, as any attempt to add console.log()s (or $deity forbid, `sit()` calls) of course makes it go away. I'll still prod it a bit, but let's fix the other ones in the meantime.