### PR TITLE
Add target tracking to fsinfo

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -850,6 +850,8 @@ this payload type:
    refers to a readable directory, an `entries` attribute will be reported
    (described below).  Use `*` to report all files.  Can also be used to
    implement search (`searc*`) or hide temporary files (`[!.]*`).
+ * `targets` (optional string): if set to 'stat' then report information about
+   symlink targets under the `targets` attribute.  See below.
  * `watch` (optional, default: false): if the channel should watch for changes
  * `follow` (default: true): if the trailing component of `path` is a symbolic
    link, whether we should follow it.  `follow: false` mode is not supported
@@ -910,6 +912,20 @@ refers to a readable directory.  It is an object where each key is the name of
 a file in the directory, and each value is an object describing that file,
 using the same attributes as above.  `entries` is not reported on entries (ie:
 no recursive listing).
+
+The `targets` attribute is reported iff the `targets` option is `"stat"`.  It
+contains information that was true at some point in time about the targets of
+symbolic links that were found in the current directory.  An entry is added
+here only in case the entry wouldn't be found in the main `entries` dictionary.
+For example, if `path` is `/usr/lib` and `fnmatch` is `*.so` and the directory
+contains the links `a.so → a-impl.so`, `b.so → b.so.0` and `c.so -> ../x/c.so`
+then the `targets` dictionary would include `b.so.0` (which isn't reported in
+entries because it doesn't match `fnmatch`) and `../x/c.so` (which isn't
+reported because it's in a different directory).  Monitoring these entries for
+changes would be expensive, so it's simply not done.  Clients are expected to
+use this information to flesh out details about directory entries, answering
+questions like "`/bin` links to `usr/bin`, but what type of file is that?".
+`targets` is incompatible with `follow: false`.
 
 If the provided `path` is a symbolic link, it is followed, unless
 `follow: false` is specified.  If symbolic links are present in the directory,

--- a/src/cockpit/channels/filesystem.py
+++ b/src/cockpit/channels/filesystem.py
@@ -493,8 +493,9 @@ class FsInfoChannel(Channel):
             self.report_error(err)
 
     def do_close(self) -> None:
-        if self.path_watch is not None:
-            self.path_watch.close()
+        # non-watch channels close immediately — if we get this, we're watching
+        assert self.path_watch is not None
+        self.path_watch.close()
         self.close()
 
     def do_open(self, options: JsonObject) -> None:


### PR DESCRIPTION
cockpit-navigator needs this for the case of "/bin is a symlink to /usr/bin, but what icon should I use for it?".

This helps us find out what "/usr/bin" is, without needing additional queries.


Note: the approach here is not the first one I considered, which was to report the target-info directly on the entry in question.  I avoided doing that because:

 - conceptually, this information doesn't belong to the directory entry in question, and since we don't update it on changes, it's a bit awkward having it in the `entries` dict (where absolutely everything else is kept absolutely up to date)
 - in the case of symlinks to the same directory (which is a common case in our "stress test" cases of `/usr/bin` and `/usr/lib64`) reporting the information for each item that links to an entry that we're already listing would be redundant, and as above, we'd have no good way to know that we need to update the information about referring links when we update the target information, which would lead to even worse data consistency

A downside of this approach is that it's more difficult for the client to consume.  Properly consuming this interface actually involves a loop, in fact: imagine that `a → b` and `b → c` and `c → /some/other`.  Because `a`, `b`, and `c` are all listed in the directory, they won't appear in "targets", but rather in "entries", where they won't be dereferenced.  That means that looking up the target of a symlink will be something like:

```js
    let target_entry = origin_entry;
    while (target_entry?.target) {
        const target = target_entry.target;
        target_entry = info.entries[target] || info.targets[target];
    }
    // now we can inspect target_entry.type
```

and, of course, you can fall into the usual 'link points (directly|indirectly) to itself' issue, which you'd also need to check for.

We could resolve that by always including items in 'targets', in which case it would always be a single step, but then we'd have redundant (and possibly-out-of-step) information again.


I'm not 100% stuck on this implementation approach and I could probably be convinced to do something else, but it would probably take some pretty good arguments...