### PR TITLE
test: Wait longer for deletion of LVM2 raid volumes

### DIFF
--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -584,7 +584,8 @@ class TestStorageLvm2(storagelib.StorageCase):
             b.wait_in_text(self.card_desc("LVM2 logical volume", "Size"), mb(expected_size))
 
             self.click_card_dropdown("LVM2 logical volume", "Delete")
-            self.confirm()
+            with b.wait_timeout(60):
+                self.confirm()
             b.wait_visible(self.card("LVM2 logical volumes"))
             b.wait_not_present(self.card_row("LVM2 logical volumes", name="lvol0"))
 
@@ -679,7 +680,8 @@ class TestStorageLvm2(storagelib.StorageCase):
             b.wait_in_text(self.card_desc("LVM2 logical volume", "Size"), mb(expected_size))
 
             self.click_card_dropdown("LVM2 logical volume", "Delete")
-            self.confirm()
+            with b.wait_timeout(60):
+                self.confirm()
             b.wait_visible(self.card("LVM2 logical volumes"))
             b.wait_not_present(self.card_row("LVM2 logical volumes", name="lvol0"))
 


### PR DESCRIPTION
We see frquent timeouts here in TF. Let's hope the test is just slow in TF and doesn't hang completely.