### PR TITLE
shell: Session menu toggle fixes

### DIFF
--- a/pkg/lib/patternfly/patternfly-5-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-5-overrides.scss
@@ -87,6 +87,12 @@ select.pf-v5-c-form-control {
   margin-inline-end: 0;
 }
 
+// Fix menus cropping contents
+// https://github.com/patternfly/patternfly/issues/6565
+.pf-v5-c-menu__item-text {
+  overflow: visible;
+}
+
 // The default gap between the rows in horizontal lists is too large
 .pf-v5-c-description-list.pf-m-horizontal-on-sm,
 .pf-v5-c-description-list.pf-m-horizontal {


### PR DESCRIPTION
Fixes cropping and highlighting, in two separate commits; one in PF overrides (the cropping) and the highlighting (in nav, as a switcher in a menu is only used in nav and PF doesn't have any examples of this, so it's a local change).