### PR TITLE
session: Drop support for sssd < 2.6.1

### DIFF
--- a/doc/guide/cert-authentication.xml
+++ b/doc/guide/cert-authentication.xml
@@ -162,22 +162,6 @@ cp /etc/ipa/ca.crt /etc/sssd/pki/sssd_auth_ca_db.pem
 ClientCertAuthentication = yes
 </programlisting>
 
-  <warning>
-    <para>Any client can generate certificates with arbitrary information, thus
-      the client certificates must be checked for validity. Cockpit currently
-      accepts any client certificate and relies on sssd to verify their validity.</para>
-
-    <para>Check if your <command>sssd</command> version is at least 2.6.1, as earlier
-      versions did not validate the user certificate against the configured CA with
-      Cockpit logins. With earlier versions, this is secure only when the
-      entire certificate gets matched, i.e. when importing the complete
-      certificates into Identity Management as shown above. Also, certificate
-      revocations are <emphasis>not checked with earlier sssd versions</emphasis>.</para>
-
-    <para><emphasis>Do not use this with local sssd <code>certmap</code> rules</emphasis>
-      which only match on Subject/Issuer properties, if you run sssd earlier than 2.6.1!</para>
- </warning>
-
   <para>When enabling this mode,
     <ulink url="https://github.com/cockpit-project/cockpit/blob/main/doc/authentication.md">
     other authentication types</ulink> commonly get disabled, so that <emphasis>only</emphasis>

--- a/src/session/client-certificate.c
+++ b/src/session/client-certificate.c
@@ -248,7 +248,7 @@ sssd_map_certificate (const char *certificate, char** username)
       goto out;
     }
 
-  /* sssd 2.6.1 introduces certificate validation against the configured CA. If present, use that API */
+  /* sssd 2.6.1 introduces certificate validation against the configured CA. This version is in all supported distros */
   r = sd_bus_call_method (bus,
                           "org.freedesktop.sssd.infopipe",
                           "/org/freedesktop/sssd/infopipe/Users",
@@ -258,24 +258,6 @@ sssd_map_certificate (const char *certificate, char** username)
                           &user_obj_msg,
                           "s",
                           certificate);
-
-  /* fallback for sssd < 2.6.1; this is only secure for matching the full certificate, not mapping rules */
-  if (r < 0 && sd_bus_error_has_name (&err, "org.freedesktop.DBus.Error.UnknownMethod"))
-    {
-      debug ("FindByValidCertificate() method does not exist, falling back to FindByCertificate()");
-      sd_bus_error_free (&err);
-      err = SD_BUS_ERROR_NULL;
-
-      r = sd_bus_call_method (bus,
-                              "org.freedesktop.sssd.infopipe",
-                              "/org/freedesktop/sssd/infopipe/Users",
-                              "org.freedesktop.sssd.infopipe.Users",
-                              "FindByCertificate",
-                              &err,
-                              &user_obj_msg,
-                              "s",
-                              certificate);
-    }
 
   if (r < 0)
     {

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -781,7 +781,7 @@ domains = local
 id_provider = files
 
 [certmap/local/alice]
-# WARNING: Requires sssd >= 2.6.1 and installing sssd_auth_ca_db.pem; with earlier sssd this is completely unsafe
+# Requires sssd >= 2.6.1 and installing sssd_auth_ca_db.pem; with earlier sssd this is completely unsafe
 matchrule = <SUBJECT>^DC=LAN,DC=COCKPIT,CN=alice$
 """, perm="0600")
         m.execute("systemctl restart sssd")
@@ -794,31 +794,18 @@ matchrule = <SUBJECT>^DC=LAN,DC=COCKPIT,CN=alice$
                                    ' org.freedesktop.sssd.infopipe.Users.User name').strip(),
                          's "alice"')
 
-        # sssd 2.6.1 introduces FindByValidCertificate() method which validates the given certificate
-        # against the configured CA. Without this, certmap rules are completely unsafe!
-        api = m.execute("busctl introspect org.freedesktop.sssd.infopipe /org/freedesktop/sssd/infopipe/Users")
-        has_validate_api = 'FindByValidCertificate' in api
-        # we don't want to completely pinpoint the OS list to avoid lockstep image refreshes+cockpit PRs
-        # and spontaneous packit test failures as sssd 2.6.1 goes into more distros; but make sure we hit
-        # this code path on some known-good ones
-        if m.image.startswith("fedora") or m.image.startswith("debian"):
-            self.assertTrue(has_validate_api)
+        err = m.execute('! busctl call org.freedesktop.sssd.infopipe /org/freedesktop/sssd/infopipe/Users '
+                        'org.freedesktop.sssd.infopipe.Users FindByValidCertificate s -- '
+                        """"$(cat %s)" 2>&1""" % alice_cert)
+        self.assertIn("Certificate authority file not found", err)
 
-        if has_validate_api:
-            err = m.execute('! busctl call org.freedesktop.sssd.infopipe /org/freedesktop/sssd/infopipe/Users '
-                            'org.freedesktop.sssd.infopipe.Users FindByValidCertificate s -- '
-                            """"$(cat %s)" 2>&1""" % alice_cert)
-            # HACK: sssd 2.6.1 has a broken error message ("Invalid certificate provided"), accept that as well
-            # until 2.6.2 is available everywhere. https://github.com/SSSD/sssd/issues/5911
-            self.assertRegex(err, "Invalid certificate provided|Certificate authority file not found")
-
-            # install our CA, so that sssd can validate
-            with open("src/tls/ca/ca.pem") as f:
-                m.write("/etc/sssd/pki/sssd_auth_ca_db.pem", f.read())
-            u = m.execute('busctl call org.freedesktop.sssd.infopipe /org/freedesktop/sssd/infopipe/Users '
-                          'org.freedesktop.sssd.infopipe.Users FindByCertificate s -- '
-                          """"$(cat %s)" | sed 's/^o "//; s/"$//' """ % alice_cert)
-            self.assertEqual(u, user_obj)
+        # install our CA, so that sssd can validate
+        with open("src/tls/ca/ca.pem") as f:
+            m.write("/etc/sssd/pki/sssd_auth_ca_db.pem", f.read())
+        u = m.execute('busctl call org.freedesktop.sssd.infopipe /org/freedesktop/sssd/infopipe/Users '
+                      'org.freedesktop.sssd.infopipe.Users FindByCertificate s -- '
+                      """"$(cat %s)" | sed 's/^o "//; s/"$//' """ % alice_cert)
+        self.assertEqual(u, user_obj)
 
         # These tests have to be run with curl, as chromium-headless does not support selecting/handling client-side
         # certificates; it just rejects cert requests. For interactive tests, grab src/tls/ca/alice.p12 and import
@@ -899,12 +886,11 @@ matchrule = <SUBJECT>^DC=LAN,DC=COCKPIT,CN=alice$
                 ['HTTP/1.1 401 Authentication disabled', '<h1>Authentication disabled</h1>'],
                 not_expected=["crsf-token"])
 
-        # with validation API and without a CA, alice's cert fails
-        if has_validate_api:
-            m.execute("rm /etc/sssd/pki/sssd_auth_ca_db.pem")
-            self.allow_journal_messages("cockpit-session: Failed to map .* Invalid certificate provided")
-            self.allow_journal_messages("cockpit-session: Failed to map .* Certificate authority file not found")
-            do_test(alice_cert_key, ['HTTP/1.1 401 Authentication failed'])
+        # wwithout a CA, alice's cert fails
+        m.execute("rm /etc/sssd/pki/sssd_auth_ca_db.pem")
+        self.allow_journal_messages("cockpit-session: Failed to map .* Invalid certificate provided")
+        self.allow_journal_messages("cockpit-session: Failed to map .* Certificate authority file not found")
+        do_test(alice_cert_key, ['HTTP/1.1 401 Authentication failed'])
 
         # sssd-dbus not available
         self.allow_journal_messages("cockpit-session: Failed to map .* Could not activate remote peer.*")

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -472,7 +472,7 @@ class CommonTests:
         do_test(alice_user_pass, ['HTTP/1.1 401 Authentication disabled', '<h1>Authentication disabled</h1>'],
                 not_expected=["crsf-token"])
 
-        # valid user certificate which fails CA validation; this requires sssd ≥ 2.6.1
+        # valid user certificate which fails CA validation
         m.execute("mv /etc/sssd/pki/sssd_auth_ca_db.pem /etc/sssd/pki/sssd_auth_ca_db.pem.valid")
         self.allow_journal_messages("cockpit-session: Failed to map certificate to user: .* Certificate authority file not found")
         with open("src/tls/ca/alice-expired.pem") as f:

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -459,7 +459,7 @@ Requires(post): (policycoreutils if selinux-policy-%{selinuxtype})
 Conflicts: firewalld < 0.6.0-1
 Recommends: sscg >= 2.3
 Recommends: system-logos
-Suggests: sssd-dbus
+Suggests: sssd-dbus >= 2.6.2
 # for cockpit-desktop
 Suggests: python3
 

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -172,7 +172,7 @@ Depends: ${misc:Depends},
          adduser,
          openssl,
          systemd (>= 235),
-Suggests: sssd-dbus,
+Suggests: sssd-dbus (>= 2.6.2),
          python3,
 Description: Cockpit Web Service
  The Cockpit Web Service listens on the network, and authenticates


### PR DESCRIPTION
All our supported distros have a newer version: Ubuntu 22.04 LTS has 2.6.3, Debian stable has 2.8.2, RHEL 8/9 have 2.9.3. So we can finally drop support for the unsafe `FindByCertificate()` call which doesn't validate certificates against the CA.