### PR TITLE
test: accept /usr/bin/bash as valid path

### DIFF
--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -183,7 +183,7 @@ class TestAccounts(testlib.MachineCase):
         b.wait_visible("#account-locked:not(:checked)")
         # check home directory and shell for root
         b.wait_text("#account-home-dir", "/root")
-        b.wait_text("#account-shell", "/bin/bash")
+        b.wait_in_text("#account-shell", "/bin/bash")  # can be /usr/bin/bash or /bin/bash
         # root account should not be locked by default on our images
         self.assertIn(m.execute("passwd -S root").split()[1], ["P", "PS"])
         # now lock account


### PR DESCRIPTION
Arch seems to want to use /usr/bin/bash as the path to the default shell.  Accept it as a valid alternative.

Hopefully this helps with https://github.com/cockpit-project/bots/pull/5861