### PR TITLE
ws: Support Content-Length in the fsread1 channel

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -1025,6 +1025,9 @@ The following options can be specified in the "open" control message:
 
  * "path": The path name of the file to read.
 
+The ready message contains a "size-hint" when the channel is opened
+with the "binary" option set to "raw".
+
 The channel will return the content of the file in one or more
 messages.  As with "stream", the boundaries of the messages are
 arbitrary.

--- a/src/bridge/cockpitfsread.h
+++ b/src/bridge/cockpitfsread.h
@@ -32,7 +32,8 @@ GType              cockpit_fsread_get_type     (void) G_GNUC_CONST;
 
 CockpitChannel *   cockpit_fsread_open         (CockpitTransport *transport,
                                                 const gchar *channel_id,
-                                                const gchar *path);
+                                                const gchar *path,
+						gboolean binary);
 
 gchar *            cockpit_get_file_tag         (const gchar *path);
 

--- a/src/cockpit/channels/filesystem.py
+++ b/src/cockpit/channels/filesystem.py
@@ -126,7 +126,10 @@ class FsReadChannel(GeneratorChannel):
                 if max_read_size is not None and buf.st_size > max_read_size:
                     raise ChannelError('too-large')
 
-                self.ready()
+                if binary and stat.S_ISREG(buf.st_mode):
+                    self.ready(size_hint=buf.st_size)
+                else:
+                    self.ready()
 
                 while True:
                     data = filep.read1(Channel.BLOCK_SIZE)

--- a/src/ws/cockpitchannelresponse.c
+++ b/src/ws/cockpitchannelresponse.c
@@ -408,6 +408,15 @@ cockpit_channel_response_control (CockpitChannel *channel,
         }
     }
 
+  if (g_str_equal (command, "ready"))
+    {
+      gint64 content_length;
+      if (cockpit_json_get_int (options, "size-hint", -1, &content_length) && content_length != -1)
+        ensure_headers (self, 200, "OK", content_length);
+
+      return TRUE;
+    }
+
   if (g_str_equal (command, "done"))
     {
       ensure_headers (self, 200, "OK", 0);


### PR DESCRIPTION
Cockpit navigator and SOS report offer a file download option, downloading a file in the browser shows the download speed but no estimation of how long it takes. This is due to the lack of the Content-Length header which could be added via the external channel options however the `fsread1` channel already has all the information.

The `fsread1` channel now emits a `size-hint` in the ready message which cockpit-ws picks up and adds a Content-Length header. The header is only included for the binary channel mode.

Closes: #19861