### PR TITLE
tools: add 'release' script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,6 @@ on:
 jobs:
   source:
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/cockpit-project/tasks:latest
-      options: --user root
     permissions:
       # create GitHub release
       contents: write
@@ -21,18 +18,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      # https://github.blog/2022-04-12-git-security-vulnerability-announced/
-      - name: Pacify git's permission check
-        run: git config --global --add safe.directory /__w/cockpit/cockpit
-
       - name: Workaround for https://github.com/actions/checkout/pull/697
         run: git fetch --force origin $(git describe --tags):refs/tags/$(git describe --tags)
 
-      - name: Bootstrap automake
-        run: ./autogen.sh
-
       - name: Build release
-        run: make dist -j$(nproc) VERSION='${{ github.ref_name }}'
+        run: tools/release '${{ github.server_url }}/${{ github.repository }}' '${{ github.ref_name }}'
 
       - id: publish
         name: Publish GitHub release

--- a/tools/release
+++ b/tools/release
@@ -1,0 +1,95 @@
+#!/bin/sh
+
+set -eux
+
+# Produce a Cockpit release tarball.
+#
+# This is the script used to create the official releases.
+#
+# It takes two mandatory arguments:
+#
+#   - the URL to clone the repository from,
+#     eg. 'https://github.com/cockpit-project/cockpit'.
+#
+#   - the version to release, which is also the tag name, eg. '215'.
+#
+# The release tarball contains a number of files that are not directly in
+# version control:
+#   - the usual automake stuff
+#   - several submodules
+#   - pre-compiled HTML and JS code
+#
+# This script shallow-clones the specified version of Cockpit from the
+# specified URL, and downloads the version of the tasks container specified in
+# that version. It then does an offline build of the release tarball, which is
+# deterministic.
+#
+# You can use this script to verify the integrity of a particular Cockpit
+# release tarball, or even use it to create the tarball for yourself, as an
+# alternative to downloading it.
+#
+# The result of running `./autogen.sh && make dist VERSION=...` on any system
+# ought to be the same, so long as the same versions of the autotools are
+# present.  Everything else present in the tarball is definitively pinned down
+# in one way or another by the contents of the git repository.  This script is
+# a bit overkill, but it's written in hopes that someone reading it can
+# reasonably convince themselves about the origin of absolutely everything in a
+# Cockpit source release.
+#
+# If this script produces a tarball with a different checksum than the
+# officially-released one, then please report a bug.
+
+URL="$1"
+VERSION="$2"
+
+# We collect the sources into a temporary directory, then use tar to pipe them
+# into a container with no network or filesystem access, where the actual build
+# takes place. The container pipes the built source release back to us.
+
+SOURCE="$(mktemp -dt 'cockpit-build-XXXXXX')"
+trap 'rm -rf "${SOURCE}"' EXIT
+
+# Clone the release and selected submodules into the temporary directory.
+git clone \
+    --depth=1 \
+    --recurse-submodules=node_modules \
+    --recurse-submodules=vendor \
+    -b "${VERSION}" \
+    "${URL}" \
+    "${SOURCE}"
+
+# Show exactly what we're building.
+git -C "${SOURCE}" show --no-patch "${VERSION}"
+
+# Download the tasks container image used for this release.
+IMAGE="$(cat "${SOURCE}"/.cockpit-ci/container)"
+podman pull "${IMAGE}"
+
+# Build the checked out sources into the release tarball, offline.
+tar -C "${SOURCE}" -c . | \
+    podman \
+        run \
+            --rm \
+            --pull=never \
+            --network=none \
+            --log-driver=none \
+            --interactive \
+            --env=VERSION="${VERSION}" \
+            "${IMAGE}" \
+            sh -euxc '
+                (
+                    mkdir work
+                    cd work
+                    rpm -q autoconf automake
+                    automake --version
+                    autoconf --version
+                    tar x
+                    ./autogen.sh
+                    make dist VERSION="${VERSION}"
+                ) >&2
+                cat work/cockpit-"${VERSION}".tar.xz
+            ' \
+    > cockpit-"${VERSION}".tar.xz
+
+# Show the result.
+sha256sum cockpit-"${VERSION}".tar.xz


### PR DESCRIPTION
This is a new script for building Cockpit releases.  It essentially does what we do now, except:

 - we use the container version specified in our .cockpit-ci/container file

 - we download everything with a single invocation of `git clone`, which downloads all the required submodules, but only does a shallow fetch

 - we run the build process entirely offline, inside of its own container

The new script is meant to be more accessible to anyone who may be interested in running it, including outside of GitHub, and is written in a way that attempts to convince its reader that nothing tricky is going on.  It should always produce a byte-for-byte identical release as the official one.  It acts as a convenient way to verify the reproducibility and validity of a Cockpit release, and also as an alternative to downloading the tarball from GitHub.


There's an example run at https://github.com/allisonkarlitskaya/cockpit/actions/runs/8525218012/job/23351627378 which shows it doing the right thing.  I've also run it locally for the 314 release and found that it produced the same checksum.