### PR TITLE
Adjust tests for Fedora 40 introducing /var subvolume

### DIFF
--- a/test/common/storagelib.py
+++ b/test/common/storagelib.py
@@ -533,6 +533,12 @@ mount {dev}1 /new-root/boot
 tar --selinux --one-file-system -cf - --exclude /boot --exclude='/var/tmp/*' --exclude='/var/cache/*' \
     --exclude='/var/lib/mock/*' --exclude='/var/lib/containers/*' --exclude='/new-root/*' \
     / | tar --selinux -C /new-root -xf -
+# latest Fedora have /var on a separate subvolume
+if mountpoint /var; then
+    tar -C /var --selinux --one-file-system -cf - --exclude='tmp/*' --exclude='cache/*' \
+        --exclude='lib/mock/*' --exclude='lib/containers/*' \
+        . | tar --selinux -C /new-root/var -xf -
+fi
 tar --one-file-system -C /boot -cf - . | tar -C /new-root/boot -xf -
 umount /new-root/boot
 mount {dev}1 /boot

--- a/test/verify/check-storage-scaling
+++ b/test/verify/check-storage-scaling
@@ -35,7 +35,7 @@ class TestStorageScaling(storagelib.StorageCase):
         b.wait_visible(self.card_row("Storage", name="/dev/vda"))
         # Wait on btrfs subvolumes on OS'es with the install on btrfs
         if m.image.startswith('fedora') or m.image == "arch":
-            b.wait_in_text(self.card("Storage"), "var/lib/machines")
+            b.wait_in_text(self.card("Storage"), "lib/machines")
         n_rows = count_rows()
 
         m.execute("modprobe scsi_debug num_tgts=200")


### PR DESCRIPTION
See https://github.com/cockpit-project/bots/pull/6101 . I locally verified that the [two failures](https://cockpit-logs.us-east-1.linodeobjects.com/pull-6101-5605b494-20240318-225526-fedora-40-storage-cockpit-project-cockpit/log.html) now pass with these fixes. I'll trigger a separate run against that bots image, but we won't be able to look at the logs right now (but still get correct pass/fail status).