### PR TITLE
selinux: Cover migration to /run

### DIFF
--- a/selinux/cockpit.fc
+++ b/selinux/cockpit.fc
@@ -13,6 +13,8 @@
 /var/lib/cockpit(/.*)?      gen_context(system_u:object_r:cockpit_var_lib_t,s0)
 
 /var/run/cockpit(/.*)?   gen_context(system_u:object_r:cockpit_var_run_t,s0)
+/run/cockpit(/.*)?   gen_context(system_u:object_r:cockpit_var_run_t,s0)
 /var/run/cockpit-ws(/.*)?   gen_context(system_u:object_r:cockpit_var_run_t,s0)
+/run/cockpit-ws(/.*)?   gen_context(system_u:object_r:cockpit_var_run_t,s0)
 
 /etc/cockpit/ws-certs\.d(/.*)?   gen_context(system_u:object_r:cert_t,s0)


### PR DESCRIPTION
With the 1f76e522a ("Rename all /var/run file context entries to /run") selinux-policy commit, all /var/run file context entries moved to /run and the equivalency was inverted. Subsequently, changes in cockpit.fc need to be done, too, in a similar manner.