### PR TITLE
workflows: stop using actions/setup-python

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,10 +106,6 @@ jobs:
     permissions: {}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-
       - name: Checkout source repository
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This was added by 09fe9eeef99bee9fe6026be19f6c724ec155db5f which needed it for `xml.etree.ElementTree.indent` but the `ubuntu-latest` GitHub Actions image has gained Python 3.10 since then, so this is now superfluous.  Drop it.

Supersedes (hopefully) #19980.