### PR TITLE
workflows: Allow urls-check to write issues

### DIFF
--- a/.github/workflows/urls-check.yml
+++ b/.github/workflows/urls-check.yml
@@ -7,7 +7,8 @@ on:
 jobs:
   urls-check:
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      issues: write
     steps:
       - name: Set up configuration and secrets
         run: |

--- a/tools/urls-check
+++ b/tools/urls-check
@@ -123,9 +123,9 @@ def check_urls(verbose):
             if resp.geturl() != url and not any(fnmatch.fnmatch(url, pattern) for pattern in KNOWN_REDIRECTS):
                 redirects.append(url)
             if resp.getcode() >= 400:
-                failed.append(url)
-        except urllib.error.URLError:
-            failed.append(url)
+                failed.append(f"{url} : {resp.getcode()} {resp.reason}")
+        except urllib.error.URLError as e:
+            failed.append(f"{url} : {e.code} {e.reason}")
 
     err = ""
     success = ""


### PR DESCRIPTION
Commit bc7e2bf38f8f729 was wrong: This workflow only doesn't need any permissions if all URLs are valid. But if not, then it wants to update/create an issue to notify us about that.

---

Fixes [this failure](https://github.com/cockpit-project/cockpit/actions/runs/8266231191/job/22613728485) which [started to happen 3 weeks ago](https://github.com/cockpit-project/cockpit/actions/workflows/urls-check.yml).