### PR TITLE
networkmanager: systemd: port to non-deprecated Dropdown

### DIFF
--- a/pkg/networkmanager/network-interface-members.jsx
+++ b/pkg/networkmanager/network-interface-members.jsx
@@ -20,7 +20,8 @@ import cockpit from "cockpit";
 import React, { useState, useContext } from "react";
 import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
 import { Card, CardHeader, CardTitle } from '@patternfly/react-core/dist/esm/components/Card/index.js';
-import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core/dist/esm/deprecated/components/Dropdown/index.js';
+import { Dropdown, DropdownItem, DropdownList } from '@patternfly/react-core/dist/esm/components/Dropdown/index.js';
+import { MenuToggle } from "@patternfly/react-core/dist/esm/components/MenuToggle";
 import { Switch } from "@patternfly/react-core/dist/esm/components/Switch/index.js";
 import { MinusIcon } from '@patternfly/react-icons';
 
@@ -181,14 +182,18 @@ export const NetworkInterfaceMembers = ({
 
     const add_btn = (
         <Dropdown onSelect={() => setIsOpen(false)}
-                  toggle={
-                      <DropdownToggle id="add-member" onToggle={(_, isOpen) => setIsOpen(isOpen)}>
+                  toggle={(toggleRef) => (
+                      <MenuToggle id="add-member" ref={toggleRef} onClick={() => setIsOpen(!isOpen)}>
                           {_("Add member")}
-                      </DropdownToggle>
-                  }
+                      </MenuToggle>
+                  )}
                   isOpen={isOpen}
-                  position="right"
-                  dropdownItems={dropdownItems} />
+                  popperProps={{ position: "right" }}
+        >
+            <DropdownList>
+                {dropdownItems}
+            </DropdownList>
+        </Dropdown>
     );
 
     return (

--- a/pkg/shell/nav.scss
+++ b/pkg/shell/nav.scss
@@ -230,11 +230,6 @@ $desktop: $phone + 1px;
       /* AAA contrast: simulate #a1a1a1 on #151515 */
       opacity: 0.6;
     }
-
-    .pf-v5-c-dropdown__menu {
-      // Correct the offset
-      margin-block-start: -4px;
-    }
   }
 
   .pf-v5-theme-dark {
@@ -621,12 +616,12 @@ $desktop: $phone + 1px;
 
 // Rework navigation toggles in desktop and (especially) mobile modes
 .super-user-indicator > button,
-.ct-nav-toggle:not(.pf-v5-c-dropdown) {
+.ct-nav-toggle:not(.pf-v5-c-menu) {
   color: var(--pf-v5-global--Color--light-100) !important;
   background: transparent;
 }
 
-.ct-nav-toggle:not(.pf-v5-c-dropdown) {
+.ct-nav-toggle:not(.pf-v5-c-menu) {
   &:hover, &:active, &.active, &.interact, &[aria-expanded="true"] {
     text-decoration: none;
     // approximate --pf-v5-global--BackgroundColor--dark-400, but with opacity
@@ -652,7 +647,7 @@ $desktop: $phone + 1px;
 // This can go away once we move the host selector inside the Masthead
 // https://github.com/patternfly/patternfly/issues/4524
 @media (max-width: $phone) {
-  .ct-nav-toggle.pf-v5-c-dropdown {
+  .ct-nav-toggle {
     &:hover, &:active, &.active, &.interact, &[aria-expanded="true"], &.pf-m-expanded {
       text-decoration: none;
       // approximate --pf-v5-global--BackgroundColor--dark-400, but with opacity
@@ -670,7 +665,7 @@ $desktop: $phone + 1px;
   }
 
   // Hide border from navigation items for mobile
-  .ct-header-item:not(:hover) button:not(:hover)::before {
+  .pf-v5-c-menu-toggle::before {
     border: none;
   }
 }
@@ -719,7 +714,7 @@ $desktop: $phone + 1px;
 @media (max-width: $phone) {
   #host-toggle,
   #nav-system-item,
-  .ct-nav-toggle > button {
+  button.ct-nav-toggle {
     // Stretch to navbar
     block-size: 100%;
     // Don't stretch to fill content; make optimal width same as height
@@ -735,34 +730,32 @@ $desktop: $phone + 1px;
     padding-inline: var(--pf-v5-global--spacer--xs);
     align-items: center;
 
-    > .pf-v5-c-select__toggle-wrapper {
-      flex: none;
-      max-inline-size: 100%;
-    }
-
     // Remove the toggled outline
-    .pf-v5-c-select__toggle::before {
+    .pf-v5-c-menu-toggle::before {
       display: none !important;
     }
-    // Don't show dropdown icon
-    .pf-v5-c-dropdown__toggle-icon {
-      display: none;
+
+    // Don't show toggle icon
+    .pf-v5-c-menu-toggle__icon {
+      margin-inline-end: 0;
     }
 
-    .pf-v5-c-dropdown__toggle-image {
+    .pf-v5-c-menu-toggle__image {
       align-self: center;
       margin: 0 !important;
     }
 
+    // #host-sel specific
     .pf-v5-c-select__toggle-arrow {
       // This is here because Chrome is weird sometimes...
       padding-block: 2px 5px;
       padding-inline: 0;
     }
-  }
 
-  .ct-nav-toggle .pf-v5-c-dropdown__menu {
-    inset-block: auto 100%;
+    > .pf-v5-c-select__toggle-wrapper {
+      flex: none;
+      max-inline-size: 100%;
+    }
   }
 }
 

--- a/pkg/systemd/overview.jsx
+++ b/pkg/systemd/overview.jsx
@@ -26,7 +26,8 @@ import React from 'react';
 import { createRoot } from "react-dom/client";
 import { Page, PageSection, PageSectionVariants } from "@patternfly/react-core/dist/esm/components/Page/index.js";
 import { Gallery } from "@patternfly/react-core/dist/esm/layouts/Gallery/index.js";
-import { Dropdown, DropdownItem, DropdownPosition, DropdownToggle, DropdownToggleAction } from '@patternfly/react-core/dist/esm/deprecated/components/Dropdown/index.js';
+import { Dropdown, DropdownItem, DropdownList } from '@patternfly/react-core/dist/esm/components/Dropdown/index.js';
+import { MenuToggle, MenuToggleAction } from "@patternfly/react-core/dist/esm/components/MenuToggle";
 
 import { superuser } from "superuser";
 
@@ -119,25 +120,34 @@ class OverviewPage extends React.Component {
         if (this.state.privileged)
             headerActions = (
                 <Dropdown onSelect={() => this.setState({ actionIsOpen: true })}
-                    toggle={
-                        <DropdownToggle
-                            splitButtonItems={[
-                                <DropdownToggleAction id='reboot-button'
-                                    key='reboot-button'
-                                    onClick={() => Dialogs.show(<ShutdownModal />)}>
-                                    {_("Reboot")}
-                                </DropdownToggleAction>
-                            ]}
-                            toggleVariant="secondary"
-                            splitButtonVariant="action"
-                            onToggle={(_event, isOpen) => this.setState({ actionIsOpen: isOpen })}
+                    toggle={(toggleRef) => (
+                        <MenuToggle
+                            ref={toggleRef}
+                            variant="secondary"
+                            splitButtonOptions={{
+                                variant: "action",
+                                items: [
+                                    <MenuToggleAction
+                                        id='reboot-button'
+                                        key='reboot-button'
+                                        onClick={() => Dialogs.show(<ShutdownModal />)}
+                                    >
+                                        {_("Reboot")}
+                                    </MenuToggleAction>
+                                ],
+                            }}
+                            onClick={() => this.setState({ actionIsOpen: !actionIsOpen })}
                             id="shutdown-group"
                         />
-                    }
+                    )}
                     isOpen={actionIsOpen}
-                    position={DropdownPosition.right}
-                    dropdownItems={dropdownItems}
-                />);
+                    popperProps={{ position: "right" }}
+                >
+                    <DropdownList>
+                        {dropdownItems}
+                    </DropdownList>
+                </Dropdown>
+            );
 
         const show_superuser = (
             cockpit.transport.host && cockpit.transport.host != "localhost" &&

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -243,7 +243,7 @@ class TestApps(packagelib.PackageCase):
         def set_lang(lang):
             b.switch_to_top()
             b.open_session_menu()
-            b.click(".display-language-menu")
+            b.click("button.display-language-menu")
             b.wait_visible('#display-language-modal')
             b.click(f'#display-language-modal li[data-value={lang}] button')
             b.click("#display-language-modal footer button.pf-m-primary")

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -33,7 +33,7 @@ class TestPages(testlib.MachineCase):
         b = self.browser
 
         b.click("#toggle-docs")
-        b.wait_visible("#toggle-docs + ul")
+        b.wait_visible("#toggle-docs-menu")
         expected = "Web Console"
         expected += "".join(items)
         expected += "About Web Console"
@@ -45,9 +45,9 @@ class TestPages(testlib.MachineCase):
         elif m.image == "arch":
             expected = "Arch Linux documentation" + expected
 
-        b.wait_collected_text("#toggle-docs + ul", expected)
+        b.wait_collected_text("#toggle-docs-menu", expected)
         b.click("#toggle-docs")
-        b.wait_not_present("#toggle-docs + ul")
+        b.wait_not_present("#toggle-docs-menu")
 
     def check_system_menu(self, label, present):
         b = self.browser
@@ -60,7 +60,7 @@ class TestPages(testlib.MachineCase):
         self.browser.switch_to_top()
         self.browser.open_session_menu()
 
-        self.browser.click(".display-language-menu")
+        self.browser.click("button.display-language-menu")
         self.browser.wait_visible('#display-language-modal')
 
     def testBasic(self):
@@ -121,10 +121,10 @@ OnCalendar=daily
         b.switch_to_top()
         self.checkDocs(["Managing services"])
         b.click("#toggle-docs")
-        b.wait_visible(f'#toggle-docs + ul a:contains("Managing services")[href^="{RHEL_DOC_BASE}"]')
-        b.wait_visible(f'#toggle-docs + ul a:contains("Web Console")[href^="{RHEL_DOC_BASE}"]')
+        b.wait_visible(f'#toggle-docs-menu a:contains("Managing services")[href^="{RHEL_DOC_BASE}"]')
+        b.wait_visible(f'#toggle-docs-menu a:contains("Web Console")[href^="{RHEL_DOC_BASE}"]')
         b.click("#toggle-docs")
-        b.wait_not_present("#toggle-docs + ul")
+        b.wait_not_present("#toggle-docs-menu")
         b.go("/network")
         self.checkDocs(["Managing networking bonds", "Managing networking teams",
                         "Managing networking bridges", "Managing VLANs", "Managing firewall"])

--- a/test/verify/check-shell-menu
+++ b/test/verify/check-shell-menu
@@ -81,11 +81,11 @@ class TestMenu(testlib.MachineCase):
 
         # Clicking inside the iframed pages should close the docs menu
         b.click("#toggle-docs")
-        b.wait_visible("#toggle-docs + ul")
+        b.wait_visible("#toggle-docs-menu")
         b.enter_page("/system")
         b.focus("#overview main")
         b.switch_to_top()
-        b.wait_not_present("#toggle-docs + ul")
+        b.wait_not_present("#toggle-docs-menu")
 
         # Check that we can use a link with a hash in it
         b.click_system_menu("/system/#/memory")


### PR DESCRIPTION
This moves us away from all deprecated Dropdown usages in Cockpit, and it requires a slight pixel test change:

https://cockpit-logs.us-east-1.linodeobjects.com/pull-20223-b1e6ffe7-20240402-105419-fedora-39-other/log.html


