### PR TITLE
systemd: Fix state handling with creating repeating timers

### DIFF
--- a/pkg/systemd/timer-dialog.jsx
+++ b/pkg/systemd/timer-dialog.jsx
@@ -91,17 +91,17 @@ const CreateTimerDialogBody = ({ owner }) => {
                     time={repeatPatterns[idx].time || "00:00"}
                     is24Hour
                     isOpen={repeatPatterns[idx].isOpen || false}
-                    setIsOpen={isOpen => {
-                        const arr = JSON.parse(JSON.stringify(repeatPatterns));
+                    setIsOpen={isOpen => setRepeatPatterns(old => {
+                        const arr = [...old];
                         arr[idx].isOpen = isOpen;
-                        setRepeatPatterns(arr);
-                    }}
+                        return arr;
+                    })}
                     menuAppendTo={() => document.body}
-                    onChange={(_, time) => {
-                        const arr = JSON.parse(JSON.stringify(repeatPatterns));
+                    onChange={(_, time) => setRepeatPatterns(old => {
+                        const arr = [...old];
                         arr[idx].time = time;
-                        setRepeatPatterns(arr);
-                    }}
+                        return arr;
+                    })}
         />
     );
 
@@ -287,32 +287,32 @@ const CreateTimerDialogBody = ({ owner }) => {
                                             <TextInput className='delay-number'
                                                        id={repeat}
                                                        value={repeatPatterns[idx].second}
-                                                       onChange={(_event, second) => {
-                                                           const arr = [...repeatPatterns];
+                                                       onChange={(_event, second) => setRepeatPatterns(old => {
+                                                           const arr = [...old];
                                                            arr[idx].second = second;
-                                                           setRepeatPatterns(arr);
-                                                       }}
+                                                           return arr;
+                                                       })}
                                                        validated={submitted && validationFailedSecond ? "error" : "default"} />
                                         }
                                         {repeat == "hourly" &&
                                             <TextInput className='delay-number'
                                                        value={repeatPatterns[idx].minute}
-                                                       onChange={(_event, minute) => {
-                                                           const arr = [...repeatPatterns];
+                                                       onChange={(_event, minute) => setRepeatPatterns(old => {
+                                                           const arr = [...old];
                                                            arr[idx].minute = minute;
-                                                           setRepeatPatterns(arr);
-                                                       }}
+                                                           return arr;
+                                                       })}
                                                        validated={submitted && validationFailedMinute ? "error" : "default"} />
                                         }
                                         {repeat == "daily" && timePicker(idx)}
                                         {repeat == "weekly" && <>
                                             <FormSelect value={repeatPatterns[idx].day}
                                                         className="week-days"
-                                                        onChange={(_, day) => {
-                                                            const arr = [...repeatPatterns];
+                                                        onChange={(_, day) => setRepeatPatterns(old => {
+                                                            const arr = [...old];
                                                             arr[idx].day = day;
-                                                            setRepeatPatterns(arr);
-                                                        }}
+                                                            return arr;
+                                                        })}
                                                         aria-label={_("Repeat weekly")}>
                                                 <FormSelectOption value="mon" label={_("Mondays")} />
                                                 <FormSelectOption value="tue" label={_("Tuesdays")} />
@@ -327,11 +327,11 @@ const CreateTimerDialogBody = ({ owner }) => {
                                         {repeat == "monthly" && <>
                                             <FormSelect value={repeatPatterns[idx].day}
                                                         className="month-days"
-                                                        onChange={(_, day) => {
-                                                            const arr = [...repeatPatterns];
+                                                        onChange={(_, day) => setRepeatPatterns(old => {
+                                                            const arr = [...old];
                                                             arr[idx].day = day;
-                                                            setRepeatPatterns(arr);
-                                                        }}
+                                                            return arr;
+                                                        })}
                                                         aria-label={_("Repeat monthly")}>
                                                 {[_("1st"), _("2nd"), _("3rd"), _("4th"), _("5th"),
                                                     _("6th"), _("7th"), _("8th"), _("9th"), _("10th"),
@@ -348,11 +348,11 @@ const CreateTimerDialogBody = ({ owner }) => {
                                                         buttonAriaLabel={_("Toggle date picker")}
                                                         locale={timeformat.dateFormatLang()}
                                                         weekStart={timeformat.firstDayOfWeek()}
-                                                        onChange={(_, str, data) => {
-                                                            const arr = [...repeatPatterns];
+                                                        onChange={(_, str, data) => setRepeatPatterns(old => {
+                                                            const arr = [...old];
                                                             arr[idx].date = str;
-                                                            setRepeatPatterns(arr);
-                                                        }}
+                                                            return arr;
+                                                        })}
                                                         appendTo={() => document.body} />
                                             {timePicker(idx)}
                                         </>}
@@ -361,24 +361,24 @@ const CreateTimerDialogBody = ({ owner }) => {
                                                 <Button aria-label={_("Remove")}
                                                         variant="secondary"
                                                         isDisabled={repeatPatterns.length == 1}
-                                                        onClick={() => setRepeatPatterns(repeatPatterns.filter((item, item_idx) => idx != item_idx))}>
+                                                        onClick={() => setRepeatPatterns(old => old.filter((item, item_idx) => idx != item_idx))}>
                                                     <MinusIcon />
                                                 </Button>
                                                 <Button aria-label={_("Add")}
                                                         variant="secondary"
                                                         onClick={() => {
                                                             if (repeat == "minutely")
-                                                                setRepeatPatterns([...repeatPatterns, { key: repeatPatterns.length, second: "0" }]);
+                                                                setRepeatPatterns(old => [...old, { key: repeatPatterns.length, second: "0" }]);
                                                             else if (repeat == "hourly")
-                                                                setRepeatPatterns([...repeatPatterns, { key: repeatPatterns.length, minute: "0" }]);
+                                                                setRepeatPatterns(old => [...old, { key: repeatPatterns.length, minute: "0" }]);
                                                             else if (repeat == "daily")
-                                                                setRepeatPatterns([...repeatPatterns, { key: repeatPatterns.length, time: "00:00" }]);
+                                                                setRepeatPatterns(old => [...old, { key: repeatPatterns.length, time: "00:00" }]);
                                                             else if (repeat == "weekly")
-                                                                setRepeatPatterns([...repeatPatterns, { key: repeatPatterns.length, day: "mon", time: "00:00" }]);
+                                                                setRepeatPatterns(old => [...old, { key: repeatPatterns.length, day: "mon", time: "00:00" }]);
                                                             else if (repeat == "monthly")
-                                                                setRepeatPatterns([...repeatPatterns, { key: repeatPatterns.length, day: 1, time: "00:00" }]);
+                                                                setRepeatPatterns(old => [...old, { key: repeatPatterns.length, day: 1, time: "00:00" }]);
                                                             else if (repeat == "yearly")
-                                                                setRepeatPatterns([...repeatPatterns, { key: repeatPatterns.length, date: undefined, time: "00:00" }]);
+                                                                setRepeatPatterns(old => [...old, { key: repeatPatterns.length, date: undefined, time: "00:00" }]);
                                                         }}>
                                                     <PlusIcon />
                                                 </Button>

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -1480,7 +1480,7 @@ class TestTimers(testlib.MachineCase):
         m.execute("timedatectl set-time '2036-03-07 00:00:00'")
         wait_systemctl_timer("2036-03-08 21:12")
         self.assertIn("2036-03-08 21:12", m.execute("systemctl list-timers"))
-        # creates a new weekly timer that runs on Fri at 12:45 and Sun at 20:12 every week
+        # creates a new weekly timer that runs on Fri at 12:30 and Sun at 20:12 every week
         b.click('#create-timer')
         b.wait_visible("#timer-dialog")
         b.set_input_text("#servicename", "weekly_timer")
@@ -1491,7 +1491,9 @@ class TestTimers(testlib.MachineCase):
         b.wait_visible("[data-index='0'] .week-days")
         b.click("[data-index='0'] [aria-label='Add']")
         b.select_from_dropdown("[data-index='0'] .week-days select", "fri")
-        b.set_input_text("[data-index='0'] .create-timer-time-picker input", "12:45")
+        # select time from dropdown with mouse
+        b.select_PF5("#timer-dialog [data-index='0'] .create-timer-time-picker input", ".pf-v5-c-menu", "12:30")
+        # type time with keyboard
         b.select_from_dropdown("[data-index='1'] .week-days select", "sun")
         b.set_input_text("[data-index='1'] .create-timer-time-picker input", "20:12")
         b.click("#timer-save-button")
@@ -1504,15 +1506,15 @@ class TestTimers(testlib.MachineCase):
         wait_systemctl_timer("Sun 2036-03-09 20:12")
         self.assertIn("Sun 2036-03-09 20:12", m.execute("systemctl list-timers"))
         m.execute("timedatectl set-time '2036-03-10 00:00:00'")
-        wait_systemctl_timer("Fri 2036-03-14 12:45")
-        self.assertIn("Fri 2036-03-14 12:45", m.execute("systemctl list-timers"))
+        wait_systemctl_timer("Fri 2036-03-14 12:30")
+        self.assertIn("Fri 2036-03-14 12:30", m.execute("systemctl list-timers"))
         # checks if timer runs on next week's Friday and Sunday
         m.execute("timedatectl set-time '2036-03-15 00:00:00'")
         wait_systemctl_timer("Sun 2036-03-16 20:12")
         self.assertIn("Sun 2036-03-16 20:12", m.execute("systemctl list-timers"))
         m.execute("timedatectl set-time '2036-03-17 00:00:00'")
-        wait_systemctl_timer("Fri 2036-03-21 12:45")
-        self.assertIn("Fri 2036-03-21 12:45", m.execute("systemctl list-timers"))
+        wait_systemctl_timer("Fri 2036-03-21 12:30")
+        self.assertIn("Fri 2036-03-21 12:30", m.execute("systemctl list-timers"))
         # creates a new daily timer that runs at 2:40 and at 21:15 every day
         b.click('#create-timer')
         b.wait_visible("#timer-dialog")

--- a/tools/vulture_suppressions/testlib.py
+++ b/tools/vulture_suppressions/testlib.py
@@ -5,7 +5,6 @@ Browser.get_checked
 
 # kept as being potentially useful in the future
 Browser.wait_attr_not_contains
-Browser.select_PF5
 
 # https://github.com/jendrikseipp/vulture/issues/249
 BrowserLayout.theme  # type: ignore[attr-defined]


### PR DESCRIPTION
When setting the time of a repeated timer with the mouse, this triggered both `onChange()` and `setOpen()` at the same time, both of which calling `setRepeatPatterns()`. Due to the async/deferred nature of React, these both worked on old data, so that the first callback was effectively ignored, and created timers ended up with the default "00:00" time. Fix that with a functional state update.

Also replace the weird JSON stringify/parse cycle with a spread, like all the other callbacks already did -- the only purpose of that was to copy the list.

This didn't happen when setting the time with the keyboard, because the dropdown wasn't opened then. So change TestTimers() to set the "Friday" repeat time with the mouse (keep the Monday one with the keyboard, to cover both cases). As we only have 30-minute granularity, change the time from 12:45 to 12:30.

The test uses select_PF5(), so drop it from the vulture suppressions. (c-machines also uses that function.)

Fixes #19278