### PR TITLE
test/static-code: speed up JSON validation

### DIFF
--- a/test/static-code
+++ b/test/static-code
@@ -112,10 +112,20 @@ test_unsafe_security_policy() {
 
 test_json_verify() {
     # Check (almost) all JSON files for validity
+    git ls-files -z '*.json' | grep -zv ^tsconfig | xargs -r -0 python3 -c "
+import argparse
+import json
 
-    git ls-files -z '*.json' | grep -zv ^tsconfig | while read -d '' filename; do
-        python3 -m json.tool "${filename}" /dev/null 2>&1 | sed "s@^@${filename}: @"
-    done
+parser = argparse.ArgumentParser()
+parser.add_argument('files', nargs='+', type=argparse.FileType(encoding='utf-8'))
+args = parser.parse_args()
+
+for file in args.files:
+    try:
+        json.load(file)
+    except ValueError as exc:  # both JSONDecodeError and UnicodeError
+        print(f'{file.name}: {exc}')
+"
 }
 
 test_html_verify() {


### PR DESCRIPTION
After mypy (addressed in #20342) the slowest thing in test/static-code is... JSON validation.  This is caused by the fact that `json.tool` doesn't support multiple filenames, so we have to invoke it separately for every single JSON file (and we have many).

Replace that with a small script which runs in a single Python invocation and improves the output by printing the name of the file containing the failure (which `json.tool` doesn't do).