### PR TITLE
packit.yaml: add centos-10-stream

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -34,6 +34,7 @@ jobs:
       - centos-stream-8-x86_64
       - centos-stream-9-x86_64
       - centos-stream-9-aarch64
+      - centos-stream-10-x86_64
 
   # current Fedora runs reverse dependency testing against https://copr.fedorainfracloud.org/coprs/g/cockpit/main-builds/
   - job: tests


### PR DESCRIPTION
RHEL 10 has been branched so we should start testing on centos-10-stream as well.