### PR TITLE
tmt: Pass TEST_* environment into test container

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -95,6 +95,7 @@ exec podman \
         --rm \
         --shm-size=1024m \
         --security-opt=label=disable \
+        --env='TEST_*' \
         --volume="${TMT_TEST_DATA}":/logs:rw,U --env=LOGS=/logs \
         --volume="$(pwd)":/source:rw,U --env=SOURCE=/source \
         --volume=/usr/lib/os-release:/run/host/usr/lib/os-release:ro \


### PR DESCRIPTION
So that things like TEST_AUDIT_NO_SELINUX can be set from the outside.