### PR TITLE
storage: pass configured swap partition in the cockpit_mount_points

### DIFF
--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -1770,8 +1770,13 @@ client.export_mount_point_mapping = () => {
         for (const c of b.Configuration) {
             if (c[0] == "fstab") {
                 const dir = client.strip_mount_point_prefix(utils.decode_filename(c[1].dir.v));
+                const device = utils.decode_filename(b.PreferredDevice);
+                const type = utils.decode_filename(c[1].type.v);
+
                 if (dir)
-                    mpm[dir] = utils.decode_filename(b.PreferredDevice);
+                    mpm[dir] = device;
+                if (type === "swap")
+                    mpm[type] = device;
             }
         }
     }


### PR DESCRIPTION
I have a test for that at https://github.com/rhinstaller/anaconda-webui/pull/72 