### PR TITLE
test: Expect rhcd_t SELinux modification on RHEL

### DIFF
--- a/test/verify/check-selinux
+++ b/test/verify/check-selinux
@@ -285,8 +285,8 @@ class TestSelinux(testlib.MachineCase):
         b.enter_page("/selinux")
         with b.wait_timeout(30):
             if m.image.startswith("rhel"):
-                # insights-client sets itself as permissive on RHEL, and `semanage permissive -D` gets OOM-killed
-                b.wait_text_matches("ul[aria-label='System modifications']", "No system modifications|permissive -a insights_client_t")
+                # HACK: rhc sets itself as permissive on RHEL; https://issues.redhat.com/browse/RHEL-20352
+                b.wait_text_matches("ul[aria-label='System modifications']", "No system modifications|permissive -a rhcd_t")
             else:
                 b.wait_text("ul[aria-label='System modifications']", "No system modifications")
         b.relogin("/selinux", "admin", superuser=False)


### PR DESCRIPTION
The most recent RHEL 9.4 cloud images added the "rhc" package. This currently contains a hack to locally modify the SELinux policy [1], so we need to ignore this.

At least we can drop the insights_client hack, it was fixed properly in https://bugzilla.redhat.com/show_bug.cgi?id=2226684

[1] https://issues.redhat.com/browse/RHEL-20352

---

this blocks https://github.com/cockpit-project/bots/pull/5724