### PR TITLE
lib: Close Dropdown after selection instead of toggling it

### DIFF
--- a/pkg/lib/cockpit-components-dropdown.jsx
+++ b/pkg/lib/cockpit-components-dropdown.jsx
@@ -45,7 +45,7 @@ export const KebabDropdown = ({ dropdownItems, position, isDisabled, toggleButto
         <Dropdown
             {...props}
             onOpenChange={isOpen => setKebabOpen(isOpen)}
-            onSelect={() => setKebabOpen(!isKebabOpen)}
+            onSelect={() => setKebabOpen(false)}
             toggle={(toggleRef) => (
                 <MenuToggle
                     id={toggleButtonId}


### PR DESCRIPTION
This probably makes no difference since onSelect is probably only called when isOpen is true anyway. But this is more explicit and follows the example code more closely.