### PR TITLE
Drop cockpit-appstream split

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -31,7 +31,6 @@ jobs:
       - fedora-39
       - fedora-latest-aarch64
       - fedora-development
-      - centos-stream-8-x86_64
       - centos-stream-9-x86_64
       - centos-stream-9-aarch64
 

--- a/test/README.md
+++ b/test/README.md
@@ -155,7 +155,7 @@ to push pixel tests.
 You can set these environment variables to configure the test suite:
 
     TEST_OS    The OS to run the tests in.  Currently supported values:
-                  "centos-8-stream"
+                  "centos-9-stream"
                   "debian-stable"
                   "debian-testing"
                   "fedora-38"
@@ -164,7 +164,7 @@ You can set these environment variables to configure the test suite:
                   "fedora-testing"
                   "rhel-8-10"
                   "rhel-8-10-distropkg"
-                  "rhel-9-3"
+                  "rhel-9-4"
                   "rhel4edge",
                   "ubuntu-2204"
                   "ubuntu-stable"

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -7,24 +7,6 @@ cd "$SOURCE"
 
 . /etc/os-release
 
-# on Fedora we always test all packages;
-# on RHEL/CentOS 8 we have a split package, only test basic bits for "cockpit" and optional bits for "c-appstream"
-if [ "$PLATFORM_ID" = "platform:el8" ]; then
-    if ls ../cockpit-appstream* 1> /dev/null 2>&1; then
-        if [ "$PLAN" = "basic" ] || [ "$PLAN" = "network" ]; then
-            echo "SKIP: not running basic/network tests for cockpit-appstream"
-            echo 0 > "$LOGS/exitcode"
-            exit 0
-        fi
-    else
-        if [ "$PLAN" = "optional" ]; then
-            echo "SKIP: not running optional tests for split RHEL 8 cockpit"
-            echo 0 > "$LOGS/exitcode"
-            exit 0
-        fi
-    fi
-fi
-
 # tests need cockpit's bots/ libraries
 git clone --depth=1 https://github.com/cockpit-project/bots
 

--- a/test/image-prepare
+++ b/test/image-prepare
@@ -134,76 +134,6 @@ def build_install_ostree(dist_tar, image, verbose, quick):
     return args
 
 
-def build_install_rhel8(dist_tar, image, verbose, quick):
-    """Special treatment of build/install on RHEL/CentOS 8
-
-    Here, cockpit is delivered as two mostly identical source packages: "cockpit" with
-    build_basic=1, and "cockpit-appstream" with build_optional=1. The spec has proper build_*
-    defaults depending on the Name:.
-    """
-    vm_dist_tar = os.path.join("/var/tmp", os.path.basename(dist_tar))
-
-    args = ["--upload", f"{dist_tar}:{vm_dist_tar}"]
-
-    # in distropkg, keep basic OS packages, otherwise build/install cockpit
-    if 'distropkg' not in image:
-        args += [
-            "--run-command",
-            fr"""
-                # remove already installed packages
-                if rpm -q cockpit-ws >/dev/null 2>&1; then
-                    rpm --erase --nodeps --verbose cockpit cockpit-ws cockpit-bridge cockpit-system
-                fi
-
-                # create cockpit.spec
-                tar xf '{vm_dist_tar}' -O '*/tools/cockpit.spec' | sed '/%define build_all/d' > /var/tmp/cockpit.spec
-
-                # create srpm
-                su builder -c 'rpmbuild --define "_topdir /var/tmp/build" \
-                                       --define "_sourcedir /var/tmp" \
-                                       -bs /var/tmp/cockpit.spec'
-
-                # build rpms in mock
-                su builder -c '
-                    mock --no-clean --no-cleanup-after \
-                                    --disablerepo=* \
-                                    --offline \
-                                    --resultdir /var/tmp/build \
-                                    {"--nocheck" if quick else ""} \
-                                    {"--verbose" if verbose else ""} \
-                                    --rebuild /var/tmp/build/SRPMS/*.src.rpm'
-
-                # install rpms
-                rpm -U --force --verbose $(find /var/tmp/build -name '*.rpm' -not -name '*.src.rpm')
-            """
-        ]
-
-    # always build cockpit-appstream
-    args += [
-        "--run-command",
-        fr"""
-            # create cockpit-appstream.spec
-            tar xf '{vm_dist_tar}' -O '*/tools/cockpit.spec' |
-                sed '/^Name:/ s/$/-appstream/; /%define build_all/d' > /var/tmp/cockpit-appstream.spec
-
-            # create srpm
-            su builder -c 'rpmbuild --define "_topdir /var/tmp/appstream" \
-                                    --define "_sourcedir /var/tmp" \
-                                    -bs /var/tmp/cockpit-appstream.spec'
-
-            # build rpms in mock
-            su builder -c 'mock --no-clean --disablerepo=* --offline \
-                                --resultdir /var/tmp/appstream \
-                                --nocheck {"--verbose" if verbose else ""} \
-                                --rebuild /var/tmp/appstream/SRPMS/*.src.rpm'
-
-            # install rpms
-            rpm -i --verbose $(find /var/tmp/appstream -name '*.rpm' -not -name '*.src.rpm')
-        """
-    ]
-    return args
-
-
 def validate_packages():
     """Post-install package checks"""
 
@@ -251,8 +181,6 @@ def main():
 
     if args.image in ["fedora-coreos", "rhel4edge"]:
         customize += build_install_ostree(dist_tar, args.image, args.verbose, args.quick)
-    elif args.image.startswith("rhel-8") or args.image.startswith("centos-8"):
-        customize += build_install_rhel8(dist_tar, args.image, args.verbose, args.quick)
     else:
         customize += build_install_package(dist_tar, args.image)
 


### PR DESCRIPTION
This was only a thing on RHEL 8, which we don't support on this branch any more.