### PR TITLE
tools: Fix pam_listfile PAM stage

### DIFF
--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -741,7 +741,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         # root login is disabled by default via /etc/cockpit/disallowed-users on everything except RHEL 8
         if not m.image.startswith("rhel-8") and not m.image.startswith("centos-8"):
             b.try_login("root", "foobar")
-            b.wait_in_text("#login-error-message", "Wrong user name or password")
+            b.wait_in_text("#login-error-message", "Permission denied")
 
         # disable root login with pam_access
         self.enable_root_login()

--- a/tools/arch/PKGBUILD
+++ b/tools/arch/PKGBUILD
@@ -19,7 +19,7 @@ source=("cockpit-${pkgver}.tar.xz"
         "cockpit-ws.sysuser.conf"
         "cockpit-wsinstance.sysuser.conf")
 sha256sums=('SKIP'
-            'b95cdb0a336b7c1af9af9da1eed8520dfb8eae51869609416d380fee0357c523'
+            '079bb6751214e642673f9e1212df2a17fed1a3cc6cfdd6375af2b68ed6ddd340'
             '1ad9dad75858264778bd94799b60c651f7cc1c7f7fa1c54622174303e639287a'
             '46ee8ecad7bc97ba588ab9471dde76e41c00daf40658902425626c3a1938b438')
 

--- a/tools/arch/cockpit.pam
+++ b/tools/arch/cockpit.pam
@@ -1,7 +1,7 @@
 #%PAM-1.0
 auth      include   system-remote-login
-# List of users to deny access to Cockpit, by default root is included.
-auth       required     pam_listfile.so item=user sense=deny file=/etc/cockpit/disallowed-users onerr=succeed
 account   include   system-remote-login
+# List of users to deny access to Cockpit, by default root is included.
+account   required  pam_listfile.so item=user sense=deny file=/etc/cockpit/disallowed-users onerr=succeed
 password  include   system-remote-login
 session   include   system-remote-login

--- a/tools/cockpit.debian.pam
+++ b/tools/cockpit.debian.pam
@@ -3,7 +3,7 @@ auth       required     pam_sepermit.so
 auth       substack     common-auth
 auth       optional     pam_ssh_add.so
 # List of users to deny access to Cockpit, by default root is included.
-auth       required     pam_listfile.so item=user sense=deny file=/etc/cockpit/disallowed-users onerr=succeed
+account    required     pam_listfile.so item=user sense=deny file=/etc/cockpit/disallowed-users onerr=succeed
 account    required     pam_nologin.so
 account    include      common-account
 password   include      common-password

--- a/tools/cockpit.pam
+++ b/tools/cockpit.pam
@@ -4,7 +4,7 @@ auth       substack     password-auth
 auth       include      postlogin
 auth       optional     pam_ssh_add.so
 # List of users to deny access to Cockpit, by default root is included.
-auth       required     pam_listfile.so item=user sense=deny file=/etc/cockpit/disallowed-users onerr=succeed
+account    required     pam_listfile.so item=user sense=deny file=/etc/cockpit/disallowed-users onerr=succeed
 account    required     pam_nologin.so
 account    include      password-auth
 password   include      password-auth


### PR DESCRIPTION
This should be in "account" (aka. "denied access"), not "auth" (aka. "provided wrong credentials"). Thanks to Stephen Gallagher for pointing out!

Adjust testPamAccess accordingly, which now shows the corresponding message.

---

Side issue in https://bugzilla.redhat.com/show_bug.cgi?id=2269361