### PR TITLE
test: port test-format to typescript

### DIFF
--- a/files.js
+++ b/files.js
@@ -53,7 +53,7 @@ const info = {
         "base1/test-events.js",
         "base1/test-external.js",
         "base1/test-file.js",
-        "base1/test-format.js",
+        "base1/test-format.ts",
         "base1/test-framed-cache.js",
         "base1/test-framed.js",
         "base1/test-http.js",

--- a/pkg/base1/test-format.ts
+++ b/pkg/base1/test-format.ts
@@ -42,7 +42,7 @@ QUnit.test("format_number", function (assert) {
         [-123.01, "-123", "-123"],
         [null, "", ""],
         [undefined, "", ""],
-    ];
+    ] as const;
 
     const saved_language = cockpit.language;
 
@@ -101,7 +101,7 @@ QUnit.test("format_bytes", function (assert) {
         [0, "KB", "0 KB"],
         [undefined, "KB", ""],
         [null, "KB", ""],
-    ];
+    ] as const;
 
     assert.expect(checks.length * 2 + 2);
     for (let i = 0; i < checks.length; i++) {
@@ -128,8 +128,8 @@ QUnit.test("get_byte_units", function (assert) {
     const gib_unit = { factor: gib, name: "GiB" };
     const tib_unit = { factor: tib, name: "TiB" };
 
-    function selected(unit) {
-        return { factor: unit.factor, name: unit.name, selected: true };
+    function selected<T>(unit: T) {
+        return { ...unit, selected: true };
     }
 
     const checks = [
@@ -142,11 +142,11 @@ QUnit.test("get_byte_units", function (assert) {
         [200 * gib, 1024, [mib_unit, selected(gib_unit), tib_unit]],
         [2000 * gib, 1024, [mib_unit, selected(gib_unit), tib_unit]],
         [20000 * gib, 1024, [mib_unit, gib_unit, selected(tib_unit)]]
-    ];
+    ] as const;
 
     assert.expect(checks.length);
     for (let i = 0; i < checks.length; i++) {
-        assert.deepEqual(cockpit.get_byte_units(checks[i][0], checks[i][1]), checks[i][2],
+        assert.deepEqual(cockpit.get_byte_units(checks[i][0], checks[i][1]), checks[i][2] as unknown,
                          "get_byte_units(" + checks[i][0] + ", " + checks[i][1] + ") = " + JSON.stringify(checks[i][2]));
     }
 });
@@ -171,7 +171,7 @@ QUnit.test("format_bytes_per_sec", function (assert) {
         // significant integer digits exceed custom precision
         [25555000, "kB/s", { precision: 2 }, "25555 kB/s"],
         [25555678, "kB/s", { precision: 2 }, "25556 kB/s"],
-    ];
+    ] as const;
 
     assert.expect(checks.length + 2);
     for (let i = 0; i < checks.length; i++) {
@@ -195,7 +195,7 @@ QUnit.test("format_bits_per_sec", function (assert) {
         [2555, "2.56 Kbps"],
         [2000, "2 Kbps"],
         [2003, "2.00 Kbps"]
-    ];
+    ] as const;
 
     assert.expect(checks.length);
     for (let i = 0; i < checks.length; i++) {

--- a/pkg/lib/cockpit.d.ts
+++ b/pkg/lib/cockpit.d.ts
@@ -28,6 +28,8 @@ declare module 'cockpit' {
 
     function assert(predicate: unknown, message?: string): asserts predicate;
 
+    export let language: string;
+
     /* === Events mix-in ========================= */
 
     interface EventMap {
@@ -199,7 +201,7 @@ declare module 'cockpit' {
     };
 
     type ByteUnit = {
-        name: string | null;
+        name: string;
         factor: number;
         selected?: boolean;
     };
@@ -212,12 +214,12 @@ declare module 'cockpit' {
     function ngettext(context: string, message1: string, messageN: string, n: number): string;
 
     function format(format_string: string, ...args: unknown[]): string;
-    function format_number(n: number, precision?: number): string
-    function format_bytes(n: number, factor?: 1000 | 1024, options?: FormatOptions & { separate?: false }): string;
-    function format_bytes(n: number, factor: 1000 | 1024, options: FormatOptions & { separate: true }): string[];
-    function format_bytes_per_sec(n: number, factor?: 1000 | 1024, options?: FormatOptions & { separate?: false }): string;
-    function format_bytes_per_sec(n: number, factor: 1000 | 1024, options: FormatOptions & { separate: true }): string[];
-    function format_bits_per_sec(n: number, factor?: 1000 | 1024, options?: FormatOptions & { separate?: false }): string;
-    function format_bits_per_sec(n: number, factor: 1000 | 1024, options: FormatOptions & { separate: true }): string[];
-    function get_byte_units(guide_value: number, factor?: 1000 | 1024): ByteUnit[];
+    function format_number(n: number | null | undefined, precision?: number): string
+    function format_bytes(n: number | null | undefined, factor?: 1000 | 1024 | string, options?: FormatOptions & { separate?: false } | false): string;
+    function format_bytes(n: number | null | undefined, factor: 1000 | 1024 | string | undefined, options: FormatOptions & { separate: true } | true): string[];
+    function format_bytes_per_sec(n: number, factor?: 1000 | 1024 | string, options?: FormatOptions & { separate?: false } | false): string;
+    function format_bytes_per_sec(n: number, factor: 1000 | 1024 | string | undefined, options: FormatOptions & { separate: true } | true): string[];
+    function format_bits_per_sec(n: number, factor?: 1000 | 1024 | string | undefined, options?: FormatOptions & { separate?: false } | false): string;
+    function format_bits_per_sec(n: number, factor: 1000 | 1024 | string | undefined, options: FormatOptions & { separate: true } | true): string[];
+    function get_byte_units(guide_value: number, factor?: 1000 | 1024): [ByteUnit, ByteUnit, ByteUnit];
 }


### PR DESCRIPTION
This was mostly pain-free, except that it tests a very wide range of
possible values to the format functions.  Expand the type hints
accordingly.

There was one case that required a bit of a nudge — deepEqual wants both
sides to be the same type, and one of them is very static in nature and
the other quite dynamic — just use `as unknown` to force it down.