### PR TITLE
test: End logout() with blank page

### DIFF
--- a/test/common/chromium-cdp-driver.js
+++ b/test/common/chromium-cdp-driver.js
@@ -185,10 +185,8 @@ function setupFrameTracking(client) {
     });
 
     client.Page.loadEventFired(() => {
-        if (pageLoadHandler) {
-            debug("loadEventFired, resolving pageLoadHandler");
+        if (pageLoadHandler)
             pageLoadHandler();
-        }
     });
 
     // track execution contexts so that we can map between context and frame IDs
@@ -209,22 +207,12 @@ function setupFrameTracking(client) {
 }
 
 function setupLocalFunctions(client) {
-    client.waitPageLoad = (args) => new Promise((resolve, reject) => {
-        const timeout = setTimeout(() => {
-            pageLoadHandler = null;
-            reject("Timeout waiting for page load"); // eslint-disable-line prefer-promise-reject-errors
-        }, 15000);
-        pageLoadHandler = () => {
-            clearTimeout(timeout);
-            pageLoadHandler = null;
-            resolve({});
-        };
-    });
-
-    client.reloadPageAndWait = (args) => new Promise((resolve, reject) => {
-        pageLoadHandler = () => { pageLoadHandler = null; resolve({}) };
-        client.Page.reload(args);
-    });
+    client.reloadPageAndWait = (args) => {
+        return new Promise((resolve, reject) => {
+            pageLoadHandler = () => { pageLoadHandler = null; resolve({}) };
+            client.Page.reload(args);
+        });
+    };
 
     async function setCSS({ text, frame }) {
         await client.DOM.enable();

--- a/test/common/chromium-cdp-driver.js
+++ b/test/common/chromium-cdp-driver.js
@@ -213,7 +213,7 @@ function setupLocalFunctions(client) {
         const timeout = setTimeout(() => {
             pageLoadHandler = null;
             reject("Timeout waiting for page load"); // eslint-disable-line prefer-promise-reject-errors
-        }, (args.timeout ?? 15) * 1000);
+        }, 15000);
         pageLoadHandler = () => {
             clearTimeout(timeout);
             pageLoadHandler = null;

--- a/test/common/firefox-cdp-driver.js
+++ b/test/common/firefox-cdp-driver.js
@@ -227,10 +227,8 @@ function setupFrameTracking(client) {
     });
 
     client.Page.loadEventFired(() => {
-        if (pageLoadHandler) {
-            debug("loadEventFired, resolving pageLoadHandler");
+        if (pageLoadHandler)
             pageLoadHandler();
-        }
     });
 
     // track execution contexts so that we can map between context and frame IDs
@@ -281,22 +279,12 @@ function setupFrameTracking(client) {
 }
 
 function setupLocalFunctions(client) {
-    client.waitPageLoad = (args) => new Promise((resolve, reject) => {
-        const timeout = setTimeout(() => {
-            pageLoadHandler = null;
-            reject("Timeout waiting for page load"); // eslint-disable-line prefer-promise-reject-errors
-        }, 15000);
-        pageLoadHandler = () => {
-            clearTimeout(timeout);
-            pageLoadHandler = null;
-            resolve({});
-        };
-    });
-
-    client.reloadPageAndWait = (args) => new Promise((resolve, reject) => {
-        pageLoadHandler = () => { pageLoadHandler = null; resolve({}) };
-        client.Page.reload(args);
-    });
+    client.reloadPageAndWait = (args) => {
+        return new Promise((resolve, reject) => {
+            pageLoadHandler = () => { pageLoadHandler = null; resolve({}) };
+            client.Page.reload(args);
+        });
+    };
 }
 
 // helper functions for testlib.py which are too unwieldy to be poked in from Python

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -256,7 +256,7 @@ class Browser:
             # But that option has the inverse effect with Chromium (argh)
             opts["transitionType"] = "reload"
         self.cdp.invoke("Page.navigate", url=href, **opts)
-        self.cdp.invoke("waitPageLoad", timeout=self.cdp.timeout)
+        self.cdp.invoke("waitPageLoad")
 
     def set_user_agent(self, ua: str):
         """Set the user agent of the browser

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -249,6 +249,7 @@ class Browser:
 
         self.switch_to_top()
         self.cdp.invoke("Page.navigate", url=href)
+        wait(lambda: self.cdp.command("Promise.resolve(getFrameExecId(null) !== undefined)"), delay=0.2, tries=10)
 
     def set_user_agent(self, ua: str):
         """Set the user agent of the browser

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -846,6 +846,7 @@ class Browser:
         self.logout()
         if wait_remote_session_machine:
             wait_remote_session_machine.execute("while pgrep -a cockpit-ssh; do sleep 1; done")
+        self.open(path or "/")
         self.try_login(user, password=password, superuser=superuser)
         self._wait_present('#content')
         self.wait_visible('#content')

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -838,6 +838,11 @@ class Browser:
                 if "Execution context was destroyed" not in str(e):
                     raise
         self.wait_visible('#login')
+        # avoid browser optimizations when the last URL and future open(URL) are the same (like in
+        # TestKeys.testAuthorizedKeys). Telling Page.navigate to "yes, *really* load the given URL"
+        # is hilariously difficult, so load the blank page here to clean the slate. This will also make
+        # it more obvious when a test tries to do something on the page after logout().
+        self.cdp.invoke("Page.navigate", url="about:blank")
 
         self.machine.allow_restart_journal_messages()
 

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -248,15 +248,7 @@ class Browser:
             self.cdp.invoke("Network.setCookie", **cookie)
 
         self.switch_to_top()
-        opts = {}
-        if self.cdp.browser.name == "firefox":
-            # by default, Firefox optimizes this away if the current and the given href URL
-            # are the same (Like in TestKeys.testAuthorizedKeys).
-            # Force a reload in this case, to make tests and the waitPageLoad below predictable
-            # But that option has the inverse effect with Chromium (argh)
-            opts["transitionType"] = "reload"
-        self.cdp.invoke("Page.navigate", url=href, **opts)
-        self.cdp.invoke("waitPageLoad")
+        self.cdp.invoke("Page.navigate", url=href)
 
     def set_user_agent(self, ua: str):
         """Set the user agent of the browser

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -255,11 +255,6 @@ class Browser:
             # Force a reload in this case, to make tests and the waitPageLoad below predictable
             # But that option has the inverse effect with Chromium (argh)
             opts["transitionType"] = "reload"
-        elif self.cdp.browser.name == 'chromium':
-            # Chromium also optimizes this away, but doesn't have a knob to force loading
-            # so load the blank page first
-            self.cdp.invoke("Page.navigate", url="about:blank")
-            self.cdp.invoke("waitPageLoad", timeout=5)
         self.cdp.invoke("Page.navigate", url=href, **opts)
         self.cdp.invoke("waitPageLoad", timeout=self.cdp.timeout)
 


### PR DESCRIPTION
It turns out that the `waitPageLoad()` approach from commit
49ee017f26bab07 is unreliable, and sometimes does not work with at least
RHEL/CentOS 9's Firefox ESR. Also, that whole approach has become too
complicated and messy.

Revert that plus the two follow up commits df77763d12f603 and
2404d6a0a761caf5 and instead unconditionally open the blank page after
logout(). This is much simpler, doesn't require any explicit waiting,
works on all browsers, and stops penalizing the first login with the
extra action (so the cost to tests which don't logout is zero). It also
has the added robustification that trying to do something to the page
after calling logout() now fails very clearly -- you *have* to navigate
somewhere after logging out.

-----

See #20300 for the debugging notes, stress test, and links to example failures.