### PR TITLE
test: Clean up "closing" sessions before polling them

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1602,7 +1602,7 @@ class MachineCase(unittest.TestCase):
                     m.execute(f"while loginctl show-session {s}; do sleep 0.2; done", timeout=30)
                 except RuntimeError:
                     # show the status in debug logs, to see what's wrong
-                    m.execute(f"loginctl session-status {s} >&2")
+                    m.execute(f"loginctl session-status {s}; systemd-cgls", stdout=None)
                     raise
 
             # terminate all systemd user services for users who are not logged in


### PR DESCRIPTION
After our round of {kill,terminate}-session, logind sessions often end
up in "closing" state, and neither their leader process nor their cgroup
actually exist any more. To avoid error messages and timeouts in the
following poll/wait loop, restart logind to mop up these closing
sessions.

Note that we still keep the other restart after stopping user@*
services, as that may again cause orphaned sessions.

Fixes #19972

-----

See #19972 for the debugging notes. I tested this in https://github.com/cockpit-project/cockpit-podman/pull/1582 with 6 parallel 3x affected runs, and it *never* failed session cleanup.