### PR TITLE
test: Bump PCP config dialog timeout

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -75,7 +75,7 @@ def redisService(image):
 
 def applySettings(browser, dialog_selector):
     browser.click(f"{dialog_selector} button.pf-m-primary")
-    with browser.wait_timeout(30):
+    with browser.wait_timeout(60):
         browser.wait_not_present(dialog_selector)
 
 


### PR DESCRIPTION
On RHEL/CentOS 10 this often times out or hits the roof:

> Waiting for !ph_is_present("#pcp-settings-modal:first-child") took 28.5 seconds, which is 94% of the timeout.

Increase the timeout. While that's somewhat absurd, it's not our problem/bug, and dialogs with a spinner are often expected to take long to apply settings.

---

See https://github.com/cockpit-project/bots/pull/6474

Fixes [flake from the weather report](https://ci-weather-cockpit.apps.ocp.cloud.ci.centos.org/tests.html?days=7&repo=cockpit-project%2Fcockpit&test=test%2Fverify%2Fcheck-metrics+TestGrafanaClient.testBasic)