### PR TITLE
packit.yaml: only run packit tests when no-test is not present

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -34,6 +34,10 @@ jobs:
       - centos-stream-8-x86_64
       - centos-stream-9-x86_64
       - centos-stream-9-aarch64
+    require:
+      label:
+        absent:
+          - no-test
 
   # current Fedora runs reverse dependency testing against https://copr.fedorainfracloud.org/coprs/g/cockpit/main-builds/
   - job: tests


### PR DESCRIPTION
Packit recently introduced an option to run tests based on a label being present or absent. This means the `no-test` label now also applies for testing farm tests.