### PR TITLE
storage: Don't ignore encryption for new empty partitions

### DIFF
--- a/pkg/storaged/block/format-dialog.jsx
+++ b/pkg/storaged/block/format-dialog.jsx
@@ -319,7 +319,7 @@ function format_dialog_internal(client, path, start, size, enable_dos_extended, 
     ];
 
     const action_variants_for_empty = [
-        { tag: null, Title: create_partition ? _("Create") : _("Format") }
+        { tag: "nomount", Title: create_partition ? _("Create") : _("Format") }
     ];
 
     let action_variants_for_swap = [
@@ -581,8 +581,6 @@ function format_dialog_internal(client, path, start, size, enable_dos_extended, 
                     if (create_partition) {
                         if (type == "dos-extended")
                             return block_ptable.CreatePartition(start, vals.size, "0x05", "", { });
-                        else if (type == "empty")
-                            return block_ptable.CreatePartition(start, vals.size, partition_type, "", { });
                         else
                             return block_ptable.CreatePartitionAndFormat(start, vals.size, partition_type, "", { },
                                                                          type, options);
@@ -640,7 +638,7 @@ function format_dialog_internal(client, path, start, size, enable_dos_extended, 
                     if (type == "swap" && mount_now)
                         return (client.wait_for(() => block_swap_for_block(path))
                                 .then(block_swap => block_swap.Start({})));
-                    if (is_encrypted(vals) && (is_filesystem(vals) || type == "swap") && !mount_now)
+                    if (is_encrypted(vals) && !mount_now)
                         return (client.wait_for(() => block_crypto_for_block(path))
                                 .then(block_crypto => block_crypto.Lock({ })));
                 }

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -201,10 +201,6 @@ class TestStorageLuks(storagelib.StorageCase):
                      "crypto": self.default_crypto_type,
                      "passphrase": "vainu-reku-toma-rolle-kaja",
                      "passphrase2": "vainu-reku-toma-rolle-kaja"})
-        b.wait_visible(self.card("Unformatted data"))
-
-        # Lock it
-        b.click(self.card_button("Unformatted data", "Lock"))
         b.wait_visible(self.card("Locked data"))
 
         # Make it readonly
@@ -228,6 +224,21 @@ class TestStorageLuks(storagelib.StorageCase):
         self.dialog({"type": "ext4",
                      "mount_point": "/run/foo"})
         b.wait_visible(self.card("ext4 filesystem"))
+        self.wait_mounted("ext4 filesystem")
+
+        # Now create a empty, encrypted partition
+        self.click_card_dropdown("Solid State Drive", "Create partition table")
+        self.dialog({"type": "gpt"})
+        b.wait_text(self.card_row_col("GPT partitions", 1, 1), "Free space")
+        self.click_dropdown(self.card_row("GPT partitions", 1), "Create partition")
+        self.dialog({"type": "empty",
+                     "crypto": self.default_crypto_type,
+                     "passphrase": "vainu-reku-toma-rolle-kaja",
+                     "passphrase2": "vainu-reku-toma-rolle-kaja"})
+        b.wait_text(self.card_row_col("GPT partitions", 1, 2), "Locked data (encrypted)")
+        self.click_dropdown(self.card_row("GPT partitions", 1), "Unlock")
+        self.dialog({"passphrase": "vainu-reku-toma-rolle-kaja"})
+        b.wait_text(self.card_row_col("GPT partitions", 1, 2), "Unformatted data (encrypted)")
 
     def testKeepKeys(self):
         b = self.browser


### PR DESCRIPTION
The code would take a shortcut when creating a new partition of type "empty", but that is wrong since there might be encryption options that should not be ignored.

Also, lock the encryption in more cases, for consistency.