### PR TITLE
systemd: Prevent insights-client crash when stdout is closed

### DIFF
--- a/pkg/systemd/overview-cards/insights-poll-hack.sh
+++ b/pkg/systemd/overview-cards/insights-poll-hack.sh
@@ -32,7 +32,9 @@ details_out_of_date ()
 
 tries=0
 while [ $tries -lt 20 ] && details_out_of_date; do
-    insights-client --check-results
+    # We let insights-client write to /dev/null so that it doesn't
+    # crash should our stdout be closed.
+    insights-client --check-results >/dev/null
     if [ $tries -lt 5 ]; then
         sleep 10
     else


### PR DESCRIPTION
Insights-client produces a long backtrace in the journal when it tries to log a warning or error to a closed stdout. This has started to hapen recently and causes our tests to fail due to the unexpected journal messages.