### PR TITLE
storaged: when a menu item is disabled don't show a warning color

### DIFF
--- a/pkg/storaged/storage-controls.jsx
+++ b/pkg/storaged/storage-controls.jsx
@@ -227,7 +227,7 @@ export const StorageSize = ({ size }) => {
 };
 
 export const StorageMenuItem = ({ onClick, onlyNarrow, danger, excuse, children }) => (
-    <DropdownItem className={(onlyNarrow ? "show-only-when-narrow" : "") + (danger ? " delete-resource-dangerous" : "")}
+    <DropdownItem className={(onlyNarrow ? "show-only-when-narrow" : "") + (danger && !excuse ? " delete-resource-dangerous" : "")}
                   description={excuse}
                   isDisabled={!!excuse}
                   onClick={checked(onClick, null, excuse)}>


### PR DESCRIPTION
Disabled items can't be interacted with so showing the red danger color is not so important and as it's not a disabled color it confuses users.