### PR TITLE
storage: Fix listing of btrfs subvols in fstab

### DIFF
--- a/pkg/storaged/btrfs/volume.jsx
+++ b/pkg/storaged/btrfs/volume.jsx
@@ -167,22 +167,11 @@ function make_btrfs_subvolume_pages(parent, volume) {
         let has_root = false;
         for (const config of block.Configuration) {
             if (config[0] == "fstab") {
-                const fstab_subvol = {};
-                let opts = config[1].opts;
+                const opts = config[1].opts;
                 if (!opts)
                     continue;
 
-                opts = decode_filename(opts.v).split(",");
-                for (const opt of opts) {
-                    const fstab_subvol = parse_subvol_from_options(opt);
-
-                    if (!fstab_subvol)
-                        continue;
-
-                    if (fstab_subvol.id && fstab_subvol.pathname) {
-                        break;
-                    }
-                }
+                const fstab_subvol = parse_subvol_from_options(decode_filename(opts.v));
 
                 if (fstab_subvol && fstab_subvol.pathname === "/") {
                     has_root = true;

--- a/test/common/storagelib.py
+++ b/test/common/storagelib.py
@@ -580,8 +580,8 @@ grubby --update-kernel=ALL --args="root=UUID=$uuid rootflags=defaults rd.luks.uu
         # We need to click on a <td> element since that's where the handlers are...
         self.browser.click(self.card_row(title, index, name, location) + " td:nth-child(1)")
 
-    def card_row_col(self, title, row_index, col_index):
-        return self.card_row(title, row_index) + f" td:nth-child({col_index})"
+    def card_row_col(self, title, row_index=None, col_index=None, row_name=None, row_location=None):
+        return self.card_row(title, row_index, row_name, row_location) + f" td:nth-child({col_index})"
 
     def card_desc(self, card_title, desc_title):
         return self.card(card_title) + f" [data-test-desc-title='{desc_title}'] [data-test-value=true]"

--- a/test/verify/check-storage-btrfs
+++ b/test/verify/check-storage-btrfs
@@ -464,6 +464,30 @@ ExecStart=/usr/bin/sleep infinity
         self.confirm()
         b.wait_in_text(self.card_row("Storage", location=mount_point), "btrfs subvolume")
 
+    def testNothingMounted(self):
+        m = self.machine
+        b = self.browser
+
+        disk = self.add_ram_disk(size=128)
+
+        m.execute(f"mkfs.btrfs -L butter {disk}; mount {disk} /mnt; btrfs subvolume create /mnt/home; btrfs subvolume create /mnt/backups; umount /mnt")
+
+        self.login_and_go("/storage")
+
+        self.click_card_row("Storage", name="butter")
+        b.wait_visible(self.card_row("btrfs subvolumes", name="/"))
+        b.wait_not_present(self.card_row("btrfs subvolumes", name="home"))
+        b.wait_not_present(self.card_row("btrfs subvolumes", name="backups"))
+
+        # Add some fstab entries. Cockpit should pick up the
+        # subvolumes mentioned in them and show them.
+
+        m.execute(f"echo >>/etc/fstab '{disk} /home auto noauto,subvol=home 0 0'")
+        m.execute(f"echo >>/etc/fstab '{disk} /mnt/backups auto noauto,subvol=backups 0 0'")
+
+        b.wait_text(self.card_row_col("btrfs subvolumes", row_name="home", col_index=3), "/home (not mounted)")
+        b.wait_text(self.card_row_col("btrfs subvolumes", row_name="backups", col_index=3), "/mnt/backups (not mounted)")
+
 
 if __name__ == '__main__':
     testlib.test_main()


### PR DESCRIPTION
The parse_subvol_from_options function wants the whole options string, not individual options.
