### PR TITLE
build: Force `pip install` to not check for already installed module

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -26,7 +26,8 @@ install-python:
 	@# wheel-based installation with .dist-info.
 	@# This needs to work on RHEL8 up through modern Fedora, offline, with
 	@# system packages available to the build.
-	python3 -m pip install --no-index --force-reinstall --root='$(DESTDIR)/' --prefix='$(prefix)' \
+	@# See https://github.com/pypa/pip/issues/3063 for --ignore-installed
+	python3 -m pip install --no-index --force-reinstall --ignore-installed --root='$(DESTDIR)/' --prefix='$(prefix)' \
 		"$$(python3 '$(srcdir)'/src/build_backend.py --wheel '$(srcdir)' tmp/wheel)"
 	mkdir -p $(DESTDIR)$(libexecdir)
 	mv -t $(DESTDIR)$(libexecdir) $(DESTDIR)$(bindir)/cockpit-askpass


### PR DESCRIPTION
This previously broke distro package builds when they happened with the `cockpit-bridge` package installed:

```
Processing ./tmp/wheel/cockpit-0-py3-none-any.whl
Installing collected packages: cockpit
  Attempting uninstall: cockpit
    Found existing installation: cockpit 311
ERROR: Cannot uninstall cockpit 311, RECORD file not found. Hint: The package was installed by debian.
```

This is a `pip` bug (https://github.com/pypa/pip/issues/3063), work around it with `--ignore-installed`.

----

See https://github.com/cockpit-project/cockpit/issues/19343#issuecomment-1965154956 ff. for how this failed. I verified that this works fine now.