### PR TITLE
storaged: btrfs: don't break on a btrfs mount without subvol

### DIFF
--- a/pkg/storaged/btrfs/volume.jsx
+++ b/pkg/storaged/btrfs/volume.jsx
@@ -173,13 +173,14 @@ function make_btrfs_subvolume_pages(parent, volume) {
 
                 const fstab_subvol = parse_subvol_from_options(decode_filename(opts.v));
 
-                if (fstab_subvol && fstab_subvol.pathname === "/") {
-                    has_root = true;
-                }
+                if (fstab_subvol === null)
+                    continue;
 
-                if (fstab_subvol.pathname) {
+                if (fstab_subvol.pathname === "/")
+                    has_root = true;
+
+                if (fstab_subvol.pathname)
                     make_btrfs_subvolume_page(parent, volume, fstab_subvol);
-                }
             }
         }
 

--- a/test/verify/check-storage-btrfs
+++ b/test/verify/check-storage-btrfs
@@ -603,6 +603,25 @@ ExecStart=/usr/bin/sleep infinity
         self.confirm()
         b.wait_in_text(self.card_row("Storage", location=mount_point), "btrfs subvolume")
 
+    def testNoSubvolMount(self):
+        m = self.machine
+        b = self.browser
+
+        disk = self.add_ram_disk(size=128)
+        mount_point = "/run/butter"
+
+        m.execute(f"""
+            mkfs.btrfs -L butter {disk}
+            mkdir -p {mount_point}
+            mount {disk} {mount_point}
+            echo '{disk} {mount_point} auto defaults 0 0' >> /etc/fstab
+        """)
+
+        self.login_and_go("/storage")
+
+        self.click_card_row("Storage", name="butter")
+        b.wait_visible(self.card_row("btrfs subvolumes", name="/"))
+
     def testNothingMounted(self):
         m = self.machine
         b = self.browser


### PR DESCRIPTION
We always assume fstab_subvol to be truthy while when fstab contains a btrfs mount without a subvol option it is not and we should just show the root subvolume.

In an ideal case we would call GetDefaultSubvolume when the filesystem is mounted and then show the subvolume name instead. I'll leave this for a follow up.

@mvollmer what do you think of ^, I believe this is correct.

---

I would like to merge this as is, as this blocks the btrfs filesystem creation at the moment.