### PR TITLE
tools: Lower kdumpctl dependency to Recommends on RHEL

### DIFF
--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -87,6 +87,7 @@ class KdumpHelpers(testlib.MachineCase):
 
 @testlib.skipOstree("kexec-tools not installed")
 @testlib.skipImage("kexec-tools not installed", "debian-*", "ubuntu-*", "arch")
+@testlib.skipImage("https://issues.redhat.com/browse/RHEL-35567", "centos-10", "rhel-10*")
 @testlib.timeout(900)
 @testlib.skipDistroPackage()
 class TestKdump(KdumpHelpers):
@@ -457,6 +458,7 @@ class TestKdump(KdumpHelpers):
 
 @testlib.skipOstree("kexec-tools not installed")
 @testlib.skipImage("kexec-tools not installed", "debian-*", "ubuntu-*", "arch")
+@testlib.skipImage("https://issues.redhat.com/browse/RHEL-35567", "centos-10", "rhel-10*")
 @testlib.timeout(900)
 @testlib.skipDistroPackage()
 class TestKdumpNFS(KdumpHelpers):

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -328,11 +328,11 @@ Provides: cockpit-users = %{version}-%{release}
 Obsoletes: cockpit-dashboard < %{version}-%{release}
 %if 0%{?rhel}
 Requires: NetworkManager >= 1.6
-Requires: /usr/bin/kdumpctl
 Requires: sos
 Requires: sudo
 Recommends: PackageKit
 Recommends: setroubleshoot-server >= 3.3.3
+Recommends: /usr/bin/kdumpctl
 Suggests: NetworkManager-team
 Provides: cockpit-kdump = %{version}-%{release}
 Provides: cockpit-networkmanager = %{version}-%{release}


### PR DESCRIPTION
Most of cockpit-system works fine without kdump functionality, and the kdump page fails gracefully without it ("Kdump service is not installed" alert). As recommends are installed by default, this is the right dependency level.

kdump does not currently exist on RHEL/CentOS 10 [1], so skip the test there.

[1] https://issues.redhat.com/browse/RHEL-35567

---

Blocks https://github.com/cockpit-project/bots/pull/6280 . I'm not triggering the new image tests here, as there are almost surely other regressions, and I don't want to land this red.