### PR TITLE
storage: Announce new pages with an alert if necessary

### DIFF
--- a/pkg/storaged/alerts.jsx
+++ b/pkg/storaged/alerts.jsx
@@ -1,0 +1,68 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import { AlertGroup, Alert, AlertActionCloseButton } from "@patternfly/react-core/dist/esm/components/Alert/index.js";
+
+import { useEvent } from "hooks.js";
+
+class GlobalAlerts extends EventTarget {
+    constructor() {
+        super();
+        this.alerts = [];
+    }
+
+    emit_changed() {
+        this.dispatchEvent(new CustomEvent("changed"));
+    }
+
+    add_alert(props) {
+        this.alerts.push(props);
+        this.emit_changed();
+    }
+
+    filter_alerts(pred) {
+        const prev_length = this.alerts.length;
+        this.alerts = this.alerts.filter(pred);
+        if (this.alerts.length != prev_length)
+            this.emit_changed();
+    }
+
+    remove_alert(a) {
+        this.filter_alerts(b => b !== a);
+    }
+}
+
+export const global_alerts = new GlobalAlerts();
+
+export const GlobalAlertGroup = () => {
+    useEvent(global_alerts, "changed");
+
+    return (
+        <AlertGroup isToast isLiveRegion>
+            {global_alerts.alerts.map(a =>
+                <Alert key={a.title}
+                       variant={a.variant}
+                       title={a.title}
+                       actionClose={<AlertActionCloseButton onClose={() => global_alerts.remove_alert(a)} />}>
+                    {a.body}
+                </Alert>)
+            }
+        </AlertGroup>);
+};

--- a/pkg/storaged/btrfs/subvolume.jsx
+++ b/pkg/storaged/btrfs/subvolume.jsx
@@ -23,7 +23,9 @@ import React from "react";
 import { CardBody } from "@patternfly/react-core/dist/esm/components/Card/index.js";
 import { DescriptionList } from "@patternfly/react-core/dist/esm/components/DescriptionList/index.js";
 
-import { StorageCard, StorageDescription, new_card, new_page, navigate_away_from_card } from "../pages.jsx";
+import {
+    StorageCard, StorageDescription, new_card, new_page, navigate_away_from_card, announce_new_page
+} from "../pages.jsx";
 import { StorageUsageBar } from "../storage-controls.jsx";
 import {
     encode_filename, get_fstab_config_with_client, reload_systemd, extract_option, parse_options,
@@ -169,6 +171,9 @@ function subvolume_create(volume, subvol, parent_dir) {
                 if (vals.mount_point !== "") {
                     await set_mount_options(subvol, block, vals);
                 }
+                const new_name = subvol.pathname == "/" ? vals.name : subvol.pathname + "/" + vals.name;
+                announce_new_page(cockpit.format(_("Subvolume $0 has been created."), new_name),
+                                  ["btrfs", volume.data.uuid, new_name]);
             }
         }
     });

--- a/pkg/storaged/lvm2/volume-group.jsx
+++ b/pkg/storaged/lvm2/volume-group.jsx
@@ -32,7 +32,7 @@ import { StorageButton, StorageLink } from "../storage-controls.jsx";
 import {
     StorageCard, StorageDescription, ChildrenTable, PageTable,
     new_page, new_card, get_crossrefs, PAGE_CATEGORY_VIRTUAL,
-    navigate_to_new_card_location, navigate_away_from_card
+    navigate_to_new_card_location, navigate_away_from_card, announce_new_page,
 } from "../pages.jsx";
 import {
     fmt_size_long, get_active_usage, teardown_active_usage, for_each_async,
@@ -110,6 +110,8 @@ function vgroup_delete(client, vgroup, card) {
 }
 
 function create_snapshot(lvol) {
+    const vgroup = lvol && client.vgroups[lvol.VolumeGroup];
+
     dialog_open({
         Title: _("Create snapshot"),
         Fields: [
@@ -118,8 +120,9 @@ function create_snapshot(lvol) {
         ],
         Action: {
             Title: _("Create"),
-            action: function (vals) {
-                return lvol.CreateSnapshot(vals.name, vals.size || 0, { });
+            action: async function (vals) {
+                await lvol.CreateSnapshot(vals.name, vals.size || 0, { });
+                announce_new_page(_("Snapshot has been created"), ["vg", vgroup.Name, vals.name]);
             }
         }
     });

--- a/pkg/storaged/storaged.jsx
+++ b/pkg/storaged/storaged.jsx
@@ -31,7 +31,7 @@ import { PlotState } from "plot.js";
 
 import client from "./client";
 import { update_plot_state } from "./plot.jsx";
-import { StoragePage } from "./pages.jsx";
+import { StoragePage, cleanup_new_page_alerts } from "./pages.jsx";
 
 import "./storage.scss";
 
@@ -43,7 +43,10 @@ class Application extends React.Component {
         this.state = { inited: false, slow_init: false, path: cockpit.location.path };
         this.plot_state = new PlotState();
         this.on_client_changed = () => { if (!client.busy) this.setState({}); };
-        this.on_navigate = () => { this.setState({ path: cockpit.location.path }) };
+        this.on_navigate = () => {
+            cleanup_new_page_alerts(cockpit.location.path);
+            this.setState({ path: cockpit.location.path });
+        };
     }
 
     componentDidMount() {

--- a/test/verify/check-storage-btrfs
+++ b/test/verify/check-storage-btrfs
@@ -254,6 +254,60 @@ class TestStorageBtrfs(storagelib.StorageCase):
         subvol_loc = f"{os.path.basename(ro_subvol)}/readonly"
         self.check_dropdown_action_disabled(self.card_row("Storage", name=subvol_loc), "Create subvolume", "Subvolume needs to be mounted")
 
+    def testCreationAlert(self):
+        m = self.machine
+        b = self.browser
+
+        disk1 = self.add_ram_disk(size=140)
+        label = "test_subvol"
+        mount_point = "/run/butter"
+
+        m.execute(f"mkfs.btrfs -L {label} {disk1}")
+        self.login_and_go("/storage")
+
+        # creation of btrfs filesystems can take a while on TF.
+        with b.wait_timeout(30):
+            b.wait_visible(self.card_row("Storage", name=disk1))
+
+        # Create a new subvolume while only the "/" subvolume is
+        # visible. This should cause an alert to pop up.
+
+        self.click_card_row("Storage", name=disk1)
+        self.click_card_row("btrfs filesystem", name="/")
+        b.click(self.card_button("btrfs subvolume", "Mount"))
+        self.dialog({"mount_point": mount_point})
+
+        b.click(self.card_button("btrfs subvolume", "Create subvolume"))
+        self.dialog({"name": "cake"}, secondary=True)
+        b.wait_in_text(".pf-v5-c-alert.pf-m-success", "Subvolume cake has been created")
+
+        # Dismiss alert explicitly
+        b.click(".pf-v5-c-alert.pf-m-success .pf-v5-c-alert__action button")
+        b.wait_not_present(".pf-v5-c-alert.pf-m-success")
+
+        b.click(self.card_button("btrfs subvolume", "Create subvolume"))
+        self.dialog({"name": "cake2"}, secondary=True)
+        b.wait_in_text(".pf-v5-c-alert.pf-m-success", "Subvolume cake2 has been created")
+
+        # Follow link, alert should be dismissed automatically
+        b.click(".pf-v5-c-alert.pf-m-success button:contains(Show)")
+        b.wait_text(self.card_desc("btrfs subvolume", "Name"), "cake2")
+        b.wait_not_present(".pf-v5-c-alert.pf-m-success")
+
+        # Back to root subvolume, and once more
+        b.click(self.card_parent_link())
+        self.click_card_row("btrfs filesystem", name="/")
+
+        b.click(self.card_button("btrfs subvolume", "Create subvolume"))
+        self.dialog({"name": "cake3"}, secondary=True)
+        b.wait_in_text(".pf-v5-c-alert.pf-m-success", "Subvolume cake3 has been created")
+
+        # Navigate to page with list of all subvolumes, alert should
+        # be dismissed automatically.
+        b.click(self.card_parent_link())
+        b.wait_visible(self.card("btrfs filesystem"))
+        b.wait_not_present(".pf-v5-c-alert.pf-m-success")
+
     def testDeleteSubvolume(self):
         m = self.machine
         b = self.browser


### PR DESCRIPTION
Often, after creating a new storage object such as a partition, that new object immediately appears on the current page in some list, and a it is even highlighted with a small animation.

However, there are also situations where the new object will not appear on the current page. For example, creating a LVM2 snapshot from the details page a logical volume does not show immediately show the snapshot (since logical volumes don't list their snapshots).

To reduce confusion, we now show an alert in these situations with a link to the page of the new object. The alert goes away automatically when the user navigates to the new page, or to one of its parents.

Demo: https://www.youtube.com/watch?v=HLOgBm6qH5Y
