### PR TITLE
workflows: Run release on Ubuntu 20.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,8 @@ on:
 
 jobs:
   source:
-    runs-on: ubuntu-latest
+    # 22.04's podman has issues with piping and causes tar errors
+    runs-on: ubuntu-20.04
     permissions:
       # create GitHub release
       contents: write


### PR DESCRIPTION
Just like the "reposchutz" and "dependabot" workflows, run "release" on ubuntu 20.04. Podman in 22.04 creates truncated tarballs when streaming them through stdout.

----

This broke the release, the 315 tarballs were only ~ 200 to 300 kB and truncated.