### PR TITLE
test: drop packagekit 1.2.4 version check

### DIFF
--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -49,11 +49,8 @@ class TestUpdates(NoSubManCase):
     def setUp(self):
         super().setUp()
 
-        pkcon_version = self.machine.execute("pkcon --version").strip()
-
-        # only the PackageKit ≥ 1.2.4 dnf (https://github.com/PackageKit/PackageKit/issues/268) backends
-        # properly recognize "enhancement" severity; apt does not have that metadata
-        self.supports_severity = not (self.backend == "apt" or pkcon_version < "1.2.4")
+        # apt does not support severity enhancement metadata
+        self.supports_severity = self.backend != "apt"
 
         if self.supports_severity:
             self.enhancement_severity = "enhancement"


### PR DESCRIPTION
Debian-stable / RHEL-9-4 has packagekit 1.2.6, RHEL-8-10 has 1.4.2. So nothing in CI should still require this check.