### PR TITLE
test: allow direct rendering to body warnings

### DIFF
--- a/test/common/chromium-cdp-driver.js
+++ b/test/common/chromium-cdp-driver.js
@@ -108,10 +108,6 @@ function setupLogging(client) {
         if (details.exception && details.exception.className === "PhWaitCondTimeout")
             return;
 
-        // HACK: https://github.com/cockpit-project/cockpit/issues/14871
-        if (details.description && details.description.indexOf("Rendering components directly into document.body is discouraged") > -1)
-            return;
-
         process.stderr.write(details.description || JSON.stringify(details) + "\n");
 
         unhandledExceptions.push(details.exception.message ||


### PR DESCRIPTION
React discourages rendering directly to `document.body` as its children might be manipulated by other third-party scripts. We used to render to body directly in machines, but currently this is no longer true and all our pages should also render to a <div> inside <body>.