### PR TITLE
don't try and install pytest requirements on suse for now

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -138,7 +138,7 @@ Requires: subscription-manager-cockpit
 
 BuildRequires:  python3-devel
 BuildRequires:  python3-pip
-%if 0%{?rhel} == 0
+%if 0%{?rhel} == 0 && !0%{?suse_version}
 # All of these are only required for running pytest (which we only do on Fedora)
 BuildRequires:  procps-ng
 BuildRequires:  pyproject-rpm-macros


### PR DESCRIPTION
these are changes required to for the opensuse testing image, we currently do not package `python3-tox-current-env` nor `pyproject-rpm-macros` so until both of those are packaged we can not run the pytest suit. This may change in the future but for now the simplest solution is not installing those dependencies. 