### PR TITLE
lib: drop webpack support in cockpit-po-plugin

### DIFF
--- a/pkg/Makefile.am
+++ b/pkg/Makefile.am
@@ -32,7 +32,7 @@ V_BUNDLE = $(V_BUNDLE_$(V))
 V_BUNDLE_ = $(V_BUNDLE_$(AM_DEFAULT_VERBOSITY))
 V_BUNDLE_0 = @echo "  BUNDLE   dist";
 
-# delete the stamp first; neither webpack nor esbuild touch it if the contents didn't change,
+# delete the stamp first; esbuild does not touch it if the contents didn't change,
 # but this is just a representative for all of dist/*
 $(DIST_STAMP): $(srcdir)/package-lock.json $(PKG_INPUTS)
 	@rm -f $(DIST_STAMP)

--- a/pkg/lib/README
+++ b/pkg/lib/README
@@ -1,5 +1,5 @@
 # Cockpit shared components
 
-This directory contains React components, JavaScript modules, webpack/esbuild
+This directory contains React components, JavaScript modules, esbuild
 plugins, and build tools which are shared between all Cockpit projects.
 External projects usually clone this directory into their own source tree.


### PR DESCRIPTION
We've switched over to ESBuild from Webpack one year ago and all our projects switched over as well. This was the last Webpack plugin we still had in our Git repository.

---

Let's discuss if this is the way we want to go.