### PR TITLE
First pass `tsc --checkJs true` run

### DIFF
--- a/pkg/lib/cockpit.d.ts
+++ b/pkg/lib/cockpit.d.ts
@@ -154,6 +154,10 @@ declare module 'cockpit' {
 
     export const location: Location;
 
+    /* === cockpit page visibility =============== */
+
+    export let hidden: boolean;
+
     /* === cockpit.dbus ========================== */
 
     interface DBusProxyEvents extends EventMap {

--- a/pkg/metrics/metrics.jsx
+++ b/pkg/metrics/metrics.jsx
@@ -1490,7 +1490,7 @@ const PCPConfigDialog = ({
                                 isChecked={dialogLoggerValue}
                                 isDisabled={!s_pmlogger.exists && !packagekitExists}
                                 label={
-                                    <Flex spaceItems={{ modifier: 'spaceItemsXl' }}>
+                                    <Flex>
                                         <FlexItem>{ _("Collect metrics") }</FlexItem>
                                         <TextContent>
                                             <Text component={TextVariants.small}>(pmlogger.service)</Text>
@@ -1507,7 +1507,7 @@ const PCPConfigDialog = ({
                     <Switch id="switch-pmproxy"
                                 isChecked={dialogProxyValue}
                                 label={
-                                    <Flex spaceItems={{ modifier: 'spaceItemsXl' }}>
+                                    <Flex>
                                         <FlexItem>{ _("Export to network") }</FlexItem>
                                         <TextContent>
                                             <Text component={TextVariants.small}>(pmproxy.service)</Text>

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -340,7 +340,7 @@ function updateItem(remarkable, info, pkgNames, key) {
     if (pkgNames.some(pkg => isKpatchPackage(pkg.name)))
         pkgsTruncated.push(
             <LabelGroup key={`${key}-kpatches-labelgroup`} className="kpatches-labelgroup">
-                {" "}<Badge color="blue" variant="filled">{_("patches")}</Badge>
+                {" "}<Badge color="blue">{_("patches")}</Badge>
             </LabelGroup>
         );
 

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -582,7 +582,6 @@ const ApplyUpdates = ({ transactionProps, actions, onCancel, rebootAfter, setReb
     if (actions.length === 0 && percentage === 0) {
         return <EmptyStatePanel title={ _("Initializing...") }
                                 headingLevel="h5"
-                                titleSize="4xl"
                                 secondary={cancelButton}
                                 loading
         />;

--- a/pkg/systemd/overview-cards/cryptoPolicies.jsx
+++ b/pkg/systemd/overview-cards/cryptoPolicies.jsx
@@ -223,7 +223,7 @@ export const CryptoPolicyStatus = () => {
     if (isInconsistentPolicy(currentCryptoPolicy, fipsEnabled)) {
         return (
             <li className="system-health-crypto-policies">
-                <Flex spacer={{ default: 'spaceItemsSm' }} flexWrap={{ default: 'nowrap' }}>
+                <Flex flexWrap={{ default: 'nowrap' }}>
                     <FlexItem><ExclamationTriangleIcon className="crypto-policies-health-card-icon" /></FlexItem>
                     <div>
                         <div id="inconsistent_crypto_policy">

--- a/pkg/systemd/overview-cards/lastLogin.jsx
+++ b/pkg/systemd/overview-cards/lastLogin.jsx
@@ -111,7 +111,7 @@ const LastLogin = () => {
 
     return (
         <li className="last-login" id="page_status_last_login">
-            <Flex spacer={{ default: 'spaceItemsSm' }} flexWrap={{ default: 'nowrap' }}>
+            <Flex flexWrap={{ default: 'nowrap' }}>
                 <FlexItem>{icon}</FlexItem>
                 <div>
                     <div id="system_last_login"

--- a/pkg/systemd/overview-cards/shutdownStatus.jsx
+++ b/pkg/systemd/overview-cards/shutdownStatus.jsx
@@ -96,9 +96,9 @@ export const ShutDownStatus = () => {
 
     return (
         <li id="system-health-shutdown-status">
-            <Flex spacer={{ default: 'spaceItemsSm' }} flexWrap={{ default: 'nowrap' }}>
+            <Flex flexWrap={{ default: 'nowrap' }}>
                 <FlexItem>{icon}</FlexItem>
-                <Flex id="system-health-shutdown-status-text" direction={{ default: 'column' }}>
+                <Flex id="system-health-shutdown-status-text" spaceItems={{ default: 'spaceItemsNone' }} direction={{ default: 'column' }}>
                     {cockpit.format(text, displayDate)}
                     <FlexItem>
                         <Button variant="link" isInline

--- a/pkg/systemd/overview.jsx
+++ b/pkg/systemd/overview.jsx
@@ -119,7 +119,7 @@ class OverviewPage extends React.Component {
         let headerActions = null;
         if (this.state.privileged)
             headerActions = (
-                <Dropdown onSelect={() => this.setState({ actionIsOpen: true })}
+                <Dropdown onSelect={() => this.setState({ actionIsOpen: false })}
                     toggle={(toggleRef) => (
                         <MenuToggle
                             ref={toggleRef}

--- a/pkg/users/accounts-list.js
+++ b/pkg/users/accounts-list.js
@@ -81,7 +81,7 @@ const UserActions = ({ account }) => {
         </DropdownItem>,
     );
 
-    return <KebabDropdown id="accounts-actions" dropdownItems={actions} />;
+    return <KebabDropdown toggleButtonId="accounts-actions" dropdownItems={actions} />;
 };
 
 const getGroupRow = (group, accounts) => {


### PR DESCRIPTION


Plus a small bug fix:

![image](https://github.com/cockpit-project/cockpit/assets/67428/bdea6c61-2dd6-4005-b3f7-cf39b1e5a899)

To

![image](https://github.com/cockpit-project/cockpit/assets/67428/2a6e3571-04e8-4b30-8510-20a3d24f684d)

And now we close the Reboot dropdown after clicking on a dropdown item.