### PR TITLE
pkg: update documentation links to rhel-9

### DIFF
--- a/pkg/kdump/manifest.json
+++ b/pkg/kdump/manifest.json
@@ -8,7 +8,7 @@
             "docs": [
                 {
                     "label": "Configuring kdump",
-                    "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_systems_using_the_rhel_8_web_console/configuring-kdump-in-the-web-console_system-management-using-the-rhel-8-web-console"
+                    "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_systems_using_the_rhel_9_web_console/configuring-kdump-in-the-web-console_system-management-using-the-rhel-9-web-console"
                 }
             ],
             "keywords": [

--- a/pkg/networkmanager/bond.jsx
+++ b/pkg/networkmanager/bond.jsx
@@ -148,7 +148,7 @@ export const BondDialog = ({ connection, dev, settings }) => {
                                           variant='link'
                                           isInline
                                           icon={<ExternalLinkSquareAltIcon />} iconPosition="right"
-                                          href="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_systems_using_the_rhel_8_web_console/configuring-network-bonds-using-the-web-console_system-management-using-the-rhel-8-web-console">
+                                          href="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_systems_using_the_rhel_9_web_console/configuring-network-bonds-using-the-web-console_system-management-using-the-rhel-9-web-console">
                                       {_("Learn more")}
                                   </Button>
                               }

--- a/pkg/networkmanager/manifest.json
+++ b/pkg/networkmanager/manifest.json
@@ -10,23 +10,23 @@
             "docs": [
                 {
                     "label": "Managing networking bonds",
-                    "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_systems_using_the_rhel_8_web_console/configuring-network-bonds-using-the-web-console_system-management-using-the-rhel-8-web-console"
+                    "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_systems_using_the_rhel_9_web_console/configuring-network-bonds-using-the-web-console_system-management-using-the-rhel-9-web-console"
                 },
                 {
                     "label": "Managing networking teams",
-                    "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_systems_using_the_rhel_8_web_console/configuring-network-teams-using-the-web-console_system-management-using-the-rhel-8-web-console"
+                    "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_systems_using_the_rhel_9_web_console/configuring-network-teams-using-the-web-console_system-management-using-the-rhel-9-web-console"
                 },
                 {
                     "label": "Managing networking bridges",
-                    "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_systems_using_the_rhel_8_web_console/configuring-network-bridges-in-the-web-console_system-management-using-the-rhel-8-web-console"
+                    "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_systems_using_the_rhel_9_web_console/configuring-network-bridges-in-the-web-console_system-management-using-the-rhel-9-web-console"
                 },
                 {
                     "label": "Managing VLANs",
-                    "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_systems_using_the_rhel_8_web_console/configuring-vlans-in-the-web-console_system-management-using-the-rhel-8-web-console"
+                    "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_systems_using_the_rhel_9_web_console/configuring-vlans-in-the-web-console_system-management-using-the-rhel-9-web-console"
                 },
                 {
                     "label": "Managing firewall",
-                    "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_systems_using_the_rhel_8_web_console/managing_firewall_using_the_web_console"
+                    "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_systems_using_the_rhel_9_web_console/managing_firewall_using_the_web_console"
                 }
             ],
             "keywords": [

--- a/pkg/packagekit/manifest.json
+++ b/pkg/packagekit/manifest.json
@@ -12,7 +12,7 @@
             "docs": [
                 {
                     "label": "Managing software updates",
-                    "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_systems_using_the_rhel_8_web_console/managing-software-updates-in-the-web-console_system-management-using-the-rhel-8-web-console"
+                    "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_systems_using_the_rhel_9_web_console/managing-software-updates-in-the-web-console_system-management-using-the-rhel-9-web-console"
                 }
             ],
             "keywords": [

--- a/pkg/storaged/manifest.json
+++ b/pkg/storaged/manifest.json
@@ -14,31 +14,31 @@
             "docs": [
                 {
                     "label": "Managing partitions",
-                    "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_systems_using_the_rhel_8_web_console/managing-partitions-using-the-web-console_system-management-using-the-rhel-8-web-console"
+                    "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_systems_using_the_rhel_9_web_console/managing-partitions-using-the-web-console_system-management-using-the-rhel-9-web-console"
                 },
                 {
                     "label": "Managing NFS mounts",
-                    "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_systems_using_the_rhel_8_web_console/managing-nfs-mounts-in-the-web-console_system-management-using-the-rhel-8-web-console"
+                    "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_systems_using_the_rhel_9_web_console/managing-nfs-mounts-in-the-web-console_system-management-using-the-rhel-9-web-console"
                 },
                 {
                     "label": "Managing RAIDs",
-                    "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_systems_using_the_rhel_8_web_console/managing-redundant-arrays-of-independent-disks-in-the-web-console_system-management-using-the-rhel-8-web-console"
+                    "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_systems_using_the_rhel_9_web_console/managing-redundant-arrays-of-independent-disks-in-the-web-console_system-management-using-the-rhel-9-web-console"
                 },
                 {
                     "label": "Managing LVMs",
-                    "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_systems_using_the_rhel_8_web_console/using-the-web-console-for-configuring-lvm-logical-volumes_system-management-using-the-rhel-8-web-console"
+		    "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_systems_using_the_rhel_9_web_console/using-the-web-console-for-configuring-lvm-logical-volumes_system-management-using-the-rhel-8-web-console"
                 },
                 {
                     "label": "Managing physical drives",
-                    "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_systems_using_the_rhel_8_web_console/using-the-web-console-for-changing-physical-drives-in-volume-groups_system-management-using-the-rhel-8-web-console"
+                    "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_systems_using_the_rhel_9_web_console/using-the-web-console-for-changing-physical-drives-in-volume-groups_system-management-using-the-rhel-8-web-console"
                 },
                 {
                     "label": "Managing VDOs",
-                    "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_systems_using_the_rhel_8_web_console/using-the-web-console-for-managing-virtual-data-optimizer-volumes_system-management-using-the-rhel-8-web-console"
+                    "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_systems_using_the_rhel_9_web_console/using-the-web-console-for-managing-virtual-data-optimizer-volumes_system-management-using-the-rhel-8-web-console"
                 },
                 {
                     "label": "Using LUKS encryption",
-                    "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_systems_using_the_rhel_8_web_console/locking-data-with-luks-password-in-the-rhel-web-console_system-management-using-the-rhel-8-web-console"
+		    "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_systems_using_the_rhel_9_web_console/locking-data-with-luks-password-in-the-rhel-web-console_system-management-using-the-rhel-9-web-console"
                 },
                 {
                     "label": "Using Tang server",

--- a/pkg/systemd/manifest.json
+++ b/pkg/systemd/manifest.json
@@ -12,7 +12,7 @@
             "docs": [
                 {
                     "label": "Configuring system settings",
-                    "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_systems_using_the_rhel_8_web_console/getting-started-with-the-rhel-8-web-console_system-management-using-the-rhel-8-web-console"
+                    "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_systems_using_the_rhel_9_web_console/getting-started-with-the-rhel-9-web-console_system-management-using-the-rhel-9-web-console"
                 }
             ],
             "keywords": [
@@ -35,7 +35,7 @@
             "docs": [
                 {
                     "label": "Managing services",
-                    "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_systems_using_the_rhel_8_web_console/managing-services-in-the-web-console_system-management-using-the-rhel-8-web-console"
+                    "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_systems_using_the_rhel_9_web_console/managing-services-in-the-web-console_system-management-using-the-rhel-9-web-console"
                 }
             ],
             "keywords": [
@@ -54,7 +54,7 @@
             "docs": [
                 {
                     "label": "Reviewing logs",
-                    "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_systems_using_the_rhel_8_web_console/reviewing-logs_system-management-using-the-rhel-8-web-console"
+                    "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_systems_using_the_rhel_9_web_console/reviewing-logs_system-management-using-the-rhel-9-web-console"
                 }
             ],
             "keywords": [

--- a/pkg/systemd/overview-cards/cryptoPolicies.jsx
+++ b/pkg/systemd/overview-cards/cryptoPolicies.jsx
@@ -115,7 +115,7 @@ const CryptoPolicyDialog = ({
                     variant='link'
                     isInline
                     icon={<ExternalLinkSquareAltIcon />} iconPosition="right"
-                    href="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/assembly_installing-a-rhel-8-system-with-fips-mode-enabled_security-hardening">
+                    href="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening">
                 {_("Learn more")}
             </Button>
         </Flex>),

--- a/pkg/users/manifest.json
+++ b/pkg/users/manifest.json
@@ -6,7 +6,7 @@
             "docs": [
                 {
                     "label": "Managing user accounts",
-                    "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_systems_using_the_rhel_8_web_console/managing-user-accounts-in-the-web-console_system-management-using-the-rhel-8-web-console"
+		    "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_systems_using_the_rhel_9_web_console/managing-user-accounts-in-the-web-console_system-management-using-the-rhel-9-web-console"
                 }
             ],
             "keywords": [


### PR DESCRIPTION
One issue: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_systems_using_the_rhel_8_web_console/configuring-automated-unlocking-using-a-tang-key-in-the-web-console_system-management-using-the-rhel-8-web-console has no equivalent in RHEL 9.