### PR TITLE
storage: Show stopped mdraids in Anaconda mode

### DIFF
--- a/pkg/storaged/mdraid/mdraid.jsx
+++ b/pkg/storaged/mdraid/mdraid.jsx
@@ -182,10 +182,7 @@ function missing_bitmap(mdraid) {
 export function make_mdraid_page(parent, mdraid) {
     const block = client.mdraids_block[mdraid.path];
 
-    if (block && should_ignore(client, block.path))
-        return;
-
-    if (!block && client.in_anaconda_mode())
+    if (should_ignore(client, mdraid.path))
         return;
 
     let add_excuse = false;

--- a/pkg/storaged/pages.jsx
+++ b/pkg/storaged/pages.jsx
@@ -272,7 +272,12 @@ export function get_crossrefs(key) {
  */
 
 const NotFoundCard = ({ card }) => {
-    return <span>{_("Not found")}</span>;
+    return (
+        <StorageCard card={card}>
+            <CardBody>
+                {_("Not found")}
+            </CardBody>
+        </StorageCard>);
 };
 
 const not_found_page = new_page(null, new_card({ page_name: _("Not found"), component: NotFoundCard }));

--- a/pkg/storaged/utils.js
+++ b/pkg/storaged/utils.js
@@ -632,19 +632,20 @@ function get_parent(client, path) {
 }
 
 function get_direct_parent_blocks(client, path) {
-    let parent = get_parent(client, path);
-    if (!parent)
+    if (client.blocks[path])
+        path = get_parent(client, path);
+    if (!path)
         return [];
-    if (client.blocks[parent])
-        return [parent];
-    if (client.mdraids[parent])
-        return client.mdraids_members[parent].map(function (m) { return m.path });
-    if (client.lvols[parent])
-        parent = client.lvols[parent].VolumeGroup;
-    if (client.vgroups[parent])
-        return client.vgroups_pvols[parent].map(function (pv) { return pv.path });
-    if (client.stratis_pools[parent])
-        return client.stratis_pool_blockdevs[parent].map(bd => client.slashdevs_block[bd.Devnode].path);
+    if (client.blocks[path])
+        return [path];
+    if (client.mdraids[path])
+        return client.mdraids_members[path].map(function (m) { return m.path });
+    if (client.lvols[path])
+        path = client.lvols[path].VolumeGroup;
+    if (client.vgroups[path])
+        return client.vgroups_pvols[path].map(function (pv) { return pv.path });
+    if (client.stratis_pools[path])
+        return client.stratis_pool_blockdevs[path].map(bd => client.slashdevs_block[bd.Devnode].path);
     return [];
 }
 

--- a/test/verify/check-storage-anaconda
+++ b/test/verify/check-storage-anaconda
@@ -482,6 +482,68 @@ class TestStorageAnaconda(storagelib.StorageCase):
 
         self.expectExportedDevice(disk, {"type": "swap"})
 
+    def testMDRaid(self):
+        b = self.browser
+
+        disk1 = self.add_loopback_disk(name="loop10")
+        disk2 = self.add_loopback_disk(name="loop11")
+
+        anaconda_config = {
+            "mount_point_prefix": "/sysroot",
+            "available_devices": [disk1, disk2],
+        }
+
+        self.login_and_go("/storage")
+        self.enterAnacondaMode(anaconda_config)
+
+        # Create a mirrored MDRAID
+        self.click_devices_dropdown("Create MDRAID device")
+        self.dialog_wait_open()
+        b.wait(lambda: b.call_js_func('ph_count', "#dialog .select-space-name") == 2)
+        self.dialog_wait_val("name", "raid0")
+        self.dialog_set_val("level", "raid1")
+        self.dialog_set_val("disks", {disk1: True, disk2: True})
+        self.dialog_apply()
+        self.dialog_wait_close()
+
+        # Create a partition with a filesystem on it
+        self.click_dropdown(self.card_row("Storage", name="md/raid0"), "Create partition table")
+        self.confirm()
+        b.wait_text(self.card_row_col("Storage", 4, 2), "Free space")
+        self.click_dropdown(self.card_row("Storage", 4), "Create partition")
+        self.dialog({})
+
+        # Stop the MDRAID, it should still be shown
+        self.click_card_row("Storage", name="md/raid0")
+        b.wait_visible(self.card("GPT partitions"))
+        b.click(self.card_button("MDRAID device", "Stop"))
+        self.confirm()
+        b.wait_not_present(self.card("GPT partitions"))
+        b.wait_visible(self.card("MDRAID device"))
+
+        b.click(self.card_parent_link())
+        b.wait_visible(self.card_row("Storage", name="raid0"))
+
+        # Now remove disk2 from "available_devices". This should hide the mdraid.
+
+        anaconda_config = {
+            "mount_point_prefix": "/sysroot",
+            "available_devices": [disk1],
+        }
+
+        self.enterAnacondaMode(anaconda_config)
+
+        b.wait_visible(self.card("Storage"))
+        b.wait_not_present(self.card_row("Storage", name="raid0"))
+        b.wait_not_present(self.card_row("Storage", name="md/raid0"))
+
+        # But it is still reachable via disk1.  This leads to a "Not
+        # found" page.
+
+        self.click_card_row("Storage", name=disk1)
+        b.click(self.card_desc("MDRAID disk", "MDRAID device") + " button")
+        b.wait_in_text("body", "Not found")
+
 
 if __name__ == '__main__':
     testlib.test_main()


### PR DESCRIPTION
They were probably hidden earlier because there was no easy way to
enumerate their members without a block device for the mdraid
itself. But we can pretty easily make the should_ignore function work
with the o.fd.UDisks2.MDRaid path directly.
    
https://bugzilla.redhat.com/show_bug.cgi?id=2265241
