### PR TITLE
storage: Allow removing of fstab entries

### DIFF
--- a/pkg/storaged/filesystem/mounting-dialog.jsx
+++ b/pkg/storaged/filesystem/mounting-dialog.jsx
@@ -250,7 +250,7 @@ export function mounting_dialog(client, block, mode, forced_options, subvol) {
                                                                 block,
                                                                 client.add_mount_point_prefix(val),
                                                                 mode == "update" && !is_filesystem_mounted,
-                                                                true,
+                                                                mode == "update",
                                                                 subvol)
                       }),
             mount_options(opt_ro, extra_options),

--- a/pkg/storaged/filesystem/utils.jsx
+++ b/pkg/storaged/filesystem/utils.jsx
@@ -109,9 +109,9 @@ function find_blocks_for_mount_point(client, mount_point, self_block, self_subvo
     return blocks;
 }
 
-export function is_valid_mount_point(client, block, val, format_only, for_fstab, subvol) {
+export function is_valid_mount_point(client, block, val, will_not_mount, allow_empty, subvol) {
     if (val === "") {
-        if (!format_only || for_fstab)
+        if (!will_not_mount && !allow_empty)
             return _("Mount point cannot be empty");
         return null;
     }
@@ -120,7 +120,7 @@ export function is_valid_mount_point(client, block, val, format_only, for_fstab,
     if (other_blocks.length > 0)
         return cockpit.format(_("Mount point is already used for $0"), other_blocks.join(", "));
 
-    if (!format_only) {
+    if (!will_not_mount) {
         const children = find_children_for_mount_point(client, val, block);
         if (Object.keys(children).length > 0)
             return <>

--- a/test/verify/check-storage-anaconda
+++ b/test/verify/check-storage-anaconda
@@ -93,10 +93,6 @@ class TestStorageAnaconda(storagelib.StorageCase):
         self.click_dropdown(self.card_row("Storage", name="lvol0"), "Edit mount point")
         self.dialog_wait_open()
         self.dialog_wait_val("mount_point", "/")
-        # Empty mount point should be failure
-        self.dialog_set_val("mount_point", "")
-        self.dialog_apply()
-        self.dialog_wait_error("mount_point", "Mount point cannot be empty")
         self.dialog_set_val("mount_point", "/var")
         self.dialog_apply()
         self.dialog_wait_close()

--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -112,7 +112,14 @@ ExecStart=/usr/bin/sleep infinity
         b.wait_in_text(self.card_desc(filesystem, "Mount point"), mount_point_bar)
 
         b.click(self.card_button(filesystem, "Mount"))
-        self.confirm()
+        self.dialog_wait_open()
+        self.dialog_wait_val("mount_point", mount_point_bar)
+        self.dialog_set_val("mount_point", "")
+        self.dialog_apply()
+        self.dialog_wait_error("mount_point", "Mount point cannot be empty")
+        self.dialog_set_val("mount_point", mount_point_bar)
+        self.dialog_apply()
+        self.dialog_wait_close()
         b.wait_not_in_text(self.card_desc(filesystem, "Mount point"), "The filesystem is not mounted")
 
         # Set the "Never unlock at boot option"
@@ -149,6 +156,14 @@ ExecStart=/usr/bin/sleep infinity
 
         self.click_card_row("Storage", location=mount_point_bar)
         b.wait_in_text(self.card_desc("Solid State Drive", "Serial number"), "8000")  # scsi_debug serial
+
+        # Remove fstab entry
+
+        b.click(self.card_desc(filesystem, "Mount point") + " button")
+        self.dialog(expect={"mount_point": mount_point_bar},
+                    values={"mount_point": ""})
+        self.assertEqual(self.configuration_field("/dev/sda", "fstab", "dir"), "")
+        b.wait_in_text(self.card_desc(filesystem, "Mount point"), "The filesystem has no permanent mount point.")
 
     @testlib.skipImage('no btrfs support', 'rhel-*', 'centos-*')
     def testMountingHelpBtrfs(self):


### PR DESCRIPTION
By giving a empty mount point to the "Mount configuration" dialog.

The code was already all there, we just have to allow the empty string in the input field.