### PR TITLE
test: ignore usage bar in lvm pixel tests

### DIFF
--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -236,7 +236,9 @@ class TestStorageLvm2(storagelib.StorageCase):
         b.click(self.card_parent_link())
         b.wait_text(self.card_row_col("Thinly provisioned LVM2 logical volumes", 1, 3), mount_point_thin)
 
-        b.assert_pixels('body', "pool-page")
+        # prevent unstable usage numbers from failing the pixel test
+        b.assert_pixels('body', "pool-page", mock={".usage-text": "1 / 100 MB"},
+                        ignore=[".usage-bar"])
 
         # remove pool
         self.click_card_dropdown("Pool for thinly provisioned LVM2 logical volumes", "Delete")


### PR DESCRIPTION
The TestStorageLvm2.testLvm pool page pixel test flakes due to not waiting on sizes to "settle". Instead of waiting on a hardcoded value mock the values so in the future we won't have issues when a thin pool is allocated bigger or smaller by default.

Closes: #20053

---

Pixel changes https://cockpit-logs.us-east-1.linodeobjects.com/pull-20068-20240221-104351-68c22789-fedora-39-storage/log.html