### PR TITLE
tools: Rely on pam.pc to get pam's libdir in Debian packaging

### DIFF
--- a/tools/debian/cockpit-ws.install
+++ b/tools/debian/cockpit-ws.install
@@ -10,8 +10,8 @@ ${env:deb_systemdsystemunitdir}/cockpit-wsinstance-https-factory.socket
 ${env:deb_systemdsystemunitdir}/cockpit-wsinstance-https@.service
 ${env:deb_systemdsystemunitdir}/cockpit-wsinstance-https@.socket
 ${env:deb_systemdsystemunitdir}/system-cockpithttps.slice
-lib/*/security/pam_ssh_add.so
-lib/*/security/pam_cockpit_cert.so
+${env:deb_pamlibdir}/security/pam_ssh_add.so
+${env:deb_pamlibdir}/security/pam_cockpit_cert.so
 usr/lib/tmpfiles.d/cockpit-tempfiles.conf
 usr/lib/cockpit/cockpit-session
 usr/lib/cockpit/cockpit-ws

--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -10,6 +10,8 @@ ifneq ($(SLOW_ARCHES),)
 endif
 
 export deb_systemdsystemunitdir = $(shell pkgconf --variable=systemdsystemunitdir systemd | sed s,^/,,)
+# pam.pc doesn't yet have a libdir on older releases
+export deb_pamlibdir = $(shell { pkgconf --variable=libdir pam || echo /lib/$(DEB_HOST_MULTIARCH); } | sed s,^/,,)
 
 %:
 	dh $@ --buildsystem=autoconf --with=python3
@@ -18,7 +20,7 @@ override_dh_auto_configure:
 	dh_auto_configure -- \
 		--with-cockpit-user=cockpit-ws \
 		--with-cockpit-ws-instance-user=cockpit-wsinstance \
-		--with-pamdir=/lib/$(DEB_HOST_MULTIARCH)/security \
+		--with-pamdir=/$(deb_pamlibdir)/security \
 		--libexecdir=/usr/lib/cockpit $(CONFIG_OPTIONS)
 
 # HACK: Debian's pip breaks --prefix: https://bugs.debian.org/1035546 with


### PR DESCRIPTION
This will install the PAM modules into /usr once pam.pc switches over.

https://bugs.debian.org/1061198

----

This takes @mbiebl 's patch from https://salsa.debian.org/utopia-team/cockpit/-/merge_requests/1 , I want to run it through CI for all our supported Debian and Ubuntu releases.