### PR TITLE
storaged: stop using Array.prototype.toSorted for now

### DIFF
--- a/pkg/storaged/pages.jsx
+++ b/pkg/storaged/pages.jsx
@@ -637,7 +637,9 @@ export const PageTable = ({ emptyCaption, aria_label, pages, crossrefs, sorted, 
     function sort(things, accessor, sorted) {
         if (sorted === false)
             return things;
-        return things.toSorted((a, b) => page_compare(accessor(a), accessor(b)));
+        // HACK: Use toSorted() once enough users upgrade to at least Firefox ESR 115
+        // See: https://github.com/cockpit-project/cockpit/issues/19848
+        return things.slice().sort((a, b) => page_compare(accessor(a), accessor(b)));
     }
 
     function make_page_rows(pages, level, last_has_border, key, sorted) {


### PR DESCRIPTION
Several users have reported a broken storage page as their browser was too old, technically we don't support such old browsers but as enough users complain and using sort() doesn't drastically complicated the code use that for now instead.

Fixes: #19848