### PR TITLE
test: tuned 2.23 fixes

### DIFF
--- a/test/verify/check-system-tuned
+++ b/test/verify/check-system-tuned
@@ -76,18 +76,18 @@ class TestTuned(testlib.MachineCase):
         b.wait_visible(f"{body_selector} li > button.pf-m-selected .pf-v5-c-label:contains('recommended')")
         b.wait_visible(f"{body_selector} li > button.pf-m-selected .pf-v5-c-label:contains('active')")
 
-        b.click(f"{body_selector} li[data-value='balanced'] > button")
-        b.wait_visible(f"{body_selector} li > button.pf-m-selected p:contains('balanced')")
+        b.click(f"{body_selector} li[data-value='desktop'] > button")
+        b.wait_visible(f"{body_selector} li > button.pf-m-selected p:contains('desktop')")
 
         b.click(f"{body_selector} button.pf-m-primary")
         b.wait_not_present(title_selector)
 
-        b.wait_text('#tuned-status-button', "balanced")
+        b.wait_text('#tuned-status-button', "desktop")
         check_status_tooltip("This system is using a custom profile")
 
         # Check the status of tuned, it should show the profile
         output = m.execute("tuned-adm active 2>&1 || true")
-        self.assertIn("balanced", output)
+        self.assertIn("desktop", output)
         output = m.execute("systemctl status tuned")
         self.assertIn("enabled;", output)
 

--- a/test/verify/check-system-tuned
+++ b/test/verify/check-system-tuned
@@ -76,7 +76,7 @@ class TestTuned(testlib.MachineCase):
         b.wait_visible(f"{body_selector} li > button.pf-m-selected .pf-v5-c-label:contains('recommended')")
         b.wait_visible(f"{body_selector} li > button.pf-m-selected .pf-v5-c-label:contains('active')")
 
-        b.click(f"{body_selector} li > button p:contains('balanced')")
+        b.click(f"{body_selector} li[data-value='balanced'] > button")
         b.wait_visible(f"{body_selector} li > button.pf-m-selected p:contains('balanced')")
 
         b.click(f"{body_selector} button.pf-m-primary")


### PR DESCRIPTION
This fixes the tuned [rawhide failures](https://artifacts.dev.testing-farm.io/a1d98007-75db-4903-b753-a7c9d0f91fe9/) that recently started to make our and selinux-policy's tests red.

Noe that they will still fail due to ABRT #20559, but TestTuned* should succeed now.