### PR TITLE
Enable CentOS Stream 10 tests

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -156,6 +156,7 @@ You can set these environment variables to configure the test suite:
 
     TEST_OS    The OS to run the tests in.  Currently supported values:
                   "centos-9-stream"
+                  "centos-10"
                   "debian-stable"
                   "debian-testing"
                   "fedora-39"

--- a/test/common/storagelib.py
+++ b/test/common/storagelib.py
@@ -563,8 +563,9 @@ grub2-install {dev}
 grubby --update-kernel=ALL --args="root=UUID=$uuid rootflags=defaults rd.luks.uuid=$luks_uuid rd.lvm.lv=root/root"
 ! test -f /etc/kernel/cmdline || cp /etc/kernel/cmdline /new-root/etc/kernel/cmdline
 """, timeout=300)
-        m.spawn("dd if=/dev/zero of=/dev/vda bs=1M count=100; reboot", "reboot", check=False)
-        m.wait_reboot(300)
+        # destroy bootability of the current root partition, just to make sure
+        m.execute("rm -rf /etc/*")
+        m.reboot()
         self.assertEqual(m.execute("findmnt -n -o SOURCE /").strip(), "/dev/mapper/root-root")
 
     # Cards and tables

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -1295,7 +1295,7 @@ ProtocolHeader = X-Forwarded-Proto
         b.logout()
         b.cdp.invoke("Browser.close")
 
-    @testlib.skipImage("nginx not installed", "centos-8-stream", "rhel-*", "debian-*", "ubuntu-*", "arch")
+    @testlib.skipImage("nginx not installed", "centos-*", "rhel-*", "debian-*", "ubuntu-*", "arch")
     @testlib.skipOstree("nginx not installed")
     @testlib.skipBrowser("Firefox needs proper cert and CA", "firefox")
     def testNginxTLS(self):
@@ -1374,7 +1374,7 @@ server {
         b.click('#login-button')
         b.wait_visible('.pf-v5-c-card.system-health')
 
-    @testlib.skipImage("nginx not installed", "centos-8-stream", "rhel-*", "debian-*", "ubuntu-*", "arch")
+    @testlib.skipImage("nginx not installed", "centos-*", "rhel-*", "debian-*", "ubuntu-*", "arch")
     @testlib.skipOstree("nginx not installed")
     @testlib.skipBrowser("Firefox needs proper cert and CA", "firefox")
     def testNginxNoTLS(self):

--- a/test/verify/check-networkmanager-bond
+++ b/test/verify/check-networkmanager-bond
@@ -297,7 +297,7 @@ class TestBondingVirt(netlib.NetworkCase):
         b.wait_not_present("#networking-interfaces tr[data-interface='tbond']")
         b.wait_visible(f"#networking-interfaces tr[data-interface='{iface}']")
 
-    @testlib.skipImage("TODO: no dhclient on Arch image", "arch")
+    @testlib.skipImage("no dhclient on OS image", "arch", "centos-10*", "rhel-10*")
     @testlib.skipImage("Main interface can't be managed", "debian-*", "ubuntu-*")
     @testlib.skipOstree("not using dhclient")
     def testSlowly(self):

--- a/test/verify/check-networkmanager-checkpoints
+++ b/test/verify/check-networkmanager-checkpoints
@@ -66,7 +66,7 @@ class TestNetworkingCheckpoints(netlib.NetworkCase):
             b.wait_not_present("#confirm-breaking-change-popup")
 
     @testlib.skipImage("Main interface settings are read-only", "debian-*")
-    @testlib.skipImage("not using dhclient", "arch")
+    @testlib.skipImage("no dhclient on OS image", "arch", "centos-10*", "rhel-10*")
     @testlib.skipOstree("not using dhclient")
     def testCheckpointSlowRollback(self):
         b = self.browser

--- a/test/verify/check-networkmanager-settings
+++ b/test/verify/check-networkmanager-settings
@@ -129,7 +129,7 @@ class TestNetworkingSettings(netlib.NetworkCase):
 
         # Check that IPv4/IPv6 settings dialogs only show the supported IP methods for wireguard
         # Skip images without the wireguard-tools package
-        if m.image not in ["rhel4edge", "centos-8-stream"] and not m.image.startswith("rhel-8"):
+        if m.image not in ["rhel4edge", "centos-8-stream", "centos-10"] and not m.image.startswith("rhel-8"):
             b.go("/network")
             b.click("#networking-add-wg")
             b.set_input_text("#network-wireguard-settings-addresses-input", "1.2.3.4/24")

--- a/test/verify/check-networkmanager-team
+++ b/test/verify/check-networkmanager-team
@@ -25,6 +25,7 @@ import testlib
 
 @testlib.skipOstree("NetworkManager-team not installed")
 @testlib.skipImage("TODO: networkmanager fails on Arch Linux", "arch")
+@testlib.skipImage("team not supported", "centos-10*", "rhel-10*")
 @testlib.skipDistroPackage()
 @testlib.nondestructive
 class TestTeam(netlib.NetworkCase):

--- a/test/verify/check-networkmanager-wireguard
+++ b/test/verify/check-networkmanager-wireguard
@@ -8,6 +8,7 @@ import packagelib
 import testlib
 
 
+@testlib.skipImage("wireguard not available", "centos-10*", "rhel-10*")
 class TestWireGuard(packagelib.PackageCase, netlib.NetworkCase):
     provision = {
         "machine1": {"address": "192.168.100.11/24", "memory_mb": 768},

--- a/test/verify/check-storage-vdo
+++ b/test/verify/check-storage-vdo
@@ -24,6 +24,7 @@ import testlib
 SIZE_10G = "10000000000"
 
 
+@testlib.skipImage("vdo not currently available in RHEL 10", "rhel-10*", "centos-10*")
 class TestStorageVDO(storagelib.StorageCase):
 
     provision = {"0": {"memory_mb": 1800}}
@@ -389,6 +390,7 @@ config: !Configuration
 
 
 @testlib.onlyImage("VDO API only supported on RHEL", "rhel-*", "centos-*")
+@testlib.skipImage("vdo not currently available in RHEL 10", "rhel-10*", "centos-10*")
 class TestStoragePackagesVDO(packagelib.PackageCase, storagelib.StorageHelpers):
 
     provision = {"0": {"memory_mb": 1500}}

--- a/test/vm.install
+++ b/test/vm.install
@@ -46,6 +46,11 @@ if [ "${PLATFORM_ID#platform:el}" != "$PLATFORM_ID" ]; then
     echo 'Defaults secure_path = /sbin:/usr/sbin:/usr/local/bin:/bin:/usr/bin' > /etc/sudoers.d/usr-local
 fi
 
+if [ "$PLATFORM_ID" = "platform:el10" ]; then
+    # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=2273078
+    printf  '[network]\nfirewall_driver = "nftables"\n' > /etc/containers/containers.conf
+fi
+
 # start cockpit once to ensure it works, and generate the certificate (to avoid re-doing that for each test)
 systemctl start cockpit
 systemctl stop cockpit


### PR DESCRIPTION
 - [x] https://github.com/cockpit-project/bots/pull/6229
 - [x] Add naughty patterns for https://github.com/cockpit-project/bots/issues/6231 for `TestCurrentMetrics.test{Memory,CPU}`, and https://github.com/cockpit-project/bots/issues/6234 for team failures: https://github.com/cockpit-project/bots/pull/6235
 - [x] investigate F40+C10 package mixup in [TF run](https://github.com/cockpit-project/bots/pull/623500098a2f-4e8e-4939-9b40-9b8c128a59f2/): reported as https://issues.redhat.com/browse/TFT-2564 , difficult to work around, so dropping packit enablement
 - [x] https://github.com/cockpit-project/bots/pull/6236
 - [x] Rebase after #20330