### PR TITLE
test: Fix race condition with waiting for page load

### DIFF
--- a/test/common/cdp.py
+++ b/test/common/cdp.py
@@ -196,8 +196,13 @@ class CDP:
         if fn == 'Runtime.evaluate':
             cmd = "%s, contextId: getFrameExecId(%s)%s" % (cmd[:-2], jsquote(self.cur_frame), cmd[-2:])
 
+        waitPageLoad = fn in ['Page.navigate', 'Page.reload']
+
         if trace:
-            print("-> " + kwargs.get('trace', cmd))
+            print("-> " + kwargs.get('trace', cmd) + (" (with waitPageLoad)" if waitPageLoad else ""))
+
+        if waitPageLoad:
+            self.command(f"client.setupPageLoadHandler({self.timeout})")
 
         # avoid having to write the "client." prefix everywhere
         cmd = "client." + cmd
@@ -207,6 +212,11 @@ class CDP:
                 print("<- " + repr(res["result"]))
             else:
                 print("<- " + repr(res))
+
+        if waitPageLoad:
+            res = self.command("client.pageLoadPromise")
+            if trace:
+                print("<- pageLoadPromise " + repr(res))
         return res
 
     def command(self, cmd):


### PR DESCRIPTION
The `client.waitPageLoad()` introduced in commit 49ee017f26ba was inherently racy: It set up the `client.Page.loadEventFired()` callback after doing the `Page.navigate()` call. Sometimes, that event happened in between the navigate and waitPageLoad calls, and the callback was missed. This broke especially often on CentOS 9 aarch64 (with older Firefox ESR versions), but also sometimes on x86 and on our CI.

Fix this by handling this inside of `CDP.invoke()`, and setting up a page load handler for all `Page.{navigate,reload}` calls *before* doing the actual call, and then waiting for the load event to happen after the call. With that we can also drop the `client.reloadPageAndWait()` special-case wrapper, and just let clients use the standard CDP `Page.reload()` method.

With that we can also unify the `Browser.open()` approach to fight the "open same URL as the current one" browser optimizations: Always open the blank page first to force a load. This avoids browser special cases and magical half-working options, and makes the whole approach much simpler.

---

See https://github.com/cockpit-project/cockpit/pull/20300 for the debugging notes, stress test, and links to example failures. #20304 was my earlier attempt at fixing this, but it failed. I feel much better about this one!