### PR TITLE
dependabot: Group react packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,9 @@ updates:
       esbuild:
         patterns:
           - "esbuild*"
+      react:
+        patterns:
+          - "react*"
       stylelint:
         patterns:
           - "stylelint*"


### PR DESCRIPTION
react and react-dom need to be kept in sync.