### PR TITLE
fmf: Drop NetworkManager-team test dependency

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -37,6 +37,8 @@ if grep -q 'ID=.*fedora' /etc/os-release && [ "$PLAN" = "main" ]; then
     dnf install -y tcsh
     # required by TestJournal.testAbrt*
     dnf install -y abrt abrt-addon-ccpp reportd libreport-plugin-bugzilla libreport-fedora
+    # required by TestTeam
+    dnf install -y NetworkManager-team
 fi
 
 if grep -q 'ID=.*fedora' /etc/os-release && [ "$PLAN" = "storage-basic" ]; then

--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -18,7 +18,6 @@
     - glibc-all-langpacks
     - libvirt-daemon-config-network
     - firewalld
-    - NetworkManager-team
     - rpm-build
     - sssd
     - sssd-dbus


### PR DESCRIPTION
This package does not exist any more in RHEL 10 (but still in CentOS 10 stream, which is why the test passes there). Install it dynamically for Fedora instead.

---

This made the RHEL 10 release fail for 317.