### PR TITLE
test: Clean up encrypted swap as well

### DIFF
--- a/test/verify/check-storage-swap
+++ b/test/verify/check-storage-swap
@@ -94,6 +94,7 @@ class TestStorageswap(storagelib.StorageCase):
         m = self.machine
 
         disk = self.add_ram_disk()
+        self.addCleanup(m.execute, f"swapoff $(lsblk -plno NAME {disk} | tail -1) || true")
 
         self.login_and_go("/storage")
 


### PR DESCRIPTION
The test teardown will remove /dev/sda and then we have a dangling device mapper. The next test in the same VM can fail, probably when it uses swap. This happens reliably in the testing farm on fedora-rawhide.