### PR TITLE
tools: Bring back static cockpit-ws system user creation on Debian

### DIFF
--- a/tools/debian/cockpit-ws.postinst
+++ b/tools/debian/cockpit-ws.postinst
@@ -3,6 +3,12 @@ set -e
 
 #DEBHELPER#
 
+# HACK: This is normally a DynamicUser=, but Debian's default nsswitch doesn't include `passwd: systemd`
+if ! grep 'passwd:.*\bsystemd\b' /etc/nsswitch.conf; then
+    echo "nss-systemd not configured, so DynamicUser= does not work. Creating static cockpit-ws user"
+    adduser --system --group --home /nonexistent --no-create-home --quiet cockpit-ws
+fi
+
 if ! dpkg-statoverride --list /usr/lib/cockpit/cockpit-session >/dev/null; then
     dpkg-statoverride --update --add root cockpit-wsinstance 4750 /usr/lib/cockpit/cockpit-session
 fi

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -33,7 +33,7 @@ Build-Depends: debhelper-compat (= 13),
                procps <!nocheck>,
                python3-pytest-asyncio <!nocheck>,
                python3-pytest-timeout <!nocheck>,
-Standards-Version: 4.6.2
+Standards-Version: 4.7.0
 Homepage: https://cockpit-project.org/
 Vcs-Git: https://salsa.debian.org/utopia-team/cockpit.git
 Vcs-Browser: https://salsa.debian.org/utopia-team/cockpit
@@ -124,7 +124,7 @@ Depends: ${misc:Depends},
          python3,
          python3-dbus
 Suggests: udisks2-btrfs,
-          udisks2-lvm2, 
+          udisks2-lvm2,
           mdadm,
 Description: Cockpit user interface for storage
  The Cockpit components for interacting with storage.


### PR DESCRIPTION
Debian's /etc/nsswitch.conf doesn't include "passwd: systemd" by default, which breaks services with `DynamicUser=yes`. So we can't use that in Debian unconditionally yet (Ubuntu does set it up).

Go back to the static `adduser` call in that case.

---

This works everywhere else, but we didn't see that in our debian-testing tests as that image has a pre-existing `cockpit-ws` user from the pre-installed 311 version. The next image refresh won't have that any more, though. This was spotted by [autopkgtest](https://ci.debian.net/packages/c/cockpit/testing/amd64/47370887/). I tested this in a local VM with cleaned up static user, and committed it to Debian: https://salsa.debian.org/utopia-team/cockpit/-/commit/285b75cfb93