### PR TITLE
storaged: refactor mount point text code into a common function

### DIFF
--- a/pkg/storaged/filesystem/filesystem.jsx
+++ b/pkg/storaged/filesystem/filesystem.jsx
@@ -35,7 +35,7 @@ import { StorageLink, StorageUsageBar, StorageSize } from "../storage-controls.j
 import { StorageCard, StorageDescription, new_card, useIsNarrow } from "../pages.jsx";
 
 import { format_dialog } from "../block/format-dialog.jsx";
-import { is_mounted, MountPoint } from "./utils.jsx";
+import { is_mounted, MountPoint, mount_point_text } from "./utils.jsx";
 import { mounting_dialog } from "./mounting-dialog.jsx";
 import { check_mismounted_fsys, MismountAlert } from "./mismounting.jsx";
 
@@ -83,15 +83,9 @@ export function make_filesystem_card(next, backing_block, content_block, fstab_c
     const mismount_warning = check_mismounted_fsys(backing_block, content_block, fstab_config);
     const mounted = content_block && is_mounted(client, content_block);
 
-    let mp_text;
-    if (mount_point) {
-        mp_text = client.strip_mount_point_prefix(mount_point);
-        if (mp_text == false)
-            return null;
-        if (!mounted)
-            mp_text = mp_text + " " + _("(not mounted)");
-    } else
-        mp_text = _("(not mounted)");
+    const mp_text = mount_point_text(mount_point, mounted);
+    if (mp_text == null)
+        return null;
 
     return new_card({
         title: content_block ? cockpit.format(_("$0 filesystem"), content_block.IdType) : _("Filesystem"),

--- a/pkg/storaged/filesystem/utils.jsx
+++ b/pkg/storaged/filesystem/utils.jsx
@@ -178,3 +178,16 @@ export const MountPoint = ({ fstab_config, forced_options, backing_block, conten
             { extra_text }
         </>);
 };
+
+export const mount_point_text = (mount_point, mounted) => {
+    let mp_text;
+    if (mount_point) {
+        mp_text = client.strip_mount_point_prefix(mount_point);
+        if (mp_text == false)
+            return null;
+        if (!mounted)
+            mp_text = mp_text + " " + _("(not mounted)");
+    } else
+        mp_text = _("(not mounted)");
+    return mp_text;
+};

--- a/pkg/storaged/stratis/filesystem.jsx
+++ b/pkg/storaged/stratis/filesystem.jsx
@@ -37,7 +37,7 @@ import {
 import {
     MountPoint,
     is_valid_mount_point, is_mounted,
-    get_fstab_config
+    get_fstab_config, mount_point_text,
 } from "../filesystem/utils.jsx";
 import { MismountAlert, check_mismounted_fsys } from "../filesystem/mismounting.jsx";
 import { mounting_dialog } from "../filesystem/mounting-dialog.jsx";
@@ -183,15 +183,9 @@ export function make_stratis_filesystem_page(parent, pool, fsys,
         });
     }
 
-    let mp_text;
-    if (mount_point) {
-        mp_text = client.strip_mount_point_prefix(mount_point);
-        if (mp_text == false)
-            return;
-        if (!fs_is_mounted)
-            mp_text = mp_text + " " + _("(not mounted)");
-    } else
-        mp_text = _("(not mounted)");
+    const mp_text = mount_point_text(mount_point, fs_is_mounted);
+    if (mp_text == null)
+        return null;
 
     const fsys_card = new_card({
         title: _("Stratis filesystem"),


### PR DESCRIPTION
In the btrfs PR this logic was copied over again and then refactored in a function. As this was conflictly I pulled it apart as it already is useful for Cockpit itself.