### PR TITLE
storage: Rename "Name" field to "Filesystem label" and move it down

### DIFF
--- a/pkg/storaged/block/format-dialog.jsx
+++ b/pkg/storaged/block/format-dialog.jsx
@@ -343,12 +343,6 @@ function format_dialog_internal(client, path, start, size, enable_dos_extended, 
         Title: title,
         Teardown: TeardownMessage(usage),
         Fields: [
-            TextInput("name", _("Name"),
-                      {
-                          value: content_block?.IdLabel,
-                          validate: (name, vals) => validate_fsys_label(name, vals.type),
-                          visible: is_filesystem
-                      }),
             TextInput("mount_point", _("Mount point"),
                       {
                           visible: is_filesystem,
@@ -374,6 +368,12 @@ function format_dialog_internal(client, path, start, size, enable_dos_extended, 
                                return create_partition;
                            }
                        }),
+            TextInput("name", _("Filesystem label"),
+                      {
+                          value: content_block?.IdLabel,
+                          validate: (name, vals) => validate_fsys_label(name, vals.type),
+                          visible: is_filesystem
+                      }),
             CheckBoxes("erase", _("Overwrite"),
                        {
                            fields: [


### PR DESCRIPTION
Both partitions and filesystems can have "names", and people don't know that this field is for when creating a partition.  Also, giving a filesystem a label is optional and not very important, so having it at the top makes it seem more important than it is.

https://bugzilla.redhat.com/show_bug.cgi?id=2264540 
https://github.com/cockpit-project/cockpit/issues/19170