### PR TITLE
base1: test that watch with read=false never reads

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -981,6 +981,8 @@ fields:
  * "type": If the event was created this contains the type of the new file.
    Will be one of: file, directory, link, special or unknown.
 
+* "tag": Blah blah blah
+
 In case of an error, the channel will be closed.  In addition to the
 usual "problem" field, the "close" control message sent by the server
 might have the following additional fields:

--- a/pkg/base1/test-file.js
+++ b/pkg/base1/test-file.js
@@ -319,10 +319,24 @@ QUnit.test("watching without reading", assert => {
             cockpit.spawn(["bash", "-c", "rm " + dir + "/foobar"]);
         } else if (n == 3) {
             assert.equal(content, null, "finally non-existent");
-            assert.equal(tag, "-", "empty tag");
+            assert.equal(tag, null, "empty tag");
             watch.remove();
             done();
         }
+    }, { read: false });
+});
+
+QUnit.test("watching without reading pre-created", async assert => {
+    const done = assert.async();
+    assert.expect(2);
+
+    // Pre-create foobar
+    const file = cockpit.file(dir + "/foobar");
+    await cockpit.spawn(["bash", "-c", `echo 1234 > ${dir}/foobar`]);
+    file.watch((content, tag) => {
+        assert.equal(content, null, "non-existant because read is false");
+        assert.equal(tag, null, "empty tag");
+        done();
     }, { read: false });
 });
 

--- a/pkg/lib/cockpit.js
+++ b/pkg/lib/cockpit.js
@@ -3673,7 +3673,10 @@ function factory() {
             ensure_watch_channel(options);
 
             watch_tag = null;
-            read();
+            if (options && options.read !== undefined && !options.read)
+                fire_watch_callbacks(null, null);
+            else
+                read();
 
             return {
                 remove: function () {


### PR DESCRIPTION
When a file already exists the initial setup of cockpit.file().watch will fsread1 the file once to obtain the file tag.