### PR TITLE
packagekit: support dnf5-plugin-automatic

### DIFF
--- a/pkg/packagekit/autoupdates.jsx
+++ b/pkg/packagekit/autoupdates.jsx
@@ -57,63 +57,14 @@ class ImplBase {
     }
 
     // Init data members. Return a promise that resolves when done.
-    getConfig() {
+    async getConfig() {
         throw new Error("abstract method");
     }
 
     // Update configuration for given non-null values, and update member variables on success;
     // return a promise that resolves when done, or fails when configuration writing fails
-    setConfig(enabled, type, day, time) {
+    async setConfig(enabled, type, day, time) {
         throw new Error("abstract method", enabled, type, day, time);
-    }
-}
-
-class DnfImpl extends ImplBase {
-    getConfig() {
-        return new Promise((resolve, reject) => {
-            this.packageName = "dnf-automatic";
-
-            // - dnf has two ways to enable automatic updates: Either by enabling dnf-automatic-install.timer
-            //   or by setting "apply_updates = yes" in the config file and enabling dnf-automatic.timer
-            // - the config file determines whether to apply security updates only
-            // - by default this runs every day (OnUnitInactiveSec=1d), but the timer can be changed with a timer unit
-            //   drop-in, so get the last line
-            cockpit.script("set -e; if rpm -q " + this.packageName + " >/dev/null; then echo installed; fi; " +
-                           "if grep -q '^[ \\t]*upgrade_type[ \\t]*=[ \\t]*security' /etc/dnf/automatic.conf; then echo security; fi; " +
-                           "TIMER=dnf-automatic-install.timer; " +
-                           "if systemctl --quiet is-enabled dnf-automatic-install.timer 2>/dev/null; then echo enabled; " +
-                           "elif systemctl --quiet is-enabled dnf-automatic.timer 2>/dev/null && grep -q '^[ \t]*apply_updates[ \t]*=[ \t]*yes' " +
-                           "    /etc/dnf/automatic.conf; then echo enabled; TIMER=dnf-automatic.timer; " +
-                           "fi; " +
-                           'OUT=$(systemctl cat $TIMER 2>/dev/null || true); ' +
-                           'echo "$OUT" | grep "^OnUnitInactiveSec= *[^ ]" | tail -n1; ' +
-                           'echo "$OUT" | grep "^OnCalendar= *[^ ]" | tail -n1; ',
-                           [], { err: "message" })
-                    .then(output => {
-                        this.installed = (output.indexOf("installed\n") >= 0);
-                        this.enabled = (output.indexOf("enabled\n") >= 0);
-                        this.type = (output.indexOf("security\n") >= 0) ? "security" : "all";
-
-                        // if we have OnCalendar=, use that (we disable OnUnitInactiveSec= in our drop-in)
-                        const calIdx = output.indexOf("OnCalendar=");
-                        if (calIdx >= 0) {
-                            this.parseCalendar(output.substr(calIdx).split('\n')[0].split("=")[1]);
-                        } else {
-                            if (output.indexOf("InactiveSec=1d\n") >= 0)
-                                this.day = this.time = "";
-                            else if (this.installed)
-                                this.supported = false;
-                        }
-
-                        debug(`dnf getConfig: supported ${this.supported}, enabled ${this.enabled}, type ${this.type}, day ${this.day}, time ${this.time}, installed ${this.installed}; raw response '${output}'`);
-                        resolve();
-                    })
-                    .catch(error => {
-                        console.error("dnf getConfig failed:", error);
-                        this.supported = false;
-                        resolve();
-                    });
-        });
     }
 
     parseCalendar(spec) {
@@ -140,8 +91,54 @@ class DnfImpl extends ImplBase {
         else
             this.supported = false;
     }
+}
 
-    setConfig(enabled, type, day, time) {
+class DnfImpl extends ImplBase {
+    async getConfig() {
+        this.packageName = "dnf-automatic";
+
+        try {
+            // - dnf has two ways to enable automatic updates: Either by enabling dnf-automatic-install.timer
+            //   or by setting "apply_updates = yes" in the config file and enabling dnf-automatic.timer
+            // - the config file determines whether to apply security updates only
+            // - by default this runs every day (OnUnitInactiveSec=1d), but the timer can be changed with a timer unit
+            //   drop-in, so get the last line
+            const output = await cockpit.script(
+                "set -e; if rpm -q " + this.packageName + " >/dev/null; then echo installed; fi; " +
+                "if grep -q '^[ \\t]*upgrade_type[ \\t]*=[ \\t]*security' /etc/dnf/automatic.conf; then echo security; fi; " +
+                "TIMER=dnf-automatic-install.timer; " +
+                "if systemctl --quiet is-enabled dnf-automatic-install.timer 2>/dev/null; then echo enabled; " +
+                "elif systemctl --quiet is-enabled dnf-automatic.timer 2>/dev/null && grep -q '^[ \t]*apply_updates[ \t]*=[ \t]*yes' " +
+                "    /etc/dnf/automatic.conf; then echo enabled; TIMER=dnf-automatic.timer; " +
+                "fi; " +
+                'OUT=$(systemctl cat $TIMER 2>/dev/null || true); ' +
+                'echo "$OUT" | grep "^OnUnitInactiveSec= *[^ ]" | tail -n1; ' +
+                'echo "$OUT" | grep "^OnCalendar= *[^ ]" | tail -n1; ',
+                [], { err: "message" });
+
+            this.installed = (output.indexOf("installed\n") >= 0);
+            this.enabled = (output.indexOf("enabled\n") >= 0);
+            this.type = (output.indexOf("security\n") >= 0) ? "security" : "all";
+
+            // if we have OnCalendar=, use that (we disable OnUnitInactiveSec= in our drop-in)
+            const calIdx = output.indexOf("OnCalendar=");
+            if (calIdx >= 0) {
+                this.parseCalendar(output.substr(calIdx).split('\n')[0].split("=")[1]);
+            } else {
+                if (output.indexOf("InactiveSec=1d\n") >= 0)
+                    this.day = this.time = "";
+                else if (this.installed)
+                    this.supported = false;
+            }
+
+            debug(`dnf getConfig: supported ${this.supported}, enabled ${this.enabled}, type ${this.type}, day ${this.day}, time ${this.time}, installed ${this.installed}; raw response '${output}'`);
+        } catch (error) {
+            console.error("dnf getConfig failed:", error);
+            this.supported = false;
+        }
+    }
+
+    async setConfig(enabled, type, day, time) {
         const timerConf = "/etc/systemd/system/dnf-automatic-install.timer.d/time.conf";
         let script = "set -e; ";
 
@@ -205,19 +202,20 @@ class DnfImpl extends ImplBase {
 
         debug(`setConfig(${enabled}, "${type}", "${day}", "${time}"): script "${script}"`);
 
-        return cockpit.script(script, [], { superuser: "require" })
-                .then(() => {
-                    debug("dnf setConfig: configuration updated successfully");
-                    if (enabled !== null)
-                        this.enabled = enabled;
-                    if (type !== null)
-                        this.type = type;
-                    if (day !== null)
-                        this.day = day;
-                    if (time !== null)
-                        this.time = time;
-                })
-                .catch(error => console.error("dnf setConfig failed:", error.toString()));
+        try {
+            await cockpit.script(script, [], { superuser: "require" });
+            debug("dnf setConfig: configuration updated successfully");
+            if (enabled !== null)
+                this.enabled = enabled;
+            if (type !== null)
+                this.type = type;
+            if (day !== null)
+                this.day = day;
+            if (time !== null)
+                this.time = time;
+        } catch (error) {
+            console.error("dnf setConfig failed:", error.toString());
+        }
     }
 }
 

--- a/test/common/packagelib.py
+++ b/test/common/packagelib.py
@@ -118,6 +118,7 @@ class PackageCase(MachineCase):
             if self.machine.image == "fedora-41":
                 self.addCleanup(self.machine.execute, "systemctl disable --now dnf-automatic.timer 2>/dev/null")
             else:
+                self.restore_file("/etc/dnf/automatic.conf")
                 self.machine.execute("systemctl disable --now dnf-automatic dnf-automatic-install "
                                      "dnf-automatic.service dnf-automatic-install.timer")
                 self.machine.execute("rm -r /etc/systemd/system/dnf-automatic* && systemctl daemon-reload || true")

--- a/test/common/packagelib.py
+++ b/test/common/packagelib.py
@@ -125,7 +125,9 @@ class PackageCase(MachineCase):
             self.machine.execute("rm -r /etc/systemd/system/dnf-automatic* && systemctl daemon-reload || true")
 
         if self.backend == 'dnf5':
+            self.restore_file("/etc/dnf/dnf5-plugins/automatic.conf")
             self.addCleanup(self.machine.execute, "systemctl disable --now dnf5-automatic.timer 2>/dev/null || true")
+            self.addCleanup(self.machine.execute, "rm -r /etc/systemd/system/dnf5-automatic*.d && systemctl daemon-reload || true")
 
         self.updateInfo = {}
 

--- a/test/common/packagelib.py
+++ b/test/common/packagelib.py
@@ -116,7 +116,7 @@ class PackageCase(MachineCase):
         if self.backend == 'dnf':
             # DNF5 has a different automatic systemd unit
             if self.machine.image in ["fedora-41", "fedora-rawhide"]:
-                self.addCleanup(self.machine.execute, "systemctl disable --now dnf-automatic.timer 2>/dev/null")
+                self.addCleanup(self.machine.execute, "systemctl disable --now dnf5-automatic.timer 2>/dev/null")
             else:
                 self.restore_file("/etc/dnf/automatic.conf")
                 self.machine.execute("systemctl disable --now dnf-automatic dnf-automatic-install "

--- a/test/common/packagelib.py
+++ b/test/common/packagelib.py
@@ -115,7 +115,7 @@ class PackageCase(MachineCase):
         # reset automatic updates
         if self.backend == 'dnf':
             # DNF5 has a different automatic systemd unit
-            if self.machine.image == "fedora-41":
+            if self.machine.image in ["fedora-41", "fedora-rawhide"]:
                 self.addCleanup(self.machine.execute, "systemctl disable --now dnf-automatic.timer 2>/dev/null")
             else:
                 self.restore_file("/etc/dnf/automatic.conf")

--- a/test/common/packagelib.py
+++ b/test/common/packagelib.py
@@ -17,6 +17,7 @@
 
 import logging
 import os
+import re
 import textwrap
 
 from testlib import MachineCase
@@ -37,8 +38,12 @@ class PackageCase(MachineCase):
             self.backend = "apt"
             self.primary_arch = "all"
             self.secondary_arch = "amd64"
+        elif re.match(r"fedora-(39|40)|(centos|rhel)-(8|9|10).*", self.machine.image):
+            self.backend = "dnf4"
+            self.primary_arch = "noarch"
+            self.secondary_arch = "x86_64"
         elif self.machine.image.startswith("fedora") or self.machine.image.startswith("rhel-") or self.machine.image.startswith("centos-"):
-            self.backend = "dnf"
+            self.backend = "dnf5"
             self.primary_arch = "noarch"
             self.secondary_arch = "x86_64"
         elif self.machine.image == "arch":
@@ -113,15 +118,14 @@ class PackageCase(MachineCase):
             self.addCleanup(self.machine.execute, "mv /etc/resolv.conf.test /etc/resolv.conf")
 
         # reset automatic updates
-        if self.backend == 'dnf':
-            # DNF5 has a different automatic systemd unit
-            if self.machine.image in ["fedora-41", "fedora-rawhide"]:
-                self.addCleanup(self.machine.execute, "systemctl disable --now dnf5-automatic.timer 2>/dev/null")
-            else:
-                self.restore_file("/etc/dnf/automatic.conf")
-                self.machine.execute("systemctl disable --now dnf-automatic dnf-automatic-install "
-                                     "dnf-automatic.service dnf-automatic-install.timer")
-                self.machine.execute("rm -r /etc/systemd/system/dnf-automatic* && systemctl daemon-reload || true")
+        if self.backend == 'dnf4':
+            self.restore_file("/etc/dnf/automatic.conf")
+            self.machine.execute("systemctl disable --now dnf-automatic dnf-automatic-install "
+                                 "dnf-automatic.service dnf-automatic-install.timer")
+            self.machine.execute("rm -r /etc/systemd/system/dnf-automatic* && systemctl daemon-reload || true")
+
+        if self.backend == 'dnf5':
+            self.addCleanup(self.machine.execute, "systemctl disable --now dnf5-automatic.timer 2>/dev/null || true")
 
         self.updateInfo = {}
 

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1369,13 +1369,6 @@ class TestAutoUpdates(NoSubManCase):
         super().setUp()
         # not implemented for apt yet, only dnf
         self.supported_backend = self.backend in ["dnf"]
-        if self.backend == 'dnf':
-            self.restore_file("/etc/dnf/automatic.conf")
-            # DNF5 has a different automatic systemd unit
-            if self.machine.image == "fedora-41":
-                self.addCleanup(self.machine.execute, "systemctl disable --now dnf-automatic.timer 2>/dev/null")
-            else:
-                self.addCleanup(self.machine.execute, "systemctl disable --now dnf-automatic-install.timer 2>/dev/null; rm -rf /etc/systemd/system/dnf-automatic-*")
 
     def closeSettings(self, browser):
         browser.click("#automatic-updates-dialog button:contains('Save changes')")

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1369,6 +1369,12 @@ class TestAutoUpdates(NoSubManCase):
         super().setUp()
         # not implemented for apt yet, only dnf
         self.supported_backend = "dnf" in self.backend
+        if self.backend == "dnf5":
+            self.timer_unit = "dnf5-automatic"
+            self.config = "/etc/dnf/dnf5-plugins/automatic.conf"
+        elif self.backend == "dnf4":
+            self.timer_unit = "dnf-automatic-install"
+            self.config = "/etc/dnf/automatic.conf"
 
     def closeSettings(self, browser):
         browser.click("#automatic-updates-dialog button:contains('Save changes')")
@@ -1389,7 +1395,7 @@ class TestAutoUpdates(NoSubManCase):
             return
 
         def assertTimerDnf(hour, dow):
-            out = m.execute("systemctl --no-legend list-timers dnf-automatic-install.timer")
+            out = m.execute(f"systemctl --no-legend list-timers {self.timer_unit}.timer")
             if hour:
                 # don't test the minutes, due to RandomizedDelaySec=60m
                 self.assertRegex(out, f" {hour}:")
@@ -1402,20 +1408,20 @@ class TestAutoUpdates(NoSubManCase):
                 self.assertNotIn(" day", out)
 
             # service should not run right away
-            self.assertEqual(m.execute("systemctl is-active dnf-automatic-install.service || true").strip(), "inactive")
+            self.assertEqual(m.execute(f"systemctl is-active {self.timer_unit}.service || true").strip(), "inactive")
 
             # automatic reboots should be enabled whenever timer is enabled
-            out = m.execute("systemctl cat dnf-automatic-install.service")
+            out = m.execute(f"systemctl cat {self.timer_unit}.service")
             if hour:
                 if m.image.startswith("rhel-8"):
                     # for RHEL 8, dnf-automatic does not support reboot; we have a unit drop-in hack
                     self.assertRegex(out, "ExecStartPost=/.*shutdown")
                     # validate our assumption
-                    self.assertNotIn("reboot", m.execute("cat /etc/dnf/automatic.conf"))
+                    self.assertNotIn("reboot", m.execute(f"cat {self.config}"))
                 else:
                     # newer dnf supports that natively
                     self.assertNotIn("ExecStartPost", out)
-                    self.assertIn("reboot = when-needed", m.execute("cat /etc/dnf/automatic.conf"))
+                    self.assertIn("reboot = when-needed", m.execute(f"cat {self.config}"))
             else:
                 self.assertNotIn("ExecStartPost", out)
 
@@ -1433,7 +1439,7 @@ class TestAutoUpdates(NoSubManCase):
             else:
                 raise ValueError(_type)
 
-            self.assertIn(match, m.execute("grep upgrade_type /etc/dnf/automatic.conf"))
+            self.assertIn(match, m.execute(f"grep upgrade_type {self.config}"))
 
         def assertType(_type):
             if "dnf" in self.backend:
@@ -1521,9 +1527,9 @@ class TestAutoUpdates(NoSubManCase):
             b.click("#all-updates")
             self.closeSettings(b)
             # OnCalendar= parsing: only time
-            m.execute("mkdir -p /etc/systemd/system/dnf-automatic.timer.d")
+            m.execute(f"mkdir -p /etc/systemd/system/{self.timer_unit}.timer.d")
             m.execute(r'printf "[Timer]\nOnUnitInactiveSec=\nOnCalendar=08:00\n" > '
-                      r'/etc/systemd/system/dnf-automatic-install.timer.d/time.conf; systemctl daemon-reload')
+                      f'/etc/systemd/system/{self.timer_unit}.timer.d/time.conf; systemctl daemon-reload')
             b.reload()
             b.enter_page("/updates")
             b.wait_in_text("#autoupdates-settings", "Updates will be applied every day at 8:00")
@@ -1531,7 +1537,7 @@ class TestAutoUpdates(NoSubManCase):
 
             # OnCalendar= parsing: weekday and time
             m.execute(r'printf "[Timer]\nOnUnitInactiveSec=\nOnCalendar=Tue 20:00\n" > '
-                      r'/etc/systemd/system/dnf-automatic-install.timer.d/time.conf; systemctl daemon-reload')
+                      f'/etc/systemd/system/{self.timer_unit}.timer.d/time.conf; systemctl daemon-reload')
             b.reload()
             b.enter_page("/updates")
             b.wait_in_text("#autoupdates-settings", "Updates will be applied every Tuesday at 20:00")
@@ -1539,7 +1545,7 @@ class TestAutoUpdates(NoSubManCase):
 
             # OnCalendar= parsing: "every day" calendar and time
             m.execute(r'printf "[Timer]\nOnUnitInactiveSec=\nOnCalendar=*-*-* 07:00\n" > '
-                      r'/etc/systemd/system/dnf-automatic-install.timer.d/time.conf; systemctl daemon-reload')
+                      f'/etc/systemd/system/{self.timer_unit}.timer.d/time.conf; systemctl daemon-reload')
             b.reload()
             b.enter_page("/updates")
             b.wait_in_text("#autoupdates-settings", "Updates will be applied every day at 7:00")
@@ -1547,7 +1553,7 @@ class TestAutoUpdates(NoSubManCase):
 
             # OnCalendar= parsing: unsupported
             m.execute(r'printf "[Timer]\nOnUnitInactiveSec=\nOnCalendar=*-02-* 11:00\n" > '
-                      r'/etc/systemd/system/dnf-automatic-install.timer.d/time.conf; systemctl daemon-reload')
+                      f'/etc/systemd/system/{self.timer_unit}.timer.d/time.conf; systemctl daemon-reload')
             b.reload()
             b.enter_page("/updates")
             time.sleep(5)
@@ -1583,9 +1589,9 @@ class TestAutoUpdates(NoSubManCase):
 
         if "dnf" in self.backend:
             # dial down the random sleep to avoid the test having to wait 5 mins
-            self.sed_file("/random_sleep/ s/=.*$/= 3/", "/etc/dnf/automatic.conf")
+            self.sed_file("/random_sleep/ s/=.*$/= 3/", self.config)
             # then manually start the upgrade job like the timer would
-            m.execute("systemctl start dnf-automatic-install.service")
+            m.execute(f"systemctl start {self.timer_unit}.service")
             try:
                 # new kernel-rt package got installed
                 m.execute("test -f /stamp-kernel-rt-1.0-2")
@@ -1599,15 +1605,15 @@ class TestAutoUpdates(NoSubManCase):
                 m.execute("shutdown -c; test ! -f /run/nologin")
             # service should show kernel-rt upgrade
             out = m.execute(
-                "if systemctl status --lines=50 dnf-automatic-install.service; then echo 'expected service to be stopped'; exit 1; fi")
+                f"if systemctl status --lines=50 {self.timer_unit}.service; then echo 'expected service to be stopped'; exit 1; fi")
             self.assertIn("kernel-rt", out)
 
             # run it again, now there are no available updates → no reboot
-            m.execute("systemctl start dnf-automatic-install.service")
+            m.execute(f"systemctl start {self.timer_unit}.service")
             m.execute("test -f /stamp-kernel-rt-1.0-2; test ! -f /run/nologin")
             # service should not do much
             out = m.execute(
-                "if systemctl status dnf-automatic-install.service; then echo 'expected service to be stopped'; exit 1; fi")
+                f"if systemctl status {self.timer_unit}.service; then echo 'expected service to be stopped'; exit 1; fi")
             self.assertNotIn("kernel-rt", out)
         else:
             raise NotImplementedError(self.backend)
@@ -1649,7 +1655,12 @@ class TestAutoUpdatesInstall(NoSubManCase):
         b = self.browser
         m = self.machine
 
-        m.execute("if type dnf; then dnf remove -y dnf-automatic; elif type apt; then dpkg -P unattended-upgrades; fi")
+        if self.backend == 'dnf5':
+            m.execute("dnf remove -y dnf5-plugin-automatic")
+        elif self.backend == 'dnf4':
+            m.execute("dnf remove -y dnf-automatic")
+        elif self.backend == 'apt':
+            m.execute("dpkg -P unattended-upgrades")
 
         # first test with available upgrades
         self.createPackage("vanilla", "1.0", "1", install=True)
@@ -1680,8 +1691,6 @@ class TestAutoUpdatesInstall(NoSubManCase):
         b = self.browser
         m = self.machine
 
-        m.execute('dnf remove -y dnf-automatic')
-
         # provide minimal content in order for the backend to be seen as supported
         timerContent = """
 [Unit]
@@ -1697,11 +1706,25 @@ Unit=-.mount
 [Install]
 WantedBy=basic.target
         """
-        self.createPackage('dnf-automatic', '1', '1', content={
-            '/etc/dnf/automatic.conf': '',
-            '/usr/lib/systemd/system/dnf-automatic.timer': timerContent,
-            '/usr/lib/systemd/system/dnf-automatic-install.timer': timerContent
-        })
+
+        if self.backend == 'dnf5':
+            m.execute("dnf remove -y dnf5-plugin-automatic")
+            self.createPackage('dnf5-plugin-automatic', '1', '1', content={
+                '/etc/dnf/dnf5-plugins/automatic.conf': '',
+                '/usr/lib/systemd/system/dnf5-automatic.timer': timerContent,
+            })
+
+        elif self.backend == 'dnf4':
+            m.execute("dnf remove -y dnf-automatic")
+
+            self.createPackage('dnf-automatic', '1', '1', content={
+                '/etc/dnf/automatic.conf': '',
+                '/usr/lib/systemd/system/dnf-automatic.timer': timerContent,
+                '/usr/lib/systemd/system/dnf-automatic-install.timer': timerContent,
+            })
+        elif self.backend == 'apt':
+            m.execute("dpkg -P unattended-upgrades")
+
         self.enableRepo()
 
         self.login_and_go('/updates')

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1000,7 +1000,7 @@ ExecStart=/usr/local/bin/{packageName}
         m = self.machine
 
         # this tends to corrupt the rpm database, so do a backup/restore
-        if self.backend == 'dnf':
+        if 'dnf' in self.backend:
             # https://www.fedoraproject.org/wiki/Changes/RelocateRPMToUsr
             exists = self.machine.execute("if test -e %s; then echo yes; fi" % "/usr/lib/sysimage/rpm").strip() != ""
             if exists:
@@ -1368,7 +1368,7 @@ class TestAutoUpdates(NoSubManCase):
     def setUp(self):
         super().setUp()
         # not implemented for apt yet, only dnf
-        self.supported_backend = self.backend in ["dnf"]
+        self.supported_backend = "dnf" in self.backend
 
     def closeSettings(self, browser):
         browser.click("#automatic-updates-dialog button:contains('Save changes')")
@@ -1420,7 +1420,7 @@ class TestAutoUpdates(NoSubManCase):
                 self.assertNotIn("ExecStartPost", out)
 
         def assertTimer(hour, dow=None):
-            if self.backend == "dnf":
+            if "dnf" in self.backend:
                 assertTimerDnf(hour, dow)
             else:
                 raise NotImplementedError(self.backend)
@@ -1436,7 +1436,7 @@ class TestAutoUpdates(NoSubManCase):
             self.assertIn(match, m.execute("grep upgrade_type /etc/dnf/automatic.conf"))
 
         def assertType(_type):
-            if self.backend == "dnf":
+            if "dnf" in self.backend:
                 assertTypeDnf(_type)
             else:
                 raise NotImplementedError(self.backend)
@@ -1515,7 +1515,7 @@ class TestAutoUpdates(NoSubManCase):
         b.wait_in_text("#autoupdates-settings", "Disabled")
         assertTimer(None)
 
-        if self.backend == "dnf":
+        if "dnf" in self.backend:
             b.click("#autoupdates-settings button:contains('Edit')")
             b.wait_visible("#automatic-updates-dialog")
             b.click("#all-updates")
@@ -1581,7 +1581,7 @@ class TestAutoUpdates(NoSubManCase):
         self.closeSettings(b)
         b.wait_in_text("#autoupdates-settings", "Updates will be applied every day at 06:00")
 
-        if self.backend == 'dnf':
+        if "dnf" in self.backend:
             # dial down the random sleep to avoid the test having to wait 5 mins
             self.sed_file("/random_sleep/ s/=.*$/= 3/", "/etc/dnf/automatic.conf")
             # then manually start the upgrade job like the timer would
@@ -1667,7 +1667,7 @@ class TestAutoUpdatesInstall(NoSubManCase):
             b.wait_visible(".pf-v5-c-empty-state__title:contains('Update was successful')")
         b.click("#ignore")
 
-        if self.backend == 'dnf':
+        if "dnf" in self.backend:
             b.wait_in_text("#autoupdates-settings", "Not set up")
             b.wait_not_present("#settings .pf-v5-c-alert")
             b.click("#autoupdates-settings button:contains('Enable')")


### PR DESCRIPTION
Fixes #20260

---

We don't run our tests on the `fedora-rawhide` image, and anyway our current bots image is too old (it still defaults to dnf4), see https://github.com/cockpit-project/bots/issues/6393 . But I prepared and updated an image locally, and `TEST_OS=fedora-rawhide test/verify/check-packagekit` succeeds.