### PR TITLE
lib: add gid field to UserInfo

### DIFF
--- a/doc/guide/cockpit-session.xml
+++ b/doc/guide/cockpit-session.xml
@@ -44,7 +44,8 @@ promise.then(user => { ... });
       </varlistentry>
       <varlistentry>
         <term><code>"groups"</code></term>
-        <listitem><para>This is an array of group names to which the user belongs.</para></listitem>
+        <listitem><para>This is an array of group names to which the user belongs.  Since
+        version 318, the first item in this list is the primary group.</para></listitem>
       </varlistentry>
       <varlistentry>
         <term><code>"home"</code></term>

--- a/doc/guide/cockpit-session.xml
+++ b/doc/guide/cockpit-session.xml
@@ -31,6 +31,10 @@ promise.then(user => { ... });
         <listitem><para>This is unix user id.</para></listitem>
       </varlistentry>
       <varlistentry>
+        <term><code>"gid"</code></term>
+        <listitem><para>This is unix user group id.</para></listitem>
+      </varlistentry>
+      <varlistentry>
         <term><code>"name"</code></term>
         <listitem><para>This is the unix user name like <code>"root"</code>.</para></listitem>
       </varlistentry>

--- a/pkg/base1/test-user.js
+++ b/pkg/base1/test-user.js
@@ -22,6 +22,7 @@ QUnit.test("user object", async assert => {
     assert.equal(typeof user.shell, "string", "user shell");
     assert.equal(typeof user.home, "string", "user home");
     assert.equal(typeof user.id, "number", "user id");
+    assert.equal(typeof user.gid, "number", "group id");
     assert.ok(Array.isArray(user.groups), "user groups");
 });
 

--- a/pkg/lib/cockpit.d.ts
+++ b/pkg/lib/cockpit.d.ts
@@ -239,6 +239,7 @@ declare module 'cockpit' {
 
     type UserInfo = {
         id: number;
+        gid: number;
         name: string;
         full_name: string;
         groups: Array<string>;

--- a/pkg/lib/cockpit.js
+++ b/pkg/lib/cockpit.js
@@ -2380,6 +2380,7 @@ function factory() {
                     .then(([user]) => {
                         the_user = {
                             id: user.Id.v,
+                            gid: user.Gid.v,
                             name: user.Name.v,
                             full_name: user.Full.v,
                             groups: user.Groups.v,

--- a/pkg/playground/test.html
+++ b/pkg/playground/test.html
@@ -41,6 +41,10 @@
                 <textarea id="edit-file"></textarea>
                 <br/>
                 Visibility: <label id="hidden"></label>
+                <div class="user-channel">
+			<p>cockpit.user() information</p>
+			<div id="user-info" />
+                </div>
             </section>
         </main>
     </div>

--- a/pkg/playground/test.js
+++ b/pkg/playground/test.js
@@ -125,6 +125,11 @@ document.addEventListener("DOMContentLoaded", () => {
         document.getElementById("hidden").textContent = cockpit.hidden ? "hidden" : "visible";
     }
 
+    cockpit.user().then(info => {
+        console.log(info);
+        document.getElementById("user-info").textContent = JSON.stringify(info);
+    });
+
     cockpit.addEventListener("visibilitychange", show_hidden);
     show_hidden();
 });

--- a/src/cockpit/internal_endpoints.py
+++ b/src/cockpit/internal_endpoints.py
@@ -149,7 +149,14 @@ class cockpit_User(bus.Object):
         self.gid = user.pw_gid
         self.home = user.pw_dir
         self.shell = user.pw_shell
-        self.groups = [gr.gr_name for gr in grp.getgrall() if user.pw_name in gr.gr_mem]
+
+        # We want the primary group first in the list, without duplicates.
+        # This is a bit awkward because `set()` is unordered...
+        groups = [grp.getgrgid(user.pw_gid).gr_name]
+        for gr in grp.getgrall():
+            if user.pw_name in gr.gr_mem and gr.gr_name not in groups:
+                groups.append(gr.gr_name)
+        self.groups = groups
 
 
 EXPORTS = [

--- a/src/cockpit/internal_endpoints.py
+++ b/src/cockpit/internal_endpoints.py
@@ -136,6 +136,7 @@ class cockpit_User(bus.Object):
     name = bus.Interface.Property('s', value='')
     full = bus.Interface.Property('s', value='')
     id = bus.Interface.Property('i', value=0)
+    gid = bus.Interface.Property('i', value=0)
     home = bus.Interface.Property('s', value='')
     shell = bus.Interface.Property('s', value='')
     groups = bus.Interface.Property('as', value=[])
@@ -145,6 +146,7 @@ class cockpit_User(bus.Object):
         self.name = user.pw_name
         self.full = user.pw_gecos
         self.id = user.pw_uid
+        self.gid = user.pw_gid
         self.home = user.pw_dir
         self.shell = user.pw_shell
         self.groups = [gr.gr_name for gr in grp.getgrall() if user.pw_name in gr.gr_mem]

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
+import json
 import os
 import subprocess
 import tempfile
@@ -954,6 +955,25 @@ OnCalendar=daily
         with b.wait_timeout(30):
             b.wait(lambda: int(m.execute(f"ls {dest_dir} | wc -l").strip()) == len(files))
         b.wait_visible("#upload-file-btn:not(:disabled)")
+
+    def testUserInfo(self) -> None:
+        b = self.browser
+        m = self.machine
+
+        m.execute("""
+            groupadd test
+            gpasswd -a admin test
+        """)
+
+        self.login_and_go("/playground/test")
+        b.wait_visible("#user-info")
+        user_info = json.loads(b.text("#user-info"))
+        self.assertEqual(user_info["home"], "/var/home/admin" if m.ostree_image else "/home/admin")
+        # default group is first
+        self.assertEqual(user_info["groups"][0], m.execute("id -gn admin").strip())
+        self.assertIn("test", user_info["groups"])
+        self.assertEqual(str(user_info["id"]), m.execute("id -u admin").strip())
+        self.assertEqual(str(user_info["gid"]), m.execute("id -g admin").strip())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Cockpit files now obtains this via `id` while it is available in the bridge via `struct_passwd`.