### PR TITLE
bridge: Copy file permissions in fsreplace1 with expected tag

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -1081,6 +1081,10 @@ content will be replaced with a "rename" syscall when the channel is
 closed without problem code.  If the channel is closed with a problem
 code (by either client or server), the file will be left untouched.
 
+If `tag` is given, file owner and mode are preserved (copied from the
+original file). Other attributes (like ACLs or locally modified SELinux
+context) are never copied.
+
 In addition to the usual "problem" field, the "close" control message
 sent by the server might have the following additional fields:
 

--- a/pkg/systemd/overview-cards/motdCard.jsx
+++ b/pkg/systemd/overview-cards/motdCard.jsx
@@ -36,7 +36,7 @@ import './motdCard.scss';
 
 const _ = cockpit.gettext;
 
-const MotdEditDialog = ({ text }) => {
+const MotdEditDialog = ({ text, expectedTag }) => {
     const Dialogs = useDialogs();
     const [value, setValue] = useState(text);
     const [error, setError] = useState(null);
@@ -52,7 +52,7 @@ const MotdEditDialog = ({ text }) => {
                    <>
                        <Button variant='primary'
                                onClick={() => cockpit.file("/etc/motd", { superuser: "try", err: "message" })
-                                       .replace(value)
+                                       .replace(value, expectedTag)
                                        .then(Dialogs.close)
                                        .catch(exc => {
                                            setError(_("Failed to save changes in /etc/motd"));
@@ -81,15 +81,17 @@ const MotdEditDialog = ({ text }) => {
 export const MotdCard = () => {
     const Dialogs = useDialogs();
     const [motdText, setMotdText] = useState("");
+    const [motdTag, setMotdTag] = useState(null);
     const [motdVisible, setMotdVisible] = useState(false);
 
     useInit(() => {
-        cockpit.file("/etc/motd").watch(content => {
+        cockpit.file("/etc/motd").watch((content, tag) => {
             /* trim initial empty lines and trailing space, but keep initial spaces to not break ASCII art */
             if (content)
                 content = content.trimRight().replace(/^\s*\n/, '');
             if (content && content != cockpit.localStorage.getItem('dismissed-motd')) {
                 setMotdText(content);
+                setMotdTag(tag);
                 setMotdVisible(true);
             } else {
                 setMotdVisible(false);
@@ -109,7 +111,7 @@ export const MotdCard = () => {
         {superuser.allowed &&
         <Button variant="plain"
                 id="motd-box-edit"
-                onClick={() => Dialogs.show(<MotdEditDialog text={motdText} />)}
+                onClick={() => Dialogs.show(<MotdEditDialog text={motdText} expectedTag={motdTag} />)}
                 aria-label={_("Edit motd")}>
             <EditIcon />
         </Button>}

--- a/pkg/users/authorized-keys.js
+++ b/pkg/users/authorized-keys.js
@@ -114,12 +114,24 @@ function AuthorizedKeys (user_name, home_dir) {
                 });
     };
 
-    // don't use cockpit.file.modify() here, as that doesn't preserve permissions
-    // (https://github.com/cockpit-project/cockpit/issues/18033)
-    self.remove_key = key => cockpit.spawn(
-        ["sed", "-i", "\\!^" + key + "$!d", filename],
-        { superuser: "try", err: "message" }
-    );
+    self.remove_key = function(key) {
+        return file.modify(function(content) {
+            let lines = null;
+            const new_lines = [];
+
+            if (!content)
+                return "";
+
+            lines = content.trim().split('\n');
+            for (let i = 0; i < lines.length; i++) {
+                if (lines[i] === key)
+                    key = undefined;
+                else
+                    new_lines.push(lines[i]);
+            }
+            return new_lines.join("\n");
+        });
+    };
 
     self.close = function() {
         if (watch)

--- a/src/cockpit/channels/filesystem.py
+++ b/src/cockpit/channels/filesystem.py
@@ -50,7 +50,7 @@ logger = logging.getLogger(__name__)
 
 
 def tag_from_stat(buf):
-    return f'1:{buf.st_ino}-{buf.st_mtime}'
+    return f'1:{buf.st_ino}-{buf.st_mtime}-{buf.st_mode:o}-{buf.st_uid}-{buf.st_gid}'
 
 
 def tag_from_path(path):

--- a/test/pytest/test_bridge.py
+++ b/test/pytest/test_bridge.py
@@ -497,6 +497,24 @@ async def test_fsreplace1(transport: MockTransport, tmp_path: Path) -> None:
     # no leftover files
     assert os.listdir(tmp_path) == ['newfile']
 
+    # get the current tag
+    ch = await transport.check_open('fsread1', path=str(myfile))
+    transport.send_done(ch)
+    await transport.assert_data(ch, b'new new new!')
+    await transport.assert_msg('', command='done', channel=ch)
+    transport.send_close(ch)
+    close_msg = await transport.next_msg('')
+    assert close_msg['command'] == 'close'
+    tag = close_msg['tag']
+
+    # update contents with expected tag
+    ch = await transport.check_open('fsreplace1', path=str(myfile), tag=tag)
+    transport.send_data(ch, b'even newer')
+    transport.send_done(ch)
+    await transport.assert_msg('', command='done', channel=ch)
+    await transport.check_close(channel=ch)
+    assert myfile.read_bytes() == b'even newer'
+
     # write empty file
     ch = await transport.check_open('fsreplace1', path=str(myfile))
     transport.send_data(ch, b'')
@@ -511,6 +529,37 @@ async def test_fsreplace1(transport: MockTransport, tmp_path: Path) -> None:
     await transport.assert_msg('', command='done', channel=ch)
     await transport.check_close(channel=ch)
     assert not myfile.exists()
+
+
+@pytest.mark.asyncio
+async def test_fsreplace1_change_conflict(transport: MockTransport, tmp_path: Path) -> None:
+    myfile = tmp_path / 'data'
+    myfile.write_text('hello')
+
+    # get current tag from fsread1
+    ch = await transport.check_open('fsread1', path=str(myfile))
+    transport.send_done(ch)
+    await transport.assert_data(ch, b'hello')
+    await transport.assert_msg('', command='done', channel=ch)
+    transport.send_close(ch)
+    close_msg = await transport.next_msg('')
+    assert close_msg['command'] == 'close'
+    tag = close_msg['tag']
+
+    # modify the file in between read and replace operations
+    # we have to wait a bit, assuming that file systems we run tests on have at least centisecond mtime resolution
+    await asyncio.sleep(0.2)
+    myfile.write_text('goodbye')
+
+    # try to replace it, expecting the old contents (via tag)
+    ch = await transport.check_open('fsreplace1', path=str(myfile), tag=tag)
+    transport.send_data(ch, b'newcontent')
+    transport.send_done(ch)
+    await transport.assert_msg('', command='close', channel=ch, problem='change-conflict')
+    transport.send_close(ch)
+
+    # file was not touched by fsreplace1 due to conflict
+    assert myfile.read_text() == 'goodbye'
 
 
 @pytest.mark.asyncio

--- a/test/pytest/test_bridge.py
+++ b/test/pytest/test_bridge.py
@@ -498,6 +498,10 @@ async def test_fsreplace1(transport: MockTransport, tmp_path: Path) -> None:
     # no leftover files
     assert os.listdir(tmp_path) == ['newfile']
 
+    # set funny permissions to check that they are preserved
+    perms = 0o625
+    myfile.chmod(perms)
+
     # get the current tag
     ch = await transport.check_open('fsread1', path=str(myfile))
     transport.send_done(ch)
@@ -515,6 +519,9 @@ async def test_fsreplace1(transport: MockTransport, tmp_path: Path) -> None:
     await transport.assert_msg('', command='done', channel=ch)
     await transport.check_close(channel=ch)
     assert myfile.read_bytes() == b'even newer'
+
+    # preserves existing permissions when giving expected tag
+    assert stat.S_IMODE(myfile.stat().st_mode) == perms
 
     # write empty file
     ch = await transport.check_open('fsreplace1', path=str(myfile))

--- a/test/verify/check-shell-keys
+++ b/test/verify/check-shell-keys
@@ -131,7 +131,7 @@ class TestKeys(testlib.MachineCase):
         b.wait_not_in_text("#account-authorized-keys", "Invalid key")
         b.wait_js_func("ph_count_check", "#account-authorized-keys-list tr", 1)
         data = m.execute("cat /home/user/.ssh/authorized_keys")
-        self.assertEqual(data, KEY + "\n\n")
+        self.assertEqual(data, KEY + "\n")
         # Permissions are still ok
         check_perms()
         b.logout()

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -207,12 +207,14 @@ class TestSystemInfo(testlib.MachineCase):
         b = self.browser
 
         self.restore_file("/etc/motd")
+        # run this test with a tight umask to check preserving file permissions
+        self.sed_file(r"/^UMASK/ s/0../077/", "/etc/login.defs")
         m.execute("rm -f /etc/motd")
 
         self.login_and_go("/system")
         b.wait_not_present('#motd-box')
 
-        m.execute(r"printf '\n  \n  Hello\n  World\n\n' >/etc/motd")
+        m.execute(r"printf '\n  \n  Hello\n  World\n\n' >/etc/motd; chmod 644 /etc/motd")
         b.wait_visible('#motd-box')
         # strips empty lines, but not leading spaces
         b.wait_text('#motd', "  Hello\n  World")


### PR DESCRIPTION
This provides an API to stop the bridge from vandalizing permissions
with `cockpit.file.replace()`. The worst impact was with writing ssh
keys which we hacked around [1], but it hits other places like changing
/etc/motd (#19905).

When an expected tag is provided, copy owner and permissions from the
existing file. This still isn't perfect (it's e.g. missing ACLs or
customized SELinux context), but much less broken than the status quo.
Note that we can't use `shutil.copystat()` for this -- it does *not*
copy owner (which we need), but copies access/modification times (which
we don't want). The tag collision detection together with the previous
commit of inclusing permissions into the tag will ensure that the
permissions don't change in between creating, writing, and renaming the
updated file.

It is useful to retain the "atomic update" behaviour, as with all the
moving parts and networking we really don't want to produce half-written
files.

Fixes #18033

[1] https://github.com/cockpit-project/cockpit/commit/a3694802b7b2

----

To prove that this works, this PR also moves over our current two users of that API (motd and SSH authorized_keys editing).