### PR TITLE
dependabot: Update all typescript related packages as a group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,10 @@ updates:
       stylelint:
         patterns:
           - "stylelint*"
+      types:
+        patterns:
+          - "@types*"
+          - "types*"
       xterm:
         patterns:
           - "xterm*"


### PR DESCRIPTION
They get new releases very often and cause too much CI churn/conflicts otherwise.

---

See last night's #20290, #20291, and #20292. They step on each other's toes.