### PR TITLE
jsonutil: reorganize our Json* type names

### DIFF
--- a/src/cockpit/beiboot.py
+++ b/src/cockpit/beiboot.py
@@ -291,7 +291,7 @@ async def run(args) -> None:
     StdioTransport(asyncio.get_running_loop(), bridge)
 
     try:
-        message = await bridge.ssh_peer.start()
+        message = dict(await bridge.ssh_peer.start())
 
         # See comment in do_init() above: we tell cockpit-ws that we support
         # this and then handle it ourselves when we get the init message.

--- a/src/cockpit/channel.py
+++ b/src/cockpit/channel.py
@@ -20,7 +20,7 @@ import json
 import logging
 from typing import BinaryIO, ClassVar, Dict, Generator, List, Optional, Sequence, Set, Tuple, Type
 
-from .jsonutil import JsonDocument, JsonError, JsonObject, create_object, get_bool, get_str
+from .jsonutil import JsonError, JsonObject, JsonValue, create_object, get_bool, get_str
 from .protocol import CockpitProblem
 from .router import Endpoint, Router, RoutingRule
 
@@ -192,7 +192,7 @@ class Channel(Endpoint):
         self.close()
 
     # output
-    def ready(self, **kwargs: JsonDocument) -> None:
+    def ready(self, **kwargs: JsonValue) -> None:
         self.thaw_endpoint()
         self.send_control(command='ready', **kwargs)
 
@@ -278,11 +278,11 @@ class Channel(Endpoint):
 
     json_encoder: ClassVar[json.JSONEncoder] = json.JSONEncoder(indent=2)
 
-    def send_json(self, **kwargs: JsonDocument) -> bool:
+    def send_json(self, **kwargs: JsonValue) -> bool:
         pretty = self.json_encoder.encode(create_object(None, kwargs)) + '\n'
         return self.send_data(pretty.encode())
 
-    def send_control(self, command: str, **kwargs: JsonDocument) -> None:
+    def send_control(self, command: str, **kwargs: JsonValue) -> None:
         self.send_channel_control(self.channel, command, None, **kwargs)
 
     def send_pong(self, message: JsonObject) -> None:

--- a/src/cockpit/channels/packages.py
+++ b/src/cockpit/channels/packages.py
@@ -58,7 +58,7 @@ class PackagesChannel(AsyncChannel):
             # Note: we can't cache documents right now.  See
             # https://github.com/cockpit-project/cockpit/issues/19071
             # for future plans.
-            out_headers: JsonObject = {
+            out_headers = {
                 'Cache-Control': 'no-cache, no-store',
                 'Content-Type': document.content_type,
             }

--- a/src/cockpit/channels/stream.py
+++ b/src/cockpit/channels/stream.py
@@ -22,7 +22,7 @@ import subprocess
 from typing import Dict
 
 from ..channel import ChannelError, ProtocolChannel
-from ..jsonutil import JsonObject, get_bool, get_int, get_object, get_str, get_strv
+from ..jsonutil import JsonDict, JsonObject, get_bool, get_int, get_object, get_str, get_strv
 from ..transports import SubprocessProtocol, SubprocessTransport, WindowSize
 
 logger = logging.getLogger(__name__)
@@ -75,7 +75,7 @@ class SubprocessStreamChannel(ProtocolChannel, SubprocessProtocol):
 
     def _get_close_args(self) -> JsonObject:
         assert isinstance(self._transport, SubprocessTransport)
-        args: JsonObject = {'exit-status': self._transport.get_returncode()}
+        args: JsonDict = {'exit-status': self._transport.get_returncode()}
         stderr = self._transport.get_stderr()
         if stderr is not None:
             args['message'] = stderr

--- a/src/cockpit/jsonutil.py
+++ b/src/cockpit/jsonutil.py
@@ -16,12 +16,18 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from enum import Enum
-from typing import Callable, Dict, List, Optional, Sequence, Type, TypeVar, Union
+from typing import Callable, Dict, List, Mapping, Optional, Sequence, Type, TypeVar, Union
 
-JsonList = List['JsonDocument']
-JsonObject = Dict[str, 'JsonDocument']
 JsonLiteral = Union[str, float, bool, None]
-JsonDocument = Union[JsonObject, JsonList, JsonLiteral]
+
+# immutable
+JsonValue = Union['JsonObject', Sequence['JsonValue'], JsonLiteral]
+JsonObject = Mapping[str, JsonValue]
+
+# mutable
+JsonDocument = Union['JsonDict', 'JsonList', JsonLiteral]
+JsonDict = Dict[str, JsonDocument]
+JsonList = List[JsonDocument]
 
 
 DT = TypeVar('DT')
@@ -36,7 +42,7 @@ class JsonError(Exception):
         self.value = value
 
 
-def typechecked(value: JsonDocument, expected_type: Type[T]) -> T:
+def typechecked(value: JsonValue, expected_type: Type[T]) -> T:
     """Ensure a JSON value has the expected type, returning it if so."""
     if not isinstance(value, expected_type):
         raise JsonError(value, f'must have type {expected_type.__name__}')
@@ -53,7 +59,7 @@ class _Empty(Enum):
 _empty = _Empty.TOKEN
 
 
-def _get(obj: JsonObject, cast: Callable[[JsonDocument], T], key: str, default: Union[DT, _Empty]) -> Union[T, DT]:
+def _get(obj: JsonObject, cast: Callable[[JsonValue], T], key: str, default: Union[DT, _Empty]) -> Union[T, DT]:
     try:
         return cast(obj[key])
     except KeyError:
@@ -95,13 +101,13 @@ def get_object(
 
 
 def get_strv(obj: JsonObject, key: str, default: Union[DT, _Empty] = _empty) -> Union[DT, Sequence[str]]:
-    def as_strv(value: JsonDocument) -> Sequence[str]:
+    def as_strv(value: JsonValue) -> Sequence[str]:
         return tuple(typechecked(item, str) for item in typechecked(value, list))
     return _get(obj, as_strv, key, default)
 
 
 def get_objv(obj: JsonObject, key: str, constructor: Callable[[JsonObject], T]) -> Union[DT, Sequence[T]]:
-    def as_objv(value: JsonDocument) -> Sequence[T]:
+    def as_objv(value: JsonValue) -> Sequence[T]:
         return tuple(constructor(typechecked(item, dict)) for item in typechecked(value, list))
     return _get(obj, as_objv, key, ())
 

--- a/src/cockpit/jsonutil.py
+++ b/src/cockpit/jsonutil.py
@@ -135,3 +135,23 @@ def create_object(message: 'JsonObject | None', kwargs: JsonObject) -> JsonObjec
         result[json_key] = value
 
     return result
+
+
+def json_merge_patch(current: JsonObject, patch: JsonObject) -> JsonObject:
+    """Perform a JSON merge patch (RFC 7396) using 'current' and 'patch'.
+    Neither of the original dictionaries is modified — the result is returned.
+    """
+    # Always take a copy ('result') — we never modify the input ('current')
+    result = dict(current)
+    for key, patch_value in patch.items():
+        if isinstance(patch_value, Mapping):
+            current_value = current.get(key, None)
+            if not isinstance(current_value, Mapping):
+                current_value = {}
+            result[key] = json_merge_patch(current_value, patch_value)
+        elif patch_value is not None:
+            result[key] = patch_value
+        else:
+            result.pop(key)
+
+    return result

--- a/src/cockpit/peer.py
+++ b/src/cockpit/peer.py
@@ -20,7 +20,7 @@ import logging
 import os
 from typing import Callable, List, Optional, Sequence
 
-from .jsonutil import JsonDocument, JsonObject
+from .jsonutil import JsonObject, JsonValue
 from .packages import BridgeConfig
 from .protocol import CockpitProblem, CockpitProtocol, CockpitProtocolError
 from .router import Endpoint, Router, RoutingRule
@@ -61,7 +61,7 @@ class Peer(CockpitProtocol, SubprocessProtocol, Endpoint):
         user_env = dict(e.split('=', 1) for e in env)
         return SubprocessTransport(loop, self, argv, env=dict(os.environ, **user_env), **kwargs)
 
-    async def start(self, init_host: Optional[str] = None, **kwargs: JsonDocument) -> JsonObject:
+    async def start(self, init_host: Optional[str] = None, **kwargs: JsonValue) -> JsonObject:
         """Request that the Peer is started and connected to the router.
 
         Creates the transport, connects it to the protocol, and participates in
@@ -126,7 +126,7 @@ class Peer(CockpitProtocol, SubprocessProtocol, Endpoint):
         return init_message
 
     # Background initialization
-    def start_in_background(self, init_host: Optional[str] = None, **kwargs: JsonDocument) -> None:
+    def start_in_background(self, init_host: Optional[str] = None, **kwargs: JsonValue) -> None:
         def _start_task_done(task: asyncio.Task) -> None:
             assert task is start_task
 

--- a/src/cockpit/protocol.py
+++ b/src/cockpit/protocol.py
@@ -21,7 +21,7 @@ import logging
 import uuid
 from typing import Dict, Optional
 
-from .jsonutil import JsonDocument, JsonError, JsonObject, create_object, get_str, typechecked
+from .jsonutil import JsonError, JsonObject, JsonValue, create_object, get_str, typechecked
 
 logger = logging.getLogger(__name__)
 
@@ -40,9 +40,9 @@ class CockpitProblem(Exception):
     """
     attrs: JsonObject
 
-    def __init__(self, problem: str, _msg: 'JsonObject | None' = None, **kwargs: JsonDocument) -> None:
+    def __init__(self, problem: str, _msg: 'JsonObject | None' = None, **kwargs: JsonValue) -> None:
+        kwargs['problem'] = problem
         self.attrs = create_object(_msg, kwargs)
-        self.attrs['problem'] = problem
         super().__init__(get_str(self.attrs, 'message', problem))
 
 
@@ -183,7 +183,7 @@ class CockpitProtocol(asyncio.Protocol):
         else:
             logger.debug('cannot write to closed transport')
 
-    def write_control(self, _msg: 'JsonObject | None' = None, **kwargs: JsonDocument) -> None:
+    def write_control(self, _msg: 'JsonObject | None' = None, **kwargs: JsonValue) -> None:
         """Write a control message.  See jsonutil.create_object() for details."""
         logger.debug('sending control message %r %r', _msg, kwargs)
         pretty = json.dumps(create_object(_msg, kwargs), indent=2) + '\n'
@@ -245,7 +245,7 @@ class CockpitProtocolServer(CockpitProtocol):
 
     # authorize request/response API
     async def request_authorization(
-        self, challenge: str, timeout: 'int | None' = None, **kwargs: JsonDocument
+        self, challenge: str, timeout: 'int | None' = None, **kwargs: JsonValue
     ) -> str:
         if self.authorizations is None:
             self.authorizations = {}

--- a/src/cockpit/remote.py
+++ b/src/cockpit/remote.py
@@ -23,7 +23,7 @@ from typing import Dict, List, Optional, Tuple
 
 from cockpit._vendor import ferny
 
-from .jsonutil import JsonDocument, JsonObject, get_str, get_str_or_none
+from .jsonutil import JsonObject, JsonValue, get_str, get_str_or_none
 from .peer import Peer, PeerError
 from .router import Router, RoutingRule
 
@@ -110,7 +110,7 @@ class SshPeer(Peer):
                 # containing the key that would need to be accepted.  That will
                 # cause the front-end to present a dialog.
                 _reason, host, algorithm, key, fingerprint = responder.hostkeys_seen[0]
-                error_args: JsonObject = {'host-key': f'{host} {algorithm} {key}', 'host-fingerprint': fingerprint}
+                error_args = {'host-key': f'{host} {algorithm} {key}', 'host-fingerprint': fingerprint}
             else:
                 error_args = {}
 
@@ -129,7 +129,7 @@ class SshPeer(Peer):
         except ferny.SshAuthenticationError as exc:
             logger.debug('authentication to host %s failed: %s', host, exc)
 
-            results: JsonObject = {method: 'not-provided' for method in exc.methods}
+            results = {method: 'not-provided' for method in exc.methods}
             if 'password' in results and self.password is not None:
                 if responder.password_attempts == 0:
                     results['password'] = 'not-tried'
@@ -171,7 +171,7 @@ class SshPeer(Peer):
 
         self.session = ferny.Session()
 
-        superuser: JsonDocument
+        superuser: JsonValue
         init_superuser = get_str_or_none(options, 'init-superuser', None)
         if init_superuser in (None, 'none'):
             superuser = False

--- a/src/cockpit/router.py
+++ b/src/cockpit/router.py
@@ -20,7 +20,7 @@ import collections
 import logging
 from typing import Dict, List, Optional
 
-from .jsonutil import JsonDocument, JsonObject
+from .jsonutil import JsonObject, JsonValue
 from .protocol import CockpitProblem, CockpitProtocolError, CockpitProtocolServer
 
 logger = logging.getLogger(__name__)
@@ -94,14 +94,14 @@ class Endpoint:
         self.router.write_channel_data(channel, data)
 
     def send_channel_control(
-        self, channel: str, command: str, _msg: 'JsonObject | None', **kwargs: JsonDocument
+        self, channel: str, command: str, _msg: 'JsonObject | None', **kwargs: JsonValue
     ) -> None:
         self.router.write_control(_msg, channel=channel, command=command, **kwargs)
         if command == 'close':
             self.router.endpoints[self].remove(channel)
             self.router.drop_channel(channel)
 
-    def shutdown_endpoint(self, _msg: 'JsonObject | None' = None, **kwargs: JsonDocument) -> None:
+    def shutdown_endpoint(self, _msg: 'JsonObject | None' = None, **kwargs: JsonValue) -> None:
         self.router.shutdown_endpoint(self, _msg, **kwargs)
 
 
@@ -168,7 +168,7 @@ class Router(CockpitProtocolServer):
         self.endpoints[endpoint] = set()
         self.no_endpoints.clear()
 
-    def shutdown_endpoint(self, endpoint: Endpoint, _msg: 'JsonObject | None' = None, **kwargs: JsonDocument) -> None:
+    def shutdown_endpoint(self, endpoint: Endpoint, _msg: 'JsonObject | None' = None, **kwargs: JsonValue) -> None:
         channels = self.endpoints.pop(endpoint)
         logger.debug('shutdown_endpoint(%s, %s) will close %s', endpoint, kwargs, channels)
         for channel in channels:

--- a/test/pytest/mocktransport.py
+++ b/test/pytest/mocktransport.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 from typing import Any, Dict, Iterable, Optional, Tuple
 
-from cockpit.jsonutil import JsonDocument, JsonObject
+from cockpit.jsonutil import JsonObject, JsonValue
 from cockpit.router import Router
 
 MOCK_HOSTNAME = 'mockbox'
@@ -120,7 +120,7 @@ class MockTransport(asyncio.Transport):
         assert channel == expected_channel
         assert data == expected_data
 
-    async def assert_msg(self, expected_channel: str, **kwargs: JsonDocument) -> JsonObject:
+    async def assert_msg(self, expected_channel: str, **kwargs: JsonValue) -> JsonObject:
         msg = await self.next_msg(expected_channel)
         assert msg == dict(msg, **{k.replace('_', '-'): v for k, v in kwargs.items()}), msg
         return msg


### PR DESCRIPTION
We pass around an awful lot of JsonObject and JsonDocument throughout the bridge, which can be a problem sometimes, because you often get messages like:

> error: Argument "headers" has incompatible type "dict[str, str]"; expected "JsonDocument"  [arg-type]
> note: "Dict" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
> note: Consider using "Mapping" instead, which is covariant in the value type

when trying to pass something which seems like it should be a perfectly valid JsonObject.

The issue here is that the object time we're passing has a more specific type (in this case, it only accepts string values), and we don't know that the function we're passing it to doesn't intend to write to it. Mapping solves this by being read-only, which allows for covariance, as noted in the message above.

At the same time: there are a few cases where we do intend to create values and modify them.

Additionally: I've regretted the name JsonDocument almost since I chose it.  I think this would be better called JsonValue.

As a solution to this problem: we introduce two parallel sets of Json types:

 - JsonObject and (newly introduced) JsonValue are immutable — they are defined using Mapping and Seqeunce and are fully covariant.  Any mapping (or dictionary) type that contains JSON data can be passed as an argument for a function expecting a JsonObject.

 - JsonDocument continues to refer to a mutable JSON document, with the newly-introduced JsonDict type referring to a JsonObject which is definitely implemented as a dictionary, and therefore supports writing (but at the cost of being invariant when used as an argument type).  JsonDict and JsonDocument also expect lists to be used.

The idea is that most places will use JsonObject and JsonValue, and JsonDocument and JsonDict will be reserved for places where they're truly required (ie: functions which modify their arguments or return values that are intended to be modified).