### PR TITLE
test: Use proper ssh service unit on Debian/Ubuntu

### DIFF
--- a/pkg/systemd/overview-cards/ssh-list-host-keys.sh
+++ b/pkg/systemd/overview-cards/ssh-list-host-keys.sh
@@ -38,7 +38,7 @@ echo "$config" | while IFS='\n' read line; do
 done
 
 # Check with systemd
-systemd=$(systemctl show --property=Listen sshd.socket || true)
+systemd=$(systemctl show --property=Listen sshd.socket || systemctl show --property=Listen ssh.socket || true)
 echo "$systemd" | while IFS='=' read -r name value; do
     if [ "$name" = "ListenStream" ]; then
         parse_addr "$value"

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1510,10 +1510,23 @@ class MachineCase(unittest.TestCase):
         if self.is_devel_build():
             self.disable_preload("packagekit", "systemd")
 
-        if self.machine.image.startswith('debian') or self.machine.image.startswith('ubuntu') or self.machine.image == 'arch':
+        image = self.machine.image
+
+        if image.startswith(('debian', 'ubuntu')) or image == 'arch':
             self.libexecdir = '/usr/lib/cockpit'
         else:
             self.libexecdir = '/usr/libexec'
+
+        if image.startswith(('debian', 'ubuntu')):
+            self.sshd_service = 'ssh.service'
+            self.sshd_socket = 'ssh.socket'
+        else:
+            self.sshd_service = 'sshd.service'
+            if image == 'arch':
+                self.sshd_socket = None
+            else:
+                self.sshd_socket = 'sshd.socket'
+        self.restart_sshd = f'systemctl try-restart {self.sshd_service}'
 
     def nonDestructiveSetup(self):
         """generic setUp/tearDown for @nondestructive tests"""

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -591,7 +591,7 @@ class TestConnection(testlib.MachineCase):
         m.execute("passwd -d user")
 
         self.sed_file('$ a\\\nPermitEmptyPasswords yes', '/etc/ssh/sshd_config',
-                      'systemctl restart sshd.service')
+                      self.restart_sshd)
 
         def assertInOrNot(string, result, expected):
             if expected:

--- a/test/verify/check-loopback
+++ b/test/verify/check-loopback
@@ -49,9 +49,9 @@ class TestLoopback(testlib.MachineCase):
         self.assertIn("no-cockpit", b.text('#login-fatal'))
 
         m.disconnect()
-        self.restore_dir("/etc/ssh", restart_unit="sshd.service")
+        self.restore_dir("/etc/ssh", restart_unit=self.sshd_service)
         m.execute("sed -i 's/.*PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config $(ls /etc/ssh/sshd_config.d/* 2>/dev/null || true)")
-        m.execute("systemctl try-restart sshd.service")
+        m.execute(self.restart_sshd)
         m.wait_execute()
 
         b.reload()

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -72,7 +72,7 @@ def kill_user_admin(machine):
     machine.execute("loginctl terminate-user admin")
 
 
-def change_ssh_port(machine, address, port=None, timeout_sec=120):
+def change_ssh_port(machine, address, sshd_socket, sshd_service, port=None, timeout_sec=120):
     try:
         port = int(port)
     except (ValueError, TypeError):
@@ -92,13 +92,16 @@ def change_ssh_port(machine, address, port=None, timeout_sec=120):
         machine.execute("systemctl restart ssh.socket")
     else:
         machine.execute("sed -i 's/.*Port .*/#\\0/' /etc/ssh/sshd_config")
-        machine.execute(
-            f"printf 'ListenAddress 127.27.0.15:22\nListenAddress {address}:{port}\n' >> /etc/ssh/sshd_config")
+        machine.write("/etc/ssh/sshd_config",
+                      f"ListenAddress 127.27.0.15:22\nListenAddress {address}:{port}\n",
+                      append=True)
         # We stop the sshd.socket unit and just go with a regular
         # daemon.  This is more portable and reloading/restarting the
         # socket doesn't seem to work well.
         #
-        machine.execute("( ! systemctl is-active sshd.socket || systemctl stop sshd.socket) && systemctl restart sshd.service")
+        if sshd_socket:
+            machine.execute(f"systemctl stop {sshd_socket}")
+        machine.execute(f"systemctl restart {sshd_service}")
 
     start_time = time.time()
     error = None
@@ -138,7 +141,7 @@ class TestMultiMachineAdd(testlib.MachineCase):
         m2 = self.machine2
         m3 = self.machine3
         m3_host = "10.111.113.3:2222"
-        change_ssh_port(m3, "10.111.113.3", 2222)
+        change_ssh_port(m3, "10.111.113.3", self.sshd_socket, self.sshd_service, port=2222)
 
         hostname_selector = "#system_information_hostname_text"
 
@@ -195,7 +198,7 @@ class TestMultiMachineAdd(testlib.MachineCase):
         m = self.machine
         m3 = self.machine3
 
-        change_ssh_port(m3, "10.111.113.3", 2222)
+        change_ssh_port(m3, "10.111.113.3", self.sshd_socket, self.sshd_service, port=2222)
         m.write("/etc/ssh/ssh_config", "Host m2\n\tHostName 10.111.113.2\n", append=True)
         m.write("/etc/ssh/ssh_config", "Host m3\n\tHostName 10.111.113.3\n\tPort 2222\n", append=True)
 
@@ -664,7 +667,7 @@ class TestMultiMachine(testlib.MachineCase):
         b.logout()
         b.wait_visible("#login")
 
-        change_ssh_port(m2, "10.111.113.2", 2222)
+        change_ssh_port(m2, "10.111.113.2", self.sshd_socket, self.sshd_service, port=2222)
         m2.disconnect()
         del self.machines["machine2"]  # No more access to m2
 

--- a/test/verify/check-shell-multi-machine-key
+++ b/test/verify/check-shell-multi-machine-key
@@ -108,8 +108,7 @@ class TestMultiMachineKeyAuth(testlib.MachineCase):
         # https://bugs.libssh.org/T233 and because we have a lot of
         # keys and cockpit-ssh tries them all, and many of them twice.
         self.machine2.write("/etc/ssh/sshd_config", "MaxAuthTries 100", append=True)
-        self.machine2.execute(
-            "( ! systemctl is-active sshd.socket || systemctl stop sshd.socket) && systemctl restart sshd.service", direct=True)
+        self.machine2.execute(self.restart_sshd, direct=True)
         self.machine2.wait_execute()
 
         # Disable preloading on all machines ("machine1" is done in testlib.py)

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -259,9 +259,9 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
         # On OSTree this happens over ssh
         if m.ostree_image:
-            self.restore_dir("/etc/ssh", restart_unit="sshd")
+            self.restore_dir("/etc/ssh", restart_unit=self.sshd_service)
             m.execute("sed -i 's/.*ChallengeResponseAuthentication.*/ChallengeResponseAuthentication yes/' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*")
-            m.execute("( ! systemctl is-active sshd.socket || systemctl stop sshd.socket) && systemctl restart sshd.service")
+            m.execute(self.restart_sshd)
 
         # test steps below assume a pam_pwquality config with retry > 1; on some images authselect drops that setting
         if not m.image.startswith('debian') and not m.image.startswith('ubuntu') and not m.image.startswith("arch"):
@@ -358,9 +358,9 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         conf = "/etc/pam.d/cockpit"
         if m.ostree_image:
             conf = "/etc/pam.d/sshd"
-            self.restore_dir("/etc/ssh", restart_unit="sshd")
+            self.restore_dir("/etc/ssh", restart_unit=self.sshd_service)
             m.execute("sed -i 's/.*ChallengeResponseAuthentication.*/ChallengeResponseAuthentication yes/' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*")
-            m.execute("( ! systemctl is-active sshd.socket || systemctl stop sshd.socket) && systemctl restart sshd.service")
+            m.execute(self.restart_sshd)
 
         # On Arch Linux the ordering matters due to an auth include for system-remote-login
         if self.machine.image == "arch":

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -132,8 +132,7 @@ class TestSystemInfo(testlib.MachineCase):
 
         # Change ssh config and restart
         self.sed_file(r"s,.*HostKey *,#,; $ a HostKey /etc/ssh/weirdname", "/etc/ssh/sshd_config",
-                      # Restart sshd but stop socket so we can make sure we are restarted
-                      "( ! systemctl is-active sshd.socket || systemctl stop sshd.socket) && systemctl restart sshd.service")
+                      self.restart_sshd)
         ssh_reconnect(m)
 
         b.click("#system-ssh-keys-link")

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -652,9 +652,9 @@ class TestAccounts(testlib.MachineCase):
 
         # On OSTree this happens over ssh
         if m.ostree_image:
-            self.restore_dir("/etc/ssh", restart_unit="sshd")
+            self.restore_dir("/etc/ssh", restart_unit=self.sshd_service)
             m.execute("sed -i 's/.*ChallengeResponseAuthentication.*/ChallengeResponseAuthentication yes/' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*")
-            m.execute("systemctl try-restart sshd.service")
+            m.execute(self.restart_sshd)
 
         b.wait_visible("#login")
         b.wait_not_visible("#conversation-group")


### PR DESCRIPTION
Factorize the various hardcoded unit names of the sshd socket and service units into `MachineCase` constants.

This will allow us to get rid of the "create sshd.service" alias hack on our Debian/Ubuntu images. This doesn't work any more on current ubuntu-stable (see https://github.com/cockpit-project/bots/pull/6172), and also hides bugs as on actual installations the service really isn't called `sshd.service`.
