### PR TITLE
lib: keep validationFailed in sync with the list state

### DIFF
--- a/pkg/lib/cockpit-components-dynamic-list.jsx
+++ b/pkg/lib/cockpit-components-dynamic-list.jsx
@@ -43,7 +43,7 @@ export class DynamicListForm extends React.Component {
     removeItem(idx) {
         const validationFailedDelta = this.props.validationFailed ? [...this.props.validationFailed] : [];
         // We also need to remove any error messages which the item (row) may have contained
-        validationFailedDelta.splice(idx, 1);
+        delete validationFailedDelta[idx];
         this.props.onValidationChange?.(validationFailedDelta);
 
         this.setState(state => {


### PR DESCRIPTION
Deleting the items leaves an "undefined" entry, while splicing the removes them from the list. In the old situation the two lists would get out of sync and a user would never be able to complete the Create container dialog because an invalid state was left.

---

See https://github.com/cockpit-project/cockpit-podman/issues/1622#issuecomment-1999610172