### PR TITLE
Fix busybox compatibility

### DIFF
--- a/pkg/sosreport/sosreport.jsx
+++ b/pkg/sosreport/sosreport.jsx
@@ -89,7 +89,7 @@ function sosLister() {
     }
 
     function update_reports() {
-        cockpit.script('find /var/tmp -maxdepth 1 -name \'*sosreport-*.tar.*\' -print0 | xargs -0 -r stat --printf="%n\\r%W\\n"', { superuser: true, err: "message" })
+        cockpit.script('printf \"\$(stat -c \'%n\\r%Y\\n\' /var/tmp/*sosreport-*.tar.*)\"', { superuser: true, err: "message" })
                 .then(output => {
                     const reports = { };
                     const lines = output.split("\n");

--- a/src/tls/cockpit-certificate-helper.in
+++ b/src/tls/cockpit-certificate-helper.in
@@ -10,7 +10,7 @@ COCKPIT_RUNTIME_DIR="/run/cockpit"
 
 install_cert() {
     local destination="${COCKPIT_WS_CERTS_D}/$1"
-    mv -Z "$1" "${destination}"
+    mv -Z "$1" "${destination}" || mv "$1" "${destination}"
 
     # The certificate should be world-readable
     chmod a+r "${destination}"
@@ -18,7 +18,7 @@ install_cert() {
 
 install_key() {
     local destination="${COCKPIT_WS_CERTS_D}/$1"
-    mv -Z "$1" "${destination}"
+    mv -Z "$1" "${destination}" || mv "$1" "${destination}"
 }
 
 selfsign_sscg() {


### PR DESCRIPTION
This PR aims to simplify cockpit integration in an embedded distribution (Yocto / Poky).

Busybox tools don't support advanced args like `mv -Z` or `find -print0`.