### PR TITLE
users: port authorized keys mobile dropdown to a KebabDropdown

### DIFF
--- a/pkg/users/authorized-keys-panel.js
+++ b/pkg/users/authorized-keys-panel.js
@@ -18,16 +18,16 @@
  */
 
 import cockpit from 'cockpit';
-import React, { useState } from 'react';
+import React from 'react';
 import { useObject, useEvent } from 'hooks.js';
 
 import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
 import { Card, CardHeader, CardTitle } from '@patternfly/react-core/dist/esm/components/Card/index.js';
-import { Dropdown, KebabToggle } from '@patternfly/react-core/dist/esm/deprecated/components/Dropdown/index.js';
 import { OverflowMenu, OverflowMenuContent, OverflowMenuControl, OverflowMenuDropdownItem, OverflowMenuGroup, OverflowMenuItem } from "@patternfly/react-core/dist/esm/components/OverflowMenu/index.js";
 import { TextArea } from "@patternfly/react-core/dist/esm/components/TextArea/index.js";
 import { show_modal_dialog } from "cockpit-components-dialog.jsx";
 import { ListingTable } from 'cockpit-components-table.jsx';
+import { KebabDropdown } from 'cockpit-components-dropdown.jsx';
 import { show_unexpected_error } from "./dialog-utils.js";
 import * as authorized_keys from './authorized-keys.js';
 
@@ -90,7 +90,6 @@ export function AuthorizedKeys({ name, home, allow_mods }) {
                               manager => manager.close(),
                               [name, home]);
     useEvent(manager, "changed");
-    const [openedMenu, setOpenedMenu] = useState([]);
 
     function remove_key(raw) {
         manager.remove_key(raw).catch(show_unexpected_error);
@@ -146,28 +145,10 @@ export function AuthorizedKeys({ name, home, allow_mods }) {
                                         </OverflowMenuGroup>
                                     </OverflowMenuContent>
                                     <OverflowMenuControl>
-                                        <Dropdown position="right"
-                                                  onSelect={() => {
-                                                      if (openedMenu.indexOf(k.fp) >= 0)
-                                                          setOpenedMenu(openedMenu.filter(m => m !== k.fp));
-                                                      else
-                                                          setOpenedMenu([...openedMenu, k.fp]);
-                                                  }}
-                                                  toggle={
-                                                      <KebabToggle
-                                                      onToggle={(_event, open) => {
-                                                          if (open)
-                                                              setOpenedMenu([...openedMenu, k.fp]);
-                                                          else
-                                                              setOpenedMenu(openedMenu.filter(m => m !== k.fp));
-                                                      }}
-                                                      />
-                                                  }
-                                                  isOpen={openedMenu.indexOf(k.fp) >= 0}
-                                                  isPlain
-                                                  dropdownItems={[<OverflowMenuDropdownItem key="delete" isShared onClick={() => remove_key(k.raw)}>
-                                                      {_("Remove")}
-                                                  </OverflowMenuDropdownItem>]}
+                                        <KebabDropdown position="right" dropdownItems={[
+                                            <OverflowMenuDropdownItem key="delete" isShared onClick={() => remove_key(k.raw)}>
+                                                {_("Remove")}
+                                            </OverflowMenuDropdownItem>]}
                                         />
                                     </OverflowMenuControl>
                                 </OverflowMenu>,

--- a/test/verify/check-shell-keys
+++ b/test/verify/check-shell-keys
@@ -68,6 +68,16 @@ class TestKeys(testlib.MachineCase):
         # add good
         add_key(KEY, FP_SHA256, "test-name")
 
+        # remove key on mobile, on mobile we show a kebab menu
+        b.set_layout("mobile")
+        b.click("#account-authorized-keys button.pf-v5-c-menu-toggle")
+        b.click("button.pf-v5-c-menu__item")
+        b.wait_js_func("ph_count_check", "#account-authorized-keys-list tr", 1)
+        b.set_layout("desktop")
+
+        # add good
+        add_key(KEY, FP_SHA256, "test-name")
+
         # Try see admin
         b.go("#/admin")
         b.wait_text("#account-user-name", "admin")


### PR DESCRIPTION
This dropdown did not work, it is only supposed to show on mobile and like our other deprecated dropdown replacements it can replaced with our own KebabDropdown. In the introduction PR of the KebabDropdown this wasn't done as it seemed non-trivial to port due to the state used.

Additionally this now adds a test to verify the dropdown works.