### PR TITLE
cdp: remove disable-gpu flag from headless Chrome

### DIFF
--- a/test/common/cdp.py
+++ b/test/common/cdp.py
@@ -94,7 +94,7 @@ class Chromium(Browser):
         exe = self.path(show_browser)
 
         return [exe, "--headless" if not show_browser else "",
-                "--disable-gpu", "--no-sandbox", "--disable-setuid-sandbox",
+                "--no-sandbox", "--disable-setuid-sandbox",
                 "--disable-namespace-sandbox", "--disable-seccomp-filter-sandbox",
                 "--disable-sandbox-denial-logging", "--disable-pushstate-throttle",
                 "--font-render-hinting=none",


### PR DESCRIPTION
This is not longer required according to https://issues.chromium.org/issues/40527919 on linux.

Sending this with the hope that it will fix some recent crashes we see in anaconda: https://cockpit-logs.us-east-1.linodeobjects.com/pull-152-20240206-142606-4d5a14ae-fedora-rawhide-boot/log.html#28-1