### PR TITLE
test: bump ansible machine memory size

### DIFF
--- a/test/verify/check-selinux
+++ b/test/verify/check-selinux
@@ -52,7 +52,7 @@ mv -f ~/.ssh/authorized_keys.test-avc ~/.ssh/authorized_keys
 class TestSelinux(testlib.MachineCase):
     provision = {
         "0": {},
-        "ansible_machine": {"image": TEST_OS_DEFAULT, "memory_mb": 512}
+        "ansible_machine": {"image": TEST_OS_DEFAULT, "memory_mb": 650}
     }
 
     @testlib.skipImage("No setroubleshoot", "debian-*", "ubuntu-*", "arch")


### PR DESCRIPTION
semanage in Fedora 40 eats a lot more ram leading to memory allocation issues. Bumping it to 600 is not enough, bumping it to 650 MB leaves ~ 40/60 MiB of memory left according to `top`.

/sbin/load_policy:  Can't load policy:  Cannot allocate memory