### PR TITLE
systemd: Use systemd-sysusers to create cockpit-wsinstance user

### DIFF
--- a/src/systemd/Makefile.am
+++ b/src/systemd/Makefile.am
@@ -33,6 +33,9 @@ install-exec-hook::
 tmpfilesconfdir = $(prefix)/lib/tmpfiles.d
 nodist_tmpfilesconf_DATA = src/systemd/tmpfiles.d/cockpit-ws.conf
 
+sysusersconfdir = $(prefix)/lib/sysusers.d
+dist_sysusersconf_DATA = src/systemd/sysusers.d/cockpit-ws.conf
+
 # we can't generate these with config.status because,
 # eg. it does "@libexecdir@" -> "${exec_prefix}/libexec"
 src/systemd/%: src/systemd/%.in

--- a/src/systemd/cockpit.service.in
+++ b/src/systemd/cockpit.service.in
@@ -3,7 +3,8 @@ Description=Cockpit Web Service
 Documentation=man:cockpit-ws(8)
 Requires=cockpit.socket
 Requires=cockpit-wsinstance-http.socket cockpit-wsinstance-https-factory.socket
-After=cockpit-wsinstance-http.socket cockpit-wsinstance-https-factory.socket
+# we need to start before the sockets so that the dynamic user exists
+Before=cockpit-wsinstance-http.socket cockpit-wsinstance-https-factory.socket
 
 [Service]
 RuntimeDirectory=cockpit/tls
@@ -11,6 +12,7 @@ RuntimeDirectory=cockpit/tls
 Environment=RUNTIME_DIRECTORY=/run/cockpit/tls
 ExecStartPre=+@libexecdir@/cockpit-certificate-ensure --for-cockpit-tls
 ExecStart=@libexecdir@/cockpit-tls
+DynamicUser=true
 User=cockpit-ws
 Group=cockpit-ws
 NoNewPrivileges=true

--- a/src/systemd/sysusers.d/cockpit-ws.conf
+++ b/src/systemd/sysusers.d/cockpit-ws.conf
@@ -1,0 +1,1 @@
+u cockpit-wsinstance - "User for cockpit-ws instances" -

--- a/src/systemd/tmpfiles.d/cockpit-ws.conf.in
+++ b/src/systemd/tmpfiles.d/cockpit-ws.conf.in
@@ -1,3 +1,4 @@
+z @libexecdir@/cockpit-session - - cockpit-wsinstance -
 C /run/cockpit/inactive.motd 0640 root @admin_group@ - @datadir@/@PACKAGE@/motd/inactive.motd
 f /run/cockpit/active.motd   0640 root @admin_group@ -
 L+ /run/cockpit/motd - - - - inactive.motd

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -423,7 +423,6 @@ class TestConnection(testlib.MachineCase):
         if not m.ostree_image:
             m.execute("""cat /etc/cockpit/ws-certs.d/cert-chain.key >> /etc/cockpit/ws-certs.d/cert-chain.crt
                          chmod 640 /etc/cockpit/ws-certs.d/cert-chain.crt
-                         chown root:cockpit-ws /etc/cockpit/ws-certs.d/cert-chain.crt
                          rm /etc/cockpit/ws-certs.d/cert-chain.key""")
             check_cert_chain()
 

--- a/tools/arch/PKGBUILD
+++ b/tools/arch/PKGBUILD
@@ -16,11 +16,9 @@ makedepends=(krb5 libssh accountsservice json-glib glib-networking
              python-build python-installer python-wheel)
 source=("cockpit-${pkgver}.tar.xz"
         "cockpit.pam"
-        "cockpit-ws.sysuser.conf"
         "cockpit-wsinstance.sysuser.conf")
 sha256sums=('SKIP'
             '079bb6751214e642673f9e1212df2a17fed1a3cc6cfdd6375af2b68ed6ddd340'
-            '1ad9dad75858264778bd94799b60c651f7cc1c7f7fa1c54622174303e639287a'
             '46ee8ecad7bc97ba588ab9471dde76e41c00daf40658902425626c3a1938b438')
 
 prepare() {
@@ -61,7 +59,6 @@ package_cockpit() {
   make DESTDIR="$pkgdir" install
   rm -rf "$pkgdir"/usr/{src,lib/firewalld}
   install -Dm644 "$srcdir"/cockpit.pam "$pkgdir"/etc/pam.d/cockpit
-  install -Dm644 "$srcdir"/cockpit-ws.sysuser.conf "$pkgdir"/usr/lib/sysusers.d/cockpit-ws.conf
   install -Dm644 "$srcdir"/cockpit-wsinstance.sysuser.conf "$pkgdir"/usr/lib/sysusers.d/cockpit-wsinstance.conf
 
   echo "z /usr/lib/cockpit/cockpit-session - - cockpit-wsinstance -" >> "$pkgdir"/usr/lib/tmpfiles.d/cockpit-ws.conf

--- a/tools/arch/PKGBUILD
+++ b/tools/arch/PKGBUILD
@@ -15,11 +15,9 @@ makedepends=(krb5 libssh accountsservice json-glib glib-networking
              git intltool gtk-doc gobject-introspection networkmanager xmlto npm pcp
              python-build python-installer python-wheel)
 source=("cockpit-${pkgver}.tar.xz"
-        "cockpit.pam"
-        "cockpit-wsinstance.sysuser.conf")
+        "cockpit.pam")
 sha256sums=('SKIP'
-            '079bb6751214e642673f9e1212df2a17fed1a3cc6cfdd6375af2b68ed6ddd340'
-            '46ee8ecad7bc97ba588ab9471dde76e41c00daf40658902425626c3a1938b438')
+            '079bb6751214e642673f9e1212df2a17fed1a3cc6cfdd6375af2b68ed6ddd340')
 
 prepare() {
   cd cockpit-$pkgver
@@ -59,7 +57,6 @@ package_cockpit() {
   make DESTDIR="$pkgdir" install
   rm -rf "$pkgdir"/usr/{src,lib/firewalld}
   install -Dm644 "$srcdir"/cockpit.pam "$pkgdir"/etc/pam.d/cockpit
-  install -Dm644 "$srcdir"/cockpit-wsinstance.sysuser.conf "$pkgdir"/usr/lib/sysusers.d/cockpit-wsinstance.conf
 
   echo "z /usr/lib/cockpit/cockpit-session - - cockpit-wsinstance -" >> "$pkgdir"/usr/lib/tmpfiles.d/cockpit-ws.conf
 

--- a/tools/arch/PKGBUILD
+++ b/tools/arch/PKGBUILD
@@ -58,8 +58,6 @@ package_cockpit() {
   rm -rf "$pkgdir"/usr/{src,lib/firewalld}
   install -Dm644 "$srcdir"/cockpit.pam "$pkgdir"/etc/pam.d/cockpit
 
-  echo "z /usr/lib/cockpit/cockpit-session - - cockpit-wsinstance -" >> "$pkgdir"/usr/lib/tmpfiles.d/cockpit-ws.conf
-
   # remove unused plugins
   rm -rf "$pkgdir"/usr/share/cockpit/{selinux,playground,sosreport} \
          "$pkgdir"/usr/share/metainfo/org.cockpit-project.cockpit-{selinux,sosreport}.metainfo.xml

--- a/tools/arch/cockpit-ws.sysuser.conf
+++ b/tools/arch/cockpit-ws.sysuser.conf
@@ -1,1 +1,0 @@
-u cockpit-ws - "User for cockpit web service"

--- a/tools/arch/cockpit-wsinstance.sysuser.conf
+++ b/tools/arch/cockpit-wsinstance.sysuser.conf
@@ -1,1 +1,0 @@
-u cockpit-wsinstance - "User for cockpit-ws instances"

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -420,11 +420,6 @@ authentication via sssd/FreeIPA.
 %ghost %{_sharedstatedir}/selinux/%{selinuxtype}/active/modules/200/%{name}
 
 %pre ws
-# HACK: old RPM and even Fedora's current RPM don't properly support sysusers
-# https://github.com/rpm-software-management/rpm/issues/3073
-getent group cockpit-wsinstance >/dev/null || groupadd -r cockpit-wsinstance
-getent passwd cockpit-wsinstance >/dev/null || useradd -r -g cockpit-wsinstance -d /nonexisting -s /sbin/nologin -c "User for cockpit-ws instances" cockpit-wsinstance
-
 if %{_sbindir}/selinuxenabled 2>/dev/null; then
     %selinux_relabel_pre -s %{selinuxtype}
 fi

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -401,6 +401,7 @@ authentication via sssd/FreeIPA.
 %{_unitdir}/cockpit-wsinstance-https@.service
 %{_unitdir}/system-cockpithttps.slice
 %{_prefix}/%{__lib}/tmpfiles.d/cockpit-ws.conf
+%{_sysusersdir}/cockpit-ws.conf
 %{pamdir}/pam_ssh_add.so
 %{pamdir}/pam_cockpit_cert.so
 %{_libexecdir}/cockpit-ws
@@ -419,6 +420,8 @@ authentication via sssd/FreeIPA.
 %ghost %{_sharedstatedir}/selinux/%{selinuxtype}/active/modules/200/%{name}
 
 %pre ws
+# HACK: old RPM and even Fedora's current RPM don't properly support sysusers
+# https://github.com/rpm-software-management/rpm/issues/3073
 getent group cockpit-wsinstance >/dev/null || groupadd -r cockpit-wsinstance
 getent passwd cockpit-wsinstance >/dev/null || useradd -r -g cockpit-wsinstance -d /nonexisting -s /sbin/nologin -c "User for cockpit-ws instances" cockpit-wsinstance
 

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -419,8 +419,6 @@ authentication via sssd/FreeIPA.
 %ghost %{_sharedstatedir}/selinux/%{selinuxtype}/active/modules/200/%{name}
 
 %pre ws
-getent group cockpit-ws >/dev/null || groupadd -r cockpit-ws
-getent passwd cockpit-ws >/dev/null || useradd -r -g cockpit-ws -d /nonexisting -s /sbin/nologin -c "User for cockpit web service" cockpit-ws
 getent group cockpit-wsinstance >/dev/null || groupadd -r cockpit-wsinstance
 getent passwd cockpit-wsinstance >/dev/null || useradd -r -g cockpit-wsinstance -d /nonexisting -s /sbin/nologin -c "User for cockpit-ws instances" cockpit-wsinstance
 

--- a/tools/debian/cockpit-ws.install
+++ b/tools/debian/cockpit-ws.install
@@ -14,6 +14,7 @@ ${env:deb_systemdsystemunitdir}/system-cockpithttps.slice
 ${env:deb_pamlibdir}/security/pam_ssh_add.so
 ${env:deb_pamlibdir}/security/pam_cockpit_cert.so
 usr/lib/tmpfiles.d/cockpit-ws.conf
+usr/lib/sysusers.d/cockpit-ws.conf
 usr/lib/cockpit/cockpit-session
 usr/lib/cockpit/cockpit-ws
 usr/lib/cockpit/cockpit-wsinstance-factory

--- a/tools/debian/cockpit-ws.postinst
+++ b/tools/debian/cockpit-ws.postinst
@@ -1,7 +1,6 @@
 #!/bin/sh
 set -e
 
-adduser --system --group --home /nonexistent --no-create-home --quiet cockpit-ws
 adduser --system --group --home /nonexistent --no-create-home --quiet cockpit-wsinstance
 
 # change group of cockpit-session on upgrades (changed in version 203)

--- a/tools/debian/cockpit-ws.postinst
+++ b/tools/debian/cockpit-ws.postinst
@@ -1,13 +1,11 @@
 #!/bin/sh
 set -e
 
-adduser --system --group --home /nonexistent --no-create-home --quiet cockpit-wsinstance
+#DEBHELPER#
 
 if ! dpkg-statoverride --list /usr/lib/cockpit/cockpit-session >/dev/null; then
     dpkg-statoverride --update --add root cockpit-wsinstance 4750 /usr/lib/cockpit/cockpit-session
 fi
-
-#DEBHELPER#
 
 # restart cockpit.service on package upgrades, if it's already running
 if [ -d /run/systemd/system ] && [ -n "$2" ]; then

--- a/tools/debian/cockpit-ws.postinst
+++ b/tools/debian/cockpit-ws.postinst
@@ -3,12 +3,6 @@ set -e
 
 adduser --system --group --home /nonexistent --no-create-home --quiet cockpit-wsinstance
 
-# change group of cockpit-session on upgrades (changed in version 203)
-if OUT=$(dpkg-statoverride --list /usr/lib/cockpit/cockpit-session) && [ "$OUT#root cockpit-ws 4750}" != "$OUT" ]; then
-    echo "Adjusting /usr/lib/cockpit/cockpit-session permissions..."
-    dpkg-statoverride --remove /usr/lib/cockpit/cockpit-session
-fi
-
 if ! dpkg-statoverride --list /usr/lib/cockpit/cockpit-session >/dev/null; then
     dpkg-statoverride --update --add root cockpit-wsinstance 4750 /usr/lib/cockpit/cockpit-session
 fi

--- a/tools/debian/cockpit-ws.postrm
+++ b/tools/debian/cockpit-ws.postrm
@@ -8,4 +8,6 @@ if [ "$1" = purge ]; then
     [ -L /etc/motd.d/cockpit ] && rm /etc/motd.d/cockpit || true
     [ -L /etc/issue.d/cockpit.issue ] && rm /etc/issue.d/cockpit.issue || true
     rm -f /etc/cockpit/disallowed-users
+
+    dpkg-statoverride --remove /usr/lib/cockpit/cockpit-session
 fi

--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -67,3 +67,7 @@ else
 	pytest -vv -k 'not linter and not test_descriptions' -opythonpath=$$(ls -d debian/cockpit-bridge/usr/lib/python3*/dist-packages)
 endif
 endif
+
+# dh compat 14 does that automatically, remove when upgrading
+execute_before_dh_installtmpfiles:
+	dh_installsysusers


### PR DESCRIPTION
Use systemd-sysusers to create users & groups

Add a templated sysusers config file and use it in the RPM spec to
create users.

Replace the current Arch Linux specific config files.

Note that the (already resolved) cockpit-sysusers.conf file is needed
for the RPM specfile as a source as the macro can not be expanded using
the content from the source archive as it is not extracted during the
stage where RPM macro expansion happens. We thus need to keep a copy in
the dist-git repo.

See: https://docs.fedoraproject.org/en-US/packaging-guidelines/UsersAndGroups/#_dynamic_allocation

----

Todo:
 - [x] broken out commit with fix: #20402 
 - [x] broken out commit with fix: #20403
 - [x] Built on top of #20425, rebase after landing
 - [x] get rid of dist-git fie duplication

@travier 's original proposal: https://github.com/travier/cockpit/commit/c5856773e32302a6b6f8016593ac8e2dd88b40ec (doesn't build, dist-git hack)