### PR TITLE
test: Terminate sessions before restoring files/directories

### DIFF
--- a/pkg/packagekit/kpatch.jsx
+++ b/pkg/packagekit/kpatch.jsx
@@ -153,7 +153,7 @@ export class KpatchSettings extends React.Component {
                                 })
                             );
                 })
-                .catch(err => console.error("Could not determine kpatch packages:", err)); // not-covered: OS error
+                .catch(err => console.error("Could not determine kpatch packages:", JSON.stringify(err))); // not-covered: OS error
 
         return Promise.allSettled([kpatch_promise, uname_promise]);
     }

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1663,45 +1663,45 @@ class MachineCase(unittest.TestCase):
                         "    swapon --show=NAME --noheadings | grep $dev | xargs -r swapoff; "
                         "done; until rmmod scsi_debug; do sleep 0.2; done", stdout=None)
 
-        def terminate_sessions() -> None:
-            # on OSTree we don't get "web console" sessions with the cockpit/ws container; just SSH; but also, some tests start
-            # admin sessions without Cockpit
-            self.machine.execute("""for u in $(loginctl --no-legend list-users  | awk '{ if ($2 != "root") print $1 }'); do
-                                        loginctl terminate-user $u 2>/dev/null || true
-                                        loginctl kill-user $u 2>/dev/null || true
-                                        pkill -9 -u $u || true
-                                        while pgrep -u $u; do sleep 0.2; done
-                                        while mountpoint -q /run/user/$u && ! umount /run/user/$u; do sleep 0.2; done
-                                        rm -rf /run/user/$u
-                                    done""")
+    def _terminate_sessions(self) -> None:
+        m = self.machine
 
-            # Terminate all other Cockpit sessions
-            sessions = self.machine.execute("loginctl --no-legend list-sessions | awk '/web console/ { print $1 }'").strip().split()
-            for s in sessions:
-                # Don't insist that terminating works, the session might be gone by now.
-                self.machine.execute(f"loginctl kill-session {s} || true; loginctl terminate-session {s} || true")
+        # on OSTree we don't get "web console" sessions with the cockpit/ws container; just SSH; but also, some tests start
+        # admin sessions without Cockpit
+        m.execute("""for u in $(loginctl --no-legend list-users  | awk '{ if ($2 != "root") print $1 }'); do
+                         loginctl terminate-user $u 2>/dev/null || true
+                         loginctl kill-user $u 2>/dev/null || true
+                         pkill -9 -u $u || true
+                         while pgrep -u $u; do sleep 0.2; done
+                         while mountpoint -q /run/user/$u && ! umount /run/user/$u; do sleep 0.2; done
+                         rm -rf /run/user/$u
+                     done""")
 
-            # Restart logind to mop up empty "closing" sessions; https://github.com/systemd/systemd/issues/26744
-            self.machine.execute("systemctl stop systemd-logind")
+        # Terminate all other Cockpit sessions
+        sessions = m.execute("loginctl --no-legend list-sessions | awk '/web console/ { print $1 }'").strip().split()
+        for s in sessions:
+            # Don't insist that terminating works, the session might be gone by now.
+            m.execute(f"loginctl kill-session {s} || true; loginctl terminate-session {s} || true")
 
-            # Wait for sessions to be gone
-            sessions = self.machine.execute("loginctl --no-legend list-sessions | awk '/web console/ { print $1 }'").strip().split()
-            for s in sessions:
-                try:
-                    m.execute(f"while loginctl show-session {s}; do sleep 0.2; done", timeout=30)
-                except RuntimeError:
-                    # show the status in debug logs, to see what's wrong
-                    m.execute(f"loginctl session-status {s}; systemd-cgls", stdout=None)
-                    raise
+        # Restart logind to mop up empty "closing" sessions; https://github.com/systemd/systemd/issues/26744
+        m.execute("systemctl stop systemd-logind")
 
-            # terminate all systemd user services for users who are not logged in
-            self.machine.execute("systemctl stop user@*.service")
+        # Wait for sessions to be gone
+        sessions = m.execute("loginctl --no-legend list-sessions | awk '/web console/ { print $1 }'").strip().split()
+        for s in sessions:
+            try:
+                m.execute(f"while loginctl show-session {s}; do sleep 0.2; done", timeout=30)
+            except RuntimeError:
+                # show the status in debug logs, to see what's wrong
+                m.execute(f"loginctl session-status {s}; systemd-cgls", stdout=None)
+                raise
 
-            # Clean up "closing" sessions again, and clean user id cache for non-system users
-            self.machine.execute("systemctl stop systemd-logind; cd /run/systemd/users/; "
-                                 "for f in $(ls); do [ $f -le 500 ] || rm $f; done")
+        # terminate all systemd user services for users who are not logged in
+        m.execute("systemctl stop user@*.service")
 
-        self.addCleanup(terminate_sessions)
+        # Clean up "closing" sessions again, and clean user id cache for non-system users
+        m.execute("systemctl stop systemd-logind; cd /run/systemd/users/; "
+                  "for f in $(ls); do [ $f -le 500 ] || rm $f; done")
 
     def tearDown(self) -> None:
         error = self.getError()
@@ -1729,6 +1729,9 @@ class MachineCase(unittest.TestCase):
             if not error:
                 self.check_browser_errors()
                 self.check_pixel_tests()
+
+        if self.is_nondestructive():
+            self._terminate_sessions()
 
         shutil.rmtree(self.tmpdir, ignore_errors=True)
 

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -38,11 +38,10 @@ class TestServices(testlib.MachineCase):
         # We manipulate with `/etc/systemd/system` so `daemon-reload` to keep it in proper state
         # Also `reset-failed` as failed units can be still listed with `systemctl` even when all files
         # were removed and daemon reloaded.
-        self.restore_dir("/etc/systemd/system", "systemctl daemon-reload; systemctl reset-failed", reboot_safe=True)
-        user_post_restore = "su - admin -c 'export XDG_RUNTIME_DIR=/run/user/$(id -u admin); systemctl --user daemon-reload; systemctl --user reset-failed'"
-        self.restore_dir("/etc/systemd/user", user_post_restore, reboot_safe=True)
-        self.restore_dir("/etc/xdg/systemd/user", user_post_restore, reboot_safe=True)
-        self.restore_dir("/home/admin/.config", user_post_restore, reboot_safe=True)
+        self.restore_dir("/etc/systemd/system", "systemctl daemon-reload; systemctl reset-failed")
+        self.restore_dir("/etc/systemd/user")
+        self.restore_dir("/etc/xdg/systemd/user")
+        self.restore_dir("/home/admin/.config")
 
     def run_systemctl(self, user, cmd):
         if user:


### PR DESCRIPTION
Most of our tests don't bother logging out at the end, they rely on our generic nondestructive setup. But this causes some noise when using `restore_dir()` and friends, e.g. in TestApps.testBasic:

```
+ rm -rf /usr/share/metainfo; mv /var/lib/cockpittest/_usr_share_metainfo /usr/share/metainfo
+ mv /var/lib/cockpittest/_var_lib_PackageKit_transactions.db /var/lib/PackageKit/transactions.db
> warning: can't remove watch: Invalid argument
can't add watch for <ctypes.c_char_Array_20 object at 0x7f9aed107750>: Permission denied
Traceback (most recent call last):
  File "<string>", line 445, in <module>
  File "<string>", line 442, in watch_db
[...]
  File "<string>", line 148, in watch_directory
PermissionError: [Errno 13] Permission denied: '/usr/share/metainfo'
```

As the tests themselves call `restore_dir()` (which happens after the generic `nonDestructiveSetup()`, the restoration also happens before `nonDestructiveSetup()` can kill all running sessions. Thus the cockpit page, bridge etc. are still active then and keep messing around with the file system.

This don't actually break the test, but errors like the above are confusing when debugging and staring at test output.

To clean this up, move the session termination into `tearDown()`, which runs first after the test method ends -- in particular, *before* the `addCleanup()` handlers. Move the previously nested `terminate_sessions()` helper function to a private method of MachineCase, so that `tearDown()` does not get too long.

This removes the need to daemon-reload the `admin` user session in TestService's cleanup -- at that point there are no user sessions at all any more.

----


This should fix #20446 as far as I understand it. If not, it at least gets rid of some unrelated noise.