### PR TITLE
storage: Improve behavior of size slider text and unit inputs

### DIFF
--- a/pkg/storaged/dialog.jsx
+++ b/pkg/storaged/dialog.jsx
@@ -1007,9 +1007,13 @@ class SizeSliderElement extends React.Component {
             text_val = cockpit.format_number(val / unit);
         }
 
-        const change_unit = (_, u) => this.setState({
-            unit: Number(u),
-        });
+        const change_unit = (_, u) => {
+            if (val.unit)
+                onChange({ text: val.text, unit: Number(u) });
+            else
+                onChange(val / unit * Number(u));
+            this.setState({ unit: Number(u) });
+        };
 
         return (
             <Grid hasGutter className="size-slider">

--- a/test/verify/check-storage-partitions
+++ b/test/verify/check-storage-partitions
@@ -167,7 +167,7 @@ class TestStoragePartitions(storagelib.StorageCase):
         self.click_card_row("GPT partitions", 2)
         self.click_card_dropdown("Partition", "Delete")
         self.confirm()
-        self.click_card_row("GPT partitions", 1)
+        self.click_card_row("GPT partitions", location="/foo1 (not mounted)")
         b.click(self.card_button("Partition", "Grow"))
         self.dialog({"size": 103})
         b.wait_visible(self.card_button("Partition", "Grow") + ":disabled")

--- a/test/verify/check-storage-partitions
+++ b/test/verify/check-storage-partitions
@@ -88,10 +88,14 @@ class TestStoragePartitions(storagelib.StorageCase):
         b.key_press(chr(37), use_ord=True)
         self.dialog_wait_val("size", 27.1)
 
-        # Check that changing units affects the text input
+        # Check that changing units doesn't affect the text input
         unit = "1000000000"
         b.select_from_dropdown(".size-unit > select", unit)
-        self.dialog_wait_val("size", "0.0271", unit)
+        self.dialog_wait_val("size", 27.1, unit)
+
+        # Change unit back to MB
+        unit = "1000000"
+        b.select_from_dropdown(".size-unit > select", unit)
 
         self.dialog_apply()
         self.dialog_wait_close()


### PR DESCRIPTION
Now the text and unit inputs stay constant when the user changes the other, and the slider moves accordingly. Previously, the slider would remain in place and the text input would change when the user changed the unit input.

I believe this is more natural: When people interact with the text and unit input, they very like start inputting the number and then they adjust the unit to what that number should be interpreted in.  In the old behavior, changing the unit would change the text so that the resulting value would still be the same. (Changing the unit from GB to MB would multiply the text by 1000.)

This was however masked by a bug: the text input did not actually change, although the SizeSLider component would pretend that it had. For example, when the unit was "GB", and the user typed in "1" into the text input and then changed the unit to "MB", a dialog would still receive 1 GB as the value of the slider.

With this change, the dialog would receive "1 MB" in this situation.