### PR TITLE
test: Move TestAD and TestConnection to the "networking" scenario

### DIFF
--- a/test/run
+++ b/test/run
@@ -25,7 +25,7 @@ PREPARE_OPTS=""
 RUN_OPTS=""
 ALL_TESTS="$(test/common/run-tests --test-dir test/verify -l)"
 
-RE_NETWORKING='Networking|Bonding|TestBridge|WireGuard|Firewall|Team|IPA|AD'
+RE_NETWORKING='Networking|Bonding|Connection|TestBridge|WireGuard|Firewall|Team|IPA|AD|Kerberos'
 RE_STORAGE='Storage'
 RE_EXPENSIVE='HostSwitching|MultiMachine|Updates|Superuser|Kdump|Pages'
 


### PR DESCRIPTION
The "expensive" and "storage" scenarios both take 14 minutes, while "other" takes 21 and "networking" only 10.

"TestKerberos" really belongs to the same group as TestIPA and TestAD, and TestConnection is at least moderately related to "networking".

This balances the test scenarios better.

---

See a typical recent test run: [expensive](https://cockpit-logs.us-east-1.linodeobjects.com/pull-20206-34a34996-20240320-142318-fedora-39-expensive/log.html) (14 mins), [networking](https://cockpit-logs.us-east-1.linodeobjects.com/pull-20206-34a34996-20240320-142319-fedora-39-networking/log.html) (10 mins), [other](https://cockpit-logs.us-east-1.linodeobjects.com/pull-20206-34a34996-20240320-142318-fedora-39-other/log.html) (21 mins), [storage](https://cockpit-logs.us-east-1.linodeobjects.com/pull-20206-34a34996-20240320-142319-fedora-39-storage/log.html) (14 mins)