### PR TITLE
fsinfo channel: tweak a couple of options

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -850,8 +850,6 @@ this payload type:
    refers to a readable directory, an `entries` attribute will be reported
    (described below).  Use `*` to report all files.  Can also be used to
    implement search (`searc*`) or hide temporary files (`[!.]*`).
- * `targets` (optional string): if set to 'stat' then report information about
-   symlink targets under the `targets` attribute.  See below.
  * `watch` (optional, default: false): if the channel should watch for changes
  * `follow` (default: true): if the trailing component of `path` is a symbolic
    link, whether we should follow it.  `follow: false` mode is not supported
@@ -906,14 +904,17 @@ is simply not reported.
    and `fsreplace1`.
  * `entries`: for directories: the contents of the directory (see below)
  * `target`: for symbolic links: the target of the link (a string)
+ * `targets`: for directories: extra information about symlink targets for
+   symlinks found in the directory (see below)
 
 The `entries` attribute is reported iff `fnmatch` is non-empty, and `path`
 refers to a readable directory.  It is an object where each key is the name of
 a file in the directory, and each value is an object describing that file,
 using the same attributes as above.  `entries` is not reported on entries (ie:
-no recursive listing).
+no recursive listing).  Listing `entries` in `attrs` is equivalent to
+`fnmatch='*'`.
 
-The `targets` attribute is reported iff the `targets` option is `"stat"`.  It
+The `targets` attribute is reported iff `targets` is listed in `attrs`.  It
 contains information that was true at some point in time about the targets of
 symbolic links that were found in the current directory.  An entry is added
 here only in case the entry wouldn't be found in the main `entries` dictionary.

--- a/test/pytest/test_bridge.py
+++ b/test/pytest/test_bridge.py
@@ -793,7 +793,7 @@ async def test_fsinfo_nofollow_watch(transport: MockTransport) -> None:
 
 @pytest.mark.asyncio
 async def test_fsinfo_nofollow_targets(transport: MockTransport) -> None:
-    await transport.check_open('fsinfo', path='/', attrs=[], targets='stat', follow=False, problem='protocol-error')
+    await transport.check_open('fsinfo', path='/', attrs=['targets'], follow=False, problem='protocol-error')
 
 
 @pytest.mark.asyncio
@@ -997,8 +997,7 @@ async def test_fsinfo_other_owner(transport: MockTransport, tmp_path: Path) -> N
 @pytest.mark.asyncio
 async def test_fsinfo_targets(transport: MockTransport, tmp_path: Path) -> None:
     # we are only interested in the things that start with 'l'
-    watch = await FsInfoClient.open(transport, tmp_path, ['type', 'target'],
-                                    fnmatch='l*', targets='stat', watch=True)
+    watch = await FsInfoClient.open(transport, tmp_path, ['type', 'target', 'targets'], fnmatch='l*', watch=True)
 
     entries: JsonDict = {}
     targets: JsonDict = {}
@@ -1054,5 +1053,5 @@ async def test_fsinfo_targets(transport: MockTransport, tmp_path: Path) -> None:
     assert await watch.next_state() == state
 
     # double-check with the non-watch variant
-    client = await FsInfoClient.open(transport, tmp_path, ['type', 'target'], fnmatch='l*', targets='stat')
+    client = await FsInfoClient.open(transport, tmp_path, ['type', 'target', 'targets'], fnmatch='l*')
     assert await client.wait() == state


### PR DESCRIPTION
 - `fnmatch` is now called `entries`, because setting this attribute will get you an item called `entries` added to your attributes

 - you can now also request all entries by adding `entries` to `attrs`

 - similarly, `targets` is now requested by adding `targets` to `attrs` with the idea that if we want to support different update methodologies in the future we are free to choose which one, and if we want to give the user control, we can add a `targets` option back again, at that point.

The general gist of these changes are making it easier to consume the API.  Both existing APIs (cockpit.print and the fsinfo client-side being developed in cockpit-navigator) support passing attributes as positional arguments, but require kwargs/object for extra options.  That turns something like:

```
  cpf fsinfo / type target fnmatch=* targets=stat | ...
```

to

```
  cpf fsinfo / type entries target targets | ...
```

and

```
  cockpit.fsinfo('/', ['type', 'target'], { fnmatch: '*', targets: 'stat' });
```

to

```
  cockpit.fsinfo('/', ['type', 'entries', 'target', 'targets']);
```