### PR TITLE
ssh: Use valid host name in test-sshbridge

### DIFF
--- a/src/ssh/test-sshbridge.c
+++ b/src/ssh/test-sshbridge.c
@@ -323,7 +323,7 @@ setup (TestCase *tc,
       if (!fixture->knownhosts_home)
           g_assert_cmpint (mkdir (tc->home_ssh_dir, 0700), ==, 0);
 
-      g_string_append (content, "Host some_host\n");
+      g_string_append (content, "Host somehost\n");
       g_string_append_printf (content, "\tHostname %s\n", hostname);
 
       if (fixture->ssh_config_port == PORT_VALID)
@@ -346,7 +346,7 @@ setup (TestCase *tc,
       if (fixture->ssh_config_user == USER_INVALID_HOST_PRIORITY)
         g_string_append_printf (new_host, "%s@", g_get_user_name ());
       /* Host in the ssh config file */
-      g_string_append (new_host, "some_host");
+      g_string_append (new_host, "somehost");
       /* The port in host should take priority over the port in ssh config */
       if (fixture->ssh_config_port == PORT_INVALID_HOST_PRIORITY)
         g_string_append_printf (new_host, ":%hu", tc->ssh_port);


### PR DESCRIPTION
libssh 0.10.6 made host name parsing stricter. `some_host` is not a valid general host name, and is rejected with the latest version.

---

This should fix the COPR build failure in rawhide, f39, and https://github.com/cockpit-project/bots/pull/5729