### PR TITLE
storage: Include special partition types in table rows

### DIFF
--- a/pkg/storaged/partitions/partition.jsx
+++ b/pkg/storaged/partitions/partition.jsx
@@ -79,8 +79,16 @@ export function make_partition_card(next, block) {
         grow_excuse = _("No free space after this partition");
     }
 
+    const type = block_part.Type.replace(/^0x/, "").toLowerCase();
+    let type_extra;
+    if (type == "c12a7328-f81f-11d2-ba4b-00a0c93ec93b" || type == "ef")
+        type_extra = _("EFI system partition");
+    else if (type == "21686148-6449-6e6f-744e-656564454649")
+        type_extra = _("BIOS boot partition");
+
     const card = new_card({
         title: _("Partition"),
+        type_extra,
         next,
         page_block: block,
         for_summary: true,

--- a/test/verify/check-storage-anaconda
+++ b/test/verify/check-storage-anaconda
@@ -355,7 +355,7 @@ class TestStorageAnaconda(storagelib.StorageCase):
         self.dialog({"type": "biosboot"})
 
         # Check the type and set it to something else
-        b.wait_text(self.card_row_col("Storage", 2, 3), "Unformatted data")
+        b.wait_text(self.card_row_col("Storage", 2, 3), "Unformatted data (BIOS boot partition)")
         self.click_card_row("Storage", 2)
         b.wait_text(self.card_desc("Partition", "Type"), "BIOS boot partition")
         b.click(self.card_desc_action("Partition", "Type"))
@@ -390,7 +390,7 @@ class TestStorageAnaconda(storagelib.StorageCase):
         self.dialog({"type": "efi"})
 
         # Check the type and set it to something else
-        b.wait_text(self.card_row_col("Storage", 2, 3), "vfat filesystem")
+        b.wait_text(self.card_row_col("Storage", 2, 3), "vfat filesystem (EFI system partition)")
         b.wait_text(self.card_row_col("Storage", 2, 4), "/boot/efi")
         self.click_card_row("Storage", 2)
         b.wait_visible(self.card("vfat filesystem"))


### PR DESCRIPTION
We still want to show all the details individually, and not hide that the EFI system partition is a vfat filesystem, but we want people to see the special partition types in the overview.

https://bugzilla.redhat.com/show_bug.cgi?id=2263972