### PR TITLE
lib: Avoid infinite layout measurements in plots

### DIFF
--- a/pkg/lib/cockpit-components-plot.jsx
+++ b/pkg/lib/cockpit-components-plot.jsx
@@ -295,7 +295,11 @@ const useLayoutSize = (init_width, init_height) => {
     useLayoutEffect(() => {
         if (ref.current) {
             const rect = ref.current.getBoundingClientRect();
-            if (rect.width != size.width || rect.height != size.height)
+            // Some browsers, such as Bromite, add noise to the result
+            // of getBoundingClientRect in order to deter
+            // fingerprinting. Let's allow for that by only reacting
+            // to significant changes.
+            if (Math.abs(rect.width - size.width) > 2 || Math.abs(rect.height - size.height) > 2)
                 setSize({ width: rect.width, height: rect.height });
         }
     });


### PR DESCRIPTION
The SvgPlot component forces a re-render when the size of its outer
"div" has changed. This requires that this outer div settles on a
stable size.
    
However, some browsers can optionally add noise to the result of
getBoundingClientRect, which causes a constant re-rendering of the
plots since the "div" never seems to settle.
    
Thus, we tolerate the noise and only re-render when the size has
changed significantly.

Fixes #20171