### PR TITLE
users: Support for watching lastlog2 and wtpmdb on overview page

### DIFF
--- a/pkg/users/utils.js
+++ b/pkg/users/utils.js
@@ -12,3 +12,17 @@ export const get_locked = name =>
                     console.warn(`Failed to obtain account lock information for ${name}`, exc);
                 }
             });
+
+export async function getUtmpPath() {
+    try {
+        await cockpit.spawn(["test", "-e", "/var/run/utmp"], { err: "ignore" });
+        return "/var/run/utmp";
+    } catch (err1) {
+        try {
+            await cockpit.spawn(["test", "-e", "/var/lib/wtmpdb/wtmp.db"], { err: "ignore" });
+            return "/var/lib/wtmpdb/wtmp.db";
+        } catch (err2) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
This follows up on the lastlog2 pr's to implement support for lastlog2. Lastlog2 slightly differs in behaviour from lastlog. Lastlog2 only prints user's who have already had entries in the lastlog2 database. Not having an entry is already treated as never logged in which matches the current behaviour