### PR TITLE
test: Move TestMultiOSDirect from centos-8-stream to rhel-8-10, drop CentOS 8 special cases

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -203,9 +203,9 @@ These shell aliases might be useful when experimenting with the protocol:
     alias cpy='PYTHONPATH=src python3 -m cockpit.bridge'
     alias cpf='PYTHONPATH=src python3 -m cockpit.misc.print'
 
-When working with the Python bridge on test images, note that `RHEL/CentOS 8`,
-`debian-stable`, and `ubuntu-2204` still use the C bridge. So if you want to
-explicitly have the Python bridge on those images use:
+When working with the Python bridge on test images, note that `rhel-8*` still
+uses the C bridge. So if you want to explicitly have the Python bridge on those
+images use:
 
     ./test/image-prepare --python
 

--- a/doc/guide/https.xml
+++ b/doc/guide/https.xml
@@ -68,7 +68,7 @@ getcert request -f /etc/cockpit/ws-certs.d/50-certmonger.cert \
                 -D myhostname.example.com \
                 [--ca=...]</programlisting>
 
-    <para>This will not work on Red Hat Enterprise Linux/CentOS 8 by default. Adjust the SELinux type of the certificate directory to <code>cert_t</code> to allow certmonger to write its certificates there:</para>
+    <para>This will not work on Red Hat Enterprise Linux 8 by default. Adjust the SELinux type of the certificate directory to <code>cert_t</code> to allow certmonger to write its certificates there:</para>
 
     <programlisting>
 semanage fcontext -a -t cert_t '/etc/cockpit/ws-certs\.d(/.*)?'

--- a/pkg/networkmanager/dialogs-common.jsx
+++ b/pkg/networkmanager/dialogs-common.jsx
@@ -215,7 +215,7 @@ export const NetworkAction = ({ buttonText, iface, connectionSettings, type }) =
                 const packagekitExits = await packagekit.detect();
                 const os_release = await read_os_release();
 
-                // RHEL/CentOS 8 does not have wireguard-tools
+                // RHEL 8 does not have wireguard-tools
                 if (packagekitExits && os_release.PLATFORM_ID !== "platform:el8")
                     await install_dialog("wireguard-tools");
             }

--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -60,11 +60,6 @@ if [ "$PLAN" = basic ] && ! grep -q el8 /etc/os-release; then
 fi
 
 
-# On CentOS Stream 8 the cockpit package is upgraded so the file isn't touched.
-if [ ! -f /etc/cockpit/disallowed-users ]; then
-    echo 'root' > /etc/cockpit/disallowed-users
-fi
-
 #HACK: unbreak RHEL 9's default choice of 999999999 rounds, see https://bugzilla.redhat.com/show_bug.cgi?id=1993919
 sed -ie 's/#SHA_CRYPT_MAX_ROUNDS 5000/SHA_CRYPT_MAX_ROUNDS 5000/' /etc/login.defs
 

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -17,19 +17,10 @@ fi
 . /run/host/usr/lib/os-release
 export TEST_OS="${ID}-${VERSION_ID/./-}"
 
-if [ "${TEST_OS#centos-}" != "$TEST_OS" ]; then
-    TEST_OS="${TEST_OS}-stream"
-fi
-
 TEST_ALLOW_JOURNAL_MESSAGES=""
 
 # HACK: CI hits this selinux denial. Unrelated to our tests.
 TEST_ALLOW_JOURNAL_MESSAGES=".*Permission denied:.*/var/cache/app-info/xmls.*"
-
-# HACK: occasional failure, annoyingly hard to debug
-if [ "${TEST_OS#centos-8}" != "$TEST_OS" ]; then
-    TEST_ALLOW_JOURNAL_MESSAGES="${TEST_ALLOW_JOURNAL_MESSAGES},couldn't create runtime dir: /run/user/1001: Permission denied"
-fi
 
 # HACK: https://github.com/systemd/systemd/issues/24150
 if [ "$ID" = "fedora" ]; then
@@ -131,7 +122,7 @@ if [ "$PLAN" = "basic" ]; then
     # PCI devices list is not predictable
     EXCLUDES="$EXCLUDES TestSystemInfo.testHardwareInfo"
 
-    if [ "${TEST_OS#rhel-8}" != "$TEST_OS" ] || [ "${TEST_OS#centos-8}" != "$TEST_OS" ]; then
+    if [ "${TEST_OS#rhel-8}" != "$TEST_OS" ]; then
         # no cockpit-tests package in RHEL 8
         EXCLUDES="$EXCLUDES TestLogin.testSELinuxRestrictedUser"
 

--- a/test/common/storagelib.py
+++ b/test/common/storagelib.py
@@ -666,7 +666,7 @@ class StorageCase(MachineCase, StorageHelpers):
         else:
             self.default_crypto_type = "luks1"
 
-        if self.image.startswith("rhel-8") or self.image.startswith("centos-8"):
+        if self.image.startswith("rhel-8"):
             # HACK: missing /etc/crypttab file upsets udisks: https://github.com/storaged-project/udisks/pull/835
             self.machine.write("/etc/crypttab", "")
 

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1462,7 +1462,7 @@ class MachineCase(unittest.TestCase):
         return os.environ.get('NODE_ENV') == 'development'
 
     def is_pybridge(self) -> bool:
-        # some tests start e.g. centos-8 as first machine, bridge may not exist there
+        # some tests start some other OS as first machine, bridge may not exist there
         return any('python' in m.execute('head -c 30 /usr/bin/cockpit-bridge || true') for m in self.machines.values())
 
     def disable_preload(self, *packages: str, machine: testvm.Machine | None = None) -> None:
@@ -1891,7 +1891,7 @@ class MachineCase(unittest.TestCase):
         "error: Could not determine kpatch packages:.*PackageKit crashed",
     ]
 
-    if testvm.DEFAULT_IMAGE.startswith('rhel-8') or testvm.DEFAULT_IMAGE.startswith('centos-8'):
+    if testvm.DEFAULT_IMAGE.startswith('rhel-8'):
         # old occasional bugs in tracer, don't happen in newer versions any more
         default_allowed_console_errors.append('Tracer failed:.*Traceback')
 

--- a/test/verify/check-client
+++ b/test/verify/check-client
@@ -20,7 +20,7 @@
 import testlib
 
 
-@testlib.skipImage("needs pybridge", "rhel-8*", "centos-8*")
+@testlib.skipImage("needs pybridge", "rhel-8*")
 # enable this once our cockpit/ws container can beiboot
 @testlib.skipOstree("client setup does not work with ws container")
 class TestClient(testlib.MachineCase):

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -612,7 +612,7 @@ class TestConnection(testlib.MachineCase):
 
         def checkMotdContent(string: str, *, expected: bool = True) -> None:
             # Needs https://github.com/linux-pam/linux-pam/pull/292 (or PAM 1.5.0)
-            old_pam = m.image.startswith('rhel-8-') or m.image in ['centos-8-stream', 'ubuntu-2204']
+            old_pam = m.image.startswith('rhel-8-') or m.image in ['ubuntu-2204']
 
             # check issue (should be exactly the same as motd)
             assertInOrNot(string, m.execute("cat /etc/issue.d/cockpit.issue"), expected=expected)
@@ -661,7 +661,7 @@ class TestConnection(testlib.MachineCase):
         m = self.machine
 
         # On RHEL-8 SSH allows password root login by default, so Cockpit does too.
-        ROOT_LOGIN_ENABLED = ['rhel-8', 'centos-8']
+        ROOT_LOGIN_ENABLED = ['rhel-8']
         root_login_disallowed = not any(m.image.startswith(img) for img in ROOT_LOGIN_ENABLED)
 
         if m.image.startswith("debian") or m.image.startswith("ubuntu"):
@@ -835,7 +835,7 @@ class TestConnection(testlib.MachineCase):
         self.assertLess(rss, 250000)
 
     @testlib.nondestructive
-    @testlib.skipImage("Broken with C bridge", "centos-8-stream", "rhel-8*")
+    @testlib.skipImage("Broken with C bridge", "rhel-8*")
     def testFlowControlUpload(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -810,9 +810,9 @@ class TestCurrentMetrics(testlib.MachineCase):
 
         m.execute(f"podman stop -t 0 {container_name}")
 
-        # RHEL-8 / CentOS-8's podman user containers do not show up as
+        # RHEL-8's podman user containers do not show up as
         # libpod-$containerid but as podman-3679.scope.
-        if m.image != "centos-8-stream" and not m.image.startswith("rhel-8"):
+        if not m.image.startswith("rhel-8"):
             # copy images for user podman tests; podman insists on user session
             m.execute(f"podman save {self.busybox_image} | sudo -i -u admin podman load")
 
@@ -957,7 +957,7 @@ class TestCurrentMetrics(testlib.MachineCase):
 
         # Test link to user services
         # older releases don't have CPU accounting enabled for user services
-        if self.machine.image != "centos-8-stream" and not self.machine.image.startswith("rhel-8-"):
+        if not self.machine.image.startswith("rhel-8-"):
             m.execute("su - admin -c 'XDG_RUNTIME_DIR=/run/user/$(id -u admin) systemd-run --user --collect --slice cockpittest -p CPUQuota=60% --unit cpu-userhog dd if=/dev/urandom of=/dev/null'")
             # user services are always running underneath user@1000.service, so these two will compete for row 1 or 2
             b.wait_in_text("table[aria-label='Top 5 CPU services'] tbody", "cpu-userhog")
@@ -1049,9 +1049,9 @@ BEGIN {{
 
         m.execute(f"podman stop -t 0 {container_name}")
 
-        # RHEL-8 / CentOS-8's podman user containers do not show up as
+        # RHEL-8's podman user containers do not show up as
         # libpod-$containerid but as podman-3679.scope.
-        if m.image != "centos-8-stream" and not m.image.startswith("rhel-8"):
+        if not m.image.startswith("rhel-8"):
             # copy images for user podman tests; podman insists on user session
             m.execute(f"podman save {self.busybox_image} | sudo -i -u admin podman load")
 
@@ -1074,7 +1074,7 @@ BEGIN {{
 
         # Test link to user services
         # older releases don't have memory accounting enabled for user services
-        if m.image != "centos-8-stream" and not m.image.startswith("rhel-8"):
+        if not m.image.startswith("rhel-8"):
             m.execute("su - admin -c 'XDG_RUNTIME_DIR=/run/user/$(id -u admin) systemd-run --user --collect --slice cockpittest --unit mem-userhog memhog.sh'")
             m.execute("while [ ! -e /tmp/hogged ]; do sleep 1; done")
             # user services are always running underneath user@1000.service, so these two will compete for row 1 or 2
@@ -1103,8 +1103,8 @@ BEGIN {{
         b.wait(lambda: re.match(r'^(0|[0-9.]+ (kB|B)/s)$', b.text("[aria-label='Disks usage'] [device-name='vda'] [data-label='Write']")))  # write should stay calm
         b.wait(lambda: re.match(r'^(0|[0-9.]+ (kB|B)/s)$', b.text("[aria-label='Disks usage'] [device-name='sr0'] [data-label='Read']")))  # other disks should stay calm
         # top service should be disk-read-hog
-        # unsupported on rhel 8 and centos 8 as they use cgroupv1
-        if m.image != "centos-8-stream" and not m.image.startswith("rhel-8"):
+        # unsupported on rhel 8 as it uses cgroupv1
+        if not m.image.startswith("rhel-8"):
             b.wait_text_matches("table[aria-label='Top 5 disk usage services'] tr:first-child td[data-label='Service']", "disk-read-hog")
             b.wait(lambda: re.match(r'^[0-9.]+ (MB|GB)/s$', b.text("table[aria-label='Top 5 disk usage services'] tr:first-child td[data-label='Read']")))
             b.wait(lambda: re.match(r'^0|([0-9.]+ (kB|B)/s)$', b.text("table[aria-label='Top 5 disk usage services'] tr:first-child td[data-label='Write']")))  # this should stay calm
@@ -1125,8 +1125,8 @@ BEGIN {{
         b.wait(lambda: re.match(r'^(0|[0-9.]+ (kB|B)/s)$', b.text("[aria-label='Disks usage'] [device-name='vda'] [data-label='Read']")))  # read should stay calm
         b.wait(lambda: re.match(r'^(0|[0-9.]+ (kB|B)/s)$', b.text("[aria-label='Disks usage'] [device-name='sr0'] [data-label='Write']")))  # other disks should stay calm
         # top service should be disk-write-hog
-        # unsupported on rhel 8 and centos 8 as they use cgroupv1
-        if m.image != "centos-8-stream" and not m.image.startswith("rhel-8"):
+        # unsupported on rhel 8 as it uses cgroupv1
+        if not m.image.startswith("rhel-8"):
             b.wait_text_matches("table[aria-label='Top 5 disk usage services'] tr:first-child td[data-label='Service']", "disk-write-hog")
             b.wait(lambda: re.match(r'^[0-9.]+ (MB|GB)/s$', b.text("table[aria-label='Top 5 disk usage services'] tr:first-child td[data-label='Write']")))
             b.wait(lambda: re.match(r'^0|([0-9.]+ (kB|B)/s)$', b.text("table[aria-label='Top 5 disk usage services'] tr:first-child td[data-label='Read']")))  # this should stay calm
@@ -1276,7 +1276,7 @@ class TestMetricsPackages(packagelib.PackageCase):
             m.execute("rm -f /etc/systemd/system/pmlogger.service.requires/pmlogger_farm.service")
         else:
             m.execute("rpm --erase --verbose cockpit-pcp pcp redis")
-        if "centos-8" in m.image or "rhel-8" in m.image:
+        if "rhel-8" in m.image:
             # RHEL 8 ships this in a module, make sure that doesn't hide our fake package
             m.execute("dnf module disable -y redis || true")
 

--- a/test/verify/check-networkmanager-settings
+++ b/test/verify/check-networkmanager-settings
@@ -129,7 +129,7 @@ class TestNetworkingSettings(netlib.NetworkCase):
 
         # Check that IPv4/IPv6 settings dialogs only show the supported IP methods for wireguard
         # Skip images without the wireguard-tools package
-        if m.image not in ["rhel4edge", "centos-8-stream", "centos-10"] and not m.image.startswith("rhel-8"):
+        if m.image not in ["rhel4edge", "centos-10"] and not m.image.startswith("rhel-8"):
             b.go("/network")
             b.click("#networking-add-wg")
             b.set_input_text("#network-wireguard-settings-addresses-input", "1.2.3.4/24")

--- a/test/verify/check-networkmanager-wireguard
+++ b/test/verify/check-networkmanager-wireguard
@@ -30,7 +30,7 @@ class TestWireGuard(packagelib.PackageCase, netlib.NetworkCase):
         b.wait_visible("#network-wireguard-settings-dialog")
         iface_name = b.val("#network-wireguard-settings-interface-name-input")
         b.wait_visible("#network-wireguard-settings-save:disabled")
-        if m1.image in ["rhel4edge", "centos-8-stream"] or m1.image.startswith("rhel-8"):
+        if m1.image in ["rhel4edge"] or m1.image.startswith("rhel-8"):
             b.wait_visible(".pf-v5-c-alert:contains('wireguard-tools package is not installed')")
             b.click("button:contains('Cancel')")
             b.wait_not_present("#network-ip-settings-dialog")

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1410,7 +1410,7 @@ class TestAutoUpdates(NoSubManCase):
             # automatic reboots should be enabled whenever timer is enabled
             out = m.execute("systemctl cat dnf-automatic-install.service")
             if hour:
-                if m.image.startswith("rhel-8") or m.image == "centos-8-stream":
+                if m.image.startswith("rhel-8"):
                     # for RHEL 8, dnf-automatic does not support reboot; we have a unit drop-in hack
                     self.assertRegex(out, "ExecStartPost=/.*shutdown")
                     # validate our assumption
@@ -1594,7 +1594,7 @@ class TestAutoUpdates(NoSubManCase):
                 # triggered reboot
                 m.execute("until test -f /run/nologin; do sleep 1; done")
                 # old distros don't have that yet; rely on /run/nologin to indicate scheduled shutdown
-                if not m.image.startswith("rhel-8") and not m.image.startswith("centos-8"):
+                if not m.image.startswith("rhel-8"):
                     self.assertIn("scheduled for", m.execute("shutdown --show 2>&1"))
             finally:
                 # always cancel the scheduled reboot

--- a/test/verify/check-shell-multi-os
+++ b/test/verify/check-shell-multi-os
@@ -85,11 +85,11 @@ class TestRHEL8(testlib.MachineCase):
 class TestMultiOSDirect(testlib.MachineCase):
     provision = {
         "0": {"address": "10.111.113.1/20", "memory_mb": 512},
-        "stock": {"address": "10.111.113.5/20", "image": "centos-8-stream", "memory_mb": 512}
+        "stock": {"address": "10.111.113.5/20", "image": "rhel-8-10", "memory_mb": 512}
     }
 
     @testlib.todoPybridgeRHEL8()
-    def testCentos8Direct(self):
+    def testRHEL8Direct(self):
         b = self.browser
 
         self.allow_hostkey_messages()

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -394,7 +394,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
         self.allow_restart_journal_messages()
 
-    @testlib.skipImage("No tlog", "debian-*", "ubuntu-*", "arch", "centos-8-stream")
+    @testlib.skipImage("No tlog", "debian-*", "ubuntu-*", "arch")
     @testlib.skipOstree("No tlog")
     def testSessionRecordingShell(self):
         m = self.machine
@@ -497,7 +497,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.click(".super-channel button")
         b.wait_in_text(".super-channel span", 'result: ')
 
-        if m.image.startswith("rhel-8") or m.image in ["centos-8-stream", "rhel-9-1"]:
+        if m.image.startswith("rhel-8"):
             # https://bugzilla.redhat.com/show_bug.cgi?id=1814569
             self.assertIn('result: access-denied', b.text(".super-channel span"))
         else:
@@ -737,7 +737,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.open("/system")
 
         # root login is disabled by default via /etc/cockpit/disallowed-users on everything except RHEL 8
-        if not m.image.startswith("rhel-8") and not m.image.startswith("centos-8"):
+        if not m.image.startswith("rhel-8"):
             b.try_login("root", "foobar")
             b.wait_in_text("#login-error-message", "Permission denied")
 

--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -56,7 +56,7 @@ class TestStorageStratis(storagelib.StorageCase):
         exe("systemctl start stratisd")
         self.addCleanup(exe, "systemctl stop stratisd")
 
-        self.stratis_v2 = self.image.startswith("rhel-8") or self.image == "centos-8-stream"
+        self.stratis_v2 = self.image.startswith("rhel-8")
         self.stop_type_opt = get_stratis_stop_type_opt(exe)
 
         self.addCleanup(exe,
@@ -299,7 +299,7 @@ class TestStorageStratis(storagelib.StorageCase):
         # After the stratis pool is deleted we can't check this, so use the value from earlier.
         self.assertFalse(udisk_contains_stratis_private)
 
-    @testlib.skipImage("Stratis too old", "rhel-8-*", "centos-8-*")
+    @testlib.skipImage("Stratis too old", "rhel-8-*")
     def testAlerts(self):
         m = self.machine
         b = self.browser
@@ -425,7 +425,7 @@ class TestStorageStratisReboot(storagelib.StorageCase):
             exe("systemctl enable --now stratisd")
             self.addCleanup(self.machine.execute, "systemctl disable --now stratisd")
 
-        self.stratis_v2 = self.image.startswith("rhel-8") or self.image == "centos-8-stream"
+        self.stratis_v2 = self.image.startswith("rhel-8")
 
     def testEncrypted(self):
         m = self.machine
@@ -646,7 +646,7 @@ class TestStorageStratisReboot(storagelib.StorageCase):
         self.assertIn("noauto", m.execute("findmnt --fstab -n -o OPTIONS /foo"))
         destroy()
 
-    @testlib.skipImage("Stratis too old", "rhel-8-*", "centos-8-*")
+    @testlib.skipImage("Stratis too old", "rhel-8-*")
     def testManagedSizes(self):
         m = self.machine
         b = self.browser
@@ -711,7 +711,7 @@ class TestStorageStratisReboot(storagelib.StorageCase):
         # And the pool should be full again
         b.wait_visible("button:contains(Create new filesystem):disabled")
 
-    @testlib.skipImage("Stratis too old", "rhel-8-*", "centos-8-*")
+    @testlib.skipImage("Stratis too old", "rhel-8-*")
     def testPoolResize(self):
         m = self.machine
         b = self.browser
@@ -810,7 +810,7 @@ class TestStoragePackagesStratis(packagelib.PackageCase, storagelib.StorageCase)
 
 
 @testlib.skipImage("No Stratis", "debian-*", "ubuntu-*")
-@testlib.skipImage("Stratis too old", "rhel-8-*", "centos-8-*")
+@testlib.skipImage("Stratis too old", "rhel-8-*")
 class TestStorageStratisNBDE(packagelib.PackageCase, storagelib.StorageCase):
     provision = {
         "0": {"address": "10.111.112.1/20", "memory_mb": 2048},

--- a/test/verify/check-storage-vdo
+++ b/test/verify/check-storage-vdo
@@ -171,7 +171,7 @@ class TestStorageVDO(storagelib.StorageCase):
         b.wait_in_text(self.card("LVM2 logical volumes"), "No logical volumes")
 
 
-@testlib.onlyImage("legacy VDO API only supported on RHEL 8", "rhel-8*", "centos-8*")
+@testlib.onlyImage("legacy VDO API only supported on RHEL 8", "rhel-8*")
 class TestStorageLegacyVDO(storagelib.StorageCase):
 
     def setUp(self):

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -444,7 +444,7 @@ machine         : 8561
 
         b.reload()
         b.enter_page('/system/hwinfo')
-        distro_without_systemd_memory_dmi = m.image == 'centos-8-stream' or m.image.startswith('rhel-8-')
+        distro_without_systemd_memory_dmi = m.image.startswith('rhel-8-')
 
         # Test more specific memory data with a fake dmidecode
         b.wait_in_text('#memory-listing tbody:nth-of-type(1) td[data-label=ID]', "BANK 0: ChannelA-DIMM0")
@@ -796,7 +796,7 @@ password=foobar
 
         # RHEL 8 has no SHA1 policy, so do not show it.
         b.click("#crypto-policy-button")
-        func = b.wait_not_present if m.image.startswith('rhel-8') or m.image.startswith('centos-8') else b.wait_visible
+        func = b.wait_not_present if m.image.startswith('rhel-8') else b.wait_visible
         func(".pf-v5-c-menu__item-main .pf-v5-c-menu__item-text:contains('DEFAULT:SHA1')")
         b.click("#crypto-policy-dialog button:contains('Cancel')")
         b.wait_not_present("#crypto-policy-dialog")

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -663,7 +663,7 @@ ExecStart=/bin/awk -f /tmp/mem-hog{params}.awk
         self.goto_service("mem-hog.service")
         b.wait_not_present("#memory")
         # In some distros systemctl is showing memory current as [Not Set] for user units
-        if not user or (m.image != "centos-8-stream" and not m.image.startswith("rhel-8-")):
+        if not user or not m.image.startswith("rhel-8-"):
             self.run_systemctl(user, "start mem-hog.service")
             # If the test fails before we stop mem-hog, the next test run will not get the correct memory usage here
             self.addCleanup(self.run_systemctl, user, "stop mem-hog.service || true")
@@ -1297,7 +1297,7 @@ WantedBy=multi-user.target
 
         # overview: alias
         self.wait_service_present("flower-byanyothername.service")
-        if m.image.startswith("rhel-8") or m.image.startswith("centos-8"):
+        if m.image.startswith("rhel-8"):
             # old systemd does not have unit file state "alias" yet
             self.wait_service_in_panel("flower-byanyothername.service", "Enabled")
         else:


### PR DESCRIPTION
I accidentally [broke main](https://cockpit-logs.us-east-1.linodeobjects.com/pull-20425-d3594a54-20240507-104057-debian-stable-other/log.html#49-2) with https://github.com/cockpit-project/bots/pull/6348 , sorry about that!