### PR TITLE
fmf: Re-disable TestStorageLvm2.testRaidRepair on rawhide

### DIFF
--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -80,6 +80,11 @@ if [ "$PLAN" = "optional" ]; then
     # FIXME: creation dialog hangs forever
     EXCLUDES="$EXCLUDES TestStorageISCSI.testISCSI"
 
+    # HACK: started to fail in rawhide and mess up the VM; https://bugzilla.redhat.com/show_bug.cgi?id=2256433
+    if [ "$TEST_OS" = "fedora-40" ]; then
+        EXCLUDES="$EXCLUDES TestStorageLvm2.testRaidRepair"
+    fi
+
     # These don't test more external APIs
     EXCLUDES="$EXCLUDES
               TestAutoUpdates.testBasic

--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -457,10 +457,10 @@ class TestStorageLvm2(storagelib.StorageCase):
 
         self.login_and_go("/storage")
 
-        disk1 = self.add_ram_disk(size=200)
-        disk2 = self.add_loopback_disk(name="loop10", size=400)
-        disk3 = self.add_loopback_disk(name="loop11", size=400)
-        disk4 = self.add_loopback_disk(name="loop12", size=400)
+        disk1 = self.add_ram_disk()
+        disk2 = self.add_loopback_disk(name="loop10")
+        disk3 = self.add_loopback_disk(name="loop11")
+        disk4 = self.add_loopback_disk(name="loop12")
 
         # Make a volume group with three physical volumes
 
@@ -525,7 +525,7 @@ class TestStorageLvm2(storagelib.StorageCase):
         b.click(self.card_button("LVM2 logical volume", "Repair"))
         self.dialog_wait_open()
         self.dialog_apply()
-        self.dialog_wait_error("pvs", "An additional 206 MB must be selected")
+        self.dialog_wait_error("pvs", "An additional 46.1 MB must be selected")
         self.dialog_set_val("pvs", {disk4: True})
         self.dialog_apply()
         self.dialog_wait_close()


### PR DESCRIPTION
It still fails way too often. Bring back the skip, and add the bug reference.

----

Over night we got lots of failure notifications in https://github.com/stratis-storage/stratisd/pull/3516 , https://github.com/fedora-selinux/selinux-policy/pull/1842,  https://github.com/storaged-project/udisks/pull/1234, and more where this still [causes](https://artifacts.dev.testing-farm.io/8fe07679-65c2-44a1-953f-1580e8316e3f/) [a mess](https://artifacts.dev.testing-farm.io/25b570cf-922a-4b03-ab7a-5be24c30ec85/).