### PR TITLE
test: Re-download package sets for daily/updates-testing scenarios

### DIFF
--- a/test/run
+++ b/test/run
@@ -36,12 +36,12 @@ case "${TEST_SCENARIO:=}" in
     *firefox*) RUN_OPTS="$RUN_OPTS "; export TEST_BROWSER=firefox ;;&
 
     *daily*)
-        bots/image-customize --fresh -v --run-command 'dnf -y copr enable rpmsoftwaremanagement/dnf-nightly && dnf -y copr enable @storage/udisks-daily && dnf -y --setopt=install_weak_deps=False update >&2' "$TEST_OS"
+        bots/image-customize --fresh -v --script test/vm.daily "$TEST_OS"
         RUN_OPTS="$RUN_OPTS "
         PREPARE_OPTS="$PREPARE_OPTS --overlay"
         ;;&
    *updates-testing*)
-        bots/image-customize --fresh -v --run-command 'dnf -y update --enablerepo=updates-testing --setopt=install_weak_deps=False >&2' "$TEST_OS"
+        bots/image-customize --fresh -v --script test/vm.updates-testing "$TEST_OS"
         RUN_OPTS="$RUN_OPTS "
         PREPARE_OPTS="$PREPARE_OPTS --overlay"
         ;;&

--- a/test/vm.daily
+++ b/test/vm.daily
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Prepare VM for "daily" scenario: Run tests against various upstream COPRs
+set -eux
+# image-customize hides stdout by default
+exec >&2
+dnf -y copr enable rpmsoftwaremanagement/dnf-nightly
+dnf -y copr enable @storage/udisks-daily
+dnf -y --setopt=install_weak_deps=False update
+/var/lib/download-package-sets.sh

--- a/test/vm.updates-testing
+++ b/test/vm.updates-testing
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Prepare VM for "updates-testing" scenario
+set -eux
+# image-customize hides stdout by default
+exec >&2
+dnf config-manager --enable updates-testing
+dnf -y update --setopt=install_weak_deps=False
+/var/lib/download-package-sets.sh


### PR DESCRIPTION
Re-run the new `download-package-sets.sh` script introduced in [1] to ensure that they match the installed package versions after updating them to the COPRs or updates-testing.

[1] https://github.com/cockpit-project/bots/pull/6110

Fixes #20184