### PR TITLE
Users account fixes

### DIFF
--- a/pkg/users/account-details.js
+++ b/pkg/users/account-details.js
@@ -105,7 +105,7 @@ export function AccountDetails({ accounts, groups, current_user, user, shells })
         const handle = cockpit.file("/var/run/utmp", { superuser: "try", binary: true });
         handle.watch(() => {
             get_expire(user).then(setExpiration);
-        });
+        }, { read: false });
         return handle.close;
     }, [user, accounts]);
 

--- a/pkg/users/users.js
+++ b/pkg/users/users.js
@@ -87,8 +87,6 @@ function AccountsPage() {
 
     const [details, setDetails] = useState(null);
     useInit(() => {
-        getLogins().then(setDetails);
-
         // Watch `/var/run/utmp` to register when user logs in or out
         const handleUtmp = cockpit.file("/var/run/utmp", { superuser: "try", binary: true });
         handleUtmp.watch(() => getLogins().then(setDetails), { read: false });


### PR DESCRIPTION
The accounts page is still wildly inefficient it averages: ~3777 ms and now 3359 ms. However that is just done with 5 test refreshes, not scientific at all :-)

useInit still has a problem that `{ read: false }` does read from disk. Basically what happens:

- first file.watch() invocation does an fsread1 to obtain the tag
- as side-effect it also reads the content and returns
- so we end up with now two invocations of getLogins (which is a fairly expensive function) as it calls `passwd -S` for every account.

Update: while reading the man page of passwd, we want `passwd --all -S`. That should fix O(n) calls. I'll handle that in an updated PR.

For a "clean" VM we call `passwd -S` 94 times!