### PR TITLE
test: Adjust for new selinuxuser_execmod flag on Fedora 40

### DIFF
--- a/test/verify/check-selinux
+++ b/test/verify/check-selinux
@@ -231,7 +231,11 @@ class TestSelinux(testlib.MachineCase):
             # See https://github.com/SELinuxProject/selinux/commit/3a9b4505b
             # Combining of versions < 3.0 with versions >= 3.0 provides a bit
             # different outputs.
-            return script.replace("permissive -D\n", "")
+            script = script.replace("permissive -D\n", "")
+            # likewise, this only started to exist in Fedora 40
+            if not m.image.startswith('fedora-4'):
+                script = script.replace("boolean -m -1 selinuxuser_execmod\n", "")
+            return script
 
         b.click("button:contains('Ansible')")
         b.wait_text_matches(ansible_script_sel, "Allow zebra.*write.*config")


### PR DESCRIPTION
Fallout from moving TEST_OS_DEFAULT to Fedora 40. RHEL 8, 9 does not yet know about this SELinux flag, so ignore it in the comparison.

Closes: #20396