### PR TITLE
spec: Don't run %tox on Suse

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -167,7 +167,7 @@ BuildRequires:  python3-tox-current-env
 %check
 make -j$(nproc) check
 
-%if 0%{?rhel} == 0
+%if 0%{?rhel} == 0 && !0%{?suse_version}
 %tox
 %endif
 


### PR DESCRIPTION
That macro doesn't exist there.