### PR TITLE
test: Adjust TestIPA.testClientCertAuthentication to changed loginctl  255 output format

### DIFF
--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -421,7 +421,10 @@ class CommonTests:
                     if "State: active" in out:  # skip closing sessions
                         self.assertIn(session_leader, out)
                         self.assertIn('cockpit-bridge', out)
-                        self.assertIn('cockpit; type web', out)
+                        # systemd < 255: "Service: cockpit; type web; class user"
+                        # systemd ≥ 255: "Service: cockpit\n   Type: web\n Class: user"
+                        self.assertRegex(out, r"Service:\s+cockpit")
+                        self.assertRegex(out, "[tT]ype.*web")
                         break
                 else:
                     self.fail("no active session for active user")


### PR DESCRIPTION
Commit 800c89f93ffa fixed this for check-static-login already. Debian testing now got systemd 255 and ran into this changed output format as well.

---

Blocks https://github.com/cockpit-project/bots/pull/5732