### PR TITLE
test: Update journal check in TestHistoryMetrics.testEvents to current systemd

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -414,10 +414,8 @@ class TestHistoryMetrics(testlib.MachineCase):
         b.wait_in_text("#metrics-hour-1615197600000 div.metrics-minute[data-minute='39'] .metrics-events span.spikes_info", "Load")
 
         # Now add the journal
-        # Journal was recorded on Fedora 33 and when trying to use it with older systemd it fails with:
-        # `Journal file /var/log/journal/*/journal.journal uses an unsupported feature, ignoring file.`
-
-        if self.machine.image == "centos-8-stream" or self.machine.image.startswith("rhel-8-"):
+        # Older systemds get a slightly wrong log window with --since/until, so only run on newer ones
+        if re.search(r"centos-9|rhel-9|debian-stable|ubuntu-2204|ubuntu-stable", self.machine.image):
             return
 
         m.upload(["verify/files/metrics-archives/journal.journal.gz"], "/tmp")
@@ -426,23 +424,25 @@ class TestHistoryMetrics(testlib.MachineCase):
         b.reload()
         b.enter_page("/metrics")
 
+        # details for load event at 10:39
         b.wait_in_text(".metrics-heading", "CPU")
         b.click("#metrics-hour-1615197600000 button.metrics-events-expander")
         b.click("#metrics-hour-1615197600000 div.metrics-minute[data-minute='39'] .metrics-events button.spikes_info")
-        b.wait_visible(".cockpit-log-message:contains('Created slice cockpittest.slice.')")
-        b.wait_in_text(".cockpit-logline:first-child .cockpit-log-message", "cpu-piglet")
-        b.click(".cockpit-logline:first-child .cockpit-log-message")
+        b.wait_in_text(".cockpit-log-panel", "load-hog.service: Succeeded.")
+        b.wait_in_text(".cockpit-log-panel", "Stopping /usr/bin/sh -ec for i in `seq 500`")
+        b.click(".cockpit-logline:contains('Stopping /usr/bin/sh -ec for i in `seq 500`') .cockpit-log-message")
         b.enter_page("/system/logs")
-        b.wait_in_text(".pf-v5-c-card__title", "cpu-piglet")
+        b.wait_in_text(".pf-v5-c-card__header", "load-hog.service")
+        b.wait_in_text(".pf-v5-c-card__title", "Stopping /usr/bin/sh -ec")
         b.click("li:contains('Logs')")
-        b.wait_visible(".cockpit-log-message:contains('Created slice cockpittest.slice.')")
+        b.wait_visible(".cockpit-log-message:contains('Stopping /usr/bin/sh -ec')")
 
         b.go("/metrics")
         b.enter_page("/metrics")
         # logs exist, should show tight range
         b.click("button:contains('View detailed logs')")
         b.enter_page("/system/logs")
-        b.wait_visible(".cockpit-log-message:contains('Created slice cockpittest.slice.')")
+        b.wait_visible(".cockpit-log-message:contains('load-hog.service: Succeeded.')")
         url = b.eval_js('window.location.hash')
         self.assertIn("priority=info", url)
         self.assertIn("since=2021-3-8%2010%3A39%3A0", url)


### PR DESCRIPTION
`journalctl` recently updated its precise behavior wrt. matching
`--since` and `--until` against journal files, see [1]. This caused the
displayed log window for the "load" spike event to shift from the
earlier "Created slice cockpittest.slice" to the later
"load-hog.service" region, so that the old expected strings don't match
any more.

Update the expected strings for load-hog.service -- this actually makes
sense as this is the "load" spike event, so it feels like earlier
systemd versions got this wrong. Skip the test on more old OSes.
This will stop skipping this test as a naughty match for
https://github.com/cockpit-project/bots/issues/5106 -- this is
established behaviour now.

Fixes #20302

[1] https://github.com/systemd/systemd/issues/28746

----

Note that the changed test invalidates the naughty pattern, so we can remove it afterwards. There's also a second place for this, I'll address that next.

 - [x] https://github.com/cockpit-project/bots/pull/6224 