### PR TITLE
test: add pixel tests for the help and session menu

### DIFF
--- a/pkg/shell/topnav.jsx
+++ b/pkg/shell/topnav.jsx
@@ -284,6 +284,7 @@ export class TopNav extends React.Component {
                             </ToolbarItem>
                             <ToolbarItem>
                                 <Dropdown
+                                    id="toggle-menu-menu"
                                     onSelect={() => {
                                         this.setState(prevState => { return { menuOpened: !prevState.menuOpened } });
                                         document.getElementById("toggle-menu").focus();

--- a/test/verify/check-shell-menu
+++ b/test/verify/check-shell-menu
@@ -29,14 +29,17 @@ class TestMenu(testlib.MachineCase):
     def testDarkThemeSwitcher(self):
         b = self.browser
 
-        def switch_style(style_class, prevPage="system"):
+        def switch_style(style_class, prevPage="system", pixel_test=False):
             b.switch_to_top()
             b.click("#toggle-menu")
+            if pixel_test:
+                b.wait_visible("#toggle-menu-menu")
+                b.assert_pixels_in_current_layout("#toggle-menu-menu", "shell-toggle-menu")
             b.click(f"#topnav {style_class}")
             b.enter_page(f"/{prevPage}")
 
         self.login_and_go("/system")
-        switch_style("#dark")
+        switch_style("#dark", pixel_test=True)
         b._wait_present("html.pf-v5-theme-dark")
 
         switch_style("#light")
@@ -82,6 +85,7 @@ class TestMenu(testlib.MachineCase):
         # Clicking inside the iframed pages should close the docs menu
         b.click("#toggle-docs")
         b.wait_visible("#toggle-docs-menu")
+        b.assert_pixels("#toggle-docs-menu", "shell-docs-menu")
         b.enter_page("/system")
         b.focus("#overview main")
         b.switch_to_top()


### PR DESCRIPTION
We have had PF regressions in the session menu and it doesn't hurt to also test the help menu.

Pixel changes: https://cockpit-logs.us-east-1.linodeobjects.com/pull-20371-076a3250-20240425-142139-fedora-39-other/log.html