### PR TITLE
List btrfs snapshots separately in the subvolume detail page

### DIFF
--- a/test/verify/check-storage-btrfs
+++ b/test/verify/check-storage-btrfs
@@ -625,6 +625,15 @@ class TestStorageBtrfs(storagelib.StorageCase):
         b.wait_visible(self.card_row("btrfs subvolume", name="foo"))
         b.wait_not_present(self.card_row("Snapshots", name="foo"))
 
+        # Snapshot details
+        self.click_card_row("Snapshots", name="snap-1")
+        b.wait_text(self.card_desc("btrfs subvolume", "Name"), "snapshots/snap-1")
+        b.wait_text(self.card_desc("btrfs subvolume", "Snapshot origin"), "subdir")
+
+        # Origin link works
+        b.click(self.card_button("btrfs subvolume", "subdir"))
+        b.wait_text(self.card_desc("btrfs subvolume", "Name"), "subdir")
+
 
 if __name__ == '__main__':
     testlib.test_main()

--- a/test/verify/check-storage-btrfs
+++ b/test/verify/check-storage-btrfs
@@ -592,6 +592,39 @@ class TestStorageBtrfs(storagelib.StorageCase):
         b.wait_text(self.card_row_col("btrfs filesystem", row_name="home", col_index=3), "/mnt/home (not mounted)")
         b.wait_text(self.card_row_col("btrfs filesystem", row_name="backups", col_index=3), "/mnt/backups (not mounted)")
 
+    def testSnapshot(self):
+        m = self.machine
+        b = self.browser
+
+        disk = self.add_ram_disk(size=128)
+        mount_point = "/run/butter"
+
+        snapshot_dir = f"{mount_point}/snapshots"
+        subdir = f"{mount_point}/subdir"
+
+        m.execute(f"""
+            mkfs.btrfs -L butter {disk}
+            mkdir -p {mount_point}
+            mount {disk} {mount_point}
+            echo '{disk} {mount_point} auto defaults 0 0' >> /etc/fstab
+            # Debian-testing/ubuntu-2204 btrfs-progrs version does not support creating multiple subvolumes at once
+            btrfs subvolume create {subdir}
+            btrfs subvolume create {snapshot_dir}
+            btrfs subvolume create {subdir}/foo
+            btrfs subvolume snapshot {subdir} {snapshot_dir}/snap-1
+            btrfs subvolume snapshot {mount_point} {snapshot_dir}/snap-2
+        """)
+
+        self.login_and_go("/storage")
+
+        self.click_card_row("Storage", name=os.path.basename(subdir))
+        b.wait_text(self.card_desc("btrfs subvolume", "Name"), "subdir")
+        b.wait_visible(self.card_row("Snapshots", name="snap-1"))
+
+        # Normal subvolume does not show under snapshots
+        b.wait_visible(self.card_row("btrfs subvolume", name="foo"))
+        b.wait_not_present(self.card_row("Snapshots", name="foo"))
+
 
 if __name__ == '__main__':
     testlib.test_main()


### PR DESCRIPTION
This PR identifies snapshots and lists them under the subvolume in a separate card.

Open questions:
* [ ] Should we have actions on snapshots when they are listed in the crossrefs table? At least "Delete" seems appropriate.
* [ ] In the detail view, we now list snapshots and subvolumes both, We should probably hide snapshots from the subvolume list?
* [ ] Do we show snapshots are "btrfs snapshot" instead of "btrfs subvolume".

---

# Show snapshots of a subvolume in the detail view

![image](https://github.com/cockpit-project/cockpit/assets/67428/ef89e27b-b614-4ea7-b46d-937993ebdd6e)

Snapshot origin is shown in snapshot detail view

![image](https://github.com/cockpit-project/cockpit/assets/67428/4ba83f0c-2f5e-41a0-942a-2ac082b5d6a9)