### PR TITLE
fmf: Reorganize and rebalance tests, fix rawhide TF scsi_admin breakage

### DIFF
--- a/plans/all.fmf
+++ b/plans/all.fmf
@@ -11,17 +11,17 @@ execute:
 environment:
     TEST_AUDIT_NO_SELINUX: 1
 
-/basic:
-    summary: Run tests for basic packages
+/main:
+    summary: Non-storage tests
     discover+:
-        test: /test/browser/basic
+        test: /test/browser/main
 
-/network:
-    summary: Run tests for cockpit-networkmanager
+/storage-basic:
+    summary: Basic storage tests
     discover+:
-        test: /test/browser/network
+        test: /test/browser/storage-basic
 
-/optional:
-    summary: Run tests for optional packages
+/storage-extra:
+    summary: More expensive storage tests (LVM, LUKS, Anaconda)
     discover+:
-        test: /test/browser/optional
+        test: /test/browser/storage-extra

--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -23,6 +23,14 @@ if rpm -q setroubleshoot-server; then
     dnf remove -y --setopt=clean_requirements_on_remove=False setroubleshoot-server
 fi
 
+# HACK: this package creates bogus/broken sda → nvme symlinks; it's new in rawhide TF default instances, not required for
+# our tests, and only causes trouble; https://github.com/amazonlinux/amazon-ec2-utils/issues/37
+if rpm -q amazon-ec2-utils; then
+    rpm -e --verbose amazon-ec2-utils
+    # clean up the symlinks
+    udevadm trigger /dev/nvme*
+fi
+
 if grep -q 'ID=.*fedora' /etc/os-release && [ "$PLAN" = "main" ]; then
     # Fedora-only packages which are not available in CentOS/RHEL
     # required by TestLogin.testBasic

--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -4,7 +4,7 @@ set -eux
 
 cd "${0%/*}/../.."
 
-# like "basic", passed on to run-test.sh
+# like "storage-basic", passed on to run-test.sh
 PLAN="$1"
 
 # show some system info
@@ -23,7 +23,7 @@ if rpm -q setroubleshoot-server; then
     dnf remove -y --setopt=clean_requirements_on_remove=False setroubleshoot-server
 fi
 
-if grep -q 'ID=.*fedora' /etc/os-release && [ "$PLAN" = "basic" ]; then
+if grep -q 'ID=.*fedora' /etc/os-release && [ "$PLAN" = "main" ]; then
     # Fedora-only packages which are not available in CentOS/RHEL
     # required by TestLogin.testBasic
     dnf install -y tcsh
@@ -31,13 +31,13 @@ if grep -q 'ID=.*fedora' /etc/os-release && [ "$PLAN" = "basic" ]; then
     dnf install -y abrt abrt-addon-ccpp reportd libreport-plugin-bugzilla libreport-fedora
 fi
 
-if grep -q 'ID=.*fedora' /etc/os-release && [ "$PLAN" = "optional" ]; then
+if grep -q 'ID=.*fedora' /etc/os-release && [ "$PLAN" = "storage-basic" ]; then
     # required by TestStorageBtrfs*
     dnf install -y udisks2-btrfs
 fi
 
-# dnf installs "missing" weak dependencies, but we don't want them for plans other than "optional"
-if [ "$PLAN" != "optional" ] && rpm -q cockpit-packagekit; then
+# dnf installs "missing" weak dependencies, but we don't want them for plans other than "main"
+if [ "$PLAN" != "main" ] && rpm -q cockpit-packagekit; then
     dnf remove -y cockpit-packagekit
 fi
 
@@ -49,11 +49,8 @@ fi
 # HACK: RHEL has these bundled in cockpit-system, but Fedora doesn't; Provides: break in CentOS/RHEL 10
 # due to https://issues.redhat.com/browse/TFT-2564
 if ! grep -q platform:el /etc/os-release; then
-    if [ "$PLAN" = "basic" ]; then
+    if [ "$PLAN" = "main" ]; then
         dnf install -y cockpit-kdump cockpit-networkmanager cockpit-sosreport
-    fi
-    if [ "$PLAN" = "network" ]; then
-        dnf install -y cockpit-networkmanager
     fi
 fi
 
@@ -64,12 +61,6 @@ if [ -n "$main_builds_repo" ]; then
     echo 'priority=0' >> "$main_builds_repo"
     dnf distro-sync -y 'cockpit*'
 fi
-
-# RHEL 8 does not build cockpit-tests; when dropping RHEL 8 support, move to test/browser/main.fmf
-if [ "$PLAN" = basic ] && ! grep -q el8 /etc/os-release; then
-    dnf install -y cockpit-tests
-fi
-
 
 #HACK: unbreak RHEL 9's default choice of 999999999 rounds, see https://bugzilla.redhat.com/show_bug.cgi?id=1993919
 sed -ie 's/#SHA_CRYPT_MAX_ROUNDS 5000/SHA_CRYPT_MAX_ROUNDS 5000/' /etc/login.defs

--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -1,5 +1,5 @@
-/basic:
-  summary: Run browser integration tests for basic Cockpit packages
+/main:
+  summary: Non-storage tests
   require:
     # ourself
     - cockpit
@@ -7,46 +7,60 @@
     # - cockpit-kdump
     # - cockpit-networkmanager
     # - cockpit-sosreport
-    # FIXME: add this after dropping RHEL8 support
-    # - cockpit-tests
+    - cockpit-packagekit
+    - cockpit-tests
     # build/test infra dependencies
     - podman
     # required by tests
+    - createrepo_c
     - dnf-automatic
-    - glibc-all-langpacks
     - firewalld
+    - glibc-all-langpacks
+    - libvirt-daemon-config-network
+    - firewalld
+    - NetworkManager-team
+    - rpm-build
     - sssd
     - sssd-dbus
     - subscription-manager
     - targetcli
     - tlog
     - tuned
-  test: ./browser.sh basic
+  test: ./browser.sh main
   duration: 1h
 
-/network:
-  summary: Run browser integration tests for cockpit-networkmanager
-  require:
-    # ourself
-    - cockpit
-    # done in browser.sh, see https://issues.redhat.com/browse/TFT-2564
-    # - cockpit-networkmanager
-    # build/test infra dependencies
-    - podman
-    # required by tests
-    - NetworkManager-team
-    - firewalld
-    - libvirt-daemon-config-network
-  test: ./browser.sh network
-  duration: 1h
-
-/optional:
-  summary: Run browser integration tests for optional Cockpit packages
+/storage-basic:
+  summary: Basic storage tests
   require:
     # ourself
     - cockpit
     - cockpit-storaged
-    - cockpit-packagekit
+    # for at least swap metrics on storage page
+    - cockpit-pcp
+    # build/test infra dependencies
+    - podman
+    # required by tests
+    - cryptsetup
+    - dnf-automatic
+    - firewalld
+    - lvm2
+    - nfs-utils
+    - python3-tracer
+    - stratis-cli
+    - stratisd
+    - subscription-manager
+    - targetcli
+    - udisks2-lvm2
+    - udisks2-iscsi
+  test: ./browser.sh storage-basic
+  duration: 1h
+
+/storage-extra:
+  summary: More expensive storage tests (LVM, LUKS, Anaconda)
+  require:
+    # ourself
+    - cockpit
+    - cockpit-storaged
     # for at least swap metrics on storage page
     - cockpit-pcp
     # build/test infra dependencies
@@ -66,5 +80,5 @@
     - targetcli
     - udisks2-lvm2
     - udisks2-iscsi
-  test: ./browser.sh optional
+  test: ./browser.sh storage-extra
   duration: 1h


### PR DESCRIPTION
The "basic" vs. "optional" package split was only a RHEL 8 thing, and was removed in commit 429b3c28. Also the test plans are very imbalanced: basic takes 14 mins, network only 4.5 mins, and optional about 30 mins.

Reorganize them to split the storage tests in two plans (`storage-{basic,extra}`) and merge the others into a `main`.

As we now have to enumerate test class names explicitly, this cleans up the `EXCLUDES` list quite a bit: We can drop the parts where we skipped all tests of a class, and instead just not mention the class in `TESTS`.

---

I also added a fix for the current rawhide breakage.

Fixes #20520