### PR TITLE
bridge: rewrite fsreplace1 as AsyncChannel

### DIFF
--- a/pkg/kdump/test-config-client.js
+++ b/pkg/kdump/test-config-client.js
@@ -83,6 +83,7 @@ QUnit.module("kdump", hooks => {
                         config.write(config.settings)
                                 .then(() => {
                                     // Close watch channel
+                                    config.removeEventListener('kdumpConfigChanged', configChanged);
                                     config.close();
                                     dataWasChanged.then(done);
                                 });

--- a/src/cockpit/channel.py
+++ b/src/cockpit/channel.py
@@ -441,12 +441,12 @@ class AsyncChannel(Channel):
     # Send-side flow control
     write_waiter = None
 
-    async def run(self, options: JsonObject) -> None:
+    async def run(self, options: JsonObject) -> 'JsonObject | None':
         raise NotImplementedError
 
     async def run_wrapper(self, options: JsonObject) -> None:
         try:
-            await self.run(options)
+            self.close(await self.run(options))
         except asyncio.CancelledError:  # user requested close
             self.close()
         except ChannelError as exc:
@@ -454,8 +454,6 @@ class AsyncChannel(Channel):
         except BaseException:
             self.close({'problem': 'internal-error', 'cause': traceback.format_exc()})
             raise
-        else:
-            self.close()
 
     async def read(self) -> 'bytes | None':
         # Three possibilities for what we'll find:


### PR DESCRIPTION
Our previous reason for avoiding tempfile.NamedTemporaryFile() was that we didn't want to chown() after the fact, but we've crossed that bridge already since 72027c1d3d5c45715030c21d6ddad18f3e06ce65, so we may as well go all the way.

Rewrite things as a single run() function using NamedTemporaryFile as a context manager.  This is a fairly substantial simplification.  We also make the channel properly asynchronous by dispatching the actual write to an executor.  We also add fdatasync(), which we were missing before.