### PR TITLE
test: Drop logind user ID cache

### DIFF
--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -28,9 +28,8 @@ good_password = "tqymuVh.ZfZnP§9Wr=LM3JyG5yx"
 def getUserAddDetails(machine):
     useradd_defaults = {}
     for line in machine.execute("useradd -D").splitlines():
-        if line:
-            key, value = line.split("=")
-            useradd_defaults[key] = value
+        key, value = line.split("=")
+        useradd_defaults[key] = value
 
     return useradd_defaults
 


### PR DESCRIPTION
TestAccounts creates and recycles UIDs a lot, with different user names.
This can lead to failures: testFirst creating user testA, then
cleaning it up, then testSecond creates testB with the same UID, and all
of a sudden logind thinks that the running session of testB belongs to
testA (literally the user name, not just the UID).

logind caches this in /run/systemd/users/, and I haven't found a way to
wean it off that cache. So delete all uid cache files in between tests.
Move from `restart` to `stop`, as otherwise the new logind will rewrite
the files; and we don't have to explicitly start it as it gets D-Bus
activated.

Move the restarting until after stopping the remaining user@ services,
as otherwise there are still legitimate processes around from the
to-be-removed user.

----

See my [debug odysee notes](https://github.com/cockpit-project/cockpit/pull/19755#issuecomment-1860555325). This definitively fixes the [failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19755-20231218-163811-3aca910f-arch-other/log.html#178) that I can reproduce 100% locally, but this is the kind of change that very likely rips something apart somewhere else. Let's see what the bots think!