### PR TITLE
test: Drop skipDistroPackage decorator

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -71,7 +71,6 @@ __all__ = (
     'opts',
     'sit',
     'skipBrowser',
-    'skipDistroPackage',
     'skipImage',
     'skipOstree',
     'test_main',
@@ -2338,17 +2337,6 @@ def skipOstree(reason: str) -> Callable[[_FT], _FT]:
     """
     if testvm.DEFAULT_IMAGE in OSTREE_IMAGES:
         return unittest.skip(f"{testvm.DEFAULT_IMAGE}: {reason}")
-    return lambda testEntity: testEntity
-
-
-def skipDistroPackage() -> Callable[[_FT], _FT]:
-    """For tests which apply to BaseOS packages
-
-    With that, tests can evolve with latest code, without constantly breaking them when
-    running against older package versions in the -distropkg tests.
-    """
-    if 'distropkg' in testvm.DEFAULT_IMAGE:
-        return unittest.skip(f"{testvm.DEFAULT_IMAGE}: Do not test BaseOS packages")
     return lambda testEntity: testEntity
 
 

--- a/test/example/check-example
+++ b/test/example/check-example
@@ -25,7 +25,6 @@ import unittest
 import testlib
 
 
-@testlib.skipDistroPackage()
 class TestExample(testlib.MachineCase):
 
     @unittest.expectedFailure
@@ -55,7 +54,6 @@ class TestExample(testlib.MachineCase):
 
 
 @testlib.nondestructive
-@testlib.skipDistroPackage()
 class TestNondestructiveExample(testlib.MachineCase):
 
     def testOne(self):
@@ -65,7 +63,6 @@ class TestNondestructiveExample(testlib.MachineCase):
         self.assertIn("usr", self.machine.execute("ls -l /").strip())
 
 
-@testlib.skipDistroPackage()
 class TestSimple(unittest.TestCase):
 
     def testOne(self):
@@ -85,7 +82,6 @@ class TestSimple(unittest.TestCase):
         self.assertTrue(True)  # noqa: FBT003
 
 
-@testlib.skipDistroPackage()
 class TestTodo(unittest.TestCase):
     def setUp(self):
         if not os.environ.get('TEST_TODO'):

--- a/test/example/check-retry
+++ b/test/example/check-retry
@@ -5,7 +5,6 @@ import unittest
 import testlib
 
 
-@testlib.skipDistroPackage()
 class NoTestRetryExample(unittest.TestCase):
 
     def testFail(self):

--- a/test/verify/check-bots-api
+++ b/test/verify/check-bots-api
@@ -30,7 +30,6 @@ from machine import testvm
 
 
 @unittest.skipUnless("TEST_OS" in os.environ, "TEST_OS not set")
-@testlib.skipDistroPackage()
 class TestImageCustomize(unittest.TestCase):
 
     def checkBoot(self, image):
@@ -127,7 +126,6 @@ class TestImageCustomize(unittest.TestCase):
 
 
 @unittest.skipUnless("TEST_OS" in os.environ, "TEST_OS not set")
-@testlib.skipDistroPackage()
 class TestBotsVM(unittest.TestCase):
 
     def testBasic(self):

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -26,7 +26,6 @@ import time
 import testlib
 
 
-@testlib.skipDistroPackage()
 class TestConnection(testlib.MachineCase):
     def setUp(self):
         super().setUp()
@@ -1246,7 +1245,6 @@ UnixPath=/run/cockpit/session
                 self.assertIn(f'{self.libexecdir}/cockpit-pcp', bridge_names)
 
 
-@testlib.skipDistroPackage()
 class TestReverseProxy(testlib.MachineCase):
 
     provision = {

--- a/test/verify/check-embed
+++ b/test/verify/check-embed
@@ -22,7 +22,6 @@ import subprocess
 import testlib
 
 
-@testlib.skipDistroPackage()
 @testlib.nondestructive
 class TestEmbed(testlib.MachineCase):
 

--- a/test/verify/check-examples
+++ b/test/verify/check-examples
@@ -8,7 +8,6 @@ EXAMPLES_DIR = os.path.join(os.path.dirname(testlib.TEST_DIR), "examples")
 
 
 @testlib.nondestructive
-@testlib.skipDistroPackage()
 class TestPinger(testlib.MachineCase):
 
     def setUp(self):
@@ -36,7 +35,6 @@ class TestPinger(testlib.MachineCase):
 
 
 @testlib.nondestructive
-@testlib.skipDistroPackage()
 class TestXHRProxy(testlib.MachineCase):
     def setUp(self):
         super().setUp()
@@ -80,7 +78,6 @@ class TestXHRProxy(testlib.MachineCase):
 
 
 @testlib.nondestructive
-@testlib.skipDistroPackage()
 class TestLongRunning(testlib.MachineCase):
 
     def setUp(self):

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -89,7 +89,6 @@ class KdumpHelpers(testlib.MachineCase):
 @testlib.skipImage("kexec-tools not installed", "debian-*", "ubuntu-*", "arch")
 @testlib.skipImage("https://issues.redhat.com/browse/RHEL-35567", "centos-10", "rhel-10*")
 @testlib.timeout(900)
-@testlib.skipDistroPackage()
 class TestKdump(KdumpHelpers):
 
     def testBasic(self):
@@ -460,7 +459,6 @@ class TestKdump(KdumpHelpers):
 @testlib.skipImage("kexec-tools not installed", "debian-*", "ubuntu-*", "arch")
 @testlib.skipImage("https://issues.redhat.com/browse/RHEL-35567", "centos-10", "rhel-10*")
 @testlib.timeout(900)
-@testlib.skipDistroPackage()
 class TestKdumpNFS(KdumpHelpers):
     provision = {
         "0": {"address": "10.111.113.1/24", "memory_mb": 1024, "capture_console": True},

--- a/test/verify/check-loopback
+++ b/test/verify/check-loopback
@@ -21,7 +21,6 @@ import testlib
 
 
 @testlib.skipOstree("OSTree always uses loopback")
-@testlib.skipDistroPackage()
 @testlib.nondestructive
 class TestLoopback(testlib.MachineCase):
 

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -77,7 +77,6 @@ def applySettings(browser, dialog_selector):
         browser.wait_not_present(dialog_selector)
 
 
-@testlib.skipDistroPackage()
 class TestHistoryMetrics(testlib.MachineCase):
     def setUp(self):
         super().setUp()
@@ -717,7 +716,6 @@ class TestHistoryMetrics(testlib.MachineCase):
         checkEnabled(expected=True)
 
 
-@testlib.skipDistroPackage()
 @testlib.nondestructive
 class TestCurrentMetrics(testlib.MachineCase):
     def setUp(self):
@@ -1248,7 +1246,6 @@ BEGIN {{
 
 
 @testlib.skipImage("TODO: Arch Linux packagekit support", "arch")
-@testlib.skipDistroPackage()
 class TestMetricsPackages(packagelib.PackageCase):
     # HACK: PF modal can have multiple id's in certain scenario's https://github.com/patternfly/patternfly-react/issues/9399
     pcp_dialog_selector = "#pcp-settings-modal:first-child"
@@ -1363,7 +1360,6 @@ class TestMetricsPackages(packagelib.PackageCase):
         self.assertIn("redis", m.execute("systemctl show -p Wants --value pmproxy").strip())
 
 
-@testlib.skipDistroPackage()
 class TestMultiCPU(testlib.MachineCase):
 
     provision = {
@@ -1410,7 +1406,6 @@ class TestMultiCPU(testlib.MachineCase):
 
 
 @testlib.skipOstree("no PCP support")
-@testlib.skipDistroPackage()
 class TestGrafanaClient(testlib.MachineCase):
 
     provision = {

--- a/test/verify/check-networkmanager-basic
+++ b/test/verify/check-networkmanager-basic
@@ -22,7 +22,6 @@ import testlib
 
 
 @testlib.nondestructive
-@testlib.skipDistroPackage()
 class TestNetworkingBasic(netlib.NetworkCase):
     def testBasic(self):
         b = self.browser

--- a/test/verify/check-networkmanager-bond
+++ b/test/verify/check-networkmanager-bond
@@ -23,7 +23,6 @@ from lib.constants import TEST_OS_DEFAULT
 
 
 @testlib.nondestructive
-@testlib.skipDistroPackage()
 class TestBonding(netlib.NetworkCase):
     def testBasic(self):
         b = self.browser
@@ -260,7 +259,6 @@ class TestBonding(netlib.NetworkCase):
         b.wait_visible(f"#network-interface-members tr[data-interface='{iface}']")
 
 
-@testlib.skipDistroPackage()
 class TestBondingVirt(netlib.NetworkCase):
     provision = {
         "machine1": {"address": "10.111.113.1/20", "memory_mb": 512},

--- a/test/verify/check-networkmanager-bridge
+++ b/test/verify/check-networkmanager-bridge
@@ -22,7 +22,6 @@ import testlib
 
 
 @testlib.nondestructive
-@testlib.skipDistroPackage()
 class TestBridge(netlib.NetworkCase):
     def testBasic(self):
         b = self.browser

--- a/test/verify/check-networkmanager-checkpoints
+++ b/test/verify/check-networkmanager-checkpoints
@@ -22,7 +22,6 @@ import testlib
 
 
 @testlib.skipImage("No network checkpoint support", "ubuntu-*")
-@testlib.skipDistroPackage()
 class TestNetworkingCheckpoints(netlib.NetworkCase):
     def testCheckpoint(self):
         b = self.browser

--- a/test/verify/check-networkmanager-firewall
+++ b/test/verify/check-networkmanager-firewall
@@ -48,7 +48,6 @@ def get_active_rules(machine):
 
 @testlib.skipOstree("no firewalld")
 @testlib.nondestructive
-@testlib.skipDistroPackage()
 class TestFirewall(netlib.NetworkCase):
     def setUp(self):
         super().setUp()

--- a/test/verify/check-networkmanager-mac
+++ b/test/verify/check-networkmanager-mac
@@ -22,7 +22,6 @@ import testlib
 from lib.constants import TEST_OS_DEFAULT
 
 
-@testlib.skipDistroPackage()
 class TestNetworkingMAC(netlib.NetworkCase):
     provision = {
         "machine1": {"memory_mb": 512},

--- a/test/verify/check-networkmanager-mtu
+++ b/test/verify/check-networkmanager-mtu
@@ -22,7 +22,6 @@ import testlib
 from lib.constants import TEST_OS_DEFAULT
 
 
-@testlib.skipDistroPackage()
 class TestNetworkingMTU(netlib.NetworkCase):
     provision = {
         "machine1": {"memory_mb": 512},

--- a/test/verify/check-networkmanager-other
+++ b/test/verify/check-networkmanager-other
@@ -21,7 +21,6 @@ import netlib
 import testlib
 
 
-@testlib.skipDistroPackage()
 @testlib.nondestructive
 class TestNetworkingOther(netlib.NetworkCase):
     def testOther(self):

--- a/test/verify/check-networkmanager-settings
+++ b/test/verify/check-networkmanager-settings
@@ -22,7 +22,6 @@ import testlib
 from lib.constants import TEST_OS_DEFAULT
 
 
-@testlib.skipDistroPackage()
 class TestNetworkingSettings(netlib.NetworkCase):
     provision = {
         "machine1": {"memory_mb": 512},

--- a/test/verify/check-networkmanager-team
+++ b/test/verify/check-networkmanager-team
@@ -26,7 +26,6 @@ import testlib
 @testlib.skipOstree("NetworkManager-team not installed")
 @testlib.skipImage("TODO: networkmanager fails on Arch Linux", "arch")
 @testlib.skipImage("team not supported", "centos-10*", "rhel-10*")
-@testlib.skipDistroPackage()
 @testlib.nondestructive
 class TestTeam(netlib.NetworkCase):
     def testBasic(self):

--- a/test/verify/check-networkmanager-unmanaged
+++ b/test/verify/check-networkmanager-unmanaged
@@ -21,7 +21,6 @@ import netlib
 import testlib
 
 
-@testlib.skipDistroPackage()
 @testlib.nondestructive
 class TestNetworkingUnmanaged(netlib.NetworkCase):
     def testUnmanaged(self):

--- a/test/verify/check-networkmanager-vlan
+++ b/test/verify/check-networkmanager-vlan
@@ -22,7 +22,6 @@ import testlib
 
 
 @testlib.nondestructive
-@testlib.skipDistroPackage()
 class TestNetworkingVLAN(netlib.NetworkCase):
     def testVlan(self):
         b = self.browser

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1072,7 +1072,6 @@ ExecStart=/usr/local/bin/{packageName}
             b.wait_visible(".system-health")
             self.assertFalse(b.is_present(self.update_text))
 
-    @testlib.skipDistroPackage()
     @testlib.nondestructive
     def testUnprivileged(self):
         b = self.browser
@@ -1618,7 +1617,6 @@ class TestAutoUpdates(NoSubManCase):
         else:
             raise NotImplementedError(self.backend)
 
-    @testlib.skipDistroPackage()
     def testPrivilegeChange(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -30,7 +30,6 @@ RHEL_DOC_BASE = "https://access.redhat.com/documentation"
 
 
 @testlib.nondestructive
-@testlib.skipDistroPackage()
 class TestPages(testlib.MachineCase):
     def checkDocs(self, items):
         m = self.machine

--- a/test/verify/check-reauthorize
+++ b/test/verify/check-reauthorize
@@ -20,7 +20,6 @@
 import testlib
 
 
-@testlib.skipDistroPackage()
 @testlib.nondestructive
 class TestReauthorize(testlib.MachineCase):
     def testBasic(self):

--- a/test/verify/check-selinux
+++ b/test/verify/check-selinux
@@ -48,7 +48,6 @@ mv -f ~/.ssh/authorized_keys.test-avc ~/.ssh/authorized_keys
 """
 
 
-@testlib.skipDistroPackage()
 class TestSelinux(testlib.MachineCase):
     provision = {
         "0": {},
@@ -297,7 +296,6 @@ class TestSelinux(testlib.MachineCase):
         b.wait_text("ul[aria-label='System modifications']", "The logged in user is not permitted to view system modifications")
 
 
-@testlib.skipDistroPackage()
 @testlib.skipImage("No cockpit-selinux", "debian-*", "ubuntu-*", "arch")
 @testlib.skipOstree("No cockpit-selinux")
 @testlib.nondestructive

--- a/test/verify/check-session
+++ b/test/verify/check-session
@@ -20,7 +20,6 @@
 import testlib
 
 
-@testlib.skipDistroPackage()
 @testlib.nondestructive
 class TestSession(testlib.MachineCase):
 

--- a/test/verify/check-shell-active-pages
+++ b/test/verify/check-shell-active-pages
@@ -20,7 +20,6 @@
 import testlib
 
 
-@testlib.skipDistroPackage()
 @testlib.nondestructive
 class TestActivePages(testlib.MachineCase):
     def testBasic(self):

--- a/test/verify/check-shell-host-switching
+++ b/test/verify/check-shell-host-switching
@@ -22,7 +22,6 @@ import time
 import testlib
 
 
-@testlib.skipDistroPackage()
 class HostSwitcherHelpers:
 
     def check_discovered_addresses(self, b, addresses):
@@ -95,7 +94,6 @@ class HostSwitcherHelpers:
         b.click("#hosts-sel button")
 
 
-@testlib.skipDistroPackage()
 @testlib.todoPybridgeRHEL8()
 class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
     provision = {

--- a/test/verify/check-shell-keys
+++ b/test/verify/check-shell-keys
@@ -23,7 +23,6 @@ FP_SHA256 = "SHA256:iyVAl4Z8riL9Jg4fV9Wv/6cbqebdDtsBEMkojNLLYX8"
 KEY = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEAkRTvQCSEZNPXpA5bP82ilQn3TMeQ6z2NO3O0UwY9z test-name"
 
 
-@testlib.skipDistroPackage()
 @testlib.nondestructive
 class TestKeys(testlib.MachineCase):
     def testAuthorizedKeys(self):

--- a/test/verify/check-shell-menu
+++ b/test/verify/check-shell-menu
@@ -23,7 +23,6 @@ import testlib
 
 
 @testlib.nondestructive
-@testlib.skipDistroPackage()
 class TestMenu(testlib.MachineCase):
 
     def testDarkThemeSwitcher(self):

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -116,7 +116,6 @@ def change_ssh_port(machine, address, sshd_socket, sshd_service, port=None, time
     raise error
 
 
-@testlib.skipDistroPackage()
 @testlib.todoPybridgeRHEL8()
 class TestMultiMachineAdd(testlib.MachineCase):
     provision = {
@@ -215,7 +214,6 @@ class TestMultiMachineAdd(testlib.MachineCase):
         self.allow_hostkey_messages()
 
 
-@testlib.skipDistroPackage()
 class TestMultiMachine(testlib.MachineCase):
     provision = {
         "machine1": {"address": "10.111.113.1/20", "memory_mb": 660},

--- a/test/verify/check-shell-multi-machine-key
+++ b/test/verify/check-shell-multi-machine-key
@@ -59,7 +59,6 @@ KEY_IDS_MD5 = [
 
 
 @testlib.skipImage("TODO: ssh key check fails on Arch Linux", "arch")
-@testlib.skipDistroPackage()
 class TestMultiMachineKeyAuth(testlib.MachineCase):
     provision = {
         "machine1": {"address": "10.111.113.1/20", "memory_mb": 512},

--- a/test/verify/check-shell-multi-os
+++ b/test/verify/check-shell-multi-os
@@ -42,7 +42,6 @@ def add_machine(b, address, password):
     b.wait_not_present('#hosts_setup_server_dialog')
 
 
-@testlib.skipDistroPackage()
 class TestRHEL8(testlib.MachineCase):
     provision = {
         "0": {"address": "10.111.113.1/20", "memory_mb": 768},
@@ -81,7 +80,6 @@ class TestRHEL8(testlib.MachineCase):
         dev_b.wait_in_text(".ct-overview-header-hostname", "running Red Hat Enterprise Linux 8")
 
 
-@testlib.skipDistroPackage()
 class TestMultiOSDirect(testlib.MachineCase):
     provision = {
         "0": {"address": "10.111.113.1/20", "memory_mb": 512},

--- a/test/verify/check-sosreport
+++ b/test/verify/check-sosreport
@@ -28,7 +28,6 @@ import testlib
 @testlib.skipOstree("No sosreport")
 @testlib.skipImage("No sosreport", "arch")
 @testlib.nondestructive
-@testlib.skipDistroPackage()
 class TestSOS(testlib.MachineCase):
 
     def testBasic(self, urlroot=""):

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -26,7 +26,6 @@ import testlib
 
 
 @testlib.nondestructive
-@testlib.skipDistroPackage()
 class TestLogin(testlib.MachineCase):
     def check_shell(self):
         b = self.browser

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -23,7 +23,6 @@ import testlib
 
 
 @testlib.nondestructive
-@testlib.skipDistroPackage()
 class TestSuperuser(testlib.MachineCase):
     def testBasic(self):
         b = self.browser
@@ -400,7 +399,6 @@ session include system-auth
         b.wait_not_present(".pf-v5-c-alert:contains('Web console is running in limited access mode.')")
 
 
-@testlib.skipDistroPackage()
 class TestSuperuserDashboard(testlib.MachineCase):
     provision = {
         "machine1": {"address": "10.111.113.1/20", "memory_mb": 512},

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -54,7 +54,6 @@ def ssh_reconnect(machine, timeout_sec=120):
     raise error
 
 
-@testlib.skipDistroPackage()
 class TestSystemInfo(testlib.MachineCase):
     def setUp(self):
         super().setUp()
@@ -863,7 +862,6 @@ password=foobar
         self.assertEqual(m.execute("cat /proc/sys/crypto/fips_enabled").strip(), "0")
 
 
-@testlib.skipDistroPackage()
 class TestSystemInfoTime(packagelib.PackageCase):
     def set_change_time_dialog_mode(self, mode):
         b = self.browser

--- a/test/verify/check-system-journal
+++ b/test/verify/check-system-journal
@@ -26,7 +26,6 @@ sleep_crash_list_sel = "#journal-box .cockpit-logline .cockpit-log-message:conta
 NO_ABRT = ["debian-*", "ubuntu-*", "fedora-coreos", "rhel*", "centos-*", "arch"]
 
 
-@testlib.skipDistroPackage()
 class TestJournal(testlib.MachineCase):
     def setUp(self):
         super().setUp()

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -73,7 +73,6 @@ ExecStart=/bin/true
         machine.execute("systemctl unmask chrony")
 
 
-@testlib.skipDistroPackage()
 class CommonTests:
 
     def wait_discover(self):
@@ -480,7 +479,6 @@ class CommonTests:
 
 @testlib.skipOstree("No realmd available")
 @testlib.skipImage("No realmd available", "arch")
-@testlib.skipDistroPackage()
 @testlib.no_retry_when_changed
 class TestRealms(testlib.MachineCase):
     """Common variables and tests for all supported domain backends"""
@@ -502,7 +500,6 @@ class TestRealms(testlib.MachineCase):
         self.allow_journal_messages("couldn't get all properties of org.freedesktop.realmd.Service.*org.freedesktop.DBus.Error.NoReply: Remote peer disconnected")
 
 
-@testlib.skipDistroPackage()
 @testlib.no_retry_when_changed
 @testlib.skipImage("freeipa not currently available", "debian-testing")
 class TestIPA(TestRealms, CommonTests):
@@ -843,7 +840,6 @@ ipa-advise enable-admins-sudo | sh -ex
 
 
 @testlib.skipImage("adcli not on test images", "debian-*", "ubuntu-*")
-@testlib.skipDistroPackage()
 @testlib.no_retry_when_changed
 class TestAD(TestRealms, CommonTests):
     def setUp(self):
@@ -999,7 +995,6 @@ sed -i '/^sudoers:/ s/files sss/sss files/' /etc/nsswitch.conf
 @testlib.skipOstree("No realmd available")
 @testlib.skipImage("No realmd available", "arch")
 @testlib.skipImage("freeipa not currently available", "debian-*")
-@testlib.skipDistroPackage()
 @testlib.no_retry_when_changed
 class TestKerberos(testlib.MachineCase):
     provision = {
@@ -1128,7 +1123,6 @@ class TestKerberos(testlib.MachineCase):
 
 @testlib.skipImage("No realmd available", "arch")
 @testlib.skipOstree("Package (un)install does not work on OSTree")
-@testlib.skipDistroPackage()
 class TestPackageInstall(packagelib.PackageCase):
 
     def setUp(self):

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -24,7 +24,6 @@ from machine import testvm
 
 
 @testlib.nondestructive
-@testlib.skipDistroPackage()
 class TestServices(testlib.MachineCase):
 
     def setUp(self):
@@ -1354,7 +1353,6 @@ WantedBy=multi-user.target
         self.check_service_details(["Read-only", "Disabled"], [], enabled=False, onoff=False, kebab=False)
 
 
-@testlib.skipDistroPackage()
 class TestTimers(testlib.MachineCase):
     def svc_sel(self, service):
         return f'tr[data-goto-unit="{service}"]'

--- a/test/verify/check-system-shutdown-restart
+++ b/test/verify/check-system-shutdown-restart
@@ -20,7 +20,6 @@
 import testlib
 
 
-@testlib.skipDistroPackage()
 class TestShutdownRestart(testlib.MachineCase):
     provision = {
         "machine1": {"address": "10.111.113.1/20", "memory_mb": 512},

--- a/test/verify/check-system-terminal
+++ b/test/verify/check-system-terminal
@@ -24,7 +24,6 @@ def line_sel(i):
     return '.terminal .xterm-accessibility-tree div:nth-child(%d)' % i
 
 
-@testlib.skipDistroPackage()
 class TestTerminal(testlib.MachineCase):
     def setUp(self):
         super().setUp()

--- a/test/verify/check-system-tuned
+++ b/test/verify/check-system-tuned
@@ -23,7 +23,6 @@ import testlib
 @testlib.nondestructive
 @testlib.skipOstree("No tuned packaged")
 @testlib.skipImage("No tuned packaged", "arch")
-@testlib.skipDistroPackage()
 class TestTuned(testlib.MachineCase):
 
     def testBasic(self):

--- a/test/verify/check-testlib
+++ b/test/verify/check-testlib
@@ -31,7 +31,6 @@ VERIFY_DIR = os.path.join(testlib.TEST_DIR, "verify")
 ROOT_DIR = os.path.dirname(testlib.TEST_DIR)
 
 
-@testlib.skipDistroPackage()
 class TestRunTestListing(unittest.TestCase):
 
     def testBasic(self):
@@ -70,7 +69,6 @@ class TestRunTestListing(unittest.TestCase):
 
 # This can't be @nondestructive, as we run our own @nondestructive test nested inside this test. This will already call the
 # cleanup handlers, and the outside cleanup would then fail to do that again.
-@testlib.skipDistroPackage()
 class TestRunTest(testlib.MachineCase):
     def testExistingMachine(self):
         env = os.environ.copy()
@@ -235,7 +233,6 @@ class TestSystemd(unittest.TestCase):
         self.assertEqual(process.returncode, 1)
 
 
-@testlib.skipDistroPackage()
 @testlib.nondestructive
 class TestTestlib(testlib.MachineCase):
     def testRestoreAPI(self):

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -106,7 +106,6 @@ def createUser(
 
 
 @testlib.nondestructive
-@testlib.skipDistroPackage()
 class TestAccounts(testlib.MachineCase):
 
     def testBasic(self):

--- a/test/verify/check-users-roles
+++ b/test/verify/check-users-roles
@@ -20,7 +20,6 @@
 import testlib
 
 
-@testlib.skipDistroPackage()
 class TestRoles(testlib.MachineCase):
 
     @testlib.nondestructive


### PR DESCRIPTION
We haven't supported RHEL 8 package builds/tests on this branch for a while now, and it doesn't impact beiboot mode.