### PR TITLE
pf5: Don't hide long dialog titles

### DIFF
--- a/pkg/lib/patternfly/patternfly-5-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-5-overrides.scss
@@ -101,6 +101,11 @@ select.pf-v5-c-form-control {
   }
 }
 
+// don't hide long dialog titles
+.pf-v5-c-modal-box__title-text {
+    white-space: normal;
+}
+
 .pf-v5-c-card {
   // https://github.com/patternfly/patternfly/issues/3959
   --pf-v5-c-card__header-toggle--MarginTop: 0;


### PR DESCRIPTION
A lot of our dialogs include parts which are not under our control (such as VM or container names), which can be long. Also, the title templates themselves may get longer in some translations.

Revert PF's `no-wrap` whitespace option (which partially hides the title in conjunction with `overflow: hidden`) to `normal`.

---

This generalizes https://github.com/cockpit-project/cockpit-machines/pull/1439 . I applied this override locally to c-machines and confirmed that it still fixes the dialogs.