### PR TITLE
workflows: Run tasks-container-update in "self" environment

### DIFF
--- a/.github/workflows/tasks-container-update.yml
+++ b/.github/workflows/tasks-container-update.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
 jobs:
   tasks-container-update:
+    environment: self
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -23,6 +24,8 @@ jobs:
 
       - name: Clone repository
         uses: actions/checkout@v4
+        with:
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       # https://github.blog/2022-04-12-git-security-vulnerability-announced/
       - name: Pacify git's permission check


### PR DESCRIPTION
This workflow produces PRs which need to run reposchutz, so they need to be pushed via SSH, not the GitHub token.

---

I landed yesterday's 20266 with admin hammer. Same as https://github.com/cockpit-project/cockpit-podman/pull/1660 and https://github.com/cockpit-project/cockpit-machines/pull/1548