### PR TITLE
tests: don't crash if no users exist when cleaning up login sessions

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1604,7 +1604,7 @@ class MachineCase(unittest.TestCase):
 
             # Restart logind to mop up empty "closing" sessions, and clean user id cache for non-system users
             self.machine.execute("systemctl stop systemd-logind; cd /run/systemd/users/; "
-                                 "for f in *; do [ $f -le 500 ] || rm $f; done")
+                                 "for f in $(ls); do [ $f -le 500 ] || rm $f; done")
 
         self.addCleanup(terminate_sessions)
 


### PR DESCRIPTION
When no files exist in the directory the existing code would try to use the * as a file:
    
kkoukiou@o2:~/k$ for f in *; do echo $f; done
*

Instead let's list the files with `ls` to avoid this corner case as this breaks anaconda tests.