### PR TITLE
ws: switch the default bridge to the Python bridge

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -143,7 +143,7 @@ These should finish very quickly. It is a good practice to do this often.
 For debugging individual tests, there are compiled binaries in the build
 directory. For QUnit tests (JavaScript), you can run
 
-    ./test-server python3 -m cockpit.bridge
+    ./test-server
 
 which will output a URL to connect to with a browser, such as
 <http://localhost:8765/qunit/base1/test-dbus.html>. Adjust the path for different

--- a/src/ws/test-server.c
+++ b/src/ws/test-server.c
@@ -941,13 +941,16 @@ main (int argc,
   argv++;
 
   /* Null terminate the bridge command line */
-  bridge_argv = g_new0 (char *, argc + 2);
+  bridge_argv = g_new0 (char *, argc + 4);
   for (i = 0; i < argc; i++)
     bridge_argv[i] = argv[i];
 
   /* Default case */
-  if (i == 0)
-    bridge_argv[i] = BUILDDIR "/cockpit-bridge";
+  if (i == 0) {
+    bridge_argv[i++] = "python3";
+    bridge_argv[i++] = "-m";
+    bridge_argv[i++] = "cockpit.bridge";
+  }
 
   // Use a local ssh session command
   cockpit_ws_ssh_program = BUILDDIR "/cockpit-ssh";


### PR DESCRIPTION
Our default bridge is the Python bridge so test-server should by default use the Python bridge.