### PR TITLE
test: Fix unexpected "truncated data in external channel" messages

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1935,6 +1935,7 @@ class MachineCase(unittest.TestCase):
                                     "We are no longer a registered authentication agent.",
                                     ".*: failed to retrieve resource: terminated",
                                     ".*: external channel failed: (terminated|protocol-error)",
+                                    ".*: truncated data in external channel",
                                     'audit:.*denied.*comm="systemd-user-se".*nologin.*',
                                     ".*No session for cookie",
 

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -52,6 +52,7 @@ class TestSuperuser(testlib.MachineCase):
         b.assert_pixels("#topnav", "topnav-unprivileged")
 
         # Check they are still gone after logout
+        self.allow_restart_journal_messages()
         b.relogin()
         b.leave_page()
         b.check_superuser_indicator("Limited access")
@@ -597,6 +598,7 @@ class TestSuperuserDashboard(testlib.MachineCase):
 
         # Logging out and logging back in should give us immediate
         # superuser on m2 (once we have logged in there).
+        self.allow_restart_journal_messages()
         b.relogin()
         b.click('#machine-troubleshoot')
         b.wait_visible('#hosts_setup_server_dialog')

--- a/test/verify/check-system-terminal
+++ b/test/verify/check-system-terminal
@@ -29,8 +29,6 @@ class TestTerminal(testlib.MachineCase):
     def setUp(self):
         super().setUp()
 
-        self.allow_journal_messages(".*external channel failed: terminated")
-
         # Make sure we get what we expect
         self.write_file("/home/admin/.bashrc", r"""
 PS1="\u@local \W]\$ "
@@ -223,6 +221,7 @@ PROMPT_COMMAND='printf "\033]0;%s@%s:%s\007" "${USER}" "${HOSTNAME%%.*}" "${PWD/
         # Relogin on different page, as reloging on terminal prompts asking if you want to leave the site
         b.go("/system")
         b.relogin("/system")
+        self.allow_restart_journal_messages()
         b.go("/system/terminal")
         b.enter_page("/system/terminal")
         b.wait_visible('.terminal')


### PR DESCRIPTION
`TestTerminal.testBasic` and `TestSuperuser.testBasic` both often fail with an unexpected message like

> /system/overview.js: truncated data in external channel

This is just a matter of timing, and can happen in a similar manner as "external channel failed: terminated". Add this to allow_restart_journal_messages() and call that in both tests, as they both call `Browser.relogin()` and thus interrupt anything that's currently going on in the session.

---

It's one of the main offenders on the [weather report](https://ci-weather-cockpit.apps.ocp.cloud.ci.centos.org/tests.html?repo=cockpit-project%2Fcockpit&days=7) (with lots of example links). I also ran into it a lot in PR #19132 ([log](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19132-cb7e27fd-20240425-065620-rhel-9-5-expensive/log.html#48), [log](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19132-cb7e27fd-20240425-065617-fedora-39-devel/log.html#355)) and other PRs.