### PR TITLE
New fsinfo channel

### DIFF
--- a/src/cockpit/channel.py
+++ b/src/cockpit/channel.py
@@ -278,8 +278,8 @@ class Channel(Endpoint):
 
     json_encoder: ClassVar[json.JSONEncoder] = json.JSONEncoder(indent=2)
 
-    def send_json(self, **kwargs: JsonValue) -> bool:
-        pretty = self.json_encoder.encode(create_object(None, kwargs)) + '\n'
+    def send_json(self, _msg: 'JsonObject | None' = None, **kwargs: JsonValue) -> bool:
+        pretty = self.json_encoder.encode(create_object(_msg, kwargs)) + '\n'
         return self.send_data(pretty.encode())
 
     def send_control(self, command: str, **kwargs: JsonValue) -> None:

--- a/src/cockpit/channels/__init__.py
+++ b/src/cockpit/channels/__init__.py
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from .dbus import DBusChannel
-from .filesystem import FsListChannel, FsReadChannel, FsReplaceChannel, FsWatchChannel
+from .filesystem import FsInfoChannel, FsListChannel, FsReadChannel, FsReplaceChannel, FsWatchChannel
 from .http import HttpChannel
 from .metrics import InternalMetricsChannel
 from .packages import PackagesChannel
@@ -26,6 +26,7 @@ from .trivial import EchoChannel, NullChannel
 CHANNEL_TYPES = [
     DBusChannel,
     EchoChannel,
+    FsInfoChannel,
     FsListChannel,
     FsReadChannel,
     FsReplaceChannel,

--- a/src/cockpit/jsonutil.py
+++ b/src/cockpit/jsonutil.py
@@ -152,7 +152,7 @@ def json_merge_patch(current: JsonObject, patch: JsonObject) -> JsonObject:
         elif patch_value is not None:
             result[key] = patch_value
         else:
-            result.pop(key)
+            result.pop(key, None)
 
     return result
 

--- a/src/cockpit/jsonutil.py
+++ b/src/cockpit/jsonutil.py
@@ -155,3 +155,26 @@ def json_merge_patch(current: JsonObject, patch: JsonObject) -> JsonObject:
             result.pop(key)
 
     return result
+
+
+def json_merge_and_filter_patch(current: JsonDict, patch: JsonDict) -> None:
+    """Perform a JSON merge patch (RFC 7396) modifying 'current' with 'patch'.
+    Also modifies 'patch' to remove redundant operations.
+    """
+    for key, patch_value in tuple(patch.items()):
+        current_value = current.get(key, None)
+
+        if isinstance(patch_value, dict):
+            if not isinstance(current_value, dict):
+                current[key] = current_value = {}
+                json_merge_and_filter_patch(current_value, patch_value)
+            else:
+                json_merge_and_filter_patch(current_value, patch_value)
+                if not patch_value:
+                    del patch[key]
+        elif current_value == patch_value:
+            del patch[key]
+        elif patch_value is not None:
+            current[key] = patch_value
+        else:
+            del current[key]

--- a/src/cockpit/misc/print.py
+++ b/src/cockpit/misc/print.py
@@ -110,6 +110,9 @@ class Printer:
     def packages_reload(self, channel: Optional[str] = None) -> None:
         self.dbus_call('/packages', 'cockpit.Packages', 'Reload', [], channel=channel)
 
+    def fsinfo(self, path: str, *attrs: str, watch: bool = True, **kwargs: Any) -> None:
+        self.open('fsinfo', path=path, attrs=attrs, watch=watch, **kwargs)
+
     def help(self) -> None:
         """Show help"""
         sys.stderr.write("""
@@ -228,7 +231,7 @@ def main() -> None:
             try:
                 value = ast.literal_eval(param)
             except (SyntaxError, ValueError):
-                if any(c in param for c in '\'":;<>,|\\(){}[]`~!@#$%^&*='):
+                if any(c in param for c in '\'":;<>,|\\(){}[]`~!@#$%^&='):
                     raise
                 else:
                     value = param

--- a/test/pytest/test_packages.py
+++ b/test/pytest/test_packages.py
@@ -80,7 +80,7 @@ def test_basic(pkgdir):
 
 
 def test_override_etc(pkgdir, confdir):
-    (confdir / 'basic.override.json').write_text('{"description": "overridden package", "priority": 5}')
+    (confdir / 'basic.override.json').write_text('{"description": null, "priority": 5, "does-not-exist": null}')
 
     packages = Packages()
     assert len(packages.packages) == 1
@@ -88,12 +88,11 @@ def test_override_etc(pkgdir, confdir):
     assert packages.packages['basic'].name == 'basic'
     assert packages.packages['basic'].manifest['requires'] == {'cockpit': '42'}
     # overridden attributes
-    assert packages.packages['basic'].manifest['description'] == 'overridden package'
+    assert 'description' not in packages.packages['basic'].manifest
     assert packages.packages['basic'].priority == 5
 
     assert json.loads(packages.manifests) == {
         'basic': {
-            'description': 'overridden package',
             'requires': {'cockpit': '42'},
             'priority': 5,
         }

--- a/tools/vulture-suppressions/cockpit.py
+++ b/tools/vulture-suppressions/cockpit.py
@@ -10,6 +10,7 @@ User.shell
 
 # getattr()
 Printer.dbus_call
+Printer.fsinfo
 Printer.help
 Printer.packages_reload
 Printer.wait


### PR DESCRIPTION
 - [x] ~#19842~ no longer depends on this
 - [x] implement less-adhoc file content size limitation (good enough for now — we can add an option if someone requests it)
 - [x] return problem code in close message on error
 - [x] once-over look at the channel implementation and docs
 - [x] really quite a lot of unit tests 

Left for follow-ups:
 - what to do about the case where `path` is a directory which gains/loses read/search permission while we're watching it
 - add support for reporting symlink target attributes (possibly without monitoring for changes)
 - maybe some kind of `file(1)`-flavour content identification attribute, mime type sniffing, etc.  gio has this.