### PR TITLE
lib: remove PatternFly workaround for DataList's

### DIFF
--- a/pkg/lib/esbuild-common.js
+++ b/pkg/lib/esbuild-common.js
@@ -18,13 +18,6 @@ export const esbuildStylesPlugins = [
             '1450px': '1100px',
         }
     }),
-    replace({
-        include: /DataList.js$/,
-        values: {
-            'import stylesGrid': "// HACK: revert when https://github.com/patternfly/patternfly-react/pull/8864 is released",
-            stylesGrid: 'styles',
-        }
-    }),
     sassPlugin({
         loadPaths: [...nodePaths, 'node_modules'],
         quietDeps: true,


### PR DESCRIPTION
A fix has been comitted to PatternFly react one year ago.

https://github.com/patternfly/patternfly-react/pull/8864