### PR TITLE
appstream: Fix launchable for Networking

### DIFF
--- a/src/appstream/org.cockpit-project.cockpit-networkmanager.metainfo.xml.in
+++ b/src/appstream/org.cockpit-project.cockpit-networkmanager.metainfo.xml.in
@@ -9,11 +9,11 @@
     	This tool manages networking such as bonds, bridges, teams, VLANs
     	and firewalls using NetworkManager and Firewalld.
         NetworkManager is incompatible with Ubuntu's default systemd-networkd and
-	Debian's ifupdown scripts. 
+	Debian's ifupdown scripts.
     </p>
   </description>
   <extends>org.cockpit_project.cockpit</extends>
-  <launchable type="cockpit-manifest">networkmanager</launchable>
+  <launchable type="cockpit-manifest">network</launchable>
   <url type="homepage">https://cockpit-project.org/</url>
   <update_contact>cockpit-devel_AT_lists.fedorahosted.org</update_contact>
 </component>


### PR DESCRIPTION
While it is pkg/networkmanager, its manifest declares its name to be "network". Fixes the link on the Apps page.

Fixes #20127

---

I verified that the other files are correct.