### PR TITLE
tools: Conditionally install AppArmor profile in Debian/Ubuntu

### DIFF
--- a/tools/debian/cockpit-ws.install
+++ b/tools/debian/cockpit-ws.install
@@ -1,6 +1,5 @@
 etc/cockpit/ws-certs.d
 etc/pam.d/cockpit
-tools/apparmor.d/cockpit-desktop etc/apparmor.d/
 ${env:deb_systemdsystemunitdir}/cockpit.service
 ${env:deb_systemdsystemunitdir}/cockpit-motd.service
 ${env:deb_systemdsystemunitdir}/cockpit.socket

--- a/tools/debian/cockpit-ws.postinst
+++ b/tools/debian/cockpit-ws.postinst
@@ -13,8 +13,8 @@ if [ -d /run/systemd/system ] && [ -n "$2" ]; then
 fi
 
 # update AppArmor profile
-if [ "$1" = "configure" ] && aa-enabled --quiet 2>/dev/null; then
-    apparmor_parser -r -T -W /etc/apparmor.d/cockpit-desktop || true
+if [ "$1" = "configure" ] && [ -e /etc/apparmor.d/cockpit-desktop ] && aa-enabled --quiet 2>/dev/null; then
+    apparmor_parser -r -T -W /etc/apparmor.d/cockpit-desktop
 fi
 
 # set up dynamic motd/issue symlinks on first-time install or upgrades from < 244 (which moved them out of the .deb)

--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -2,6 +2,9 @@
 
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
+# we need an apparmor profile for >= 4.0; this exists in Ubuntu >= 24.04, but not in Debian yet
+PRE4AA = $(filter $(shell . /etc/os-release; echo $${VERSION_ID:-unstable}),22.04 11 12 unstable)
+
 # riscv is an emulated architecture for now, and too slow to run expensive unit tests
 # hppa's threading is absurdly slow (#981127)
 SLOW_ARCHES = $(filter $(shell dpkg-architecture -qDEB_BUILD_ARCH),riscv64 hppa)
@@ -51,6 +54,15 @@ override_dh_install:
 	dh_install -Xusr/src/debug
 	# we don't need this, it contains full build paths and breaks reproducibility
 	rm -r debian/tmp/usr/lib/python*/*-packages/*.dist-info
+
+        # AppArmor profile
+ifeq ($(PRE4AA),)
+	mkdir -p debian/cockpit-ws/etc/apparmor.d/
+	install -p -m 644 tools/apparmor.d/cockpit-desktop debian/cockpit-ws/etc/apparmor.d/
+else
+	# clean up in debian unstable after broken 317-1
+	echo 'rm_conffile /etc/apparmor.d/cockpit-desktop 317-2~' > debian/cockpit-ws.maintscript
+endif
 
 	make install-tests DESTDIR=debian/cockpit-tests
 


### PR DESCRIPTION
Commit 5659be39388b introduced an AppArmor profile for Ubuntu 24.04. However, loading that fails in Debian, as even unstable still has AppArmor 3.x, and that profile requires 4.x. This causes apparmor.service to fail to start after a reboot.

```
Installing new version of config file /etc/pam.d/cockpit ...
AppArmor parser error for /etc/apparmor.d/cockpit-desktop in profile /etc/apparmor.d/cockpit-desktop at line 1: Could not open 'abi/4.0': No such file or directory

```

This was hidden before because the postinst ignored `apparmor_parser` errors: Refine the condition and make these fatal instead, so that we immediately spot bugs in CI.

Conditionally install the AppArmor profile, and add transition code to remove the profile when upgrading from a broken version.

https://bugs.debian.org/1072517

----

This is tricky to test in CI, but I manually tested an upgrade from 317-1 to 317.dev16+g3b9c57223.dirty-1 (i.e. local build), and it works:
```
Setting up cockpit-ws (317-1) ...
Installing new version of config file /etc/pam.d/cockpit ...
AppArmor parser error for /etc/apparmor.d/cockpit-desktop in profile /etc/apparmor.d/cockpit-desktop at line 1: Could not open 'abi/4.0'
: No such file or directory

# dpkg -s cockpit-ws
Package: cockpit-ws
Version: 317-1
Conffiles:
 /etc/apparmor.d/cockpit-desktop 9a03adf321bfdbee025a306720644654
 /etc/pam.d/cockpit 563206a8e24b5b95c25036426774b12d
[...]

# dpkg -iO /tmp/*.deb
Setting up cockpit-ws (317.dev16+g3b9c57223.dirty-1) ...
Removing obsolete conffile /etc/apparmor.d/cockpit-desktop ...

# dpkg -s cockpit-ws
Package: cockpit-ws
Version: 317.dev16+g3b9c57223.dirty-1
Conffiles:
 /etc/pam.d/cockpit 563206a8e24b5b95c25036426774b12d
```

and after a reboot, `apparmor.service` is happy and `systemctl --failed` is empty.