### PR TITLE
systemd: Use systemd-sysusers to create cockpit-wsinstance user

### DIFF
--- a/src/systemd/Makefile.am
+++ b/src/systemd/Makefile.am
@@ -34,6 +34,9 @@ install-exec-hook::
 tmpfilesconfdir = $(prefix)/lib/tmpfiles.d
 nodist_tmpfilesconf_DATA = src/systemd/tmpfiles.d/cockpit-ws.conf
 
+sysusersconfdir = $(prefix)/lib/sysusers.d
+dist_sysusersconf_DATA = src/systemd/sysusers.d/cockpit-wsinstance.conf
+
 # we can't generate these with config.status because,
 # eg. it does "@libexecdir@" -> "${exec_prefix}/libexec"
 src/systemd/%: src/systemd/%.in

--- a/src/systemd/sysusers.d/cockpit-wsinstance.conf
+++ b/src/systemd/sysusers.d/cockpit-wsinstance.conf
@@ -1,0 +1,1 @@
+u cockpit-wsinstance - "User for cockpit-ws instances" -

--- a/tools/arch/PKGBUILD
+++ b/tools/arch/PKGBUILD
@@ -15,11 +15,9 @@ makedepends=(krb5 libssh accountsservice json-glib glib-networking
              git intltool gtk-doc gobject-introspection networkmanager xmlto npm pcp
              python-build python-installer python-wheel)
 source=("cockpit-${pkgver}.tar.xz"
-        "cockpit.pam"
-        "cockpit-wsinstance.sysuser.conf")
+        "cockpit.pam")
 sha256sums=('SKIP'
-            '079bb6751214e642673f9e1212df2a17fed1a3cc6cfdd6375af2b68ed6ddd340'
-            '46ee8ecad7bc97ba588ab9471dde76e41c00daf40658902425626c3a1938b438')
+            '079bb6751214e642673f9e1212df2a17fed1a3cc6cfdd6375af2b68ed6ddd340')
 
 prepare() {
   cd cockpit-$pkgver
@@ -59,7 +57,6 @@ package_cockpit() {
   make DESTDIR="$pkgdir" install
   rm -rf "$pkgdir"/usr/{src,lib/firewalld}
   install -Dm644 "$srcdir"/cockpit.pam "$pkgdir"/etc/pam.d/cockpit
-  install -Dm644 "$srcdir"/cockpit-wsinstance.sysuser.conf "$pkgdir"/usr/lib/sysusers.d/cockpit-wsinstance.conf
 
   echo "z /usr/lib/cockpit/cockpit-session - - cockpit-wsinstance -" >> "$pkgdir"/usr/lib/tmpfiles.d/cockpit-ws.conf
 

--- a/tools/arch/cockpit-wsinstance.sysuser.conf
+++ b/tools/arch/cockpit-wsinstance.sysuser.conf
@@ -1,1 +1,0 @@
-u cockpit-wsinstance - "User for cockpit-ws instances"

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -402,6 +402,7 @@ authentication via sssd/FreeIPA.
 %{_unitdir}/cockpit-wsinstance-https@.service
 %{_unitdir}/system-cockpithttps.slice
 %{_prefix}/%{__lib}/tmpfiles.d/cockpit-ws.conf
+%{_sysusersdir}/cockpit-wsinstance.conf
 %{pamdir}/pam_ssh_add.so
 %{pamdir}/pam_cockpit_cert.so
 %{_libexecdir}/cockpit-ws
@@ -420,6 +421,8 @@ authentication via sssd/FreeIPA.
 %ghost %{_sharedstatedir}/selinux/%{selinuxtype}/active/modules/200/%{name}
 
 %pre ws
+# HACK: old RPM and even Fedora's current RPM don't properly support sysusers
+# https://github.com/rpm-software-management/rpm/issues/3073
 getent group cockpit-wsinstance >/dev/null || groupadd -r cockpit-wsinstance
 getent passwd cockpit-wsinstance >/dev/null || useradd -r -g cockpit-wsinstance -d /nonexisting -s /sbin/nologin -c "User for cockpit-ws instances" cockpit-wsinstance
 

--- a/tools/debian/cockpit-ws.install
+++ b/tools/debian/cockpit-ws.install
@@ -15,6 +15,7 @@ ${env:deb_systemdsystemunitdir}/system-cockpithttps.slice
 ${env:deb_pamlibdir}/security/pam_ssh_add.so
 ${env:deb_pamlibdir}/security/pam_cockpit_cert.so
 usr/lib/tmpfiles.d/cockpit-ws.conf
+usr/lib/sysusers.d/cockpit-wsinstance.conf
 usr/lib/cockpit/cockpit-session
 usr/lib/cockpit/cockpit-ws
 usr/lib/cockpit/cockpit-wsinstance-factory

--- a/tools/debian/cockpit-ws.postinst
+++ b/tools/debian/cockpit-ws.postinst
@@ -1,13 +1,11 @@
 #!/bin/sh
 set -e
 
-adduser --system --group --home /nonexistent --no-create-home --quiet cockpit-wsinstance
+#DEBHELPER#
 
 if ! dpkg-statoverride --list /usr/lib/cockpit/cockpit-session >/dev/null; then
     dpkg-statoverride --update --add root cockpit-wsinstance 4750 /usr/lib/cockpit/cockpit-session
 fi
-
-#DEBHELPER#
 
 # restart cockpit.service on package upgrades, if it's already running
 if [ -d /run/systemd/system ] && [ -n "$2" ]; then

--- a/tools/debian/cockpit-ws.postinst
+++ b/tools/debian/cockpit-ws.postinst
@@ -3,12 +3,6 @@ set -e
 
 adduser --system --group --home /nonexistent --no-create-home --quiet cockpit-wsinstance
 
-# change group of cockpit-session on upgrades (changed in version 203)
-if OUT=$(dpkg-statoverride --list /usr/lib/cockpit/cockpit-session) && [ "$OUT#root cockpit-ws 4750}" != "$OUT" ]; then
-    echo "Adjusting /usr/lib/cockpit/cockpit-session permissions..."
-    dpkg-statoverride --remove /usr/lib/cockpit/cockpit-session
-fi
-
 if ! dpkg-statoverride --list /usr/lib/cockpit/cockpit-session >/dev/null; then
     dpkg-statoverride --update --add root cockpit-wsinstance 4750 /usr/lib/cockpit/cockpit-session
 fi

--- a/tools/debian/cockpit-ws.postrm
+++ b/tools/debian/cockpit-ws.postrm
@@ -8,4 +8,6 @@ if [ "$1" = purge ]; then
     [ -L /etc/motd.d/cockpit ] && rm /etc/motd.d/cockpit || true
     [ -L /etc/issue.d/cockpit.issue ] && rm /etc/issue.d/cockpit.issue || true
     rm -f /etc/cockpit/disallowed-users
+
+    dpkg-statoverride --remove /usr/lib/cockpit/cockpit-session
 fi

--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -67,3 +67,7 @@ else
 	pytest -vv -k 'not linter and not test_descriptions' -opythonpath=$$(ls -d debian/cockpit-bridge/usr/lib/python3*/dist-packages)
 endif
 endif
+
+# dh compat 14 does that automatically, remove when upgrading
+execute_before_dh_installtmpfiles:
+	dh_installsysusers


### PR DESCRIPTION
This was originally proposed and discussed extensively in @travier 's PR #20365. However, all of a sudden  I'm not allowed to push into @travier's branch any more:
```
To github.com:travier/cockpit.git
 ! [remote rejected]     HEAD -> main-sysuserconfig (permission denied)
error: failed to push some refs to 'github.com:travier/cockpit.git'
```

So cloning the PR from my fork.
