### PR TITLE
test: Fix handling of "closing" sessions in TestSession.testBasic

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1681,7 +1681,7 @@ class MachineCase(unittest.TestCase):
                 # Don't insist that terminating works, the session might be gone by now.
                 self.machine.execute(f"loginctl kill-session {s} || true; loginctl terminate-session {s} || true")
 
-            # Restart logind to mop up empty "closing" sessions
+            # Restart logind to mop up empty "closing" sessions; https://github.com/systemd/systemd/issues/26744
             self.machine.execute("systemctl stop systemd-logind")
 
             # Wait for sessions to be gone

--- a/test/verify/check-session
+++ b/test/verify/check-session
@@ -29,7 +29,18 @@ class TestSession(testlib.MachineCase):
         b = self.browser
 
         def wait_session(should_exist):
-            testlib.wait(lambda: (should_exist == ("admin" in m.execute("loginctl list-sessions"))))
+            if should_exist:
+                m.execute("until loginctl list-sessions | grep admin; do sleep 1; done")
+            else:
+                # restart logind to mop up empty "closing" sessions, like in testlib terminate_sessions()
+                m.execute("""while true; do
+                                 OUT=$(loginctl list-sessions)
+                                 echo "$OUT" | grep admin || break
+                                 if echo "$OUT | grep closing"; then
+                                    systemctl stop systemd-logind
+                                 fi
+                                 sleep 3
+                             done""")
 
         wait_session(should_exist=False)
 


### PR DESCRIPTION
Despite multiple attempts/claims at fixing this, logind still often has empty "State: closing" sessions after logout, without any processes in it [1]. Our generic nondestructive test cleanup in testlib's terminate_sessions() has a workaround for this (restarting logind). Do the same in this test.

Only do this when waiting for the session to go away; starting new sessions should work fine.

Fixes #20379

[1] https://github.com/systemd/systemd/issues/26744

----

I could reproduces this rather well locally. Now it has survived two parallel loops of

    for i in `seq 20`; do TEST_OS=arch test/verify/check-session -s $RUNC || break; done