### PR TITLE
User promises cleanup

### DIFF
--- a/pkg/lib/cockpit-components-privileged.jsx
+++ b/pkg/lib/cockpit-components-privileged.jsx
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
 import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
@@ -24,7 +24,7 @@ import { Tooltip, TooltipPosition } from "@patternfly/react-core/dist/esm/compon
 
 import cockpit from "cockpit";
 import { superuser } from 'superuser';
-import { useEvent } from "hooks";
+import { useEvent, useLoggedInUser } from "hooks";
 
 /**
  * UI element wrapper for something that requires privilege. When access is not
@@ -51,9 +51,8 @@ export function Privileged({ excuse, allowed, placement, tooltipId, children }) 
  * Convenience element for a Privilege wrapped Button
  */
 export const PrivilegedButton = ({ tooltipId, placement, excuse, buttonId, onClick, ariaLabel, variant, isDanger, children }) => {
-    const [user, setUser] = useState(null);
+    const user = useLoggedInUser();
     useEvent(superuser, "changed");
-    useEffect(() => cockpit.user().then(user => setUser(user)));
 
     return (
         <Privileged allowed={ superuser.allowed } tooltipId={ tooltipId } placement={ placement }

--- a/test/verify/check-shell-multi-machine-key
+++ b/test/verify/check-shell-multi-machine-key
@@ -85,7 +85,7 @@ class TestMultiMachineKeyAuth(testlib.MachineCase):
                     }});
             }}
         """)
-        self.browser.eval_js("cockpit.user().done(load)")
+        self.browser.eval_js("cockpit.user().then(load)")
         self.browser.wait_js_cond('loaded === true')
 
     def check_keys(self, keys_md5, keys):


### PR DESCRIPTION
This is preparation work for landing the porting of cockpit.user() to the Promise API https://github.com/cockpit-project/cockpit/pull/18589

Maybe we can land 18589 then after the release so we have some time to stabilise possible fallout.