### PR TITLE
bridge: send acks in fsreplace when asked too :+1: 

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -1066,6 +1066,12 @@ The following options can be specified in the "open" control message:
    you don't set this field, the actual tag will not be checked.  To
    express that you expect the file to not exist, use "-" as the tag.
 
+* "send-acks": (optional) When set to "frames" the channel sends an
+  acknowledgement after each data frame is processed.  In the ready
+  message the bridge replies with an identical "send-acks" option if it
+  is supported.  Clients may not assume that flow control is enabled
+  without checking the ready message.
+
 You should write the new content to the channel as one or more
 messages.  To indicate the end of the content, send a "done" message.
 

--- a/pkg/lib/cockpit-upload-helper.js
+++ b/pkg/lib/cockpit-upload-helper.js
@@ -20,6 +20,14 @@ import cockpit from "cockpit";
 
 const BLOCK_SIZE = 16 * 1024;
 const TOTAL_FRAME_WINDOW = 128;
+
+function UploadError(message = "", detail = "") {
+    this.name = "UploadError";
+    this.message = message;
+    this.detail = detail;
+}
+UploadError.prototype = Error.prototype;
+
 /*
  * Cockpit Upload helper - uploads a blob to the provided destination with an
  * optional progress callback using the fsreplace1 channel.
@@ -150,10 +158,10 @@ export class UploadHelper {
             try {
                 await this.close();
             } catch (exc) {
-                throw new Error(exc.problem);
+                throw new Error(exc.toString());
             }
         } else if (close_message.problem) {
-            throw new Error(close_message.problem);
+            throw new UploadError(cockpit.message(close_message.problem) || close_message.message, close_message.message);
         }
     }
 

--- a/pkg/lib/cockpit-upload-helper.js
+++ b/pkg/lib/cockpit-upload-helper.js
@@ -1,0 +1,164 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+import cockpit from "cockpit";
+
+const BLOCK_SIZE = 16 * 1024;
+const TOTAL_FRAME_WINDOW = 128;
+/*
+ * Cockpit Upload helper - uploads a blob to the provided destination with an
+ * optional progress callback using the fsreplace1 channel.
+ *
+ * Example usage:
+ *
+ * const helper = UploadHelper("/tmp/file.txt")
+ * try {
+ *   const status = await helper.upload(file);
+ * } catch (exc) {
+ * }
+ *
+ * Uploads can be cancelled while in progress by calling `helper.cancel`,
+ * fsreplace1 will automatically clean up the temporary file.
+ */
+export class UploadHelper {
+    constructor(destination, onProgress, options) {
+        this.destination = destination;
+        this.progressCallback = onProgress;
+        this.outstanding = 0;
+
+        // Promise resolvers
+        this.resolveHandler = null;
+
+        options = options || {};
+        this.channel = cockpit.channel({
+            binary: true,
+            payload: "fsreplace1",
+            path: this.destination,
+            "send-acks": "frames",
+            ...options,
+        });
+        this.channel.addEventListener("control", this.on_control.bind(this));
+    }
+
+    // Private methods
+    on_control(event, message) {
+        if (message?.command === "ack") {
+            this.outstanding -= message.frames;
+
+            console.assert(this.outstanding >= 0, "outstanding went negative", this.outstanding);
+
+            if (this.resolveHandler) {
+                this.resolveHandler();
+                this.resolveHandler = null;
+            }
+        }
+    }
+
+    read_chunk(blob) {
+        return new Promise((resolve, reject) => {
+            const reader = new FileReader();
+            reader.onload = (event) => resolve(event.target.result);
+            reader.onerror = reject;
+            reader.readAsArrayBuffer(blob);
+        });
+    }
+
+    write(chunk) {
+        console.assert(this.outstanding >= 0, "ack outstanding went negative", this.outstanding);
+        this.outstanding += 1;
+        this.channel.send(chunk);
+
+        if (this.outstanding < TOTAL_FRAME_WINDOW) {
+            return Promise.resolve();
+        } else {
+            return new Promise((resolve, reject) => {
+                this.resolveHandler = resolve;
+            });
+        }
+    }
+
+    close() {
+        const channel = this.channel;
+        return new Promise((resolve, reject) => {
+            channel.addEventListener("close", function(event, message) {
+                if (message.problem) {
+                    reject(message);
+                } else {
+                    resolve();
+                }
+            });
+            channel.control({ command: "done" });
+        });
+    }
+
+    wait_ready() {
+        const channel = this.channel;
+        return new Promise((resolve, reject) => {
+            channel.addEventListener("ready", function(event, message) {
+                resolve();
+            });
+        });
+    }
+
+    // Public methods
+
+    // Flush is waiting on acks in flight
+    async upload(file) {
+        let close_message = null;
+        this.channel.addEventListener("close", (event, message) => {
+            // If we are waiting on an "ack" and the disk is full
+            if (this.resolveHandler)
+                this.resolveHandler();
+            close_message = message;
+        });
+
+        await this.wait_ready();
+
+        let chunk_start = 0;
+        let send_chunks = 0;
+
+        while (this.channel.valid && chunk_start <= file.size) {
+            const chunk_next = chunk_start + BLOCK_SIZE;
+            const blob = file.slice(chunk_start, chunk_next);
+
+            const chunk = await this.read_chunk(blob);
+            await this.write(chunk);
+
+            send_chunks += blob.size;
+            if (this.progressCallback)
+                this.progressCallback(send_chunks);
+
+            chunk_start = chunk_next;
+        }
+
+        if (this.channel.valid) {
+            try {
+                await this.close();
+            } catch (exc) {
+                throw new Error(exc.problem);
+            }
+        } else if (close_message.problem) {
+            throw new Error(close_message.problem);
+        }
+    }
+
+    cancel() {
+        // Automatically handles reject for us
+        this.channel.close();
+    }
+}

--- a/pkg/playground/react-demo-file-upload.jsx
+++ b/pkg/playground/react-demo-file-upload.jsx
@@ -1,0 +1,129 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from "cockpit";
+import React, { useRef, useState } from "react";
+import { createRoot } from 'react-dom/client';
+
+import { Alert, AlertActionCloseButton } from "@patternfly/react-core/dist/esm/components/Alert/index.js";
+import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
+import { Flex } from "@patternfly/react-core/dist/esm/layouts/Flex/index.js";
+import { Progress } from "@patternfly/react-core/dist/esm/components/Progress/index.js";
+import { TimesIcon, UploadIcon } from "@patternfly/react-icons";
+
+import { FileAutoComplete } from "cockpit-components-file-autocomplete.jsx";
+import { UploadHelper } from "cockpit-upload-helper";
+
+const _ = cockpit.gettext;
+
+export const UploadButton = () => {
+    const ref = useRef();
+    const [files, setFiles] = useState({});
+    const [alert, setAlert] = useState(null);
+    const [dest, setDest] = useState("/home/admin/");
+
+    const handleClick = () => {
+        ref.current.click();
+    };
+
+    const handleProgressIndex = (file, progress) => {
+        setFiles(oldFiles => {
+            const oldFile = oldFiles[file.name];
+            return {
+                ...oldFiles,
+                [file.name]: { ...oldFile, progress },
+            };
+        });
+    };
+
+    const onUpload = async event => {
+        setAlert(null);
+        await Promise.all(Array.from(event.target.files).map(async (file) => {
+            const helper = new UploadHelper(`${dest}${file.name}`, (progress) => handleProgressIndex(file, progress));
+
+            setFiles(oldFiles => {
+                return {
+                    [file.name]: { file, progress: 0, cancel: helper.cancel.bind(helper) },
+                    ...oldFiles,
+                };
+            });
+
+            try {
+                const status = await helper.upload(file);
+                console.debug("upload status", status);
+            } catch (exc) {
+                console.debug("upload exception", exc.toString());
+                setAlert({ variant: "danger", title: exc.toString() });
+            }
+
+            setFiles(oldFiles => {
+                const copy = { ...oldFiles };
+                delete copy[file.name];
+                return copy;
+            });
+        }));
+
+        // Reset input field in the case a download was cancelled and has to be re-uploaded
+        // https://stackoverflow.com/questions/26634616/filereader-upload-same-file-again-not-working
+        event.target.value = null;
+    };
+
+    return (
+        <>
+            <Flex direction={{ default: "column" }}>
+                <FileAutoComplete className="upload-file-dest" value={dest} onChange={setDest} />
+                <Button
+                  id="upload-file-btn"
+                  variant="secondary"
+                  icon={<UploadIcon />}
+                  isDisabled={Object.keys(files).length !== 0}
+                  isLoading={Object.keys(files).length !== 0}
+                  onClick={handleClick}
+                >
+                    {_("Upload")}
+                </Button>
+                <input
+                  ref={ref} type="file"
+                  hidden multiple onChange={onUpload}
+                />
+            </Flex>
+            {alert !== null &&
+            <Alert variant={alert.variant}
+                   title={alert.title}
+                   timeout={3000}
+                   actionClose={<AlertActionCloseButton onClose={() => setAlert(null)} />}
+            />
+            }
+            {Object.keys(files).map((key, index) => {
+                const file = files[key];
+                return (
+                    <React.Fragment key={index}>
+                        <Progress className={`upload-progress-${index}`} key={file.file.name} value={file.progress} title={file.file.name} max={file.file.size} />
+                        <Button className={`cancel-button-${index}`} icon={<TimesIcon />} onClick={file.cancel} />
+                    </React.Fragment>
+                );
+            })}
+        </>
+    );
+};
+
+export const showUploadDemo = (rootElement) => {
+    const root = createRoot(rootElement);
+    root.render(<UploadButton />);
+};

--- a/pkg/playground/react-demo-file-upload.jsx
+++ b/pkg/playground/react-demo-file-upload.jsx
@@ -68,8 +68,7 @@ export const UploadButton = () => {
                 const status = await helper.upload(file);
                 console.debug("upload status", status);
             } catch (exc) {
-                console.debug("upload exception", exc.toString());
-                setAlert({ variant: "danger", title: exc.toString() });
+                setAlert({ variant: "danger", title: exc.message, message: exc.detail });
             }
 
             setFiles(oldFiles => {
@@ -108,7 +107,9 @@ export const UploadButton = () => {
                    title={alert.title}
                    timeout={3000}
                    actionClose={<AlertActionCloseButton onClose={() => setAlert(null)} />}
-            />
+            >
+                <p>{alert.message}</p>
+            </Alert>
             }
             {Object.keys(files).map((key, index) => {
                 const file = files[key];

--- a/pkg/playground/react-patterns.html
+++ b/pkg/playground/react-patterns.html
@@ -29,6 +29,11 @@
                 <h3>Cards</h3>
                 <div id="demo-cards"></div>
             </section>
+
+            <section class="pf-v5-c-page__main-section pf-m-light">
+                <h3>Upload</h3>
+                <div id="demo-upload"></div>
+            </section>
         </main>
     </div>
 </body>

--- a/pkg/playground/react-patterns.js
+++ b/pkg/playground/react-patterns.js
@@ -27,6 +27,7 @@ import { show_modal_dialog } from "cockpit-components-dialog.jsx";
 
 import { PatternDialogBody } from "./react-demo-dialog.jsx";
 import { showCardsDemo } from "./react-demo-cards.jsx";
+import { showUploadDemo } from "./react-demo-file-upload.jsx";
 import { showFileAcDemo, showFileAcDemoPreselected } from "./react-demo-file-autocomplete.jsx";
 
 /* -----------------------------------------------------------------------------
@@ -126,4 +127,7 @@ document.addEventListener("DOMContentLoaded", function() {
 
     // Cards
     showCardsDemo(document.getElementById('demo-cards'));
+
+    // Upload
+    showUploadDemo(document.getElementById('demo-upload'));
 });

--- a/src/cockpit/channel.py
+++ b/src/cockpit/channel.py
@@ -459,9 +459,9 @@ class AsyncChannel(Channel):
 
     async def read(self) -> 'bytes | None':
         # Three possibilities for what we'll find:
-        #  - None (EOF) → return b''
+        #  - None (EOF) → return None
         #  - a ping → send a pong
-        #  - bytes → return it
+        #  - bytes → return it (possibly empty)
         while True:
             item = await self.receive_queue.get()
             if item is None:

--- a/src/cockpit/channel.py
+++ b/src/cockpit/channel.py
@@ -21,7 +21,7 @@ import logging
 import traceback
 from typing import BinaryIO, ClassVar, Dict, Generator, List, Mapping, Optional, Sequence, Set, Tuple, Type
 
-from .jsonutil import JsonError, JsonObject, JsonValue, create_object, get_bool, get_str
+from .jsonutil import JsonError, JsonObject, JsonValue, create_object, get_bool, get_enum, get_str
 from .protocol import CockpitProblem
 from .router import Endpoint, Router, RoutingRule
 
@@ -92,6 +92,7 @@ class Channel(Endpoint):
     _send_pings: bool = False
     _out_sequence: int = 0
     _out_window: int = SEND_WINDOW
+    _ack_frames: bool
 
     # Task management
     _tasks: Set[asyncio.Task]
@@ -106,15 +107,16 @@ class Channel(Endpoint):
     group = ''
 
     # input
-    def do_control(self, command, message):
+    def do_control(self, command: str, message: JsonObject) -> None:
         # Break the various different kinds of control messages out into the
         # things that our subclass may be interested in handling.  We drop the
         # 'message' field for handlers that don't need it.
         if command == 'open':
             self._tasks = set()
-            self.channel = message['channel']
+            self.channel = get_str(message, 'channel')
             if get_bool(message, 'flow-control', default=False):
                 self._send_pings = True
+            self._ack_frames = get_enum(message, 'send-acks', ['frames'], None) is not None
             self.group = get_str(message, 'group', 'default')
             self.freeze_endpoint()
             self.do_open(message)
@@ -177,6 +179,10 @@ class Channel(Endpoint):
     def do_ping(self, message: JsonObject) -> None:
         self.send_pong(message)
 
+    def send_ack(self, _data: bytes) -> None:
+        if self._ack_frames:
+            self.send_control('ack', frames=1)
+
     def do_channel_data(self, channel: str, data: bytes) -> None:
         # Already closing?  Ignore.
         if self._close_args is not None:
@@ -184,13 +190,21 @@ class Channel(Endpoint):
 
         # Catch errors and turn them into close messages
         try:
-            self.do_data(data)
+            if not self.do_data(data):
+                self.send_ack(data)
         except ChannelError as exc:
             self.close(exc.get_attrs())
 
-    def do_data(self, _data: bytes) -> None:
+    def do_data(self, data: bytes) -> 'bool | None':
+        """Handles incoming data to the channel.
+
+        Return value is True if the channel takes care of send acks on its own,
+        in which case it should call self.send_ack() on `data` at some point.
+        None or False means that the acknowledgement is sent automatically."""
         # By default, channels can't receive data.
+        del data
         self.close()
+        return True
 
     # output
     def ready(self, **kwargs: JsonValue) -> None:
@@ -469,6 +483,7 @@ class AsyncChannel(Channel):
             if isinstance(item, Mapping):
                 self.send_pong(item)
             else:
+                self.send_ack(item)
                 return item
 
     async def write(self, data: bytes) -> None:
@@ -506,13 +521,9 @@ class AsyncChannel(Channel):
     def do_ping(self, message: JsonObject) -> None:
         self.receive_queue.put_nowait(message)
 
-    def do_data(self, data: bytes) -> None:
-        if not isinstance(data, bytes):
-            # this will persist past this callback, so make sure we take our
-            # own copy, in case this was a memoryview into a bytearray.
-            data = bytes(data)
-
+    def do_data(self, data: bytes) -> bool:
         self.receive_queue.put_nowait(data)
+        return True  # we will send the 'ack' later
 
 
 class GeneratorChannel(Channel):

--- a/src/cockpit/channels/filesystem.py
+++ b/src/cockpit/channels/filesystem.py
@@ -215,7 +215,11 @@ class FsReplaceChannel(Channel):
                 self.unlink_temppath()
                 raise
 
-        self._tempfile.write(data)
+        try:
+            self._tempfile.write(data)
+        except OSError as exc:
+            self.unlink_temppath()
+            raise ChannelError('internal-error', message=str(exc)) from exc
 
     def do_done(self):
         if self._tempfile is None:

--- a/src/cockpit/channels/filesystem.py
+++ b/src/cockpit/channels/filesystem.py
@@ -154,6 +154,7 @@ class FsReplaceChannel(Channel):
     payload = 'fsreplace1'
 
     _path = None
+    _send_acks = None
     _tag = None
     _tempfile = None
     _temppath = None
@@ -169,7 +170,7 @@ class FsReplaceChannel(Channel):
         self._tag = options.get('tag')
         self.ready()
 
-    def do_data(self, data):
+    def do_data(self, data: bytes) -> None:
         if self._tempfile is None:
             # if the file exists already and we have an expected tag, check it
             stat = None

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -301,10 +301,15 @@ class Browser:
         """
         self.cdp.set_frame(None)
 
-    def upload_file(self, selector: str, file: str):
+    def upload_files(self, selector: str, files: List[str]):
+        """Upload a local file to the browser
+
+        The selector should select the <input type="file"/> element.
+        Files is a list of absolute paths to files which should be uploaded.
+        """
         r = self.cdp.invoke("Runtime.evaluate", expression='document.querySelector(%s)' % jsquote(selector))
         objectId = r["result"]["objectId"]
-        self.cdp.invoke("DOM.setFileInputFiles", files=[file], objectId=objectId)
+        self.cdp.invoke("DOM.setFileInputFiles", files=files, objectId=objectId)
 
     def raise_cdp_exception(self, func, arg, details, trailer=None):
         # unwrap a typical error string

--- a/test/pytest/test_bridge.py
+++ b/test/pytest/test_bridge.py
@@ -20,7 +20,7 @@ import pytest
 
 from cockpit._vendor.systemd_ctypes import bus
 from cockpit.bridge import Bridge
-from cockpit.channel import Channel
+from cockpit.channel import AsyncChannel, Channel, ChannelRoutingRule
 from cockpit.channels import CHANNEL_TYPES
 from cockpit.jsonutil import JsonDict, JsonObject, JsonValue, get_bool, get_dict, get_int, json_merge_patch
 from cockpit.packages import BridgeConfig
@@ -538,6 +538,16 @@ async def test_fsreplace1(transport: MockTransport, tmp_path: Path) -> None:
     await transport.check_close(channel=ch)
     assert not myfile.exists()
 
+    # acks
+    ch = await transport.check_open('fsreplace1', path=str(myfile), send_acks='frames')
+    transport.send_data(ch, b'some stuff')
+    await transport.assert_msg('', command='ack', frames=1, channel=ch)
+    transport.send_data(ch, b'some more stuff')
+    await transport.assert_msg('', command='ack', frames=1, channel=ch)
+    transport.send_done(ch)
+    await transport.assert_msg('', command='done', channel=ch)
+    await transport.check_close(channel=ch)
+
 
 @pytest.mark.asyncio
 async def test_fsreplace1_change_conflict(transport: MockTransport, tmp_path: Path) -> None:
@@ -615,6 +625,13 @@ async def test_fsreplace1_error(transport: MockTransport, tmp_path: Path) -> Non
     transport.send_data(ch, b'not me')
     transport.send_done(ch)
     await transport.assert_msg('', command='close', channel=ch, problem='not-found')
+
+    # invalid send-acks option
+    await transport.check_open('fsreplace1', path=str(tmp_path), send_acks='not-valid',
+                               problem='protocol-error',
+                               reply_keys={
+                                   'message': """attribute 'send-acks': invalid value "not-valid" not in ['frames']"""
+    })
 
 
 @pytest.mark.asyncio
@@ -733,6 +750,72 @@ async def test_channel(bridge: Bridge, transport: MockTransport, channeltype, tm
 def test_get_os_release(os_release: str, expected: str) -> None:
     with unittest.mock.patch('builtins.open', unittest.mock.mock_open(read_data=os_release)):
         assert Bridge.get_os_release() == expected
+
+
+class AckChannel(AsyncChannel):
+    payload = 'ack1'
+
+    async def run(self, options: JsonObject) -> None:
+        self.semaphore = asyncio.Semaphore(0)
+        self.ready()
+        while await self.read():
+            await self.semaphore.acquire()
+
+
+@pytest.mark.asyncio
+async def test_async_acks(bridge: Bridge, transport: MockTransport) -> None:
+    # Inject our mock channel type
+    for rule in bridge.routing_rules:
+        if isinstance(rule, ChannelRoutingRule):
+            rule.table['ack1'] = [AckChannel]
+
+    # invalid send-acks values
+    await transport.check_open('ack1', send_acks=True, problem='protocol-error')
+    await transport.check_open('ack1', send_acks='x', problem='protocol-error')
+
+    # open the channel with acks off
+    ch = await transport.check_open('ack1')
+    # send a bunch of data and get no acks
+    for _ in range(20):
+        transport.send_data(ch, b'x')
+    # this will assert that we receive only the close message (and no acks)
+    await transport.check_close(ch)
+
+    # open the channel with acks on
+    ch = await transport.check_open('ack1', send_acks='frames')
+    # send a bunch of data
+    for _ in range(20):
+        transport.send_data(ch, b'x')
+    # we should get exactly one ack (from the first read) before things block
+    await transport.assert_msg('', channel=ch, command='ack', frames=1)
+    # this will assert that we receive only the close message (and no additional acks)
+    await transport.check_close(ch)
+
+    # open the channel with acks on
+    ch = await transport.check_open('ack1', send_acks='frames')
+    # fish the open channel out of the bridge
+    ack = bridge.open_channels[ch]
+    assert isinstance(ack, AckChannel)
+    # let's give ourselves a bit more headroom
+    for _ in range(5):
+        ack.semaphore.release()
+    # send a bunch of data and get some acks
+    for _ in range(10):
+        transport.send_data(ch, b'x')
+    for _ in range(6):
+        await transport.assert_msg('', channel=ch, command='ack', frames=1)
+    # make sure that as we "consume" the data we get more acks:
+    for _ in range(4):
+        # no ack in the queue...
+        await transport.assert_empty()
+        ack.semaphore.release()
+        # ... but now there is.
+        await transport.assert_msg('', channel=ch, command='ack', frames=1)
+    # make some more room (for data we didn't send)
+    for _ in range(5):
+        ack.semaphore.release()
+    # but we shouldn't have gotten any acks for those
+    await transport.check_close(ch)
 
 
 @pytest.mark.asyncio

--- a/test/verify/check-upload-component
+++ b/test/verify/check-upload-component
@@ -71,18 +71,21 @@ class TestUploadComponent(testlib.MachineCase):
                 b.wait_visible("#upload-file-btn:not(:disabled)")
 
             # Enospace
-            # TODO: no error send back
-            # m.execute("""
-            #     mkdir /mnt/upload
-            #     mount -t tmpfs -o size=1M none /mnt/upload
-            # """)
-            # b.upload_files("#demo-upload input[type='file']", [big_file])
-            # b.wait_visible("#upload-file-btn:not(:disabled)")
+            b.set_file_autocomplete_val("#demo-upload", "/mnt/upload/")
+            m.execute("""
+                mkdir /mnt/upload
+                mount -t tmpfs -o size=1M none /mnt/upload
+                chown -R admin: /mnt/upload
+            """)
+            b.upload_files("#demo-upload input[type='file']", [big_file])
+            b.wait_visible("#upload-file-btn:not(:disabled)")
+            b.wait_in_text(".pf-v5-c-alert", "No space left on device")
 
         # Upload permission error
-        b.set_file_autocomplete_val("#demo-upload", "/mnt/upload/")
+        b.set_file_autocomplete_val("#demo-upload", "/root/")
         b.drop_superuser()
         b.upload_files("#demo-upload input[type='file']", [test_upload_file])
+        b.wait_in_text(".pf-v5-c-alert", "Not permitted to perform this action")
 
     def testMulti(self):
         b = self.browser

--- a/test/verify/check-upload-component
+++ b/test/verify/check-upload-component
@@ -1,0 +1,108 @@
+#!/usr/bin/python3 -cimport os, sys; os.execv(os.path.dirname(sys.argv[1]) + "/../common/pywrap", sys.argv)
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2024 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+import testlib
+from lib.constants import TEST_OS_DEFAULT
+
+
+@testlib.skipBrowser("Firefox CDP does not support setFileInputFiles", "firefox")
+class TestUploadComponent(testlib.MachineCase):
+
+    # Test upload component
+    # - Upload progress, slow down network to 3G and test
+    def testBasic(self):
+        b = self.browser
+        m = self.machine
+
+        self.login_and_go("/playground/react-patterns")
+        files_dir = Path(testlib.TEST_DIR) / "verify" / "files" / "metrics-archives"
+        test_upload_file = str(files_dir / "double_events.zip")
+        dest_file = "/home/admin/double_events.zip"
+
+        filehash = subprocess.check_output(["md5sum", test_upload_file]).strip().decode().split(' ')[0]
+        filesize = subprocess.check_output(["stat", "--format", "%s", test_upload_file]).strip().decode()
+
+        b.upload_files("#demo-upload input[type='file']", [test_upload_file])
+
+        with b.wait_timeout(30):
+            b.wait(lambda: m.execute(f"test -f {dest_file} && echo {dest_file} || echo 'no'").strip() == dest_file)
+        self.assertEqual(m.execute(f"stat --format '%s' {dest_file}").strip(), filesize)
+        self.assertEqual(m.execute(f"md5sum {dest_file} | awk '{{ print $1 }}'").strip(), filehash)
+        b.wait_visible("#upload-file-btn:not(:disabled)")
+
+        # big file upload
+        with tempfile.TemporaryDirectory() as tmpdir:
+            big_file = str(Path(tmpdir) / "bigfile.img")
+            subprocess.check_call(["truncate", "-s", "100M", big_file])
+            b.upload_files("#demo-upload input[type='file']", [big_file])
+
+            b.wait(lambda: b.get_pf_progress_value(".upload-progress-0") >= 2)
+            b.click(".cancel-button-0")
+            b.wait_visible("#upload-file-btn:not(:disabled)")
+
+            # Succesful
+            if self.machine.image == TEST_OS_DEFAULT:
+                subprocess.check_call(["truncate", "-s", "1000M", big_file])
+                b.upload_files("#demo-upload input[type='file']", [big_file])
+                dest_file = "/home/admin/bigfile.img"
+                with b.wait_timeout(120):
+                    b.wait(lambda: m.execute(f"test -f {dest_file} && echo {dest_file} || echo 'no'").strip() == dest_file)
+                b.wait_visible("#upload-file-btn:not(:disabled)")
+
+            # Enospace
+            # TODO: no error send back
+            # m.execute("""
+            #     mkdir /mnt/upload
+            #     mount -t tmpfs -o size=1M none /mnt/upload
+            # """)
+            # b.upload_files("#demo-upload input[type='file']", [big_file])
+            # b.wait_visible("#upload-file-btn:not(:disabled)")
+
+        # Upload permission error
+        b.set_file_autocomplete_val("#demo-upload", "/mnt/upload/")
+        b.drop_superuser()
+        b.upload_files("#demo-upload input[type='file']", [test_upload_file])
+
+    def testMulti(self):
+        b = self.browser
+        m = self.machine
+
+        dest_dir = "/home/admin/keys/"
+        m.execute(f"mkdir {dest_dir}; chown -R admin: {dest_dir}")
+        files_dir = Path(testlib.TEST_DIR) / "verify" / "files" / "ssh"
+        files = [str(files_dir / f) for f in os.listdir(files_dir)]
+        print("to be uploaded files", files)
+
+        self.login_and_go("/playground/react-patterns")
+        b.wait_visible("#demo-upload")
+        b.set_file_autocomplete_val("#demo-upload", dest_dir)
+        b.upload_files("#demo-upload input[type='file']", files)
+
+        with b.wait_timeout(30):
+            b.wait(lambda: int(m.execute(f"ls {dest_dir} | wc -l").strip()) == len(files))
+        b.wait_visible("#upload-file-btn:not(:disabled)")
+
+
+if __name__ == '__main__':
+    testlib.test_main()

--- a/tools/vulture-suppressions/testlib.py
+++ b/tools/vulture-suppressions/testlib.py
@@ -4,6 +4,5 @@ from .testlib import Browser
 Browser.get_checked
 
 # kept as being potentially useful in the future
-Browser.upload_file
 Browser.wait_attr_not_contains
 Browser.select_PF5


### PR DESCRIPTION
Python code should be ok, the JS code is rather hacky :)

---

Some notes from our discussion on Matrix:

> Implementing this on the channel level is maybe more complicated than you think
> you have to make sure it works with asyncchannel and protocolchannel
> it's not as easy as sending back the ack as soon as you get the frame
> the frame actually has to be delivered to the underlying [whatever]
> otherwise the backpressure isn't end-to-end

I've moved the sending of acks to the `Channel` class that brings some interesting questions:

* `do_data` needs to return how much was written or how many "frames" where handled. This is currently in my PoC hardcoded to 1 frame.
* AsyncChannel - as far as I see, there is no async channel that receives and writes back channel. 
* ProtocolChannel - if it uses do_channel_data, it should work. I have no test to back this up. I guess we can do something  `test_file_upload`

Maybe:
```
    channel = cockpit.spawn(["dd", "of=/tmp/spawninput"], { err: "message" });
    const chunk = 'a'.repeat(65536);
    for (let i = 0; i < 1000; i++) {
        channel.input(chunk, true);
        total += chunk.length;
    }
    channel.input(); // send EOF
```

In essence this does the same as upload!

https://github.com/cockpit-project/cockpit/blob/main/pkg/playground/speed.js#L230