### PR TITLE
Link from Docbook dev docs to Markdown files

### DIFF
--- a/doc/guide/cockpit-guide.xml
+++ b/doc/guide/cockpit-guide.xml
@@ -53,6 +53,7 @@
 
   <part id="development">
     <title>Developer Guide</title>
+    <subtitle>See also the documentation in <ulink url="https://github.com/cockpit-project/cockpit/tree/main/doc">the .md files directly in the doc folder of the cockpit source</ulink> and <ulink url="https://github.com/cockpit-project/cockpit/blob/main/HACKING.md">the HACKING.md file in the source</ulink>. These are currently not rendered here, but only the content of the folder doc/guide in the source is rendered here. Help is welcome in converting this documentation from Docbook XML to Markdown and merging these.</subtitle>
     <xi:include href="embedding.xml"/>
     <xi:include href="packages.xml"/>
     <xi:include href="urls.xml"/>


### PR DESCRIPTION
There seems to be a hesitance of adding developer documentation.
Hopefully this makes it clear that people can just add Markdown files.

This should also ensure that people reading the website do not miss the
docs only in the source.

The intent of putting it in the subtitle, even when that is not
semantically ideal, is to have this visible also on the table of
contents page.