### PR TITLE
eslint: enable no-useless-fragment rule by default

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -44,6 +44,7 @@
         "react/jsx-closing-tag-location": "off",
         "react/jsx-curly-newline": "off",
         "react/jsx-first-prop-new-line": "off",
+        "react/jsx-no-useless-fragment": "error",
         "react/prop-types": "off",
         "space-before-function-paren": "off",
         "standard/no-callback-literal": "off",

--- a/pkg/storaged/dialog.jsx
+++ b/pkg/storaged/dialog.jsx
@@ -923,6 +923,7 @@ export const CheckBoxes = (tag, title, options) => {
             if (options.fields.length == 1)
                 return fieldset;
 
+            // eslint-disable-next-line react/jsx-no-useless-fragment
             return <>{ fieldset }</>;
         }
     };


### PR DESCRIPTION
This rule is not part of the standard ESLint recommends set but is useful and can be auto-fixed.