### PR TITLE
test: add allow_download helper for Browser class

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -223,6 +223,11 @@ class Browser:
             self.layouts = [layout for layout in self.layouts if layout["theme"] != "dark"]
         self.current_layout = None
 
+    def allow_download(self) -> None:
+        """Allow browser downloads"""
+        if self.cdp.browser.name == "chromium":
+            self.cdp.invoke("Page.setDownloadBehavior", behavior="allow", downloadPath=self.cdp.download_dir)
+
     def open(self, href: str, cookie: Optional[Dict[str, str]] = None, tls: bool = False):
         """Load a page into the browser.
 

--- a/test/verify/check-sosreport
+++ b/test/verify/check-sosreport
@@ -73,8 +73,7 @@ only-plugins=release,date,host,cgroups,networking
             b.wait_not_present("#sos-dialog")
 
         b.wait_visible("tr:contains(mylabel) button:contains(Download)")
-        if b.cdp.browser.name == "chromium":
-            b.cdp.invoke("Page.setDownloadBehavior", behavior="allow", downloadPath=b.cdp.download_dir)
+        b.allow_download()
 
         def downloaded_sosreports():
             return glob.glob(os.path.join(b.cdp.download_dir, "*sosreport-*.xz.gpg"))


### PR DESCRIPTION
Cockpit-navigator wants to include download support and requires the same code to be run so let's make this re-usable.

See: https://github.com/cockpit-project/cockpit-navigator/pull/175