### PR TITLE
Packagekit: Update CVE link to go to the new site

### DIFF
--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -122,7 +122,7 @@ function parseCVEs(text) {
     const cves = text.match(/CVE-\d{4}-\d+/g);
     if (!cves)
         return [];
-    return cves.map(n => "https://cve.mitre.org/cgi-bin/cvename.cgi?name=" + n);
+    return cves.map(n => "https://www.cve.org/CVERecord?id=" + n);
 }
 
 function deduplicate(list) {

--- a/test/common/packagelib.py
+++ b/test/common/packagelib.py
@@ -362,7 +362,7 @@ post_upgrade() {{
             for b in info.get("bugs", []):
                 refs += f'      <reference href="https://bugs.example.com?bug={b}" id="{b}" title="Bug#{b} Description" type="bugzilla"/>\n'
             for c in info.get("cves", []):
-                refs += f'      <reference href="https://cve.mitre.org/cgi-bin/cvename.cgi?name={c}" id="{c}" title="{c}" type="cve"/>\n'
+                refs += f'      <reference href="https://www.cve.org/CVERecord?id={c}" id="{c}" title="{c}" type="cve"/>\n'
             if info.get("securitySeverity"):
                 refs += '      <reference href="https://access.redhat.com/security/updates/classification/#{0}" id="" title="" type="other"/>\n'.format(info[
                                                                                                                                                         "securitySeverity"])


### PR DESCRIPTION
https://cve.mitre.org/ is currently transitioning over to https://www.cve.org/ this change is just to reflect this, as support for the old site will likely be dropped eventually