### PR TITLE
tools: Add AppArmor profile for cockpit-desktop

### DIFF
--- a/tools/Makefile-tools.am
+++ b/tools/Makefile-tools.am
@@ -22,4 +22,7 @@ coverage:
 	@echo "file://$(abs_top_builddir)/tools/coverage/index.html"
 endif
 
-EXTRA_DIST += pkg/apps/content-security-policy.override
+EXTRA_DIST += \
+	pkg/apps/content-security-policy.override \
+	tools/apparmor.d/cockpit-desktop \
+	$(NULL)

--- a/tools/apparmor.d/cockpit-desktop
+++ b/tools/apparmor.d/cockpit-desktop
@@ -1,0 +1,10 @@
+abi <abi/4.0>,
+
+include <tunables/global>
+
+profile cockpit-desktop /usr/lib/cockpit/cockpit-desktop flags=(unconfined) {
+  userns,
+
+  # Site-specific additions and overrides. See local/README for details.
+  include if exists <local/cockpit-desktop>
+}

--- a/tools/debian/cockpit-ws.install
+++ b/tools/debian/cockpit-ws.install
@@ -1,5 +1,6 @@
 etc/cockpit/ws-certs.d
 etc/pam.d/cockpit
+tools/apparmor.d/cockpit-desktop etc/apparmor.d/
 ${env:deb_systemdsystemunitdir}/cockpit.service
 ${env:deb_systemdsystemunitdir}/cockpit-motd.service
 ${env:deb_systemdsystemunitdir}/cockpit.socket

--- a/tools/debian/cockpit-ws.postinst
+++ b/tools/debian/cockpit-ws.postinst
@@ -21,6 +21,11 @@ if [ -d /run/systemd/system ] && [ -n "$2" ]; then
     deb-systemd-invoke try-restart cockpit.service >/dev/null || true
 fi
 
+# update AppArmor profile
+if [ "$1" = "configure" ] && aa-enabled --quiet 2>/dev/null; then
+    apparmor_parser -r -T -W /etc/apparmor.d/cockpit-desktop || true
+fi
+
 # set up dynamic motd/issue symlinks on first-time install or upgrades from < 244 (which moved them out of the .deb)
 if [ "$1" = "configure" ] && dpkg --compare-versions "$2" lt 244; then
     mkdir -p /etc/motd.d /etc/issue.d


### PR DESCRIPTION
Ubuntu 24.04 LTS restricts user name spaces by default. Add an AppArmor profile for cockpit-desktop to allow it. This is a no-op for older releases.

See https://launchpad.net/bugs/2046477 for details.

----

Blocks https://github.com/cockpit-project/bots/pull/6048