### PR TITLE
pyproject.toml: stop linting in venvs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,7 +124,7 @@ legacy_tox_ini = """
 envlist = lint,pytest
 isolated_build = True
 labels =
-  venv = py311-lint, py3{6,7,8,9,10,11,12}-pytest
+  venv = py3{6,8,9,10,11,12,13}-pytest
 
 # The default test environments use system packages and never PyPI.
 [testenv:{lint,pytest}]


### PR DESCRIPTION
Lacking a proper requirements.txt file, we're at the mercy of whatever
got randomly uploaded to pypy last night, and we've been seeing a lot of
breaks lately.

We already run our ruff/mypy/etc. stuff as part of our unit tests
workflow, so let's stop running it in venv.  The idea is that we should
pass against the current version of the tasks container (which will
probably shift at some point to being our pinned version of the tasks
container).

While we're at it, drop Python 3.7 (which the world seems to have
collectively decided to stop caring about) and add Python 3.13 (which
has been in Fedora 39 for a while already).  Note: we do *not* drop
Python 3.6 — although it is no longer an officially supported release,
it's used in RHEL 7 and RHEL 8 and Fedora intends to keep packaging it.

