### PR TITLE
test: Increase memory of the global machines, again

### DIFF
--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -214,7 +214,7 @@ class GlobalMachine:
         # provide enough RAM for cryptsetup's PBKDF, as long as that is not configurable:
         # https://bugzilla.redhat.com/show_bug.cgi?id=1881829
         self.machine = machine_class(verbose=True, networking=self.networking, image=self.image, cpus=cpus,
-                                     memory_mb=memory_mb or 1400)
+                                     memory_mb=memory_mb or 2000)
         self.machine_class = machine_class
         if not os.path.exists(self.machine.image_file):
             self.machine.pull(self.machine.image_file)


### PR DESCRIPTION
LUKS needs moar memory!  The current 1.4 GB are cutting it quite close and tests have started failing on recent rhel-9-4 images.