### PR TITLE
add test inspector as separate project and add command line option to enable it on demand

### DIFF
--- a/test/common/make-testinsp
+++ b/test/common/make-testinsp
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 # prepare testinspector
-GITHUB_REPO='testinsp'
 SUBDIR='testinsp'
 COMMON=$(dirname $0)
 V="${V-0}" # default to friendly messages

--- a/test/common/make-testinsp
+++ b/test/common/make-testinsp
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# prepare testinspector
+GITHUB_REPO='testinsp'
+SUBDIR='testinsp'
+COMMON=$(dirname $0)
+V="${V-0}" # default to friendly messages
+
+set -eu
+cd $COMMON
+. ./git-utils.sh
+
+if [ ! -e "$COMMON/$SUBDIR" ]; then
+    git clone https://github.com/jscotka/testinsp.git $SUBDIR
+else
+    echo "$SUBDIR/ already exists, skipping"
+fi

--- a/test/common/make-testinsp
+++ b/test/common/make-testinsp
@@ -1,16 +1,16 @@
 #!/bin/sh
 
 # prepare testinspector
+
 SUBDIR='testinsp'
 COMMON=$(dirname $0)
 V="${V-0}" # default to friendly messages
 
 set -eu
 cd $COMMON
-. ./git-utils.sh
 
 if [ ! -e "$COMMON/$SUBDIR" ]; then
-    git clone https://github.com/jscotka/testinsp.git $SUBDIR
+    git clone https://github.com/jscotka/${SUBDIR}.git $SUBDIR
 else
     echo "$SUBDIR/ already exists, skipping"
 fi

--- a/test/common/pywrap
+++ b/test/common/pywrap
@@ -19,9 +19,11 @@ top_srcdir="${realpath%/*}/../.."
 
 # Check out the bots if required
 test -d "${top_srcdir}/bots" || "${top_srcdir}/test/common/make-bots"
+# Check out the test inspector if required
+test -d "$(dirname $realpath)/testinsp" || "$(dirname $realpath)/make-testinsp"
 
 # Prepend the path
-PYTHONPATH="${top_srcdir}/test/common:${top_srcdir}/bots:${top_srcdir}/bots/machine${PYTHONPATH:+:${PYTHONPATH}}"
+PYTHONPATH="${top_srcdir}/test/common/testinsp:${top_srcdir}/test/common:${top_srcdir}/bots:${top_srcdir}/bots/machine${PYTHONPATH:+:${PYTHONPATH}}"
 export PYTHONPATH
 
 # Run the script

--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -183,7 +183,18 @@ class Test:
             for line in lines[:-1]:
                 if line.startswith(b"WARNING:"):
                     write_line(line)
+            # print test inspector log
+            ti_start = False
+            for line in lines:
+                if b"RESULTS OF TEST INSPECTOR" in line:
+                    ti_start = True
+                    continue
+                if b"END OF TEST INSPECTOR" in line:
+                    break
+                if ti_start:
+                    write_line(b"WARNING: TI -> " + line)
             write_line(lines[-1])
+
         else:
             for line in lines:
                 write_line(line)

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1527,7 +1527,7 @@ class MachineCase(unittest.TestCase):
                     pprint(f">> Test Inspector FAIL - ({k}):")
                     pprint(v)
             print(" ---------- END OF TEST INSPECTOR ---------- ")
-        exclude_dict=dict()
+        exclude_dict = {}
         exclude_dict["ListEtcDir"] = ["/etc/systemd/system/cockpit.service.d/notls.conf"]
         exclude_dict["ServiceInfo"] = ["cockpit",
                                        "user@",

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1528,7 +1528,10 @@ class MachineCase(unittest.TestCase):
                     pprint(v)
             print(" ---------- END OF TEST INSPECTOR ---------- ")
         exclude_dict = {}
-        exclude_dict["ListEtcDir"] = ["/etc/systemd/system/cockpit.service.d/notls.conf"]
+        exclude_dict["ListEtcDir"] = ["/etc/systemd/system/cockpit.service.d/notls.conf",
+                                      "/etc/lvm/archive",
+                                      "/etc/lvm/backup",
+                                      ]
         exclude_dict["ServiceInfo"] = ["cockpit",
                                        "user@",
                                        "packagekit",
@@ -1536,7 +1539,9 @@ class MachineCase(unittest.TestCase):
                                        "realmd",
                                        "systemd-timedated",
                                        "systemd-hostnamed",
-                                       "systemd-logind.service"]
+                                       "systemd-logind.service",
+                                       "virtqemud",
+                                       ]
         self.test_inspecor = RunChecks(external_executor=m.execute, exclude_dict=exclude_dict)
         self.test_inspecor.init()
         self.addCleanup(test_inspector_check)

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -44,7 +44,7 @@ import cdp
 import testvm
 from lcov import write_lcov
 from lib.constants import OSTREE_IMAGES
-from testinsp import RunChecksInParallel
+from testinsp import RunChecks
 from testinsp.utils import FirstRunError
 
 try:
@@ -1555,7 +1555,7 @@ class MachineCase(unittest.TestCase):
                                        ".*freedesktop.problems.*",
                                        "sssd-kcm",
                                        ]
-        self.test_inspecor = RunChecksInParallel(external_executor=m.execute, exclude_dict=exclude_dict)
+        self.test_inspecor = RunChecks(external_executor=m.execute, exclude_dict=exclude_dict)
         try:
             self.test_inspecor.load()
         except FirstRunError:


### PR DESCRIPTION
Use test inspector as separate project and enable it via cmd line option.

time metrics:
  - **with test inspector**
    -   **round1: fedora39/** # TESTS PASSED [3558s on 4-ci-srv-04, 128 destructive tests, 260 nondestructive tests: 0: 1294s, 1: 1293s, 2: 1294s, 3: 1439s, 4: 1286s, 5: 1275s, 6: 1912s, 7: 1512s]
    - **round2:  fedora39/** # TESTS PASSED [3787s on 1-cockpit-7, 128 destructive tests, 261 nondestructive tests: 0: 1375s, 1: 1391s, 2: 1398s, 3: 1376s, 4: 1361s, 5: 1361s, 6: 1371s, 7: 1358s]
  - **without test inspector**
    - **round1: fedora39/** # TESTS PASSED [2734s on rhos-01-34, 128 destructive tests, 261 nondestructive tests: 0: 886s, 1: 881s, 2: 889s, 3: 889s, 4: 878s, 5: 887s, 6: 880s, 7: 877s]
    - **round2: fedora39/** # 2 TESTS FAILED [2747s on rhos-01-32, 128 destructive tests, 261 nondestructive tests: 0: 879s, 1: 869s, 2: 873s, 3: 869s, 4: 873s, 5: 878s, 6: 877s, 7: 866s]
  - **result** : increased running time approx 34%
  
- after quick optimization i've decreased to approximately  15% 
  - Tried also done bigger optimization with process paralelization, but unable to use `machine.execute` via processing module (troubles with serialization of processes) - need to do some optimalization on bots side
 