### PR TITLE
users: handle tab's in lastlog output

### DIFF
--- a/pkg/users/users.js
+++ b/pkg/users/users.js
@@ -167,7 +167,7 @@ async function getLogins() {
 
     // drop header and last empty line with slice
     const promises = lastlog.split('\n').slice(1, -1).map(async line => {
-        const splitLine = line.split(/ +/);
+        const splitLine = line.split(/[ \t]+/);
         const name = splitLine[0];
         const isLocked = await get_locked(name);
 


### PR DESCRIPTION
Sometimes for longer names lastlog inserts a tab for example for `systemd-timesync`. This causes `passwd -S` to be unable to look up the account name.