### PR TITLE
test: Drop rhel-8* from supported OSes, fix for ruff 0.3.1 (fixes failing "tox" test)

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -161,8 +161,6 @@ You can set these environment variables to configure the test suite:
                   "fedora-39"
                   "fedora-40"
                   "fedora-coreos"
-                  "rhel-8-10"
-                  "rhel-8-10-distropkg"
                   "rhel-9-4"
                   "rhel4edge",
                   "ubuntu-2204"

--- a/test/common/packagelib.py
+++ b/test/common/packagelib.py
@@ -421,8 +421,8 @@ Server = file://{self.repo_dir}
                 self.machine.write("/etc/pacman.conf", config, append=True)
 
         else:
-            self.machine.execute("""printf '[updates]\nname=cockpittest\nbaseurl=file://{0}\nenabled=1\ngpgcheck=0\n' > /etc/yum.repos.d/cockpittest.repo
-                                    echo '{1}' > /tmp/updateinfo.xml
-                                    createrepo_c {0}
-                                    modifyrepo_c /tmp/updateinfo.xml {0}/repodata
-                                    dnf clean all""".format(self.repo_dir, self.createYumUpdateInfo()))
+            self.machine.execute(f"""printf '[updates]\nname=cockpittest\nbaseurl=file://{self.repo_dir}\nenabled=1\ngpgcheck=0\n' > /etc/yum.repos.d/cockpittest.repo
+                                     echo '{self.createYumUpdateInfo()}' > /tmp/updateinfo.xml
+                                     createrepo_c {self.repo_dir}
+                                     modifyrepo_c /tmp/updateinfo.xml {self.repo_dir}/repodata
+                                     dnf clean all""")

--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -129,12 +129,12 @@ class Test:
 
                 if proc.returncode == 77:
                     self.returncode = proc.returncode
-                    self._print_test(skip_reason="# SKIP {0}".format(reason.decode("utf-8")))
+                    self._print_test(skip_reason=f"# SKIP {reason.decode()}")
                     return None, 0
 
                 if proc.returncode == 78:
                     self.returncode = proc.returncode
-                    self._print_test(skip_reason="# NOTE {0}".format(reason.decode("utf-8")))
+                    self._print_test(skip_reason=f"# NOTE {reason.decode()}")
                     return None, 1
 
                 if proc.returncode == 1:

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -52,7 +52,7 @@ BASE_DIR = os.path.realpath(f'{__file__}/../../..')
 TEST_DIR = f'{BASE_DIR}/test'
 BOTS_DIR = f'{BASE_DIR}/bots'
 
-os.environ["PATH"] = "{0}:{1}:{2}".format(os.environ.get("PATH"), BOTS_DIR, TEST_DIR)
+os.environ["PATH"] = f"{os.environ.get('PATH')}:{BOTS_DIR}:{TEST_DIR}"
 
 # Be careful when changing this string, check in cockpit-project/bots where it is being used
 UNEXPECTED_MESSAGE = "FAIL: Test completed, but found unexpected "
@@ -1524,7 +1524,11 @@ class MachineCase(unittest.TestCase):
         self.addCleanup(m.execute, "find /var/lib/systemd/coredump -type f -delete")
 
         # temporary directory in the VM
-        self.addCleanup(m.execute, "if [ -d {0} ]; then findmnt --list --noheadings --output TARGET | grep ^{0} | xargs -r umount; rm -r {0}; fi".format(self.vm_tmpdir))
+        self.addCleanup(m.execute, f"""
+            if [ -d {self.vm_tmpdir} ]; then
+                findmnt --list --noheadings --output TARGET | grep ^{self.vm_tmpdir} | xargs -r umount
+                rm -r {self.vm_tmpdir}
+            fi""")
 
         # users/groups/home dirs
         self.restore_file("/etc/passwd")
@@ -2372,13 +2376,16 @@ class TapRunner:
 
         # Return 77 if all tests were skipped
         if len(skips) == test_count:
-            sys.stdout.write("# SKIP {0}\n".format(", ".join([f"{s[0]!s} {s[1]}" for s in skips])))
+            skips = ", ".join([f"{s[0]!s} {s[1]}" for s in skips])
+            sys.stdout.write(f"# SKIP {skips}\n")
             return 77
         if failures:
-            sys.stdout.write("# {0} TEST{1} FAILED {2}\n".format(failures, "S" if failures > 1 else "", details))
+            plural = "S" if failures > 1 else ""
+            sys.stdout.write(f"# {failures} TEST{plural} FAILED {details}\n")
             return 1
         else:
-            sys.stdout.write("# {0} TEST{1} PASSED {2}\n".format(test_count, "S" if test_count > 1 else "", details))
+            plural = "S" if test_count > 1 else ""
+            sys.stdout.write(f"# {test_count} TEST{plural} PASSED {details}\n")
             return 0
 
 

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -451,7 +451,8 @@ ExecStart=/usr/local/bin/{self.packageName}
 """
                 self.testObj.createPackage(self.packageName, "1", "1", install=True, changes="initial package with service and run script",
                                            content={f"/usr/local/bin/{self.packageName}": scriptContent, f"/etc/systemd/system/{self.packageName}.service": unitContent},
-                                           postinst="chmod a+x /usr/local/bin/{0}; systemctl daemon-reload; systemctl start {0}.service".format(self.packageName))
+                                           postinst=(f"chmod a+x /usr/local/bin/{self.packageName};"
+                                                     f"systemctl daemon-reload; systemctl start {self.packageName}.service"))
                 self.testObj.createPackage(self.packageName, "1", "2",
                                            content={f"/usr/local/bin/{self.packageName}": scriptContent, f"/etc/systemd/system/{self.packageName}.service": unitContent},
                                            postinst=f"chmod a+x /usr/local/bin/{self.packageName}")
@@ -1143,7 +1144,8 @@ class TestWsUpdate(NoSubManCase):
         # updating this package takes longer than a cockpit start and building the page
         self.createPackage("slow", "1", "1", install=True)
         self.createPackage(
-            "slow", "1", "2", postinst="while [ ! -e {0} ]; do sleep 1; done; rm -f {0}".format(install_lockfile))
+            "slow", "1", "2",
+            postinst=f"while [ ! -e {install_lockfile} ]; do sleep 1; done; rm -f {install_lockfile}")
         self.enableRepo()
         m.execute("pkcon refresh")
 


### PR DESCRIPTION
That doesn't work any more, RHEL 8 testing now happens on the `rhel-8` branch.

----

This is primarily an excuse to work out our shiny new job-runner CI.