### PR TITLE
common: Fix crash with unsupported HTTP methods

### DIFF
--- a/src/common/cockpitwebresponse.c
+++ b/src/common/cockpitwebresponse.c
@@ -234,7 +234,9 @@ cockpit_web_response_new (GIOStream *io,
   self->url_root = NULL;
   self->full_path = g_strdup (path);
   self->path = self->full_path;
-  cockpit_web_response_set_method (self, method);
+
+  g_assert (method != NULL);
+  self->method = g_strdup (method);
 
   if (path && original_path)
     {
@@ -262,15 +264,6 @@ cockpit_web_response_new (GIOStream *io,
     self->origin = g_strdup_printf ("%s://%s", self->protocol, host);
 
   return self;
-}
-
-void
-cockpit_web_response_set_method (CockpitWebResponse *response,
-                                 const gchar *method)
-{
-  g_return_if_fail (g_strcmp0 (method, "GET") == 0 || g_strcmp0 (method, "HEAD") == 0);
-  g_free (response->method);
-  response->method = g_strdup (method);
 }
 
 /**
@@ -586,7 +579,7 @@ cockpit_web_response_queue (CockpitWebResponse *self,
       return FALSE;
     }
 
-  if (g_strcmp0 (self->method, "HEAD") == 0)
+  if (g_str_equal (self->method, "HEAD"))
     {
       g_debug ("%s: ignoring queued block for method HEAD", self->logname);
       return TRUE;
@@ -1168,7 +1161,7 @@ cockpit_web_response_error (CockpitWebResponse *self,
       cockpit_web_response_headers (self, code, message, -1, "Content-Type", "text/html; charset=utf8", NULL);
     }
 
-  if (g_str_equal (self->method, "GET"))
+  if (!g_str_equal (self->method, "HEAD"))
     {
       extern const char *cockpit_webresponse_fail_html_text;
       g_autoptr(GBytes) input = g_bytes_new_static (cockpit_webresponse_fail_html_text, strlen (cockpit_webresponse_fail_html_text));

--- a/src/common/cockpitwebresponse.h
+++ b/src/common/cockpitwebresponse.h
@@ -56,8 +56,6 @@ CockpitWebResponse *  cockpit_web_response_new           (GIOStream *io,
                                                           GHashTable *in_headers,
                                                           const gchar *method,
                                                           const gchar *protocol);
-void                  cockpit_web_response_set_method    (CockpitWebResponse *response,
-                                                          const gchar *method);
 
 
 const gchar *         cockpit_web_response_get_path      (CockpitWebResponse *self);

--- a/src/common/test-webresponse.c
+++ b/src/common/test-webresponse.c
@@ -48,6 +48,7 @@ typedef struct {
     const gchar *path;
     const gchar *header;
     const gchar *value;
+    const gchar *method;
     const gchar *expected_content_type;
     CockpitCacheType cache;
     gboolean for_tls_proxy;
@@ -88,7 +89,8 @@ setup (TestCase *tc,
       g_hash_table_insert (headers, g_strdup (fixture->header), g_strdup (fixture->value));
     }
 
-  tc->response = cockpit_web_response_new (io, path, path, headers, "GET",
+  tc->response = cockpit_web_response_new (io, path, path, headers,
+                                           (fixture && fixture->method) ? fixture->method : "GET",
                                            (fixture && fixture->for_tls_proxy) ? "https" : "http");
 
   if (headers)
@@ -339,6 +341,14 @@ static const TestFixture content_type_fixture_wasm = {
   .expected_content_type = "application/wasm",
 };
 
+static const TestFixture fixture_head = {
+  .method = "HEAD",
+};
+
+static const TestFixture fixture_unsupported_method = {
+  .method = "PATCH",
+};
+
 static void
 test_content_type (TestCase *tc,
                    gconstpointer user_data)
@@ -575,8 +585,6 @@ test_head (TestCase *tc,
   const gchar *resp;
   GBytes *content;
 
-  cockpit_web_response_set_method (tc->response, "HEAD");
-
   g_assert_cmpint (cockpit_web_response_get_state (tc->response), ==, COCKPIT_WEB_RESPONSE_READY);
 
   cockpit_web_response_headers (tc->response, 200, "OK", 19, NULL);
@@ -599,6 +607,18 @@ test_head (TestCase *tc,
   g_assert_cmpint (cockpit_web_response_get_state (tc->response), ==, COCKPIT_WEB_RESPONSE_SENT);
 
   g_assert_cmpstr (resp, ==, "HTTP/1.1 200 OK\r\nContent-Length: 19\r\n" STATIC_HEADERS);
+}
+
+static void
+test_unsupported_method (TestCase *tc,
+                         gconstpointer data)
+{
+  cockpit_web_response_error (tc->response, 405, NULL, "Unsupported method");
+
+  const gchar *resp = output_as_string (tc);
+  g_assert (g_str_has_prefix (resp, "HTTP/1.1 405 Unsupported method\r\n"));
+  /* not a HEAD request, thus has body */
+  g_assert (strstr (resp, "<body>"));
 }
 
 static void
@@ -1470,8 +1490,10 @@ main (int argc,
               setup, test_stream, teardown);
   g_test_add ("/web-response/pressure", TestCase, NULL,
               setup, test_pressure, teardown);
-  g_test_add ("/web-response/head", TestCase, NULL,
+  g_test_add ("/web-response/head", TestCase, &fixture_head,
               setup, test_head, teardown);
+  g_test_add ("/web-response/unsupported-method", TestCase, &fixture_unsupported_method,
+              setup, test_unsupported_method, teardown);
   g_test_add ("/web-response/chunked-transfer-encoding", TestCase, NULL,
               setup, test_chunked_transfer_encoding, teardown);
   g_test_add ("/web-response/chunked-zero-length", TestCase, NULL,

--- a/src/common/test-webresponse.c
+++ b/src/common/test-webresponse.c
@@ -167,8 +167,6 @@ test_return_error (TestCase *tc,
 {
   const gchar *resp;
 
-  cockpit_expect_message ("Returning error-response 500*");
-
   cockpit_web_response_error (tc->response, 500, NULL, "Reason here: %s", "booyah");
 
   resp = output_as_string (tc);
@@ -192,8 +190,6 @@ test_return_error_headers (TestCase *tc,
   const gchar *resp;
   GHashTable *headers;
 
-  cockpit_expect_message ("Returning error-response 500*");
-
   headers = cockpit_web_server_new_table ();
   g_hash_table_insert (headers, g_strdup ("Header1"), g_strdup ("value1"));
 
@@ -214,8 +210,6 @@ test_return_gerror_headers (TestCase *tc,
   const gchar *resp;
   GHashTable *headers;
   GError *error;
-
-  cockpit_expect_message ("Returning error-response 500*");
 
   headers = cockpit_web_server_new_table ();
   g_hash_table_insert (headers, g_strdup ("Header1"), g_strdup ("value1"));

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1684,9 +1684,6 @@ class MachineCase(unittest.TestCase):
 
     # List of allowed journal messages during tests; these need to match the *entire* message
     default_allowed_messages = [
-        # This is a failed login, which happens every time
-        "Returning error-response 401 with reason `Sorry'",
-
         # Reauth stuff
         '.*Reauthorizing unix-user:.*',
         '.*user .* was reauthorized.*',

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -760,6 +760,15 @@ class TestConnection(testlib.MachineCase):
         # Large requests are processed correctly with TLS
         self.assertIn('A Custom Title', m.curl('-k', 'https://localhost:9000/', headers=large_headers))
 
+        # unsupported HTTP method
+        self.assertIn("HTTP/1.1 405 Method Not Allowed",
+                      m.execute('curl -k --verbose -X PATCH https://localhost:9000/ 2>&1'))
+
+        # no body with HEAD request
+        out = m.execute('curl -k --head https://localhost:9000/')
+        self.assertIn("HTTP/1.1 200", out)
+        self.assertNotIn("<html>", out)
+
     @testlib.nondestructive
     def testHeadRequest(self):
         m = self.machine

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -191,8 +191,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
                                        "if [ -e .profile.bak ]; then mv .profile.bak .profile; else rm .profile; fi")
             b.login_and_go()
 
-        self.allow_journal_messages("Returning error-response ... with reason .*",
-                                    r"pam_unix\(cockpit:auth\): authentication failure; .*",
+        self.allow_journal_messages(r"pam_unix\(cockpit:auth\): authentication failure; .*",
                                     r"pam_unix\(cockpit:auth\): check pass; user unknown",
                                     r"pam_succeed_if\(cockpit:auth\): requirement .* not met by user .*",
                                     "noise-rc-.*")


### PR DESCRIPTION
Commit 96335a440c15859 introduced a crash: Requesting any HTTP method
other than "GET" or "HEAD" segfaulted cockpit_web_response_error() as
`self->method` is NULL. That could happen because
cockpit_web_response_set_method()` refused to set unsupported ones.

Improve the /web-response/head test to set the "HEAD" method right away
with `cockpit_web_response_new()`, instead of overwriting setup()'s
"GET" default.

That was the only consumer of `cockpit_web_response_set_method()`. This
method is rather dubious, as the method should only be set in the
constructor. So eliminate it and move the check into the constructor.

Keep the provided method value also for unknown ones.

Change the critical to a warning, as it's not an internal program error.

Fixes #19997

----

After this lands, we also need to backport this to rhel-8.

The new unit test reproduces the crash (without the fix). The new integration test also fails:
```
+ curl -k --verbose -X PATCH https://localhost:9000/ 2>&1
subprocess.CalledProcessError: Command '['env', '-u', 'LANGUAGE', 'LC_ALL=C', 'ssh', '-p', '2201', '-o', 'StrictHostKeyChecking=no', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'IdentitiesOnly=yes', '-o', 'BatchMode=yes', '-o', 'PKCS11Provider=none', '-o', 'LogLevel=ERROR', '-l', 'root', '127.0.0.2', '-o', 'ControlPath=/tmp/.cockpit-test-resources/ssh-%h-%p-%r-71851', 'set -e;', 'curl -k --verbose -X PATCH https://localhost:9000/ 2>&1']' returned non-zero exit status 52.
```

and that also crashes the cockpit-ws process (`m.spawn()`ed, not run from systemd) which would fail the next check.