### PR TITLE
pybridge: Improve beiboot error reporting for fatal login failures

### DIFF
--- a/src/cockpit/beiboot.py
+++ b/src/cockpit/beiboot.py
@@ -159,9 +159,9 @@ class AuthorizeResponder(ferny.AskpassHandler):
                                                            echo=False)
 
         b64 = response.removeprefix('X-Conversation -').strip()
-        passwd = base64.b64decode(b64.encode()).decode()
-        logger.debug('Returning a %d chars password', len(passwd))
-        return passwd
+        response = base64.b64decode(b64.encode()).decode()
+        logger.debug('Returning a %d chars response', len(response))
+        return response
 
     async def do_custom_command(self, command: str, args: tuple, fds: list[int], stderr: str) -> None:
         logger.debug('Got ferny command %s %s %s', command, args, stderr)

--- a/test/verify/check-client
+++ b/test/verify/check-client
@@ -147,13 +147,11 @@ Command = /usr/bin/env python3 -m cockpit.beiboot
             b.wait_text("#conversation-prompt", "admin@10.111.113.2's password: ")
             b.set_val("#conversation-input", "wrong")
             b.click("#login-button")
-        b.wait_in_text("#login-fatal-message", "admin@10.111.113.2: Permission denied")
-        b.click("#login-again")
-        b.wait_text("#brand", "Connect to:")
-        # resets the host field
-        b.wait_val("#server-field", "")
+        b.wait_in_text("#login-error-message", "Authentication failed")
+        b.wait_val("#server-field", "10.111.113.2")
 
         # connect to most recent host
+        b.open("/")  # reset URL from /metrics and last remote =host
         b.click("#recent-hosts-list .host-line button.host-name")
         b.wait_text("#conversation-prompt", "admin@10.111.113.2's password: ")
         b.set_val("#conversation-input", "foobar")
@@ -208,9 +206,8 @@ Command = /usr/bin/env python3 -m cockpit.beiboot
         # unreachable host
         b.set_val("#server-field", "unknownhost")
         b.click("#login-button")
-        b.wait_in_text("#login-fatal-message", "Could not resolve hostname unknownhost")
-        b.click("#login-again")
-        b.wait_text("#brand", "Connect to:")
+        b.wait_in_text("#login-error-message", "Host is unknown")
+        b.wait_val("#server-field", "unknownhost")
         # does not appear in recent hosts
         b.wait_in_text("#recent-hosts-list", "10.111.113.2")
         self.assertNotIn("unknownhost", b.text("#recent-hosts-list"))
@@ -218,7 +215,7 @@ Command = /usr/bin/env python3 -m cockpit.beiboot
         # wrong port
         b.set_val("#server-field", "10.111.113.2:222")
         b.click("#login-button")
-        b.wait_in_text("#login-fatal-message", "connect to host 10.111.113.2 port 222: No route to host")
+        b.wait_in_text("#login-error-message", "Host is unknown")
 
         # unencrypted SSH key login
         self.m_client.execute("runuser -u admin -- ssh-keygen -t rsa -N '' -f ~admin/.ssh/id_rsa")


### PR DESCRIPTION
After all SSH authentication attemps fail, e.g. entering the wrong
password three times, ferny throws an InteractionError. Merely exiting
cockpit-beiboot gets interpreted as "Internal error" which is unfriendly.

Ferny recognizes the most common errors, like DNS resolution and and
authentication failure. Use that API to convert them to proper cockpit
protocol error codes, so that they get presented and translated properly.


---

Two commits split out from PR #19401