### PR TITLE
[rhel-8] sosreport: Fix command injection with crafted report names [CVE-2024-2947]

### DIFF
--- a/pkg/sosreport/sosreport.jsx
+++ b/pkg/sosreport/sosreport.jsx
@@ -220,7 +220,16 @@ function sosDownload(path) {
 }
 
 function sosRemove(path) {
-    return cockpit.script(cockpit.format("rm -f '$0' '$0'.*", path), { superuser: true, err: "message" });
+    // there are various potential extra files; not all of them are expected to exist,
+    // the file API tolerates removing nonexisting files
+    const paths = [
+        path,
+        path + ".asc",
+        path + ".gpg",
+        path + ".md5",
+        path + ".sha256",
+    ];
+    return Promise.all(paths.map(p => cockpit.file(p, { superuser: true }).replace(null)));
 }
 
 const SOSDialog = () => {

--- a/test/verify/check-sosreport
+++ b/test/verify/check-sosreport
@@ -84,6 +84,7 @@ only-plugins=release,date,host,cgroups,networking
         report_gpg = downloaded_sosreports()[0]
         base_report_gpg = os.path.basename(report_gpg)
         report = report_gpg.replace(".gpg", "")
+        base_report = base_report_gpg.replace(".gpg", "")
 
         m.execute(f"test -f /var/tmp/{base_report_gpg}")
 
@@ -100,7 +101,8 @@ only-plugins=release,date,host,cgroups,networking
         b.click("tr:contains(mylabel) button.pf-v5-c-dropdown__toggle")
         b.click("tr:contains(mylabel) li:contains(Delete)")
         b.click("#sos-remove-dialog button:contains(Delete)")
-        testlib.wait(lambda: m.execute(f"! test -f /var/tmp/{base_report_gpg} && echo yes"))
+        # ensure it removes the report itself, and auxiliary files like .gpg
+        m.execute(f"while ls /var/tmp/{base_report}*; do sleep 1; done", stdout=None, timeout=10)
 
         # error reporting
         self.write_file("/usr/sbin/sos", """#!/bin/sh


### PR DESCRIPTION
Files in /var/tmp/ are controllable by any user. In particular, an unprivileged user could create an sosreport* file containing a `'` and a shell command, which would then run with root privileges when the admin Cockpit user tried to delete the report.

Use the `cockpit.file()` API instead, which entirely avoids shell. The main motivation for using shell and the glob was to ensure that the auxiliary files like *.gpg and *.sha256 get cleaned up -- do that explicitly (which is much safer anyway), and let our tests make sure that we don't leave files behind.

https://bugzilla.redhat.com/show_bug.cgi?id=2271614 https://bugzilla.redhat.com/show_bug.cgi?id=2271815

Cherry-picked from main commit 9c4cc9b6df632082538b5