### PR TITLE
.github: update workflow checkout actions to v4

### DIFF
--- a/.github/workflows/build-ws-container.yml
+++ b/.github/workflows/build-ws-container.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Log into container registry
         run: $RUNC login -u ${{ secrets.QUAY_BOTUSER }} -p ${{ secrets.QUAY_TOKEN }} quay.io

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Repository checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/flatpak-test.yml
+++ b/.github/workflows/flatpak-test.yml
@@ -17,7 +17,7 @@ jobs:
         run: flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
 
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # need this to also fetch tags
           fetch-depth: 0

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Trigger updates-testing scenario
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -56,7 +56,7 @@ jobs:
       options: --user root
     steps:
       - name: Checkout website repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: website
           repository: cockpit-project/cockpit-project.github.io
@@ -111,12 +111,12 @@ jobs:
           python-version: '3.10'
 
       - name: Checkout source repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: src
 
       - name: Checkout flathub repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: flathub
           repository: flathub/org.cockpit_project.CockpitClient
@@ -158,7 +158,7 @@ jobs:
     permissions: {}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up git
         run: |

--- a/.github/workflows/reposchutz.yml
+++ b/.github/workflows/reposchutz.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Clone target branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/unit-tests-refresh.yml
+++ b/.github/workflows/unit-tests-refresh.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # need this to also fetch tags
           fetch-depth: 0

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # need this to also fetch tags
           fetch-depth: 0

--- a/.github/workflows/urls-check.yml
+++ b/.github/workflows/urls-check.yml
@@ -14,7 +14,7 @@ jobs:
           echo '${{ secrets.GITHUB_TOKEN }}' > ~/.config/github-token
 
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run urls-check action
         run: |

--- a/.github/workflows/weblate-sync-po.yml
+++ b/.github/workflows/weblate-sync-po.yml
@@ -21,13 +21,13 @@ jobs:
           sudo apt install -y --no-install-recommends gettext
 
       - name: Clone source repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ssh-key: ${{ secrets.DEPLOY_KEY }}
           path: src
 
       - name: Clone weblate repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}-weblate
           path: weblate

--- a/.github/workflows/weblate-sync-pot.yml
+++ b/.github/workflows/weblate-sync-pot.yml
@@ -21,7 +21,7 @@ jobs:
         run: git config --global --add safe.directory /__w/
 
       - name: Clone source repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: src
           fetch-depth: 0
@@ -33,7 +33,7 @@ jobs:
           make po/cockpit.pot
 
       - name: Clone weblate repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: weblate
           repository: ${{ github.repository }}-weblate


### PR DESCRIPTION
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20.

See for example: https://github.com/cockpit-project/cockpit/actions/runs/7812167902