### PR TITLE
test: Wait until #account-locked gets initialized

### DIFF
--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -130,6 +130,7 @@ class TestAccounts(testlib.MachineCase):
 
         # Set a real name
         b.go("#/anton")
+        b.wait_visible("#account-locked:not([disabled])")
         b.assert_pixels("#users-page", "user-detail-page")
         b.wait_text("#account-user-name", "anton")
         b.wait_text("#account-title", "anton")


### PR DESCRIPTION
On loading the page, the "Disallow interactive password" checkbox is initially disabled, with a `null` value which shows up as [-]. Wait until it is initialized before taking the pixel test.

Fixes #19787