### PR TITLE
storage: Scroll dialog fields into view as needed

### DIFF
--- a/pkg/storaged/block/format-dialog.jsx
+++ b/pkg/storaged/block/format-dialog.jsx
@@ -392,6 +392,9 @@ function format_dialog_internal(client, path, start, size, enable_dos_extended, 
                 }
                 if (vals.type == "efi" && !vals.mount_point)
                     dlg.set_values({ mount_point: "/boot/efi" });
+            } else if (trigger == "crypto") {
+                if (vals.crypto != "none" && vals.crypto != " keep")
+                    dlg.show_field("crypto_options");
             }
         },
         Action: {

--- a/pkg/storaged/dialog.jsx
+++ b/pkg/storaged/dialog.jsx
@@ -528,7 +528,16 @@ export const dialog_open = (def) => {
                 return null;
         })).then(results => {
             const errors = { };
-            fields.forEach((f, i) => { if (results[i]) errors[f.tag] = results[i]; });
+            let scrolled = false;
+            fields.forEach((f, i) => {
+                if (results[i]) {
+                    if (!scrolled) {
+                        show_field(f.tag);
+                        scrolled = true;
+                    }
+                    errors[f.tag] = results[i];
+                }
+            });
             if (Object.keys(errors).length > 0)
                 return Promise.reject(errors);
             return validated_values;
@@ -536,6 +545,18 @@ export const dialog_open = (def) => {
     };
 
     const dlg = show_modal_dialog(props(), footer_props(null, null));
+
+    function show_field(tag) {
+        function scroll() {
+            const field_element = document.querySelector('#dialog [data-field="' + tag + '"]');
+            if (field_element)
+                field_element.scrollIntoView({ behavior: "smooth", block: "nearest" });
+        }
+        // By the time show_field is called from the "update"
+        // callback, newly visible fields don't exist yet in the
+        // DOM, so delay the scrolling a bit.
+        window.setTimeout(scroll, 10);
+    }
 
     const self = {
         run: (title, promise) => {
@@ -608,6 +629,8 @@ export const dialog_open = (def) => {
             def.Action.DangerButton = true;
             update_footer();
         },
+
+        show_field,
 
         close: () => {
             dlg.footerProps.dialog_done();


### PR DESCRIPTION
When fields fail validation, the first of them is scrolled into view. Additionally, when the encryption fields of the Format dialog are revealed, they are scrolled into view.

https://bugzilla.redhat.com/show_bug.cgi?id=2264540

Demo: https://www.youtube.com/watch?v=POn3lDoPJOc