### PR TITLE
fix flaky TestJournal.testBasic test

### DIFF
--- a/test/verify/check-system-journal
+++ b/test/verify/check-system-journal
@@ -222,6 +222,12 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         wait_log_present("JUST ERROR")
         wait_log_present("THE SERVICE")
 
+        # test: reload journals page to update identifiers
+        # Workaround the issue that identifiers are not updated when changing the priority log level in the logs page.
+        # See https://github.com/cockpit-project/cockpit/issues/20123
+        b.reload()
+        b.enter_page("/system/logs")
+
         self.browser.select_PF4("#journal-prio-menu", "Error and above")
         wait_log_not_present("THE SERVICE")
         wait_log_present("JUST ERROR")


### PR DESCRIPTION
add workaround into test to avoid test is sometimes failing, because of created issue and some race condition with journal logging, as it is very async.

https://github.com/cockpit-project/cockpit/issues/20123