### PR TITLE
bridge: report target info for '..' on fsinfo

### DIFF
--- a/test/pytest/test_bridge.py
+++ b/test/pytest/test_bridge.py
@@ -1363,6 +1363,16 @@ async def test_fsinfo_targets(transport: MockTransport, tmp_path: Path) -> None:
     (tmp_path / 'lloved').symlink_to('loved')
     entries['lloved'] = {'type': 'lnk', 'target': 'loved'}
 
+    # a link to the current directory won't show up in targets since we already
+    # report its attributes directly as our toplevel state structure
+    (tmp_path / 'ldot').symlink_to('.')
+    entries['ldot'] = {'type': 'lnk', 'target': '.'}
+
+    # a link to the parent directory should definitely show up, though
+    (tmp_path / 'ldotdot').symlink_to('..')
+    entries['ldotdot'] = {'type': 'lnk', 'target': '..'}
+    targets['..'] = {'type': 'dir'}
+
     # make sure the watch managed to pick that all up
     assert await watch.next_state() == state
 


### PR DESCRIPTION
The logic in fsinfo for reporting information on symlink targets is meant to report 'targets' iff the information isn't already reported elsewhere.  That's mostly done by checking if the symlink target contains a "/" anywhere in it and matching it against our effective fnmatch.

There are two cases that weren't considered, however: '.' and '..'. Those don't have a "/", so in the case where fnmatch is `*` (the default) they will never be reported (since `listdir()` doesn't return them and inotify doesn't report on those names).  In the case where fnmatch is something that doesn't match `.` and `..` then they will both always be reported.

Both cases are wrong.  '.' should never be reported: we already report those attributes on the toplevel, so why deliver a second copy? '..' should always be reported: there's no way that this will ever be a among the 'entries' of the current directory (even if it fnmatches).

Add special cases to ensure that '.' is never reported and '..' is always reported (if encountered as the target of a symlink).

Add tests to make sure that this is working.

See https://github.com/cockpit-project/cockpit-files/pull/502