### PR TITLE
workflows: Move weblate-sync-pot.yml to cockpit/tasks container

### DIFF
--- a/.github/workflows/weblate-sync-pot.yml
+++ b/.github/workflows/weblate-sync-pot.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     container:
-      image: ghcr.io/cockpit-project/unit-tests
+      image: quay.io/cockpit/tasks
       options: --user root
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
This was forgotten in commit f16f1fc14b88c

---

Fixes last night's [weblate-sync-pot failure](https://github.com/cockpit-project/cockpit/actions/runs/7998726367). I'll trigger a run from this branch.