### PR TITLE
test: disable popup blocking for Cockpit-files

### DIFF
--- a/test/common/cdp.py
+++ b/test/common/cdp.py
@@ -105,6 +105,8 @@ class Chromium(Browser):
                 "--disable-namespace-sandbox", "--disable-seccomp-filter-sandbox",
                 "--disable-sandbox-denial-logging", "--disable-pushstate-throttle",
                 "--font-render-hinting=none",
+                # HACK: For Cockpit-Files downloading uses `window.open` which is sometimes allowed depending on unpredictable and unknown heuristics
+                "--disable-popup-blocking",
                 "--v=0", f"--remote-debugging-port={cdp_port}", "about:blank"]
 
 


### PR DESCRIPTION
In Cockpit-files we download using `window.open` which Chromium sometimes blocks depending on how long the browser was open, the session was active or other unknown heuristics. To stop the tests from flaking disable popup blocking in general as this also allows a Developer to now run `TestFiles.testDownload` as a separate test without getting window.open blocked.

---

This sadly can't be achieve via CDP so requires a big hammer :( This should fix the two top flakes in Files:

https://cockpit-logs.us-east-1.linodeobjects.com/pull-425-13a6056a-20240501-204215-fedora-rawhide/log.html
https://cockpit-logs.us-east-1.linodeobjects.com/pull-389-0acab15d-20240422-204056-fedora-40/log.html
https://cockpit-logs.us-east-1.linodeobjects.com/pull-389-0acab15d-20240422-204056-fedora-40/log.html 