### PR TITLE
test: lcov: add coverage for ts/x files

### DIFF
--- a/test/common/lcov.py
+++ b/test/common/lcov.py
@@ -91,7 +91,7 @@ def parse_sourcemap(f, line_starts, dir_name):
 
     our_sources = set()
     for s in sources:
-        if "node_modules" not in s and (s.endswith(('.js', '.jsx'))):
+        if "node_modules" not in s and (s.endswith(('.js', '.jsx', '.ts', '.tsx'))):
             our_sources.add(s)
 
     dst_col, src_id, src_line = 0, 0, 0


### PR DESCRIPTION
Our current predicate for whether we report coverage on a file or not is "not in node_modules, and name ends in .js/x".  Add .ts and .tsx to that as well.