### PR TITLE
Add a `size` hint attribute for `fsreplace1`

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -1069,6 +1069,13 @@ The following options can be specified in the "open" control message:
 
  * "path": The path name of the file to replace.
 
+ * "size": The expected size of the file content.  If set, the file is
+   allocated immediately, and the channel "open" request will fail if
+   insufficient space is available.  If this option is set, it is not
+   possible to delete the file (ie: sending immediate EOF will result in
+   a 0 byte file) This option should always be provided if possible, to
+   avoid fragmentation, but is particularly important for large files.
+
  * "tag": The expected transaction tag of the file.  When the actual
    transaction tag of the file is different, the write will fail.  If
    you don't set this field, the actual tag will not be checked.  To
@@ -1077,9 +1084,15 @@ The following options can be specified in the "open" control message:
 You should write the new content to the channel as one or more
 messages.  To indicate the end of the content, send a "done" message.
 
-If you don't send any content messages before sending "done", the file
-will be removed.  To create an empty file, send at least one content
-message of length zero.
+If you don't send any content messages before sending "done", and no
+"size" was given, the file will be removed.  To create an empty file,
+send at least one content message of length zero, or set the "size" to
+0.
+
+If "size" is given, and less data is actually sent, then the file will
+be truncated down to the size of the data that was actually sent. If
+more data is sent, the file will grow (subject to additional
+fragmentation and potential ENOSPC errors).
 
 When the file does not have the expected tag, the channel will be
 closed with a "change-conflict" problem code.

--- a/pkg/lib/cockpit-upload-helper.ts
+++ b/pkg/lib/cockpit-upload-helper.ts
@@ -41,7 +41,7 @@ class Waiter {
 
 export async function upload(
     destination: string,
-    stream: ReadableStream,
+    contents: Blob,
     progress?: (bytes_sent: number) => void,
     signal?: AbortSignal,
     options?: cockpit.JsonObject
@@ -65,6 +65,7 @@ export async function upload(
         payload: 'fsreplace1',
         path: destination,
         binary: true,
+        size: contents.size,
         'send-acks': 'bytes',
         ...options,
     } as const;
@@ -91,8 +92,8 @@ export async function upload(
     });
 
     try {
-        debug('starting file send', stream);
-        const reader = stream.getReader({ mode: 'byob' }); // byob to choose the block size
+        debug('starting file send', contents);
+        const reader = contents.stream().getReader({ mode: 'byob' }); // byob to choose the block size
         let eof = false;
 
         // eslint-disable-next-line no-unmodified-loop-condition

--- a/pkg/playground/react-demo-file-upload.tsx
+++ b/pkg/playground/react-demo-file-upload.tsx
@@ -60,7 +60,7 @@ export const UploadButton = () => {
             });
 
             try {
-                await upload(destination, file.stream(), (progress) => {
+                await upload(destination, file, (progress) => {
                     const now = performance.now();
                     if (now < next_progress)
                         return;

--- a/src/cockpit/channel.py
+++ b/src/cockpit/channel.py
@@ -318,7 +318,6 @@ class ProtocolChannel(Channel, asyncio.Protocol):
     for setting up the connection and ensuring that .connection_made() is called.
     """
     _transport: Optional[asyncio.Transport]
-    _loop: Optional[asyncio.AbstractEventLoop]
     _send_pongs: bool = True
     _last_ping: Optional[JsonObject] = None
     _create_transport_task = None

--- a/src/cockpit/channels/filesystem.py
+++ b/src/cockpit/channels/filesystem.py
@@ -181,12 +181,11 @@ class FsReplaceChannel(AsyncChannel):
                 # otherwise, spool data into a temporary file until EOF then rename into place...
                 with tempfile.NamedTemporaryFile(dir=dirname, prefix=f'.{basename}-', delete=False) as tmp:
                     delete_on_exit = tmp.name
-                    loop = asyncio.get_running_loop()
                     while data is not None:
-                        await loop.run_in_executor(None, tmp.write, data)
+                        await self.in_thread(tmp.write, data)
                         data = await self.read()
 
-                    await loop.run_in_executor(None, os.fdatasync, tmp.fileno())
+                    await self.in_thread(os.fdatasync, tmp.fileno())
 
                     if tag is None:
                         # no preconditions about what currently exists or not

--- a/src/cockpit/channels/filesystem.py
+++ b/src/cockpit/channels/filesystem.py
@@ -29,7 +29,7 @@ import re
 import stat
 import tempfile
 from pathlib import Path
-from typing import Callable, Iterable
+from typing import Callable, Iterable, Iterator
 
 from cockpit._vendor.systemd_ctypes import Handle, PathWatch
 from cockpit._vendor.systemd_ctypes.inotify import Event as InotifyEvent
@@ -121,7 +121,7 @@ class FsListChannel(Channel):
 class FsReadChannel(GeneratorChannel):
     payload = 'fsread1'
 
-    def do_yield_data(self, options: JsonObject) -> GeneratorChannel.DataGenerator:
+    def do_yield_data(self, options: JsonObject) -> Iterator[bytes]:
         path = get_str(options, 'path')
         binary = get_enum(options, 'binary', ['raw'], None) is not None
         max_read_size = get_int(options, 'max_read_size', None)


### PR DESCRIPTION
Plus some associated cleanups.

Not in this PR: sending the `size` attribute from `cockpit.file().replace()` — the way we handle iterating over string data (which may contain non-ascii characters) makes this quite difficult at present.