### PR TITLE
test: Less aggressive pmlogger log cleaning in TestGrafanaClient

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1429,7 +1429,7 @@ class TestGrafanaClient(testlib.MachineCase):
         # avoid dynamic host name changes during PCP data collection, and start from clean slate
         m.execute("""systemctl stop pmlogger || true
                      systemctl reset-failed pmlogger || true
-                     rm -rf /var/log/pcp/pmlogger
+                     rm -rf /var/log/pcp/pmlogger/*
                      hostnamectl set-hostname grafana-client""")
 
         # start Grafana


### PR DESCRIPTION
Don't remove the /var/log/pcp/pmlogger directory itself, just its content, like we do in all other tests. Latest pcp version fails to start up if the directory isn't present. This is a regression [1], but also there's no need to be that demanding.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2275408

Fixes #20327