### PR TITLE
storage: Wait for the initial btrfs poll

### DIFF
--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -226,7 +226,7 @@ export async function btrfs_poll() {
     if (!client.uuids_btrfs_volume)
         return;
 
-    if (!client.superuser.allowed) {
+    if (!client.superuser.allowed || !client.features.btrfs) {
         return;
     }
 
@@ -995,8 +995,11 @@ function init_model(callback) {
 
                     client.storaged_client.addEventListener('notify', () => client.update());
 
-                    client.update(true);
-                    callback();
+                    update_indices();
+                    btrfs_poll().then(() => {
+                        client.update(true);
+                        callback();
+                    });
                 });
             });
         });


### PR DESCRIPTION
So that btrfs subvolumes do not get the "newly created" animation on every page load.