### PR TITLE
base1: add cockpit.assert()

### DIFF
--- a/pkg/lib/cockpit.d.ts
+++ b/pkg/lib/cockpit.d.ts
@@ -26,6 +26,8 @@ declare module 'cockpit' {
         toString(): string;
     }
 
+    function assert(predicate: unknown, message?: string): asserts predicate;
+
     /* === Events mix-in ========================= */
 
     interface EventMap {

--- a/pkg/lib/cockpit.js
+++ b/pkg/lib/cockpit.js
@@ -4415,6 +4415,12 @@ function factory() {
         return false;
     };
 
+    cockpit.assert = (predicate, message) => {
+        if (!predicate) {
+            throw new Error(`Assertion failed: ${message}`);
+        }
+    };
+
     return cockpit;
 }
 


### PR DESCRIPTION
Add and type-hint a new cockpit.assert() function which throws an error if the given predicate is not true.

Fixes #20298 

followup: add qunit tests.  This requires a bit of `.ts` hackery in our `qunit-test` file, and I don't want to block this feature.