### PR TITLE
Btrfs subvolume creation

### DIFF
--- a/pkg/storaged/block/format-dialog.jsx
+++ b/pkg/storaged/block/format-dialog.jsx
@@ -41,6 +41,7 @@ import {
 import { get_fstab_config, is_valid_mount_point } from "../filesystem/utils.jsx";
 import { init_existing_passphrase, unlock_with_type } from "../crypto/keyslots.jsx";
 import { job_progress_wrapper } from "../jobs-panel.jsx";
+import { at_boot_input, mount_options } from "../filesystem/mounting-dialog.jsx";
 
 const _ = cockpit.gettext;
 
@@ -380,42 +381,8 @@ function format_dialog_internal(client, path, start, size, enable_dos_extended, 
                                         })
                           ]
                       }),
-            SelectOne("at_boot", _("At boot"),
-                      {
-                          visible: is_filesystem,
-                          value: at_boot,
-                          explanation: mount_explanation[at_boot],
-                          choices: [
-                              {
-                                  value: "local",
-                                  title: _("Mount before services start"),
-                              },
-                              {
-                                  value: "nofail",
-                                  title: _("Mount without waiting, ignore failure"),
-                              },
-                              {
-                                  value: "netdev",
-                                  title: _("Mount after network becomes available, ignore failure"),
-                              },
-                              {
-                                  value: "never",
-                                  title: _("Do not mount"),
-                              },
-                          ]
-                      }),
-            CheckBoxes("mount_options", _("Mount options"),
-                       {
-                           visible: is_filesystem,
-                           value: {
-                               ro: opt_ro,
-                               extra: extra_options || false
-                           },
-                           fields: [
-                               { title: _("Mount read only"), tag: "ro" },
-                               { title: _("Custom mount options"), tag: "extra", type: "checkboxWithInput" },
-                           ]
-                       }),
+            at_boot_input(at_boot, is_filesystem),
+            mount_options(opt_ro, extra_options, is_filesystem),
         ],
         update: function (dlg, vals, trigger) {
             if (trigger == "at_boot")

--- a/pkg/storaged/btrfs/utils.jsx
+++ b/pkg/storaged/btrfs/utils.jsx
@@ -16,7 +16,11 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
+import cockpit from "cockpit";
+
 import { decode_filename } from "../utils.js";
+
+const _ = cockpit.gettext;
 
 /*
  * Calculate the usage based on the data from `btrfs filesystem show` which has
@@ -74,4 +78,13 @@ export function parse_subvol_from_options(options) {
         return subvol;
     else
         return null;
+}
+
+export function validate_subvolume_name(name) {
+    if (name === "")
+        return _("Name cannot be empty.");
+    if (name.length > 255)
+        return _("Name cannot be longer than 255 characters.");
+    if (name.includes('/'))
+        return cockpit.format(_("Name cannot contain the character '/'."));
 }

--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -262,7 +262,7 @@ export async function btrfs_poll() {
                 for (const line of output.split("\n")) {
                     const m = line.match(/ID (\d+).*parent (\d+).*path (<FS_TREE>\/)?(.*)/);
                     if (m)
-                        subvols.push({ pathname: m[4], id: Number(m[1]) });
+                        subvols.push({ pathname: m[4], id: Number(m[1]), parent: Number(m[2]) });
                 }
                 uuids_subvols[uuid] = subvols;
             } catch (err) {

--- a/pkg/storaged/filesystem/mounting-dialog.jsx
+++ b/pkg/storaged/filesystem/mounting-dialog.jsx
@@ -42,6 +42,48 @@ import {
 
 const _ = cockpit.gettext;
 
+export const mount_options = (opt_ro, extra_options, is_filesystem) => {
+    return CheckBoxes("mount_options", _("Mount options"),
+                      {
+                          visible: is_filesystem,
+                          value: {
+                              ro: opt_ro,
+                              extra: extra_options || false
+                          },
+                          fields: [
+                              { title: _("Mount read only"), tag: "ro" },
+                              { title: _("Custom mount options"), tag: "extra", type: "checkboxWithInput" },
+                          ]
+                      });
+};
+
+export const at_boot_input = (at_boot, is_filesystem) => {
+    return SelectOne("at_boot", _("At boot"),
+                     {
+                         visible: is_filesystem,
+                         value: at_boot,
+                         explanation: mount_explanation[at_boot],
+                         choices: [
+                             {
+                                 value: "local",
+                                 title: _("Mount before services start"),
+                             },
+                             {
+                                 value: "nofail",
+                                 title: _("Mount without waiting, ignore failure"),
+                             },
+                             {
+                                 value: "netdev",
+                                 title: _("Mount after network becomes available, ignore failure"),
+                             },
+                             {
+                                 value: "never",
+                                 title: _("Do not mount"),
+                             },
+                         ]
+                     });
+};
+
 export function mounting_dialog(client, block, mode, forced_options, subvol) {
     const block_fsys = client.blocks_fsys[block.path];
     const [old_config, old_dir, old_opts, old_parents] = get_fstab_config(block, true, subvol);
@@ -210,40 +252,8 @@ export function mounting_dialog(client, block, mode, forced_options, subvol) {
                                                                 true,
                                                                 subvol)
                       }),
-            CheckBoxes("mount_options", _("Mount options"),
-                       {
-                           value: {
-                               ro: opt_ro,
-                               extra: extra_options || false
-                           },
-                           fields: [
-                               { title: _("Mount read only"), tag: "ro" },
-                               { title: _("Custom mount options"), tag: "extra", type: "checkboxWithInput" },
-                           ]
-                       }),
-            SelectOne("at_boot", _("At boot"),
-                      {
-                          value: at_boot,
-                          explanation: mount_explanation[at_boot],
-                          choices: [
-                              {
-                                  value: "local",
-                                  title: _("Mount before services start"),
-                              },
-                              {
-                                  value: "nofail",
-                                  title: _("Mount without waiting, ignore failure"),
-                              },
-                              {
-                                  value: "netdev",
-                                  title: _("Mount after network becomes available, ignore failure"),
-                              },
-                              {
-                                  value: "never",
-                                  title: _("Do not mount"),
-                              },
-                          ]
-                      }),
+            mount_options(opt_ro, extra_options),
+            at_boot_input(at_boot),
         ];
 
         if (block.IdUsage == "crypto" && mode == "mount")

--- a/pkg/storaged/stratis/filesystem.jsx
+++ b/pkg/storaged/stratis/filesystem.jsx
@@ -25,7 +25,7 @@ import { CardBody } from "@patternfly/react-core/dist/esm/components/Card/index.
 import { DescriptionList } from "@patternfly/react-core/dist/esm/components/DescriptionList/index.js";
 
 import {
-    dialog_open, TextInput, CheckBoxes, SelectOne, BlockingMessage, TeardownMessage,
+    dialog_open, TextInput, BlockingMessage, TeardownMessage,
     init_active_usage_processes,
 } from "../dialog.jsx";
 import { StorageUsageBar, StorageLink } from "../storage-controls.jsx";
@@ -40,7 +40,7 @@ import {
     get_fstab_config, mount_point_text,
 } from "../filesystem/utils.jsx";
 import { MismountAlert, check_mismounted_fsys } from "../filesystem/mismounting.jsx";
-import { mounting_dialog } from "../filesystem/mounting-dialog.jsx";
+import { mounting_dialog, at_boot_input, mount_options } from "../filesystem/mounting-dialog.jsx";
 import { fmt_size, get_active_usage, teardown_active_usage } from "../utils.js";
 import { std_reply, validate_fs_name, set_mount_options, destroy_filesystem } from "./utils.jsx";
 import { mount_explanation } from "../block/format-dialog.jsx";
@@ -97,40 +97,8 @@ export function make_stratis_filesystem_page(parent, pool, fsys,
                                                               variant == "nomount");
                               }
                           }),
-                CheckBoxes("mount_options", _("Mount options"),
-                           {
-                               value: {
-                                   ro: false,
-                                   extra: false
-                               },
-                               fields: [
-                                   { title: _("Mount read only"), tag: "ro" },
-                                   { title: _("Custom mount options"), tag: "extra", type: "checkboxWithInput" },
-                               ]
-                           }),
-                SelectOne("at_boot", _("At boot"),
-                          {
-                              value: "nofail",
-                              explanation: mount_explanation.nofail,
-                              choices: [
-                                  {
-                                      value: "local",
-                                      title: _("Mount before services start"),
-                                  },
-                                  {
-                                      value: "nofail",
-                                      title: _("Mount without waiting, ignore failure"),
-                                  },
-                                  {
-                                      value: "netdev",
-                                      title: _("Mount after network becomes available, ignore failure"),
-                                  },
-                                  {
-                                      value: "never",
-                                      title: _("Do not mount"),
-                                  },
-                              ]
-                          }),
+                mount_options(false, false),
+                at_boot_input("nofail"),
             ],
             update: function (dlg, vals, trigger) {
                 if (trigger == "at_boot")

--- a/pkg/storaged/stratis/pool.jsx
+++ b/pkg/storaged/stratis/pool.jsx
@@ -43,7 +43,7 @@ import {
 } from "../utils.js";
 
 import {
-    dialog_open, SelectSpaces, TextInput, PassInput, CheckBoxes, SelectOne, SizeSlider,
+    dialog_open, SelectSpaces, TextInput, PassInput, SelectOne, SizeSlider,
     BlockingMessage, TeardownMessage,
     init_active_usage_processes
 } from "../dialog.jsx";
@@ -51,6 +51,7 @@ import {
 import { validate_url, get_tang_adv } from "../crypto/tang.jsx";
 import { is_valid_mount_point } from "../filesystem/utils.jsx";
 import { mount_explanation } from "../block/format-dialog.jsx";
+import { at_boot_input, mount_options } from "../filesystem/mounting-dialog.jsx";
 
 import {
     validate_pool_name, std_reply, with_keydesc, with_stored_passphrase,
@@ -109,40 +110,8 @@ function create_fs(pool) {
                                                           variant == "nomount");
                           }
                       }),
-            CheckBoxes("mount_options", _("Mount options"),
-                       {
-                           value: {
-                               ro: false,
-                               extra: false
-                           },
-                           fields: [
-                               { title: _("Mount read only"), tag: "ro" },
-                               { title: _("Custom mount options"), tag: "extra", type: "checkboxWithInput" },
-                           ]
-                       }),
-            SelectOne("at_boot", _("At boot"),
-                      {
-                          value: client.in_anaconda_mode() ? "local" : "nofail",
-                          explanation: mount_explanation.nofail,
-                          choices: [
-                              {
-                                  value: "local",
-                                  title: _("Mount before services start"),
-                              },
-                              {
-                                  value: "nofail",
-                                  title: _("Mount without waiting, ignore failure"),
-                              },
-                              {
-                                  value: "netdev",
-                                  title: _("Mount after network becomes available, ignore failure"),
-                              },
-                              {
-                                  value: "never",
-                                  title: _("Do not mount"),
-                              },
-                          ]
-                      }),
+            mount_options(false, false),
+            at_boot_input(client.in_anaconda_mode() ? "local" : "nofail"),
         ],
         update: function (dlg, vals, trigger) {
             if (trigger == "at_boot")

--- a/test/verify/check-storage-btrfs
+++ b/test/verify/check-storage-btrfs
@@ -122,6 +122,145 @@ class TestStorageBtrfs(storagelib.StorageCase):
         self.dialog_cancel()
         self.dialog_wait_close()
 
+    def testCreateSubvolume(self):
+        m = self.machine
+        b = self.browser
+
+        self.login_and_go("/storage")
+
+        disk1 = self.add_ram_disk(size=140)
+        label = "test_subvol"
+        mount_point = "/run/butter"
+        subvol = "cake"
+
+        m.execute(f"mkfs.btrfs -L {label} {disk1}")
+        self.login_and_go("/storage")
+
+        # creation of btrfs partition can take a while on TF.
+        with b.wait_timeout(30):
+            b.wait_visible(self.card_row("Storage", name=label))
+
+        root_sel = self.card_row("Storage", name=label) + " + tr"
+        b.click(self.dropdown_toggle(root_sel))
+        b.wait_visible(self.dropdown_action(root_sel, "Create subvolume") + "[disabled]")
+        b.wait_text(self.dropdown_description(root_sel, "Create subvolume"),
+                    "Subvolume needs to be mounted")
+        b.click(self.dropdown_toggle(root_sel))
+
+        self.click_dropdown(self.card_row("Storage", name=label) + " + tr", "Mount")
+        self.dialog({"mount_point": mount_point})
+        self.addCleanup(self.machine.execute, f"umount {mount_point} || true")
+        b.wait_in_text(self.card_row("Storage", location=mount_point), "btrfs subvolume")
+        self.click_dropdown(self.card_row("Storage", location=mount_point), "Create subvolume")
+
+        # Validation
+        self.dialog_wait_open()
+        self.dialog_apply_secondary()
+        self.dialog_wait_error("name", "Name cannot be empty")
+        self.dialog_set_val("name", "foo/bar")
+        self.dialog_apply_secondary()
+        self.dialog_wait_error("name", "Name cannot contain the character '/'.")
+        self.dialog_set_val("name", "a" * 256)
+        self.dialog_apply_secondary()
+        self.dialog_wait_error("name", "Name cannot be longer than 255 characters.")
+
+        # Without mount point
+        self.dialog_set_val("name", subvol)
+        self.dialog_apply_secondary()
+        self.dialog_wait_close()
+        b.wait_visible(self.card_row("Storage", name=subvol))
+        # no fstab entry
+        m.execute(f"! findmnt --fstab -n | grep subvol={subvol}")
+
+        subvol_mount = "quiche"
+        subvol_mount_point = "/run/oven"
+        self.click_dropdown(self.card_row("Storage", location=mount_point), "Create subvolume")
+
+        # With mount point
+        self.dialog_wait_open()
+        self.dialog_set_val("name", subvol_mount)
+        self.dialog_apply()
+        self.dialog_wait_error("mount_point", "Mount point cannot be empty")
+        self.dialog_set_val("mount_point", subvol_mount_point)
+        self.dialog_apply()
+        self.dialog_wait_close()
+        self.addCleanup(self.machine.execute, f"umount {subvol_mount_point} || true")
+        b.wait_in_text(self.card_row("Storage", location=subvol_mount_point), "btrfs subvolume")
+
+        # Finding the correct subvolume parent from a non-mounted subvolume
+        m.execute(f"btrfs subvolume create {subvol_mount_point}/pizza")
+        self.click_dropdown(self.card_row("Storage", name=f"{subvol_mount}/pizza"), "Create subvolume")
+        self.dialog({"name": "pineapple"}, secondary=True)
+        b.wait_in_text(self.card_row("Storage", name=f"{subvol_mount}/pizza/pineapple"), "btrfs subvolume")
+
+        left_subvol_mount = "/run/left"
+        right_subvol_mount = "/run/right"
+
+        self.click_dropdown(self.card_row("Storage", location=mount_point), "Create subvolume")
+        self.dialog({"name": os.path.basename(left_subvol_mount), "mount_point": left_subvol_mount})
+        self.click_dropdown(self.card_row("Storage", location=mount_point), "Create subvolume")
+        self.dialog({"name": os.path.basename(right_subvol_mount), "mount_point": right_subvol_mount})
+        self.addCleanup(self.machine.execute, f"umount {left_subvol_mount} || true")
+        self.addCleanup(self.machine.execute, f"umount {right_subvol_mount} || true")
+
+        b.wait_in_text(self.card_row("Storage", location=left_subvol_mount), "btrfs subvolume")
+        b.wait_in_text(self.card_row("Storage", location=right_subvol_mount), "btrfs subvolume")
+
+        self.click_dropdown(self.card_row("Storage", location=left_subvol_mount), "Create subvolume")
+        self.dialog({"name": "links"}, secondary=True)
+        b.wait_in_text(self.card_row("Storage", name="left/links"), "btrfs subvolume")
+
+        self.click_dropdown(self.card_row("Storage", location=right_subvol_mount), "Create subvolume")
+        self.dialog({"name": "rechts"}, secondary=True)
+        b.wait_in_text(self.card_row("Storage", name="right/rechts"), "btrfs subvolume")
+
+        # Read only mount, cannot create subvolumes once /run/butter
+        # is unmounted.
+
+        ro_subvol = "/run/ro"
+        self.click_dropdown(self.card_row("Storage", location=mount_point), "Create subvolume")
+        self.dialog_wait_open()
+        self.dialog_set_val("name", os.path.basename(ro_subvol))
+        self.dialog_set_val("mount_point", ro_subvol)
+        self.dialog_set_val("mount_options.ro", val=True)
+        self.dialog_apply()
+        self.dialog_wait_close()
+
+        # Since /run/butter is still mounted read-write, we can create
+        # subvolumes of "ro" using that.
+
+        self.click_dropdown(self.card_row("Storage", location=ro_subvol), "Create subvolume")
+        self.dialog_wait_open()
+        self.dialog_set_val("name", "bot")
+        self.dialog_apply_secondary()
+        self.dialog_wait_close()
+        b.wait_visible(self.card_row("Storage", name="ro/bot"))
+
+        # But once /run/butter has been unmounted, we can't create
+        # subvolumes of "ro" anymore.
+
+        self.click_dropdown(self.card_row("Storage", location="/run/butter"), "Unmount")
+        self.confirm()
+
+        b.click(self.dropdown_toggle(self.card_row("Storage", location=ro_subvol)))
+        b.wait_visible(self.dropdown_action(self.card_row("Storage", location=ro_subvol), "Create subvolume") + "[disabled]")
+        b.wait_text(self.dropdown_description(self.card_row("Storage", location=ro_subvol), "Create subvolume"),
+                    "Subvolume needs to be mounted writable")
+        b.click(self.dropdown_toggle(self.card_row("Storage", location=ro_subvol)))
+        # remount as rw, create subvolume and remount as ro to see parents are also checked
+        m.execute(f"""
+            mount -o remount,rw /dev/sda {ro_subvol}
+            btrfs subvolume create {ro_subvol}/readonly
+            mount -o remount,ro /dev/sda {ro_subvol}
+        """)
+
+        subvol_loc = f"{os.path.basename(ro_subvol)}/readonly"
+        b.click(self.dropdown_toggle(self.card_row("Storage", name=subvol_loc)))
+        b.wait_visible(self.dropdown_action(self.card_row("Storage", name=subvol_loc), "Create subvolume") + "[disabled]")
+        b.wait_text(self.dropdown_description(self.card_row("Storage", name=subvol_loc), "Create subvolume"),
+                    "Subvolume needs to be mounted")
+        b.click(self.dropdown_toggle(self.card_row("Storage", name=subvol_loc)))
+
     def testMultiDevice(self):
         m = self.machine
         b = self.browser


### PR DESCRIPTION
Support creating and optionally mounting subvolumes. Subvolumes can only be created when any parent in the tree is mounted.

![image](https://github.com/cockpit-project/cockpit/assets/67428/a28ebd4c-d355-4834-adc6-0078ee4ccb56)

![image](https://github.com/cockpit-project/cockpit/assets/67428/1a2c8d09-857d-433d-bb17-df1552ddda30)




