### PR TITLE
test: Don't create a empty pacman repo

### DIFF
--- a/test/common/packagelib.py
+++ b/test/common/packagelib.py
@@ -299,6 +299,7 @@ pkgdesc="dummy {name}"
 pkgrel={release}
 arch=({arch})
 depends=({requires})
+options=(!debug)
 {sources}
 
 {installcmds}


### PR DESCRIPTION
Recent versions of repo-add will not write any files in this case, which will cause pacman to fail later on.

Instead, create the "testrepo" repo already during setup, and put a single package in it.