### PR TITLE
[r8] TestStorageStratisReboot.testEncrypted fails

### DIFF
--- a/test/common/storagelib.py
+++ b/test/common/storagelib.py
@@ -554,8 +554,9 @@ grub2-install {dev}
 grubby --update-kernel=ALL --args="root=UUID=$uuid rootflags=defaults rd.luks.uuid=$luks_uuid rd.lvm.lv=root/root"
 ! test -f /etc/kernel/cmdline || cp /etc/kernel/cmdline /new-root/etc/kernel/cmdline
 """, timeout=300)
-        m.spawn("dd if=/dev/zero of=/dev/vda bs=1M count=100; reboot", "reboot", check=False)
-        m.wait_reboot(300)
+        # destroy bootability of the current root partition, just to make sure
+        m.execute("rm -rf /etc/*")
+        m.reboot()
         self.assertEqual(m.execute("findmnt -n -o SOURCE /").strip(), "/dev/mapper/root-root")
 
     # Cards and tables


### PR DESCRIPTION
Completely wiping the currently running root partition is too aggressive: During shutdown, recent versions of systemd-shutdown [1] re-executes itself to free all open fds on the root fs (so that it can be unmounted cleanly), which doesn't work if /usr/sbin/systemd-shutdown is gone. This leads to reboot hanging at

```
[  OK  ] Reached target reboot.target - System Reboot.
[!!!!!!] Failed to execute shutdown binary.
```

Instead, make the partition unbootable by cleaning /etc (i.e. allowed SSH keys, boot targets, etc.) Even that is redundant, as post reboot the test already checks that it booted from the encrypted partition. But let's keep the belt and suspenders.

[1] https://github.com/systemd/systemd/blob/main/src/shutdown/shutdown.c