### PR TITLE
fmf: Skip TestStorageBtrfs.testNothingMounted

### DIFF
--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -90,6 +90,8 @@ if [ "$PLAN" = "optional" ]; then
               TestAutoUpdates.testBasic
               TestAutoUpdates.testPrivilegeChange
 
+              TestStorageBtrfs.testNothingMounted
+
               TestStorageFormat.testAtBoot
               TestStorageFormat.testFormatCancel
               TestStorageFormat.testFormatTooSmall


### PR DESCRIPTION
The current F39 Testing Farm machines already have a btrfs subvolume mounted on /home which collides with what this test sets up. Also, this only tests cockpit-internal code, so it's not super useful as gating test anyway.

---

See the [recent F39 test failure](https://artifacts.dev.testing-farm.io/008fdc25-aa51-4650-9a55-d70d68333ee4/). This reproduces perfectly well locally. It was introduced 3 days ago in #19858 , although I'm not sure how/why it passed there.