### PR TITLE
test: Drop mobile pixel tests in TestHistoryMetrics.testEvents

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -238,8 +238,9 @@ class TestHistoryMetrics(testlib.MachineCase):
         b.wait_in_text("#metrics-hour-1597662000000:not(.metrics-hour-compressed) .metrics-events-hour-header-expanded .spikes_count", "3 spikes")
         b.wait_in_text("#metrics-hour-1597662000000:not(.metrics-hour-compressed) .metrics-events-hour-header-expanded .spikes_info", "1 Memory, 1 Disk I/O, 1 Network I/O")
 
+        # FIXME: mobile layout is racy in tests (only, not in reality), scrollIntoView() misplaces the menu bar
         b.assert_pixels(".metrics", "metrics-history-expanded-hour", ignore=[".spikes_count"],
-                        wait_after_layout_change=True)
+                        skip_layouts=["mobile"], wait_after_layout_change=True)
 
         b.click("#metrics-hour-1597662000000 button.metrics-events-expander")
         b.wait_in_text("#metrics-hour-1597662000000.metrics-hour-compressed", "1:00")
@@ -247,7 +248,7 @@ class TestHistoryMetrics(testlib.MachineCase):
         b.wait_in_text("#metrics-hour-1597662000000.metrics-hour-compressed .spikes_info", "1 Memory, 1 Disk I/O, 1 Network I/O")
 
         b.assert_pixels(".metrics", "metrics-history-compressed-hour", ignore=[".nodata"],
-                        wait_after_layout_change=True)
+                        skip_layouts=["mobile"], wait_after_layout_change=True)
 
         # Check that events are not visible for compressed hours
         b.wait_not_present("#metrics-hour-1597662000000 div.metrics-minute[data-minute='28'] .metrics-events")


### PR DESCRIPTION
The mobile pixel test is way too flaky (> 50% failure rate on our CI). scrollIntoViewIfNeeded() somehow misplaces the menu bar. This isn't a real problem, an interactive Firefox/Chromium works fine.

Nobody has figured this out in two weeks, earlier attempts at fixing that (commits e700960 and 790b377) also weren't effective. Figuring this out is too much effort for too little benefit, and this flake breaks every PR. So disable the mobile pixel test.

Fixes #20338