### PR TITLE
packagekit: Fix crash on unexpected `uname -r` format

### DIFF
--- a/pkg/packagekit/kpatch.jsx
+++ b/pkg/packagekit/kpatch.jsx
@@ -128,6 +128,9 @@ export class KpatchSettings extends React.Component {
         const uname_promise = cockpit.spawn(["uname", "-r"])
                 .then(data => {
                     const fields = data.split("-");
+                    // if there's no release field, we don't have an official kernel
+                    if (!fields[1])
+                        return;
                     const kpp_kernel_version = fields[0].replaceAll(".", "_");
                     let release = fields[1].split(".");
                     release = release.slice(0, release.length - 2); // remove el8.x86_64

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -982,6 +982,10 @@ ExecStart=/usr/local/bin/{packageName}
         b = self.browser
         m = self.machine
 
+        # pretend running custom kernel without distro release for kpatch detection robustness
+        self.write_file("/usr/local/bin/uname", """#!/bin/sh
+            if [ "$1" = "-r" ]; then echo 1.2; else exec /usr/bin/uname "$@"; fi""", perm="755")
+
         self.createPackage("vapor", "1", "1", install=True)
         self.createPackage("vapor", "1", "2")
 
@@ -996,6 +1000,7 @@ ExecStart=/usr/local/bin/{packageName}
         with b.wait_timeout(30):
             b.wait_visible("#available-updates")
         b.wait_in_text("#status", "1 update available")
+        b.wait_not_present("#kpatch-setup")
 
         b.click("#available-updates button#install-all")
 


### PR DESCRIPTION
With custom kernels it can happen that `uname -r` does not contain a distribution release part (after a `-`). Then trying to `split()` it caused a TypeError oops.

Fixes #20089