### PR TITLE
test: Avoid scsi-debug drives for partitions

### DIFF
--- a/test/common/storagelib.py
+++ b/test/common/storagelib.py
@@ -80,8 +80,9 @@ class StorageHelpers:
         # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1969408
         # It would be nicer to remove $F immediately after the call to
         # losetup, but that will break some versions of lvm2.
+        size_string = size if isinstance(size, str) else str(size) + "MB"
         backf = self.machine.execute("mktemp /var/tmp/loop.XXXX").strip()
-        dev = self.machine.execute(f"truncate --size={size}MB {backf}; "
+        dev = self.machine.execute(f"truncate --size={size_string} {backf}; "
                                    f"losetup -P --show {name if name else '--find'} {backf}").strip()
         # If this device had partions in its last incarnation on this
         # machine, they might come back for unknown reasons, in a

--- a/test/verify/check-storage-anaconda
+++ b/test/verify/check-storage-anaconda
@@ -340,7 +340,7 @@ class TestStorageAnaconda(storagelib.StorageCase):
     def testBiosboot(self):
         b = self.browser
 
-        disk = self.add_ram_disk()
+        disk = self.add_loopback_disk()
 
         anaconda_config = {
             "mount_point_prefix": "/sysroot",
@@ -375,7 +375,7 @@ class TestStorageAnaconda(storagelib.StorageCase):
     def testEfiSystemPartition(self):
         b = self.browser
 
-        disk = self.add_ram_disk()
+        disk = self.add_loopback_disk()
 
         anaconda_config = {
             "mount_point_prefix": "/sysroot",
@@ -413,7 +413,7 @@ class TestStorageAnaconda(storagelib.StorageCase):
         m = self.machine
         b = self.browser
 
-        disk = self.add_ram_disk()
+        disk = self.add_loopback_disk()
 
         anaconda_config = {
             "mount_point_prefix": "/sysroot",

--- a/test/verify/check-storage-basic
+++ b/test/verify/check-storage-basic
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
+import os
 import storagelib
 import testlib
 
@@ -41,15 +42,15 @@ class TestStorageBasic(storagelib.StorageCase):
         b.wait_visible(create_dropdown)
 
         # Add a disk, partition it, format it, and finally remove it.
-        disk = self.add_ram_disk()
+        disk = self.add_targetd_loopback_disk(index=1)
 
         self.click_card_row("Storage", name=disk)
-        b.wait_visible(self.card("Solid State Drive"))
+        b.wait_visible(self.card("Hard Disk Drive"))
 
-        b.wait_text(self.card_desc("Solid State Drive", "Model"), "scsi_debug")
-        b.wait_in_text(self.card_desc("Solid State Drive", "Capacity"), "50 MiB")
+        b.wait_text(self.card_desc("Hard Disk Drive", "Model"), "disk1")
+        b.wait_in_text(self.card_desc("Hard Disk Drive", "Capacity"), "50 MiB")
 
-        self.assertEqual(self.inode(b.text(self.card_desc("Solid State Drive", "Device file"))), self.inode(disk))
+        self.assertEqual(self.inode(b.text(self.card_desc("Hard Disk Drive", "Device file"))), self.inode(disk))
 
         m.execute(f'parted -s {disk} mktable gpt')
         m.execute(f'parted -s {disk} mkpart primary ext2 1M 8M')
@@ -83,8 +84,9 @@ class TestStorageBasic(storagelib.StorageCase):
                         # the table columns to shift. The usage bars
                         # are not stable but are always the same size,
                         # so it is good enough to ignore them.
+                        # The targetd loopback disk has a UUID in its name.
                         mock={".usage-text": "---"},
-                        ignore=[".usage-bar"])
+                        ignore=[".usage-bar", f"tr[data-test-row-name={os.path.basename(disk)}] td:nth-child(2)"])
         self.force_remove_disk(disk)
         b.wait_not_present(self.card_row("Storage", name=disk))
 

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -44,9 +44,9 @@ class TestStorageLuks(storagelib.StorageCase):
         self.login_and_go("/storage")
 
         # Add a disk and partition it
-        disk = self.add_ram_disk(100)
+        disk = self.add_loopback_disk(100)
         self.click_card_row("Storage", name=disk)
-        self.click_card_dropdown("Solid State Drive", "Create partition table")
+        self.click_card_dropdown("Block device", "Create partition table")
         self.dialog({"type": "gpt"})
         b.wait_text(self.card_row_col("GPT partitions", 1, 1), "Free space")
 
@@ -255,7 +255,7 @@ class TestStorageLuks(storagelib.StorageCase):
         self.login_and_go("/storage")
 
         # Add a disk and format it with luks, but without filesystem
-        disk = self.add_ram_disk()
+        disk = self.add_loopback_disk()
         self.click_card_row("Storage", name=disk)
 
         self.click_card_dropdown("Unformatted data", "Format")
@@ -291,7 +291,7 @@ class TestStorageLuks(storagelib.StorageCase):
         self.assertEqual(m.execute(f"lsblk -no RO {cleartext_dev}").strip(), "1")
 
         # Now create a empty, encrypted partition
-        self.click_card_dropdown("Solid State Drive", "Create partition table")
+        self.click_card_dropdown("Block device", "Create partition table")
         self.dialog({"type": "gpt"})
         b.wait_text(self.card_row_col("GPT partitions", 1, 1), "Free space")
         self.click_dropdown(self.card_row("GPT partitions", 1), "Create partition")

--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -293,7 +293,7 @@ class TestStorageLvm2(storagelib.StorageCase):
 
         self.login_and_go("/storage")
 
-        disk1 = self.add_ram_disk()
+        disk1 = self.add_loopback_disk()
         disk2 = self.add_loopback_disk()
         b.wait_visible(self.card_row("Storage", name=disk1))
         b.wait_visible(self.card_row("Storage", name=disk2))
@@ -305,13 +305,13 @@ class TestStorageLvm2(storagelib.StorageCase):
         # Create a volume group out of disk1
         self.dialog_with_retry(trigger=lambda: self.click_devices_dropdown('Create LVM2 volume group'),
                                expect=lambda: self.dialog_is_present('disks', disk1) and
-                               self.dialog_is_present('disks', "unpartitioned space on Linux scsi_debug"),
+                               self.dialog_is_present('disks', "unpartitioned space on " + disk1),
                                values={"disks": {disk1: True}})
 
         self.click_card_row("Storage", name="vgroup0")
 
         # Check the we are really using a partition on disk1 now
-        b.wait_in_text(self.card_row_col("LVM2 volume group", 1, 2), "Partition - Linux scsi_debug")
+        b.wait_in_text(self.card_row_col("LVM2 volume group", 1, 2), "Partition - Block device")
 
         # Add the unused space of disk2
         self.dialog_with_retry(trigger=lambda: b.click(self.card_button("LVM2 volume group",
@@ -320,6 +320,7 @@ class TestStorageLvm2(storagelib.StorageCase):
                                    'disks', "unpartitioned space on " + disk2),
                                values={"disks": {disk2: True}})
         b.wait_in_text(self.card_row_col("LVM2 volume group", 1, 2), "Partition - Block device")
+        b.wait_in_text(self.card_row_col("LVM2 volume group", 2, 2), "Partition - Block device")
 
     def testSnapshots(self):
         m = self.machine

--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -607,10 +607,10 @@ class TestStorageMountingLUKS(storagelib.StorageCase):
         # Add a disk and make two partitions on it, one on /run/foo
         # and one on /run/foo/bar
 
-        disk = self.add_ram_disk(100)
+        disk = self.add_loopback_disk(100, name="loop12")
         self.click_card_row("Storage", name=disk)
 
-        self.click_card_dropdown("Solid State Drive", "Create partition table")
+        self.click_card_dropdown("Block device", "Create partition table")
         self.dialog({"type": "gpt"})
         b.wait_text(self.card_row_col("GPT partitions", 1, 1), "Free space")
 
@@ -671,7 +671,7 @@ class TestStorageMountingLUKS(storagelib.StorageCase):
         self.dialog_wait_close()
 
         # Now /run/foo/bar should be noauto.
-        self.assert_in_configuration(disk + "2", "crypttab", "options", "noauto")
+        self.assert_in_configuration(disk + "p2", "crypttab", "options", "noauto")
         self.assertIn("noauto", m.execute("findmnt --fstab -n -o OPTIONS /run/foo/bar"))
 
         # Mount them again and check that initializing the disk will
@@ -694,7 +694,7 @@ class TestStorageMountingLUKS(storagelib.StorageCase):
             b.wait_text("#dialog tbody:nth-of-type(1) td[data-label=Location]", "/run/foo/bar")
             b.wait_text("#dialog tbody:nth-of-type(2) td[data-label=Location]", "/run/foo")
 
-        self.dialog_with_error_retry(trigger=lambda: self.click_card_dropdown("Solid State Drive",
+        self.dialog_with_error_retry(trigger=lambda: self.click_card_dropdown("Block device",
                                                                               "Create partition table"),
                                      first_setup=first_setup,
                                      errors=["Timed out waiting for object"])

--- a/test/verify/check-storage-msdos
+++ b/test/verify/check-storage-msdos
@@ -30,11 +30,11 @@ class TestStorageMsDOS(storagelib.StorageCase):
         self.login_and_go("/storage")
 
         # Add a disk
-        disk = self.add_ram_disk()
+        disk = self.add_loopback_disk()
         self.click_card_row("Storage", name=disk)
 
         # Format it with a DOS partition table
-        self.click_card_dropdown("Solid State Drive", "Create partition table")
+        self.click_card_dropdown("Block device", "Create partition table")
         self.dialog({"type": "dos"})
         b.wait_text(self.card_row_col("DOS partitions", 1, 1), "Free space")
 

--- a/test/verify/check-storage-partitions
+++ b/test/verify/check-storage-partitions
@@ -62,10 +62,10 @@ class TestStoragePartitions(storagelib.StorageCase):
 
         self.login_and_go("/storage")
 
-        disk = self.add_ram_disk()
+        disk = self.add_loopback_disk(size="50MiB")
         self.click_card_row("Storage", name=disk)
 
-        self.click_card_dropdown("Solid State Drive", "Create partition table")
+        self.click_card_dropdown("Block device", "Create partition table")
         self.dialog({"type": "gpt"})
         b.wait_text(self.card_row_col("GPT partitions", 1, 1), "Free space")
 
@@ -102,7 +102,7 @@ class TestStoragePartitions(storagelib.StorageCase):
         self.dialog_apply()
         self.dialog_wait_close()
 
-        testlib.wait(lambda: m.execute(f"lsblk -no SIZE {disk}1").strip() == "25M")
+        testlib.wait(lambda: m.execute(f"lsblk -no SIZE {disk}p1").strip() == "25M")
 
     def testResize(self):
         m = self.machine
@@ -110,10 +110,10 @@ class TestStoragePartitions(storagelib.StorageCase):
 
         self.login_and_go("/storage")
 
-        disk = self.add_ram_disk(100)
+        disk = self.add_loopback_disk("100MiB")
         self.click_card_row("Storage", name=disk)
 
-        self.click_card_dropdown("Solid State Drive", "Create partition table")
+        self.click_card_dropdown("Block device", "Create partition table")
         self.dialog({"type": "gpt"})
         b.wait_text(self.card_row_col("GPT partitions", 1, 1), "Free space")
 
@@ -169,12 +169,12 @@ class TestStoragePartitions(storagelib.StorageCase):
 
         self.login_and_go("/storage")
 
-        disk = self.add_ram_disk(100)
+        disk = self.add_loopback_disk("100MiB")
         self.click_card_row("Storage", name=disk)
 
         # GPT
 
-        self.click_card_dropdown("Solid State Drive", "Create partition table")
+        self.click_card_dropdown("Block device", "Create partition table")
         self.dialog({"type": "gpt"})
         b.wait_text(self.card_row_col("GPT partitions", 1, 1), "Free space")
 
@@ -203,7 +203,7 @@ class TestStoragePartitions(storagelib.StorageCase):
         # DOS
 
         b.click(self.card_parent_link())
-        self.click_card_dropdown("Solid State Drive", "Create partition table")
+        self.click_card_dropdown("Block device", "Create partition table")
         self.dialog({"type": "dos"})
         b.wait_text(self.card_row_col("DOS partitions", 1, 1), "Free space")
 

--- a/test/verify/check-storage-swap
+++ b/test/verify/check-storage-swap
@@ -28,14 +28,14 @@ class TestStorageswap(storagelib.StorageCase):
         b = self.browser
         m = self.machine
 
-        disk = self.add_ram_disk()
+        disk = self.add_loopback_disk()
         self.addCleanup(m.execute, f"swapoff {disk} || true; swapoff {disk}1 || true")
 
         self.login_and_go("/storage")
 
         # Create a swap partition on GPT
         self.click_card_row("Storage", name=disk)
-        self.click_card_dropdown("Solid State Drive", "Create partition table")
+        self.click_card_dropdown("Block device", "Create partition table")
         self.confirm()
         b.wait_text(self.card_row_col("GPT partitions", 1, 1), "Free space")
         self.click_dropdown(self.card_row("GPT partitions", 1), "Create partition")
@@ -45,17 +45,17 @@ class TestStorageswap(storagelib.StorageCase):
         # It should have been started and have a fstab entry
         self.click_card_row("GPT partitions", 1)
         b.wait_text(self.card_desc("Swap", "Used"), "0 B")
-        self.assertIn("defaults", m.execute(f"findmnt --fstab -n -o OPTIONS {disk}1"))
+        self.assertIn("defaults", m.execute(f"findmnt --fstab -n -o OPTIONS {disk}p1"))
 
         # Stopping should set it to noauto
         b.click(self.card_button("Swap", "Stop"))
         b.wait_text(self.card_desc("Swap", "Used"), "-")
-        self.assertIn("noauto", m.execute(f"findmnt --fstab -n -o OPTIONS {disk}1"))
+        self.assertIn("noauto", m.execute(f"findmnt --fstab -n -o OPTIONS {disk}p1"))
 
         # Start it again to test teardown below
         b.click(self.card_button("Swap", "Start"))
         b.wait_text(self.card_desc("Swap", "Used"), "0 B")
-        self.assertIn("defaults", m.execute(f"findmnt --fstab -n -o OPTIONS {disk}1"))
+        self.assertIn("defaults", m.execute(f"findmnt --fstab -n -o OPTIONS {disk}p1"))
 
         # It should have the right partition type
         b.wait_visible(self.card("Swap"))
@@ -70,7 +70,7 @@ class TestStorageswap(storagelib.StorageCase):
         self.click_card_dropdown("Swap", "Format")
         self.dialog_wait_open()
         self.dialog_set_val("type", "swap")
-        b.wait_in_text("#dialog .modal-footer-teardown", f"{disk}1")
+        b.wait_in_text("#dialog .modal-footer-teardown", f"{disk}p1")
         b.wait_in_text("#dialog .modal-footer-teardown", "stop, format")
         self.dialog_apply_secondary()
         self.dialog_wait_close()
@@ -79,8 +79,8 @@ class TestStorageswap(storagelib.StorageCase):
         # Delete the partition, the fstab entry should disappear
         self.click_card_dropdown("Partition", "Delete")
         self.confirm()
-        b.wait_visible(self.card("Solid State Drive"))
-        m.execute(f"! findmnt --fstab -n -o OPTIONS {disk}1")
+        b.wait_visible(self.card("Block device"))
+        m.execute(f"! findmnt --fstab -n -o OPTIONS {disk}p1")
 
         # Format as swap on the command line, starting it should add
         # fstab entry

--- a/test/verify/check-storage-used
+++ b/test/verify/check-storage-used
@@ -30,13 +30,13 @@ class TestStorageUsed(storagelib.StorageCase):
 
         self.login_and_go("/storage")
 
-        disk = self.add_ram_disk()
+        disk = self.add_loopback_disk()
         b.wait_visible(self.card_row("Storage", name=disk))
         m.execute(f"parted -s {disk} mktable msdos")
         m.execute(f"parted -s {disk} mkpart primary ext2 1M 25")
         m.execute("udevadm settle")
-        m.execute(f"echo einszweidrei | cryptsetup luksFormat --pbkdf-memory 32768 {disk}1")
-        m.execute(f"echo einszweidrei | cryptsetup luksOpen {disk}1 dm-test")
+        m.execute(f"echo einszweidrei | cryptsetup luksFormat --pbkdf-memory 32768 {disk}p1")
+        m.execute(f"echo einszweidrei | cryptsetup luksOpen {disk}p1 dm-test")
         m.execute("udevadm settle")
         m.execute("mke2fs -q -L TEST /dev/mapper/dm-test")
         m.execute("mount /dev/mapper/dm-test /mnt")
@@ -60,7 +60,7 @@ ExecStart=/usr/bin/sleep infinity
         # should be 'in use' but Cockpit can clean them all up anyway.
 
         self.click_card_row("Storage", name=disk)
-        b.wait_visible(self.card("Solid State Drive"))
+        b.wait_visible(self.card("Block device"))
 
         self.click_card_row("DOS partitions", 1)
         self.click_card_dropdown("ext2 filesystem", "Format")
@@ -101,7 +101,7 @@ ExecStart=/usr/bin/sleep infinity
         def retry_setup():
             self.dialog_set_val("type", "empty")
 
-        self.dialog_with_error_retry(trigger=lambda: self.click_card_dropdown("Solid State Drive",
+        self.dialog_with_error_retry(trigger=lambda: self.click_card_dropdown("Block device",
                                                                               "Create partition table"),
                                      first_setup=first_setup,
                                      retry_setup=retry_setup,


### PR DESCRIPTION
Something is causing partitions on drives backed by scsi-debug to be
permanently busy with kernel 6.9.0-64 in Testing Farm runs. Let's just
avoid them.
