### PR TITLE
pkg: make contextmenu component standalone & re-usable

### DIFF
--- a/pkg/lib/cockpit-components-context-menu.jsx
+++ b/pkg/lib/cockpit-components-context-menu.jsx
@@ -17,25 +17,21 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-import cockpit from "cockpit";
 import React from "react";
 import PropTypes from "prop-types";
 
-import { Menu, MenuContent, MenuList, MenuItem } from "@patternfly/react-core/dist/esm/components/Menu";
+import { Menu, MenuContent } from "@patternfly/react-core/dist/esm/components/Menu";
 
 import "context-menu.scss";
 
-const _ = cockpit.gettext;
-
 /*
- * A context menu component that contains copy and paste fields.
+ * A context menu component
  *
- * It requires three properties:
- *  - getText, method which is called when copy is clicked
- *  - setText, method which is called when paste is clicked
- *  - parentId, area in which it listens to left button clicks
+ * It requires two properties:
+ *  - parentId, area in which it listens to left button click
+ *  - children, a MenuList to be rendered in the context menu
  */
-export const ContextMenu = ({ parentId, getText, setText }) => {
+export const ContextMenu = ({ parentId, children }) => {
     const [visible, setVisible] = React.useState(false);
     const [event, setEvent] = React.useState(null);
     const root = React.useRef(null);
@@ -103,22 +99,12 @@ export const ContextMenu = ({ parentId, getText, setText }) => {
     return visible &&
         <Menu ref={root} className="contextMenu">
             <MenuContent ref={root}>
-                <MenuList>
-                    <MenuItem className="contextMenuOption" onClick={getText}>
-                        <div className="contextMenuName"> { _("Copy") } </div>
-                        <div className="contextMenuShortcut">{ _("Ctrl+Insert") }</div>
-                    </MenuItem>
-                    <MenuItem className="contextMenuOption" onClick={setText}>
-                        <div className="contextMenuName"> { _("Paste") } </div>
-                        <div className="contextMenuShortcut">{ _("Shift+Insert") }</div>
-                    </MenuItem>
-                </MenuList>
+                {children}
             </MenuContent>
         </Menu>;
 };
 
 ContextMenu.propTypes = {
-    getText: PropTypes.func.isRequired,
-    setText: PropTypes.func.isRequired,
-    parentId: PropTypes.string.isRequired
+    parentId: PropTypes.string.isRequired,
+    children: PropTypes.any
 };

--- a/pkg/lib/cockpit-components-terminal.jsx
+++ b/pkg/lib/cockpit-components-terminal.jsx
@@ -21,6 +21,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Modal } from "@patternfly/react-core/dist/esm/components/Modal/index.js";
 import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
+import { MenuList, MenuItem } from "@patternfly/react-core/dist/esm/components/Menu";
 import { Terminal as Term } from "xterm";
 import { CanvasAddon } from 'xterm-addon-canvas';
 
@@ -204,6 +205,19 @@ export class Terminal extends React.Component {
     }
 
     render() {
+        const contextMenuList = (
+            <MenuList>
+                <MenuItem className="contextMenuOption" onClick={this.getText}>
+                    <div className="contextMenuName"> { _("Copy") } </div>
+                    <div className="contextMenuShortcut">{ _("Ctrl+Insert") }</div>
+                </MenuItem>
+                <MenuItem className="contextMenuOption" onClick={this.setText}>
+                    <div className="contextMenuName"> { _("Paste") } </div>
+                    <div className="contextMenuShortcut">{ _("Shift+Insert") }</div>
+                </MenuItem>
+            </MenuList>
+        );
+
         return (
             <>
                 <Modal title={_("Paste error")}
@@ -224,7 +238,9 @@ export class Terminal extends React.Component {
                      onFocus={this.onFocusIn}
                      onContextMenu={this.contextMenu}
                      onBlur={this.onFocusOut} />
-                <ContextMenu parentId={this.props.parentId} setText={this.setText} getText={this.getText} />
+                <ContextMenu parentId={this.props.parentId}>
+                    {contextMenuList}
+                </ContextMenu>
             </>
         );
     }


### PR DESCRIPTION
The navigator copied the contextmenu implementation while it can be easily made re-usable by allowing passing children.

This allows us to drop:

https://github.com/cockpit-project/cockpit-navigator/blob/main/src/context-menu.jsx and scss file.