### PR TITLE
test: deal with udisks missing udev events

### DIFF
--- a/test/verify/check-storage-unrecognized
+++ b/test/verify/check-storage-unrecognized
@@ -52,6 +52,8 @@ AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
 """
         m.execute(f"base64 -d >{disk}", input=data)
+        # Wait for udev to settle and re-trigger, udisks sometimes misses udev events on ubuntu 2204.
+        m.execute("udevadm settle; udevadm trigger /dev/sda")
 
         b.wait_text(self.card_desc("Unrecognized data", "Usage"), "other")
         b.wait_text(self.card_desc("Unrecognized data", "Type"), "vdo")


### PR DESCRIPTION
On Ubuntu 2204 this test flakes as udisks misses udev events about the write. As we don't really want to test udisks here but if our UI shows the right thing, workaround the race condition.

---

Turns out this is really hard to reproduce, but I can after a while by running three tests 50 times in a loop.