### PR TITLE
flow control for file uploads

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -112,6 +112,8 @@ The following fields are defined:
  * "capabilities": Optional, array of capability strings required from the bridge
  * "session": Optional, set to "private" or "shared". Defaults to "shared"
  * "flow-control": Optional boolean whether the channel should throttle itself via flow control.
+ * "send-acks": Set to "bytes" to send "ack" messages after processing each data frame
+
 
 If "binary" is set to "raw" then this channel transfers binary messages.
 
@@ -162,7 +164,13 @@ channels in the "fence" group are closed before resuming.
 The "flow-control" option controls whether a channel should attempt to throttle
 itself via flow control when sending or receiving large amounts of data. The
 current default (when this option is not provided) is to not do flow control.
-However, this default will likely change in the future.
+However, this default will likely change in the future.  This only impacts data
+sent by the bridge to the browser.
+
+If "send-acks" is set to "bytes" then the bridge will send acknowledgement
+messages detailing the number of payload bytes that it has received and
+processed.  This mechanism is provided for senders (ie: in the browser) who
+wish to throttle the data that they're sending to the bridge.
 
 **Host values**
 

--- a/pkg/kdump/test-config-client.js
+++ b/pkg/kdump/test-config-client.js
@@ -83,6 +83,7 @@ QUnit.module("kdump", hooks => {
                         config.write(config.settings)
                                 .then(() => {
                                     // Close watch channel
+                                    config.removeEventListener('kdumpConfigChanged', configChanged);
                                     config.close();
                                     dataWasChanged.then(done);
                                 });

--- a/pkg/lib/cockpit-upload-helper.ts
+++ b/pkg/lib/cockpit-upload-helper.ts
@@ -1,0 +1,141 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from 'cockpit';
+
+// These are the same values used by the bridge (in channel.py)
+const BLOCK_SIZE = 16 << 10; // 16kiB
+const FLOW_WINDOW = 2 << 20; // 2MiB
+
+function debug(...args: unknown[]) {
+    if (window.debugging == 'all' || window.debugging?.includes('upload'))
+        console.debug('upload', ...args);
+}
+
+class UploadError extends Error {
+    name = 'UploadError';
+}
+
+class Waiter {
+    unblock = () => { };
+    block(): Promise<void> {
+        return new Promise(resolve => { this.unblock = resolve });
+    }
+}
+
+export async function upload(
+    destination: string,
+    stream: ReadableStream,
+    progress?: (bytes_sent: number) => void,
+    signal?: AbortSignal,
+    options?: cockpit.JsonObject
+) {
+    let close_message = null as (cockpit.JsonObject | null);
+    let outstanding = 0; // for flow control
+    let delivered = 0; // for progress reporting
+
+    // This variable is the most important thing in this function.  The main
+    // upload loop will do work for as long as it can, and then it .block()s on
+    // the waiter until something changes (ack, close, abort, etc).  All of
+    // those things call .unblock() to resume the loop.
+    const event_waiter = new Waiter();
+
+    if (signal) {
+        signal.throwIfAborted(); // early exit
+        signal.addEventListener('abort', event_waiter.unblock);
+    }
+
+    const opts = {
+        payload: 'fsreplace1',
+        path: destination,
+        binary: true,
+        'send-acks': 'bytes',
+        ...options,
+    } as const;
+    debug('requesting channel', opts);
+    const channel = cockpit.channel(opts);
+    channel.addEventListener('control', (_ev, message) => {
+        debug('control', message);
+        if (message.command === 'ack') {
+            cockpit.assert(typeof message.bytes === 'number', 'bytes not a number');
+            delivered += message.bytes;
+            if (progress) {
+                debug('progress', delivered);
+                progress(delivered);
+            }
+            outstanding -= message.bytes;
+            debug('outstanding -- to', outstanding);
+            event_waiter.unblock();
+        }
+    });
+    channel.addEventListener('close', (_ev, message) => {
+        debug('close', message);
+        close_message = message;
+        event_waiter.unblock();
+    });
+
+    try {
+        debug('starting file send', stream);
+        const reader = stream.getReader({ mode: 'byob' }); // byob to choose the block size
+        let eof = false;
+
+        // eslint-disable-next-line no-unmodified-loop-condition
+        while (!close_message) {
+            /* We do the following steps for as long as the channel is open:
+             *  - if there is room to write more data, do that
+             *  - otherwise, block on the waiter until something changes
+             *  - in any case, check for cancellation, repeat
+             * The idea here is that each loop iteration will `await` one
+             * thing, and once it returns, we need to re-evaluate our state.
+             */
+            if (!eof && outstanding < FLOW_WINDOW) {
+                const { done, value } = await reader.read(new Uint8Array(BLOCK_SIZE));
+                if (done) {
+                    debug('sending done');
+                    channel.control({ command: 'done' });
+                    eof = true;
+                } else {
+                    debug('sending', value.length, 'bytes');
+                    channel.send(value);
+                    outstanding += value.length;
+                    debug('outstanding ++ to', outstanding);
+                }
+                if (signal) {
+                    signal.throwIfAborted();
+                }
+            } else {
+                debug('sleeping', outstanding, 'of', FLOW_WINDOW, 'eof', eof);
+                await event_waiter.block();
+            }
+            if (signal) {
+                signal.throwIfAborted();
+            }
+        }
+
+        if (close_message.problem) {
+            throw new UploadError(cockpit.message(close_message));
+        } else {
+            cockpit.assert(typeof close_message.tag === 'string', "tag missing on close message");
+            return close_message.tag;
+        }
+    } finally {
+        debug('finally');
+        channel.close(); // maybe we got aborted
+    }
+}

--- a/pkg/lib/cockpit.d.ts
+++ b/pkg/lib/cockpit.d.ts
@@ -77,6 +77,7 @@ declare module 'cockpit' {
         id: string | null;
         binary: boolean;
         options: JsonObject;
+        ready: boolean;
         valid: boolean;
         send(data: T): void;
         control(options: ControlMessage): void;
@@ -191,6 +192,8 @@ declare module 'cockpit' {
     export function user(): Promise<UserInfo>;
 
     /* === String helpers ======================== */
+
+    function message(problem: string | JsonObject): string;
 
     function gettext(message: string): string;
     function gettext(context: string, message?: string): string;

--- a/pkg/lib/index.d.ts
+++ b/pkg/lib/index.d.ts
@@ -1,0 +1,3 @@
+interface Window {
+    debugging?: string;
+}

--- a/pkg/playground/react-demo-file-upload.tsx
+++ b/pkg/playground/react-demo-file-upload.tsx
@@ -1,0 +1,141 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from "cockpit";
+import React, { useRef, useState } from "react";
+import { Container, createRoot } from 'react-dom/client';
+
+import { Alert, AlertActionCloseButton } from "@patternfly/react-core/dist/esm/components/Alert/index.js";
+import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
+import { Flex } from "@patternfly/react-core/dist/esm/layouts/Flex/index.js";
+import { Progress } from "@patternfly/react-core/dist/esm/components/Progress/index.js";
+import { TimesIcon, UploadIcon } from "@patternfly/react-icons";
+
+import { FileAutoComplete } from "cockpit-components-file-autocomplete.jsx";
+import { upload } from "cockpit-upload-helper";
+
+const _ = cockpit.gettext;
+
+export const UploadButton = () => {
+    const ref = useRef<HTMLInputElement>(null);
+    const [files, setFiles] = useState<{[name: string]: {file: File, progress: number, cancel:() => void}}>({});
+    const [alert, setAlert] = useState<{variant: "warning" | "danger", title: string, message: string} | null>(null);
+    const [dest, setDest] = useState("/home/admin/");
+    let next_progress = 0;
+
+    const handleClick = () => {
+        if (ref.current) {
+            ref.current.click();
+        }
+    };
+
+    const onUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
+        cockpit.assert(event.target.files, "not an <input type='file'>?");
+        setAlert(null);
+        await Promise.allSettled(Array.from(event.target.files).map(async (file: File) => {
+            const destination = `${dest}${file.name}`;
+            const abort = new AbortController();
+
+            setFiles(oldFiles => {
+                return {
+                    [file.name]: { file, progress: 0, cancel: () => abort.abort() },
+                    ...oldFiles,
+                };
+            });
+
+            try {
+                await upload(destination, file.stream(), (progress) => {
+                    const now = performance.now();
+                    if (now < next_progress)
+                        return;
+                    next_progress = now + 200; // only rerender every 200ms
+                    setFiles(oldFiles => {
+                        const oldFile = oldFiles[file.name];
+                        return {
+                            ...oldFiles,
+                            [file.name]: { ...oldFile, progress },
+                        };
+                    });
+                }, abort.signal);
+            } catch (exc) {
+                cockpit.assert(exc instanceof Error, "Unknown exception type");
+                if (exc instanceof DOMException && exc.name == 'AbortError') {
+                    setAlert({ variant: "warning", title: 'Aborted', message: '' });
+                } else {
+                    setAlert({ variant: "danger", title: 'Upload Error', message: exc.message });
+                }
+            } finally {
+                setFiles(oldFiles => {
+                    const copy = { ...oldFiles };
+                    delete copy[file.name];
+                    return copy;
+                });
+            }
+        }));
+
+        // Reset input field in the case a download was cancelled and has to be re-uploaded
+        // https://stackoverflow.com/questions/26634616/filereader-upload-same-file-again-not-working
+        event.target.value = "";
+    };
+
+    return (
+        <>
+            <Flex direction={{ default: "column" }}>
+                <FileAutoComplete className="upload-file-dest" value={dest} onChange={setDest} />
+                <Button
+                  id="upload-file-btn"
+                  variant="secondary"
+                  icon={<UploadIcon />}
+                  isDisabled={Object.keys(files).length !== 0}
+                  isLoading={Object.keys(files).length !== 0}
+                  onClick={handleClick}
+                >
+                    {_("Upload")}
+                </Button>
+                <input
+                  ref={ref} type="file"
+                  hidden multiple onChange={onUpload}
+                />
+            </Flex>
+            {alert !== null &&
+            <Alert variant={alert.variant}
+                   title={alert.title}
+                   timeout={3000}
+                   actionClose={<AlertActionCloseButton onClose={() => setAlert(null)} />}
+            >
+                <p>{alert.message}</p>
+            </Alert>
+            }
+            {Object.keys(files).map((key, index) => {
+                const file = files[key];
+                return (
+                    <React.Fragment key={index}>
+                        <Progress className={`upload-progress-${index}`} key={file.file.name} value={file.progress} title={file.file.name} max={file.file.size} />
+                        <Button className={`cancel-button-${index}`} icon={<TimesIcon />} onClick={file.cancel} />
+                    </React.Fragment>
+                );
+            })}
+        </>
+    );
+};
+
+export const showUploadDemo = (rootElement: Container) => {
+    const root = createRoot(rootElement);
+    root.render(<UploadButton />);
+};

--- a/pkg/playground/react-patterns.html
+++ b/pkg/playground/react-patterns.html
@@ -29,6 +29,11 @@
                 <h3>Cards</h3>
                 <div id="demo-cards"></div>
             </section>
+
+            <section class="pf-v5-c-page__main-section pf-m-light">
+                <h3>Upload</h3>
+                <div id="demo-upload"></div>
+            </section>
         </main>
     </div>
 </body>

--- a/pkg/playground/react-patterns.js
+++ b/pkg/playground/react-patterns.js
@@ -27,6 +27,7 @@ import { show_modal_dialog } from "cockpit-components-dialog.jsx";
 
 import { PatternDialogBody } from "./react-demo-dialog.jsx";
 import { showCardsDemo } from "./react-demo-cards.jsx";
+import { showUploadDemo } from "./react-demo-file-upload.jsx";
 import { showFileAcDemo, showFileAcDemoPreselected } from "./react-demo-file-autocomplete.jsx";
 
 /* -----------------------------------------------------------------------------
@@ -126,4 +127,7 @@ document.addEventListener("DOMContentLoaded", function() {
 
     // Cards
     showCardsDemo(document.getElementById('demo-cards'));
+
+    // Upload
+    showUploadDemo(document.getElementById('demo-upload'));
 });

--- a/src/cockpit/channel.py
+++ b/src/cockpit/channel.py
@@ -441,12 +441,12 @@ class AsyncChannel(Channel):
     # Send-side flow control
     write_waiter = None
 
-    async def run(self, options: JsonObject) -> None:
+    async def run(self, options: JsonObject) -> 'JsonObject | None':
         raise NotImplementedError
 
     async def run_wrapper(self, options: JsonObject) -> None:
         try:
-            await self.run(options)
+            self.close(await self.run(options))
         except asyncio.CancelledError:  # user requested close
             self.close()
         except ChannelError as exc:
@@ -454,8 +454,6 @@ class AsyncChannel(Channel):
         except BaseException:
             self.close({'problem': 'internal-error', 'cause': traceback.format_exc()})
             raise
-        else:
-            self.close()
 
     async def read(self) -> 'bytes | None':
         # Three possibilities for what we'll find:

--- a/src/cockpit/channel.py
+++ b/src/cockpit/channel.py
@@ -457,9 +457,9 @@ class AsyncChannel(Channel):
 
     async def read(self) -> 'bytes | None':
         # Three possibilities for what we'll find:
-        #  - None (EOF) → return b''
+        #  - None (EOF) → return None
         #  - a ping → send a pong
-        #  - bytes → return it
+        #  - bytes → return it (possibly empty)
         while True:
             item = await self.receive_queue.get()
             if item is None:

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -301,10 +301,15 @@ class Browser:
         """
         self.cdp.set_frame(None)
 
-    def upload_file(self, selector: str, file: str):
+    def upload_files(self, selector: str, files: 'list[str]') -> None:
+        """Upload a local file to the browser
+
+        The selector should select the <input type="file"/> element.
+        Files is a list of absolute paths to files which should be uploaded.
+        """
         r = self.cdp.invoke("Runtime.evaluate", expression='document.querySelector(%s)' % jsquote(selector))
         objectId = r["result"]["objectId"]
-        self.cdp.invoke("DOM.setFileInputFiles", files=[file], objectId=objectId)
+        self.cdp.invoke("DOM.setFileInputFiles", files=files, objectId=objectId)
 
     def raise_cdp_exception(self, func, arg, details, trailer=None):
         # unwrap a typical error string

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -18,9 +18,13 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import subprocess
+import tempfile
 import time
+from pathlib import Path
 
 import testlib
+from lib.constants import TEST_OS_DEFAULT
 
 RHEL_DOC_BASE = "https://access.redhat.com/documentation"
 
@@ -861,6 +865,96 @@ OnCalendar=daily
 
         # logging out too fast, some D-Bus services get disconnected
         self.allow_restart_journal_messages()
+
+    @testlib.skipBrowser(".upload_files() doesn't work on Firefox", "firefox")
+    def testUpload(self) -> None:
+        b = self.browser
+        m = self.machine
+
+        self.restore_dir("/home/admin")
+        self.login_and_go("/playground/react-patterns")  # , debugging="upload")
+        files_dir = Path(testlib.TEST_DIR) / "verify" / "files" / "metrics-archives"
+        test_upload_file = str(files_dir / "double_events.zip")
+        dest_file = "/home/admin/double_events.zip"
+
+        filehash = subprocess.check_output(["sha512sum", test_upload_file]).strip().decode().split(' ')[0]
+        filesize = subprocess.check_output(["stat", "--format", "%s", test_upload_file]).strip().decode()
+
+        b.upload_files("#demo-upload input[type='file']", [test_upload_file])
+
+        testlib.wait(lambda: m.execute(f"test -f {dest_file} && echo {dest_file} || echo 'no'").strip() == dest_file)
+        self.assertEqual(m.execute(f"stat --format '%s' {dest_file}").strip(), filesize)
+        self.assertEqual(m.execute(f"sha512sum {dest_file} | awk '{{ print $1 }}'").strip(), filehash)
+        b.wait_visible("#upload-file-btn:not(:disabled)")
+
+        # Various cases of big file upload
+        with tempfile.TemporaryDirectory() as tmpdir:
+            big_file = str(Path(tmpdir) / "bigfile.img")
+            # the VM has a total of 1.5G memory, so this would fill it
+            # use SI sizes to make sure we test the last incomplete block
+            subprocess.check_call(["truncate", "-s", "1500MB", big_file])
+
+            # Uploaded to completion.  It's slow, so only do it on default OS.
+            # We do this to make sure the file is spooled to disk, not memory.
+            if self.machine.image == TEST_OS_DEFAULT:
+                b.upload_files("#demo-upload input[type='file']", [big_file])
+                b.wait(lambda: b.get_pf_progress_value(".upload-progress-0") >= 2)
+                with b.wait_timeout(120):
+                    b.wait_visible("#upload-file-btn:not(:disabled)")
+                self.assertEqual(int(m.execute('stat -c%s /home/admin/bigfile.img')), 1500 * 1000 * 1000)
+                m.execute('rm /home/admin/bigfile.img')
+
+            # Cancelled
+            b.upload_files("#demo-upload input[type='file']", [big_file])
+            b.wait(lambda: b.get_pf_progress_value(".upload-progress-0") >= 2)
+            b.click(".cancel-button-0")
+            b.wait_visible("#upload-file-btn:not(:disabled)")
+            b.wait_in_text(".pf-v5-c-alert", "Aborted")
+            m.execute('! test -f /home/admin/bigfile.img')
+
+            # Early ENOSPC error (before we would block on 'ack')
+            m.execute("mkdir -p /mnt/upload; mount -t tmpfs -o size=1M none /mnt/upload;")
+            self.addCleanup(m.execute, "umount /mnt/upload; rmdir /mnt/upload;")
+            b.set_file_autocomplete_val("#demo-upload", "/mnt/upload/")
+            b.upload_files("#demo-upload input[type='file']", [big_file])
+            b.wait_visible("#upload-file-btn:not(:disabled)")
+            b.wait_in_text(".pf-v5-c-alert", "No space left on device")
+            self.assertEqual(m.execute('ls -A /mnt/upload'), '')  # nothing left behind
+
+            # Later ENOSPC error (after we've blocked)
+            m.execute("umount /mnt/upload; mount -t tmpfs -o size=10M none /mnt/upload;")
+            b.set_file_autocomplete_val("#demo-upload", "/mnt/upload/")
+            b.upload_files("#demo-upload input[type='file']", [big_file])
+            b.wait_visible("#upload-file-btn:not(:disabled)")
+            b.wait_in_text(".pf-v5-c-alert", "No space left on device")
+            self.assertEqual(m.execute('ls -A /mnt/upload'), '')
+
+        # Upload permission error
+        b.set_file_autocomplete_val("#demo-upload", "/root/")
+        b.drop_superuser()
+        b.upload_files("#demo-upload input[type='file']", [test_upload_file])
+        b.wait_in_text(".pf-v5-c-alert", "Not permitted to perform this action")
+
+    @testlib.skipBrowser(".upload_files() doesn't work on Firefox", "firefox")
+    def testUploadMultiple(self) -> None:
+        b = self.browser
+        m = self.machine
+
+        self.restore_dir("/home/admin")
+        dest_dir = "/home/admin/keys/"
+        m.execute(['runuser', '-u', 'admin', 'mkdir', dest_dir])
+        files_dir = Path(testlib.TEST_DIR) / "verify" / "files" / "ssh"
+        files = [str(files_dir / f) for f in os.listdir(files_dir)]
+        print("to be uploaded files", files)
+
+        self.login_and_go("/playground/react-patterns")  # , debugging="upload")
+        b.wait_visible("#demo-upload")
+        b.set_file_autocomplete_val("#demo-upload", dest_dir)
+        b.upload_files("#demo-upload input[type='file']", files)
+
+        with b.wait_timeout(30):
+            b.wait(lambda: int(m.execute(f"ls {dest_dir} | wc -l").strip()) == len(files))
+        b.wait_visible("#upload-file-btn:not(:disabled)")
 
 
 if __name__ == '__main__':

--- a/tools/vulture-suppressions/testlib.py
+++ b/tools/vulture-suppressions/testlib.py
@@ -4,6 +4,5 @@ from .testlib import Browser
 Browser.get_checked
 
 # kept as being potentially useful in the future
-Browser.upload_file
 Browser.wait_attr_not_contains
 Browser.select_PF5


### PR DESCRIPTION
 - add a flow control mechanism to the bridge (sending 'ack' control messages to confirm that data was received)
 - add a helper api (`upload()`) to `pkg/lib` to allow uploading large amounts of data (from a `ReadableStream`) using flow control, with progress reporting

This is my take on #20160 