### PR TITLE
cockpit.js: make access to Gid field conditional

### DIFF
--- a/pkg/lib/cockpit.js
+++ b/pkg/lib/cockpit.js
@@ -2380,7 +2380,7 @@ function factory() {
                     .then(([user]) => {
                         the_user = {
                             id: user.Id.v,
-                            gid: user.Gid.v,
+                            gid: user.Gid?.v,
                             name: user.Name.v,
                             full_name: user.Full.v,
                             groups: user.Groups.v,


### PR DESCRIPTION
cockpit.js can be bundled with users which don't depend on the latest-and-greatest bridge version, so we have to deal with the case where this field isn't present.

Let's not bother mentioning that in the type annotations — things will catch up eventually.  The actual access to this properly is causing Oopses today, though, so it needs to be fixed.