### PR TITLE
build: Remove cockpit(-ws-instance) user/group config option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -230,62 +230,6 @@ fi
 AM_CONDITIONAL(WITH_ASAN, test "$enable_asan" = "yes")
 AC_MSG_RESULT($asan_status)
 
-# User and group for running cockpit web server (cockpit-tls or -ws in customized setups)
-
-AC_ARG_WITH(cockpit_user,
-	    AS_HELP_STRING([--with-cockpit-user=<user>],
-			   [User for running cockpit (root)]
-                          )
-           )
-AC_ARG_WITH(cockpit_group,
-	    AS_HELP_STRING([--with-cockpit-group=<group>],
-			   [Group for running cockpit]
-                          )
-           )
-if test -z "$with_cockpit_user"; then
-    COCKPIT_USER=root
-    COCKPIT_GROUP=
-else
-    COCKPIT_USER=$with_cockpit_user
-    if test -z "$with_cockpit_group"; then
-        COCKPIT_GROUP=$with_cockpit_user
-    else
-	COCKPIT_GROUP=$with_cockpit_group
-    fi
-fi
-
-AC_SUBST(COCKPIT_USER)
-AC_SUBST(COCKPIT_GROUP)
-
-# User for running cockpit-ws instances from cockpit-tls
-
-AC_ARG_WITH(cockpit_ws_instance_user,
-	    AS_HELP_STRING([--with-cockpit-ws-instance-user=<user>],
-			   [User for running cockpit-ws instances from cockpit-tls (root)]
-                          )
-           )
-AC_ARG_WITH(cockpit_ws_instance_group,
-	    AS_HELP_STRING([--with-cockpit-ws-instance-group=<group>],
-			   [Group for running cockpit-ws instances from cockpit-tls]
-                          )
-           )
-if test -z "$with_cockpit_ws_instance_user"; then
-    if test "$COCKPIT_USER" != "root"; then
-        AC_MSG_ERROR([--with-cockpit-ws-instance-user is required when setting --with-cockpit-user])
-    fi
-    COCKPIT_WSINSTANCE_USER=root
-else
-    COCKPIT_WSINSTANCE_USER=$with_cockpit_ws_instance_user
-    if test -z "$with_cockpit_ws_instance_group"; then
-        COCKPIT_WSINSTANCE_GROUP=$with_cockpit_ws_instance_user
-    else
-        COCKPIT_WSINSTANCE_GROUP=$with_cockpit_ws_instance_group
-    fi
-fi
-
-AC_SUBST(COCKPIT_WSINSTANCE_USER)
-AC_SUBST(COCKPIT_WSINSTANCE_GROUP)
-
 # admin users group
 AC_ARG_WITH([admin-group],
             [AS_HELP_STRING([--with-admin-group=GROUP],
@@ -477,10 +421,6 @@ echo "
         cflags:                     ${CFLAGS}
         cppflags:                   ${CPPFLAGS}
 
-        cockpit-ws user:            ${COCKPIT_USER}
-        cockpit-ws group:           ${COCKPIT_GROUP}
-        cockpit-ws instance user:   ${COCKPIT_WSINSTANCE_USER}
-        cockpit-ws instance group:  ${COCKPIT_WSINSTANCE_GROUP}
         admin group:                ${admin_group}
         cockpit-session PATH:       ${default_session_path}
 

--- a/src/session/Makefile-session.am
+++ b/src/session/Makefile-session.am
@@ -21,8 +21,7 @@ cockpit_session_SOURCES = \
 	src/session/session.c \
 	$(NULL)
 
-# If running cockpit-ws as a non-standard user, we also set up
-# cockpit-session to be setuid root, but only runnable by cockpit-session
+# set up cockpit-session to be setuid root, but only runnable by cockpit-session
 install-exec-hook::
-	chown -f root:$(COCKPIT_WSINSTANCE_GROUP) $(DESTDIR)$(libexecdir)/cockpit-session || true
-	test "$(COCKPIT_USER)" != "root" && chmod -f 4750 $(DESTDIR)$(libexecdir)/cockpit-session || true
+	chown -f root:cockpit-wsinstance $(DESTDIR)$(libexecdir)/cockpit-session || true
+	chmod -f 4750 $(DESTDIR)$(libexecdir)/cockpit-session || true

--- a/src/systemd/Makefile.am
+++ b/src/systemd/Makefile.am
@@ -6,7 +6,6 @@ nodist_systemdunit_DATA = \
 	src/systemd/cockpit.service \
 	src/systemd/cockpit.socket \
 	src/systemd/cockpit-session@.service \
-	src/systemd/cockpit-session.socket \
 	src/systemd/cockpit-wsinstance-http.service \
 	src/systemd/cockpit-wsinstance-http.socket \
 	src/systemd/cockpit-wsinstance-https-factory@.service \
@@ -16,6 +15,7 @@ nodist_systemdunit_DATA = \
 	$(NULL)
 
 dist_systemdunit_DATA = \
+	src/systemd/cockpit-session.socket \
 	src/systemd/system-cockpithttps.slice \
 	$(NULL)
 
@@ -40,11 +40,7 @@ src/systemd/%: src/systemd/%.in
 	-e 's,[@]PACKAGE[@],$(PACKAGE),g' \
 	-e 's,[@]admin_group[@],$(admin_group),g' \
 	-e 's,[@]datadir[@],$(datadir),g' \
-	-e 's,[@]group[@],$(COCKPIT_GROUP),g' \
 	-e 's,[@]libexecdir[@],$(libexecdir),g' \
-	-e 's,[@]user[@],$(COCKPIT_USER),g' \
-	-e 's,[@]wsinstancegroup[@],$(COCKPIT_WSINSTANCE_GROUP),g' \
-	-e 's,[@]wsinstanceuser[@],$(COCKPIT_WSINSTANCE_USER),g' \
 	$< > $@.tmp && mv -f $@.tmp $@
 
 systemdgenerated = \

--- a/src/systemd/cockpit-session.socket
+++ b/src/systemd/cockpit-session.socket
@@ -4,6 +4,6 @@ Description=Initiator socket for Cockpit sessions
 [Socket]
 ListenStream=/run/cockpit/session
 SocketUser=root
-SocketGroup=@wsinstancegroup@
+SocketGroup=cockpit-wsinstance
 SocketMode=0660
 Accept=yes

--- a/src/systemd/cockpit-wsinstance-http.service.in
+++ b/src/systemd/cockpit-wsinstance-http.service.in
@@ -5,5 +5,5 @@ Documentation=man:cockpit-ws(8)
 
 [Service]
 ExecStart=@libexecdir@/cockpit-ws --no-tls --port=0
-User=@wsinstanceuser@
-Group=@wsinstancegroup@
+User=cockpit-wsinstance
+Group=cockpit-wsinstance

--- a/src/systemd/cockpit-wsinstance-http.socket.in
+++ b/src/systemd/cockpit-wsinstance-http.socket.in
@@ -5,5 +5,5 @@ Documentation=man:cockpit-ws(8)
 
 [Socket]
 ListenStream=/run/cockpit/wsinstance/http.sock
-SocketUser=@user@
+SocketUser=cockpit-ws
 SocketMode=0600

--- a/src/systemd/cockpit-wsinstance-https-factory.socket.in
+++ b/src/systemd/cockpit-wsinstance-https-factory.socket.in
@@ -6,5 +6,5 @@ Documentation=man:cockpit-ws(8)
 [Socket]
 ListenStream=/run/cockpit/wsinstance/https-factory.sock
 Accept=yes
-SocketUser=@user@
+SocketUser=cockpit-ws
 SocketMode=0600

--- a/src/systemd/cockpit-wsinstance-https@.service.in
+++ b/src/systemd/cockpit-wsinstance-https@.service.in
@@ -6,5 +6,5 @@ Documentation=man:cockpit-ws(8)
 [Service]
 Slice=system-cockpithttps.slice
 ExecStart=@libexecdir@/cockpit-ws --for-tls-proxy --port=0
-User=@wsinstanceuser@
-Group=@wsinstancegroup@
+User=cockpit-wsinstance
+Group=cockpit-wsinstance

--- a/src/systemd/cockpit-wsinstance-https@.socket.in
+++ b/src/systemd/cockpit-wsinstance-https@.socket.in
@@ -9,5 +9,5 @@ Documentation=man:cockpit-ws(8)
 
 [Socket]
 ListenStream=/run/cockpit/wsinstance/https@%i.sock
-SocketUser=@user@
+SocketUser=cockpit-ws
 SocketMode=0600

--- a/src/systemd/cockpit.service.in
+++ b/src/systemd/cockpit.service.in
@@ -11,8 +11,8 @@ RuntimeDirectory=cockpit/tls
 Environment=RUNTIME_DIRECTORY=/run/cockpit/tls
 ExecStartPre=+@libexecdir@/cockpit-certificate-ensure --for-cockpit-tls
 ExecStart=@libexecdir@/cockpit-tls
-User=@user@
-Group=@group@
+User=cockpit-ws
+Group=cockpit-ws
 NoNewPrivileges=true
 ProtectSystem=strict
 ProtectHome=true

--- a/tools/arch/PKGBUILD
+++ b/tools/arch/PKGBUILD
@@ -40,8 +40,6 @@ build() {
     --disable-dependency-tracking \
     --disable-silent-rules \
     --with-admin-group=wheel \
-    --with-cockpit-user=cockpit-ws \
-    --with-cockpit-ws-instance-user=cockpit-wsinstance
   make all
 }
 

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -154,8 +154,6 @@ BuildRequires:  python3-tox-current-env
 %build
 %configure \
     %{?selinux_configure_arg} \
-    --with-cockpit-user=cockpit-ws \
-    --with-cockpit-ws-instance-user=cockpit-wsinstance \
 %if 0%{?suse_version}
     --docdir=%_defaultdocdir/%{name} \
 %endif

--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -18,8 +18,6 @@ export deb_pamlibdir = $(shell { pkgconf --variable=libdir pam || echo /lib/$(DE
 
 override_dh_auto_configure:
 	dh_auto_configure -- \
-		--with-cockpit-user=cockpit-ws \
-		--with-cockpit-ws-instance-user=cockpit-wsinstance \
 		--with-pamdir=/$(deb_pamlibdir)/security \
 		--libexecdir=/usr/lib/cockpit $(CONFIG_OPTIONS)
 


### PR DESCRIPTION
All distributions use the same value anyway, and this paves the way for unifying them further with moving to systemd-sysusers.

We never test the upstream default of running them as root, so it might not even work and we also don't want to support/encourage that.

----

Broken out of #20365 and fixed. I want to test/land this separately, as it's quite intrusive.

@travier FYI

## configure: Remove configurable system users

This release drops the `./configure` options for customizing the two system users of cockpit's web server:
`--with-cockpit-user`, `--with-cockpit-group`, `--with-cockpit-ws-instance-user`, and `--with-cockpit-ws-instance-user`. All supported distributions use the same name anyway. We don't test, support, or recommend running the web server as root, which so far has been the default with `./configure; make; make install`.

This happens in anticipation of moving to [systemd-sysusers](https://www.freedesktop.org/software/systemd/man/latest/sysusers.d.html#) for creating these users.