### PR TITLE
test: Add fake default route to work around podman 5 regression

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -765,6 +765,11 @@ class TestCurrentMetrics(testlib.MachineCase):
         self.busybox_image = m.execute("podman images --format '{{.Repository}}' | grep busybox").strip()
         self.login_and_go("/metrics")
 
+        # hack around https://github.com/containers/podman/issues/21896 for our offline test VMs
+        if not m.execute("ip route show default").strip() and "5.0" in m.execute("podman version"):
+            m.execute("nmcli con add type dummy con-name fake ifname fake0 ip4 1.2.3.4/24 gw4 1.2.3.1")
+            self.addCleanup(m.execute, "nmcli con delete fake")
+
     def testCPU(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -751,17 +751,18 @@ class TestHistoryMetrics(testlib.MachineCase):
 class TestCurrentMetrics(testlib.MachineCase):
     def setUp(self):
         super().setUp()
+        m = self.machine
         # packagekit/dnf often eats a lot of CPU; silence it to have better control over CPU usage
-        packagekitd = "/usr/lib/packagekitd" if self.machine.image == "arch" else "/usr/libexec/packagekitd"
-        self.machine.execute(f"systemctl mask packagekit && killall -9 {packagekitd} && killall -9 dnf || true")
+        packagekitd = "/usr/lib/packagekitd" if m.image == "arch" else "/usr/libexec/packagekitd"
+        m.execute(f"systemctl mask packagekit && killall -9 {packagekitd} && killall -9 dnf || true")
 
-        self.addCleanup(self.machine.execute, "systemctl unmask packagekit")
+        self.addCleanup(m.execute, "systemctl unmask packagekit")
         # make sure to clean up our test resource consumers on failures
-        self.addCleanup(self.machine.execute, "systemctl stop cockpittest.slice 2>/dev/null || true")
-        self.addCleanup(self.machine.execute, "su - admin -c 'XDG_RUNTIME_DIR=/run/user/$(id -u admin) "
-                                              "systemctl --user stop cockpittest.slice 2>/dev/null || true'")
+        self.addCleanup(m.execute, "systemctl stop cockpittest.slice 2>/dev/null || true")
+        self.addCleanup(m.execute, "su - admin -c 'XDG_RUNTIME_DIR=/run/user/$(id -u admin) "
+                                   "systemctl --user stop cockpittest.slice 2>/dev/null || true'")
 
-        self.busybox_image = self.machine.execute("podman images --format '{{.Repository}}' | grep busybox").strip()
+        self.busybox_image = m.execute("podman images --format '{{.Repository}}' | grep busybox").strip()
         self.login_and_go("/metrics")
 
     def testCPU(self):


### PR DESCRIPTION
podman 5 regressed user containers if there is no default route [1].
While that is being sorted out, add a fake interface with a default
route for our offline tests, to unbreak upstream podman PRs testing.

Same hack as in https://github.com/cockpit-project/cockpit-podman/commit/cecb2cc6e8f2

[1] https://github.com/containers/podman/issues/21896

------

See [this failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-6050-20240309-073607-686c9e16-fedora-40-other-cockpit-project-cockpit/log.html) in https://github.com/cockpit-project/bots/pull/6050

I  trigger a fedora-40/other@bots#6050 run, but due to a bug in our new infra it will be reported as "fedora-40" (see pilot board).