### PR TITLE
lib: the channel superuser option takes "try" or "require"

### DIFF
--- a/pkg/lib/cockpit.d.ts
+++ b/pkg/lib/cockpit.d.ts
@@ -86,7 +86,7 @@ declare module 'cockpit' {
 
     interface ChannelOptions {
         payload: string;
-        superuser?: string;
+        superuser?: "try" | "require";
         [_: string]: JsonValue | undefined;
     }
 


### PR DESCRIPTION
Specify exactly which superuser options we support so language server users see warnings for wrong options in their editor.