### PR TITLE
ci: Don't use "make" in tasks-container-update

### DIFF
--- a/.github/workflows/tasks-container-update.yml
+++ b/.github/workflows/tasks-container-update.yml
@@ -30,5 +30,5 @@ jobs:
 
       - name: Run tasks-container-update
         run: |
-          make bots
+          test/common/make-bots
           bots/tasks-container-update


### PR DESCRIPTION
Instead, use test/common/make-bots directly. The Makefile only exists after running autogen.sh, and we really don't need to do that just to get the bots.