### PR TITLE
storaged: anaconda: invert the keys/values in the cockpit_mount_points object

### DIFF
--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -1773,10 +1773,7 @@ client.export_mount_point_mapping = () => {
                 const device = utils.decode_filename(b.PreferredDevice);
                 const type = utils.decode_filename(c[1].type.v);
 
-                if (dir)
-                    mpm[dir] = device;
-                if (type === "swap")
-                    mpm[type] = device;
+                mpm[device] = { dir, type };
             }
         }
     }


### PR DESCRIPTION
The device names should be always unique, the mount points / device types are not. An example is swap, where the user is allowed to configure multiple swap partitions. For this reason, let's make the keys of the cockpit_mount_points storage object have the device paths as keys.