### PR TITLE
tools: Depend on kdumpctl binary

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -330,7 +330,7 @@ Provides: cockpit-users = %{version}-%{release}
 Obsoletes: cockpit-dashboard < %{version}-%{release}
 %if 0%{?rhel}
 Requires: NetworkManager >= 1.6
-Requires: kexec-tools
+Requires: /usr/bin/kdumpctl
 Requires: sos
 Requires: sudo
 Recommends: PackageKit
@@ -479,7 +479,7 @@ fi
 Summary: Cockpit user interface for kernel crash dumping
 Requires: cockpit-bridge >= %{required_base}
 Requires: cockpit-shell >= %{required_base}
-Requires: kexec-tools
+Requires: /usr/bin/kdumpctl
 BuildArch: noarch
 
 %description kdump


### PR DESCRIPTION
`kdumpctl` moved from the kexec-tools to the kdump-utils package in Fedora Rawhide, and the former does not require the latter. To make sure we get the one we want, depend on the program path directly.

https://bugzilla.redhat.com/show_bug.cgi?id=2275385