### PR TITLE
storage: Allow truncation of ID column

### DIFF
--- a/pkg/lib/cockpit-components-truncate.jsx
+++ b/pkg/lib/cockpit-components-truncate.jsx
@@ -1,0 +1,42 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* This is our version of the PatternFly Truncate component. We have
+   it since we don't want Patternfly's unconditional tooltip.
+
+   Truncation in the middle doesn't work with Patternsfly's approach
+   in mixed RTL/LTR environments, so we only offer truncation at the
+   end.
+ */
+
+import * as React from "react";
+import './cockpit-components-truncate.scss';
+
+export const Truncate = ({
+    content,
+    ...props
+}) => {
+    return (
+        <span className="pf-v5-c-truncate ct-no-truncate-min-width" {...props}>
+            <span className="pf-v5-c-truncate__start">
+                {content}
+            </span>
+        </span>
+    );
+};

--- a/pkg/lib/cockpit-components-truncate.scss
+++ b/pkg/lib/cockpit-components-truncate.scss
@@ -1,0 +1,4 @@
+.pf-v5-c-truncate.ct-no-truncate-min-width {
+    --pf-v5-c-truncate--MinWidth: 0;
+    --pf-v5-c-truncate__start--MinWidth: 0;
+}

--- a/pkg/storaged/pages.jsx
+++ b/pkg/storaged/pages.jsx
@@ -43,6 +43,7 @@ import { StorageButton, StorageBarMenu, StorageMenuItem, StorageSize } from "./s
 import { MultipathAlert } from "./multipath.jsx";
 import { AnacondaAdvice } from "./anaconda.jsx";
 import { JobsPanel } from "./jobs-panel.jsx";
+import { Truncate } from "../lib/cockpit-components-truncate.jsx";
 
 const _ = cockpit.gettext;
 
@@ -591,7 +592,7 @@ export const PageTable = ({ emptyCaption, aria_label, pages, crossrefs, sorted, 
                     <CardBody>
                         <Split hasGutter>
                             { icon && <SplitItem>{icon}</SplitItem> }
-                            <SplitItem isFilled><strong>{name}</strong>{info}</SplitItem>
+                            <SplitItem isFilled><strong><Truncate content={name} /></strong>{info}</SplitItem>
                             <SplitItem>{actions}</SplitItem>
                         </Split>
                         <Split hasGutter isWrappable>
@@ -603,9 +604,14 @@ export const PageTable = ({ emptyCaption, aria_label, pages, crossrefs, sorted, 
                 </Card>);
         } else {
             const cols = [
-                <Td key="1" onClick={onClick}><span>{name}{info}</span></Td>,
-                <Td key="2" onClick={onClick}>{type}</Td>,
-                <Td key="3" onClick={onClick}>{location}</Td>,
+                <Td key="1" onClick={onClick}>
+                    <div className={"content-level-" + level}>
+                        <Truncate content={name} />
+                        {info}
+                    </div>
+                </Td>,
+                <Td key="2" onClick={onClick} modifier="nowrap">{type}</Td>,
+                <Td key="3" onClick={onClick} modifier="nowrap">{location}</Td>,
                 <Td key="4" onClick={onClick} className="storage-size-column">{size}</Td>,
                 <Td key="5" className="pf-v5-c-table__action">{actions || <div /> }</Td>,
             ];
@@ -614,8 +620,7 @@ export const PageTable = ({ emptyCaption, aria_label, pages, crossrefs, sorted, 
 
             rows.push(
                 <Tr key={key}
-                    className={"content-level-" + level +
-                               (border ? "" : " remove-border") +
+                    className={(border ? "" : " remove-border") +
                                (is_new ? " ct-new-item" : "")}
                     data-test-row-name={page.name} data-test-row-location={page.columns[1]}
                     isClickable={!!page.location}

--- a/pkg/storaged/storage.scss
+++ b/pkg/storaged/storage.scss
@@ -109,17 +109,16 @@ td.job-action {
 }
 
 // FIXME: This is visual only; it needs to be fixed for a11y reasons, likely at the JSX level
-tr[class*="content-level-"] {
+div[class*="content-level-"] {
   --multiplier: 0;
   --offset: calc(var(--pf-v5-global--spacer--md) * var(--multiplier));
 
-  > td:nth-child(2) > span {
-    padding-inline-start: var(--offset);
-  }
+  padding-inline-start: var(--offset);
+  white-space: nowrap;
 }
 
 @for $i from 1 through 10 {
-  tr.content-level-#{$i} {
+  div.content-level-#{$i} {
     --multiplier: #{$i};
   }
 }
@@ -356,7 +355,7 @@ a.disabled {
 .storage-size-column-header {
     text-align: end;
     // Align the "Size" header with the text of the usage bars.
-    // var(--pf-v5-global--spacer--sm): padding of compat td cells
+    // var(--pf-v5-global--spacer--sm): padding of compact td cells
     // 3.5em: width of short progress bars
     // 1em: margin between text and progress bar
     padding-inline-end: calc(var(--pf-v5-global--spacer--sm) + 3.5em + 1em) !important;

--- a/test/verify/check-storage-basic
+++ b/test/verify/check-storage-basic
@@ -69,6 +69,15 @@ class TestStorageBasic(storagelib.StorageCase):
         b.go("#/")
         b.wait_visible(self.card("Storage"))
         b.wait_visible(self.card_row("Storage", name=disk))
+
+        # Create a subvolume with a really long name to show
+        # truncation in the pixel test.
+
+        if b.pixels_label:
+            long = "really-" * 15 + "long-name-that-will-be-truncated"
+            m.execute(f"btrfs subvol create /{long}")
+            self.addCleanup(m.execute, f"btrfs subvol delete /{long}")
+            b.wait_visible(self.card_row("Storage", name=f"root/{long}"))
         b.assert_pixels(self.card("Storage"), "overview",
                         # Usage numbers are not stable and also cause
                         # the table columns to shift. The usage bars


### PR DESCRIPTION
And redo indentation magic. Now also tables without icons will show indentations, and the Truncate element will get a correct width on indented columns.

Thanks a lot to MohdMohsin97 for the initial version of this!

Fixes #19767