### PR TITLE
logs: Do not use duplicate object to keep state

### DIFF
--- a/pkg/systemd/logs.jsx
+++ b/pkg/systemd/logs.jsx
@@ -274,6 +274,7 @@ export const LogsPage = () => {
                          id="journal-box">
                 <JournalBox dataFollowing={dataFollowing}
                             defaultSince={timeFilter ? timeFilter.value : getTimeFilterOption({}).value}
+                            currentIdentifiers={currentIdentifiers}
                             setCurrentIdentifiers={setCurrentIdentifiers}
                             setFilteredQuery={setFilteredQuery}
                             updateIdentifiersList={updateIdentifiersList}
@@ -293,7 +294,7 @@ const IdentifiersFilter = ({ identifiersFilter, onIdentifiersFilterChange, curre
             <Divider component="li" key="divider" />
         ];
         identifiersArray = identifiersArray.concat(
-            Array.from(currentIdentifiers)
+            currentIdentifiers
                     .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
                     .map(unit => <SelectOption key={unit} value={unit} />)
         );


### PR DESCRIPTION
The source of the truth should be `currentIdentifiers` as defined in `logs.jsx`.
`logsJournal.jsx` had separate object to keep the same information and
than this `currentIdentifiers` was being synced. This was not ideal
solution which might fail when there are multiple updates at the same
time as well as it might not trigger update correctly when just editing
set object.

This commit only uses one source of the truth and uses updater callback
to make sure the list is always correctly updated.