### PR TITLE
static: Avoid leading/trailing space on browser check message

### DIFF
--- a/pkg/lib/html2po.js
+++ b/pkg/lib/html2po.js
@@ -171,7 +171,14 @@ function extract(children) {
             str.push(node.data);
     });
 
-    return str.join("");
+    const msgid = str.join("");
+
+    if (msgid != msgid.trim()) {
+        console.error("FATAL: string contains leading or trailing whitespace:", msgid);
+        process.exit(1);
+    }
+
+    return msgid;
 }
 
 /* Escape a string for inclusion in po file */

--- a/pkg/static/login.html
+++ b/pkg/static/login.html
@@ -58,9 +58,7 @@
           <svg height="16" width="16" viewBox="0 0 16 16" id="option-caret" class="caret caret-right" aria-hidden="true">
             <polygon fill="#ffffff" points="4,0 4,14 12,7"></polygon>
           </svg>
-          <span id="bypass-browser-check" translate="yes">
-            Bypass browser check
-          </span>
+          <span id="bypass-browser-check" translate="yes">Bypass browser check</span>
         </summary>
         <div id="login-override-content"></div>
       </details>


### PR DESCRIPTION
This fixes translatability and avoids brittle handling of the leading/trailing spaces.
---

This brings back the fix in PR #19746 from @NeftaliYagua , with an additional validation commit.