### PR TITLE
Remove bodies from HTTP 301 redirects

### DIFF
--- a/src/tls/httpredirect.c
+++ b/src/tls/httpredirect.c
@@ -113,9 +113,7 @@ http_redirect (FILE *input,
   fprintf (output, "HTTP/1.1 301 Moved Permanently\r\n"
                    "Content-Type: text/html\r\n"
                    "Location: https://%s%s\r\n"
-                   "\r\n"
-                   "<html><head><title>Moved</title></head>"
-                   "<body>Please use TLS</body></html>\r\n", host, path);
+                   "\r\n", host, path);
 
   return true;
 }

--- a/src/tls/test-server.c
+++ b/src/tls/test-server.c
@@ -183,7 +183,7 @@ recv_reply (int fd, char *buf, size_t buflen)
   close (fd);
   if (len < 0)
     g_error ("recv_reply: unexpected error: %m");
-  g_assert_cmpint (len, >=, 100);
+  g_assert_cmpint (len, >=, 50);
   buf[len] = '\0'; /* so that we can use string functions on it */
 
   return buf;
@@ -200,7 +200,7 @@ do_request (TestCase *tc, const char *request)
   /* wait until data is available */
   for (int timeout = 0; timeout < 100; ++timeout) {
     res = recv (fd, buf, 100, MSG_PEEK | MSG_DONTWAIT);
-    if (res >= 100)
+    if (res >= 50)
       return recv_reply (fd, buf, sizeof (buf));
 
     server_poll_event (100);


### PR DESCRIPTION
...we don't need them for GET and for HEAD they're forbidden (and the new curl version complains).  Just never send them.

Hopefully this helps with https://github.com/cockpit-project/bots/pull/5861