### PR TITLE
users: log exceptions for obtaining locked status

### DIFF
--- a/pkg/users/utils.js
+++ b/pkg/users/utils.js
@@ -7,4 +7,8 @@ export const get_locked = name =>
                 // libuser uses "LK", shadow-utils use "L".
                 return status == "LK" || status == "L";
             })
-            .catch(() => null);
+            .catch(exc => {
+                if (exc.problem !== "access-denied") {
+                    console.warn(`Failed to obtain account lock information for ${name}`, exc);
+                }
+            });


### PR DESCRIPTION
This doesn't fix anything but might might help uncover our TestAccounts.testBasic flake where the locked checkbox is shown as null instead of unchecked.