### PR TITLE
Add docs about security contact and threat model

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Reporting Security Issues
+
+Please see https://access.redhat.com/security/team/contact/ for how to report
+an issue. Red Hat Product Security will also take reports for the version of
+cockpit in Git, even if that is not a Red Hat Product.
+
+We take security very seriously, and we aim to take immediate action to address
+serious security-related problems that involve cockpit or its infrastructure.
+
+Further details for the vulnerability process are linked from that page, like
+the preference for embargo disclosure timelines of less than 45 days.
+
+See also the documentation of [the threat model of
+cockpit](docs/threat-model.md).

--- a/doc/threat-model.md
+++ b/doc/threat-model.md
@@ -1,0 +1,9 @@
+Until there is a more concise explanation here about the threat model (what it
+defends against) and assurance case (why it is secure), one should be able to
+get the necessary informaion from this blog post:
+https://cockpit-project.org/blog/is-cockpit-secure.html
+
+The post is not exactly clear on this, but there could be a security boundary
+between cockpit-ws running on one host and another host where cockpit-bridge is
+spawned via ssh, where if the second host was infected with malware it should
+be prevented from harming the first.


### PR DESCRIPTION
I have linked to the good blog post as a starting point.

That specific file name in the Git root is now used by various tools.

For future reference what a threat model documentation looks like, a few links from my bookmarks are:
- https://github.com/TryQuiet/quiet/wiki/Threat-Model
- https://docs.openprivacy.ca/cwtch-security-handbook/risk.html
- https://code.briarproject.org/briar/briar/-/wikis/threat-model