### PR TITLE
test: don't fail tests on DNF5

### DIFF
--- a/test/common/packagelib.py
+++ b/test/common/packagelib.py
@@ -114,9 +114,13 @@ class PackageCase(MachineCase):
 
         # reset automatic updates
         if self.backend == 'dnf':
-            self.machine.execute("systemctl disable --now dnf-automatic dnf-automatic-install "
-                                 "dnf-automatic.service dnf-automatic-install.timer")
-            self.machine.execute("rm -r /etc/systemd/system/dnf-automatic* && systemctl daemon-reload || true")
+            # DNF5 has a different automatic systemd unit
+            if self.machine.image == "fedora-41":
+                self.addCleanup(self.machine.execute, "systemctl disable --now dnf-automatic.timer 2>/dev/null")
+            else:
+                self.machine.execute("systemctl disable --now dnf-automatic dnf-automatic-install "
+                                     "dnf-automatic.service dnf-automatic-install.timer")
+                self.machine.execute("rm -r /etc/systemd/system/dnf-automatic* && systemctl daemon-reload || true")
 
         self.updateInfo = {}
 

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1562,6 +1562,7 @@ class TestAutoUpdates(NoSubManCase):
             # don't allow stomping over unparsable custom settings
             b.wait_not_present("#autoupdates-settings button")
 
+    @testlib.skipImage("TODO: support DNF5 automatic updates", "fedora-41")
     def testWithAvailableUpdates(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1371,7 +1371,11 @@ class TestAutoUpdates(NoSubManCase):
         self.supported_backend = self.backend in ["dnf"]
         if self.backend == 'dnf':
             self.restore_file("/etc/dnf/automatic.conf")
-            self.addCleanup(self.machine.execute, "systemctl disable --now dnf-automatic-install.timer 2>/dev/null; rm -rf /etc/systemd/system/dnf-automatic-*")
+            # DNF5 has a different automatic systemd unit
+            if self.machine.image == "fedora-41":
+                self.addCleanup(self.machine.execute, "systemctl disable --now dnf-automatic.timer 2>/dev/null")
+            else:
+                self.addCleanup(self.machine.execute, "systemctl disable --now dnf-automatic-install.timer 2>/dev/null; rm -rf /etc/systemd/system/dnf-automatic-*")
 
     def closeSettings(self, browser):
         browser.click("#automatic-updates-dialog button:contains('Save changes')")


### PR DESCRIPTION
DNF 5 changed the systemd timers for dnf-automatic, this commit does not make Cockpit compatible with the new timers and configuration but unbreaks the current TF rawhide tests.

Related: #20260