### PR TITLE
test: add device is in use test for formatting btrfs

### DIFF
--- a/test/common/storagelib.py
+++ b/test/common/storagelib.py
@@ -137,6 +137,9 @@ class StorageHelpers:
     def dialog_wait_alert(self, text):
         self.browser.wait_in_text('#dialog .pf-v5-c-alert__title', text)
 
+    def dialog_wait_title(self, text):
+        self.browser.wait_in_text('#dialog .pf-v5-c-modal-box__title', text)
+
     def dialog_field(self, field):
         return f'#dialog [data-field="{field}"]'
 

--- a/test/verify/check-storage-btrfs
+++ b/test/verify/check-storage-btrfs
@@ -429,6 +429,13 @@ class TestStorageBtrfs(storagelib.StorageCase):
         b.wait_in_text(self.card_row("Storage", name=os.path.basename(disk1)), "btrfs device")
         b.wait_in_text(self.card_row("Storage", name=os.path.basename(disk2)), "btrfs device")
 
+        # We don't allow formatting of multi device btrfs filesystems
+        self.click_dropdown(self.card_row("Storage", name=os.path.basename(disk1)), "Format")
+        self.dialog_wait_open()
+        self.dialog_wait_title(f"{disk1} is in use")
+        self.dialog_cancel()
+        self.dialog_wait_close()
+
         # mount /
         self.click_dropdown(self.card_row("Storage", name=label) + " + tr", "Mount")
         self.dialog({"mount_point": mount_point})


### PR DESCRIPTION
When we have a multi device setup we want to not allow formatting of btrfs devices as this breaks multi disk setups. We had a test for this but it was only in testBasic, since we do allow formatting of a single btrfs filesystem device now the test was wrongly removed and should have been moved to testMultiDevice.