### PR TITLE
test: Also allow modern "mount" error message

### DIFF
--- a/test/common/storagelib.py
+++ b/test/common/storagelib.py
@@ -136,8 +136,11 @@ class StorageHelpers:
     def dialog_wait_open(self):
         self.browser.wait_visible('#dialog')
 
-    def dialog_wait_alert(self, text):
-        self.browser.wait_in_text('#dialog .pf-v5-c-alert__title', text)
+    def dialog_wait_alert(self, text1, text2=None):
+        def has_alert_title():
+            t = self.browser.text('#dialog .pf-v5-c-alert__title')
+            return text1 in t or (text2 is not None and text2 in t)
+        self.browser.wait(has_alert_title)
 
     def dialog_wait_title(self, text):
         self.browser.wait_in_text('#dialog .pf-v5-c-modal-box__title', text)

--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -314,7 +314,7 @@ ExecStart=/usr/bin/sleep infinity
         self.dialog_wait_open()
         self.dialog_set_val("mount_options.extra", "hurr")
         self.dialog_apply()
-        self.dialog_wait_alert("bad option")
+        self.dialog_wait_alert("Unknown parameter 'hurr'", "bad option")
         self.dialog_cancel()
         self.dialog_wait_close()
 
@@ -342,7 +342,7 @@ ExecStart=/usr/bin/sleep infinity
         self.dialog_wait_open()
         self.dialog_set_val("mount_options.extra", "hurr")
         self.dialog_apply()
-        self.dialog_wait_alert("bad option")
+        self.dialog_wait_alert("Unknown parameter 'hurr'", "bad option")
         self.dialog_cancel()
         self.dialog_wait_close()
 


### PR DESCRIPTION
Newer versions of the things involved in mountin seem to give much better error messages and we can be very specific. The old much more generic error message is treated as an afterthought.