### PR TITLE
lib: Make date-fns/locale import compatible with 3.0; test improvements

### DIFF
--- a/pkg/lib/timeformat.js
+++ b/pkg/lib/timeformat.js
@@ -5,7 +5,7 @@
  */
 import cockpit from "cockpit";
 import { parse, formatDistanceToNow } from 'date-fns';
-import * as locales from 'date-fns/locale/index.js';
+import * as locales from 'date-fns/locale';
 
 // this needs to be dynamic, as some pages don't initialize cockpit.language right away
 export const dateFormatLang = () => cockpit.language.replace('_', '-');

--- a/test/common/storagelib.py
+++ b/test/common/storagelib.py
@@ -124,6 +124,11 @@ class StorageHelpers:
         # the removal trips up PCP and our usage graphs
         self.allow_browser_errors("direct: instance name lookup failed.*")
 
+    def addCleanupVG(self, vgname):
+        """Ensure the given VG is removed after the test"""
+
+        self.addCleanup(self.machine.execute, f"if [ -d /dev/{vgname} ]; then vgremove --force {vgname}; fi")
+
     # Dialogs
 
     def dialog_wait_open(self):

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -173,6 +173,17 @@ def attach(filename: str, move: bool = False):
             shutil.copy(filename, dest)
 
 
+def unique_filename(base, ext):
+    for i in range(20):
+        if i == 0:
+            f = f"{base}.{ext}"
+        else:
+            f = f"{base}-{i}.{ext}"
+        if not os.path.exists(f):
+            return f
+    return f"{base}.{ext}"
+
+
 class Browser:
     def __init__(self, address, label, machine, pixels_label=None, coverage_label=None, port=None):
         if ":" in address:
@@ -943,7 +954,7 @@ class Browser:
         if self.cdp and self.cdp.valid:
             self.cdp.command("clearExceptions()")
 
-            filename = f"{label or self.label}-{title}.png"
+            filename = unique_filename(f"{label or self.label}-{title}", "png")
             if self.body_clip:
                 ret = self.cdp.invoke("Page.captureScreenshot", clip=self.body_clip, no_trace=True)
             else:
@@ -956,7 +967,7 @@ class Browser:
             else:
                 print("Screenshot not available")
 
-            filename = f"{label or self.label}-{title}.html"
+            filename = unique_filename(f"{label or self.label}-{title}", "html")
             html = self.cdp.invoke("Runtime.evaluate", expression="document.documentElement.outerHTML",
                                    no_trace=True)["result"]["value"]
             with open(filename, 'wb') as f:
@@ -1237,7 +1248,7 @@ class Browser:
 
         logs = list(self.get_js_log())
         if logs:
-            filename = f"{label or self.label}-{title}.js.log"
+            filename = unique_filename(f"{label or self.label}-{title}", "js.log")
             with open(filename, 'wb') as f:
                 f.write('\n'.join(logs).encode('UTF-8'))
             attach(filename, move=True)
@@ -1967,7 +1978,7 @@ class MachineCase(unittest.TestCase):
         # write the report
         if suffix:
             suffix = "-" + suffix
-        filename = f"{label or self.label()}{suffix}-axe.json.gz"
+        filename = unique_filename(f"{label or self.label()}{suffix}-axe", "json.gz")
         with gzip.open(filename, "wb") as f:
             f.write(json.dumps(report).encode('UTF-8'))
         print("Wrote accessibility report to " + filename)
@@ -2002,7 +2013,7 @@ class MachineCase(unittest.TestCase):
     def copy_journal(self, title: str, label: Optional[str] = None):
         for _, m in self.machines.items():
             if m.ssh_reachable:
-                log = "%s-%s-%s.log.gz" % (label or self.label(), m.label, title)
+                log = unique_filename("%s-%s-%s" % (label or self.label(), m.label, title), "log.gz")
                 with open(log, "w") as fp:
                     m.execute("journalctl|gzip", stdout=fp)
                     print("Journal extracted to %s" % (log))

--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -57,7 +57,7 @@ class TestStorageLvm2(storagelib.StorageCase):
         # Create a volume group out of two disks
         m.execute(f"vgcreate TEST1 {dev_1} {dev_2}")
         # just in case the test fails
-        self.addCleanup(m.execute, "vgremove --force TEST1 2>/dev/null || true")
+        self.addCleanupVG("TEST1")
         self.click_card_row("Storage", name="TEST1")
         b.wait_visible(self.card_row("LVM2 volume group", name=dev_1))
         b.wait_visible(self.card_row("LVM2 volume group", name=dev_2))
@@ -125,7 +125,7 @@ class TestStorageLvm2(storagelib.StorageCase):
                                                  dev_2: True}})
 
         # just in case the test fails
-        self.addCleanup(m.execute, "vgremove --force vgroup0 2>/dev/null || true")
+        self.addCleanupVG("vgroup0")
         b.wait_visible(self.card_row("Storage", name="vgroup0"))
 
         # Check that the next name is "vgroup1"
@@ -330,7 +330,7 @@ class TestStorageLvm2(storagelib.StorageCase):
 
         m.execute(f"vgcreate TEST {disk}")
 
-        self.addCleanup(m.execute, "vgremove --force TEST")
+        self.addCleanupVG("TEST")
         self.click_card_row("Storage", name="TEST")
 
         # Create a thinpool and a thin volume in it
@@ -366,7 +366,6 @@ class TestStorageLvm2(storagelib.StorageCase):
         b.wait_not_present(self.card_row("LVM2 logical volumes", name="snap0"))
 
     def testRaid(self):
-        m = self.machine
         b = self.browser
 
         self.skip_if_no_layouts()
@@ -392,7 +391,7 @@ class TestStorageLvm2(storagelib.StorageCase):
                                                      disk3: True,
                                                      disk4: True}})
 
-        self.addCleanup(m.execute, "vgremove --force vgroup0 2>/dev/null || true")
+        self.addCleanupVG("vgroup0")
 
         # Make a raid5 on three PVs, using about half of each
 
@@ -452,7 +451,6 @@ class TestStorageLvm2(storagelib.StorageCase):
         b.assert_pixels(card, "raid5-card2")
 
     def testRaidRepair(self):
-        m = self.machine
         b = self.browser
 
         self.skip_if_no_layouts()
@@ -476,7 +474,7 @@ class TestStorageLvm2(storagelib.StorageCase):
                                                      disk2: True,
                                                      disk3: True}})
 
-        self.addCleanup(m.execute, "vgremove --force vgroup0 2>/dev/null || true")
+        self.addCleanupVG("vgroup0")
 
         # Make a raid5 on the three PVs
 
@@ -547,7 +545,6 @@ class TestStorageLvm2(storagelib.StorageCase):
         b.wait_not_present(".pf-v5-c-alert")
 
     def testBrokenLinear(self):
-        m = self.machine
         b = self.browser
 
         self.skip_if_no_layouts()
@@ -570,7 +567,7 @@ class TestStorageLvm2(storagelib.StorageCase):
                                                      disk2: True,
                                                      disk3: True}})
 
-        self.addCleanup(m.execute, "vgremove --force vgroup0 2>/dev/null || true")
+        self.addCleanupVG("vgroup0")
 
         # Make a linear volume on two of them
 
@@ -641,7 +638,7 @@ class TestStorageLvm2(storagelib.StorageCase):
                                                      disk4: True,
                                                      disk5: True,
                                                      disk6: True}})
-        self.addCleanup(self.machine.execute, "vgremove --force vgroup0 2>/dev/null || true")
+        self.addCleanupVG("vgroup0")
         self.click_card_row("Storage", name="vgroup0")
 
         def mb(size):
@@ -726,7 +723,7 @@ class TestStorageLvm2(storagelib.StorageCase):
                                                      disk4: True,
                                                      disk5: True,
                                                      disk6: True}})
-        self.addCleanup(self.machine.execute, "vgremove --force vgroup0 2>/dev/null || true")
+        self.addCleanupVG("vgroup0")
         self.click_card_row("Storage", name="vgroup0")
 
         def mb(size):
@@ -818,7 +815,7 @@ class TestStorageLvm2(storagelib.StorageCase):
                                                      disk3: True,
                                                      disk4: True,
                                                      disk5: True}})
-        self.addCleanup(self.machine.execute, "vgremove --force vgroup0 2>/dev/null || true")
+        self.addCleanupVG("vgroup0")
         self.click_card_row("Storage", name="vgroup0")
 
         def create(row, layout, expected_name):
@@ -896,7 +893,7 @@ class TestStorageLvm2(storagelib.StorageCase):
         m.execute(f"echo einszweidrei | cryptsetup luksOpen {disk} dm-test")
         self.addCleanup(m.execute, "cryptsetup close dm-test || true")
         m.execute("vgcreate vgroup0 /dev/mapper/dm-test")
-        self.addCleanup(m.execute, "vgremove --force vgroup0 2>/dev/null || true")
+        self.addCleanupVG("vgroup0")
         m.execute("lvcreate vgroup0 -n lvol0 -l100%FREE")
 
         self.click_card_row("Storage", name="lvol0")

--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -427,10 +427,10 @@ class TestStorageMountingLUKS(storagelib.StorageCase):
 
         self.login_and_go("/storage")
 
+        self.addCleanupVG("test")
         self.addCleanup(m.execute,
                         "umount /run/data || true;"
-                        "cryptsetup close $(lsblk -lno NAME /dev/test/one | tail -1) || true;"
-                        "vgremove --force test 2>/dev/null || true")
+                        "cryptsetup close $(lsblk -lno NAME /dev/test/one | tail -1) || true")
 
         # Quickly make two logical volumes
         disk = self.add_ram_disk()

--- a/test/verify/check-storage-used
+++ b/test/verify/check-storage-used
@@ -123,7 +123,7 @@ ExecStart=/usr/bin/sleep infinity
 
         # Create a volume group out of two disks
         m.execute(f"vgcreate TEST1 {dev_1} {dev_2}")
-        self.addCleanup(m.execute, "vgremove --force TEST1 2>/dev/null || true")
+        self.addCleanupVG("TEST1")
         b.wait_visible(self.card_row("Storage", name="TEST1"))
 
         # Formatting dev_1 should cleanly remove it from the volume


### PR DESCRIPTION
The index.js import ceases to work with date-fns 3.0.0. This also works with our current version 2.30.

---

See https://github.com/cockpit-project/cockpit-ostree/pull/477 -- we need to land this, bump the cockpit lib in ostree, and then can go ahead with that date-fns bump. This will also proactively fix the date-fns version bump in cockpit itself (which likely will happen in the next days).