### PR TITLE
test: Skip FreeIPA tests on debian-testing

### DIFF
--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -504,6 +504,7 @@ class TestRealms(testlib.MachineCase):
 
 @testlib.skipDistroPackage()
 @testlib.no_retry_when_changed
+@testlib.skipImage("freeipa not currently available", "debian-testing")
 class TestIPA(TestRealms, CommonTests):
     def setUp(self):
         super().setUp()
@@ -997,6 +998,7 @@ sed -i '/^sudoers:/ s/files sss/sss files/' /etc/nsswitch.conf
 
 @testlib.skipOstree("No realmd available")
 @testlib.skipImage("No realmd available", "arch")
+@testlib.skipImage("freeipa not currently available", "debian-*")
 @testlib.skipDistroPackage()
 @testlib.no_retry_when_changed
 class TestKerberos(testlib.MachineCase):


### PR DESCRIPTION
It will take some time until FreeIPA re-enters Debian testing, and it became entirely uninstallable even in unstable now. So we'll drop the packages from the image (https://github.com/cockpit-project/bots/issues/6377).

---

This needs to land before the image refresh, but isn't blocked by itself (no lockstep).