### PR TITLE
tools: Drop i686 build on CentOS/RHEL 9 as well

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -53,7 +53,7 @@ Version:        0
 Release:        1%{?dist}
 Source0:        https://github.com/cockpit-project/cockpit/releases/download/%{version}/cockpit-%{version}.tar.xz
 
-%if 0%{?fedora} >= 41 || 0%{?rhel} >= 10
+%if 0%{?fedora} >= 41 || 0%{?rhel}
 ExcludeArch: %{ix86}
 %endif
 


### PR DESCRIPTION
The pcp i686 regression now affects CentOS/RHEL 9 as well, causing unit test crashes/build hangs. But CentOS/RHEL don't even publish i686 packages, so building them is entirely in vain.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2284431