### PR TITLE
test: btrfs: umount in a busy loop

### DIFF
--- a/test/verify/check-storage-btrfs
+++ b/test/verify/check-storage-btrfs
@@ -494,7 +494,7 @@ class TestStorageBtrfs(storagelib.StorageCase):
             mount {disk1} {mount_point}
             btrfs subvolume create {subvol_path}
             btrfs subvolume set-default {subvol_path}
-            umount {mount_point}
+            while mountpoint -q {mount_point} && ! umount {mount_point}; do sleep 0.2; done;
             mount {disk1} {mount_point}
         """)
 


### PR DESCRIPTION
On debian-stable in CI tests can fail with `umount: /mnt: target is busy` presumbly btrfs is still "busy" creating a subvolume so waiting is required.