### PR TITLE
workflows: Run trigger-anaconda in our tasks container

### DIFF
--- a/.github/workflows/trigger-anaconda.yml
+++ b/.github/workflows/trigger-anaconda.yml
@@ -19,16 +19,18 @@ jobs:
     permissions:
       contents: read
       statuses: write
-    container: registry.fedoraproject.org/fedora:rawhide
+    container:
+      image: ghcr.io/cockpit-project/tasks
+      options: --user root
     # this polls for a COPR build, which can take long
     timeout-minutes: 120
 
     steps:
       - name: Install dependencies
         run: |
-          dnf install -y git-core dnf5-plugins || {
+          dnf install -y git-core dnf-plugins-core || {
             sleep 60
-            dnf install -y git-core dnf5-plugins
+            dnf install -y git-core dnf-plugins-core
           }
 
       # Naïvely this should wait for github.event.pull_request.head.sha, but


### PR DESCRIPTION
It has everything and Rawhide is moving stuff around a lot recently.