### PR TITLE
common: Mark our memfds as non-executable

### DIFF
--- a/src/common/cockpitjsonprint.c
+++ b/src/common/cockpitjsonprint.c
@@ -183,7 +183,14 @@ FILE *
 cockpit_json_print_open_memfd (const char *name,
                                int         version)
 {
-  int fd = memfd_create ("cockpit login messages", MFD_ALLOW_SEALING | MFD_CLOEXEC);
+  int fd;
+  /* current kernels moan about not specifying exec mode */
+#ifdef MFD_NOEXEC_SEAL
+  fd = memfd_create ("cockpit login messages", MFD_ALLOW_SEALING | MFD_CLOEXEC | MFD_NOEXEC_SEAL);
+  /* fallback for older kernels */
+  if (fd == -1 && errno == EINVAL)
+#endif
+    fd = memfd_create ("cockpit login messages", MFD_ALLOW_SEALING | MFD_CLOEXEC);
   assert (fd != -1);
 
   FILE *stream = fdopen (fd, "w");


### PR DESCRIPTION
We only ever use them to store data. Recent Linux kernels now encourage explicitly declaring whether a memfd is supposed to be executable [1]. This avoids an unsightly warning at boot:

> login: [   85.637785] cockpit-tls[1176]: memfd_create() called without MFD_EXEC or MFD_NOEXEC_SEAL set

Older kernel releases don't know about that flag yet, so add some ifdeffery and runtime fallback. We need to support building for a new distro/include files, but running on an older kernel.

[1] https://lwn.net/Articles/918106/

---

You can see this with `bots/vm-run fedora-39`