### PR TITLE
lib: Accept `false` values in manifest configuration

### DIFF
--- a/pkg/lib/utils.jsx
+++ b/pkg/lib/utils.jsx
@@ -36,7 +36,7 @@ export function fmt_to_fragments(fmt) {
 
 function try_fields(dict, fields, def) {
     for (let i = 0; i < fields.length; i++)
-        if (fields[i] && dict[fields[i]])
+        if (fields[i] && dict[fields[i]] !== undefined)
             return dict[fields[i]];
     return def;
 }


### PR DESCRIPTION
More precisely check if a key is defined -- specifying `false` in the manifest should count as a match. This didn't affect Apps and Storage, but it does affect Machines:
https://github.com/cockpit-project/cockpit-machines/pull/1671