### PR TITLE
shell: Fix and test skip links

### DIFF
--- a/pkg/shell/indexes.jsx
+++ b/pkg/shell/indexes.jsx
@@ -90,7 +90,7 @@ function MachinesIndex(index_options, machines, loader) {
     Array.from(skiplinks).forEach(skiplink => {
         skiplink.addEventListener("click", ev => {
             document.getElementById(ev.target.hash.substring(1)).focus();
-            return false;
+            ev.preventDefault();
         });
     });
 

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -565,6 +565,11 @@ class Browser:
             args["type"] = "keyUp"
             self.cdp.invoke("Input.dispatchKeyEvent", **args)
 
+    # FIXME: This should be key_press(), and key_press() should be something else
+    def key(self, name: str) -> None:
+        self.cdp.invoke("Input.dispatchKeyEvent", type="keyDown", key=name)
+        self.cdp.invoke("Input.dispatchKeyEvent", type="keyUp", key=name)
+
     def select_from_dropdown(self, selector: str, value: object) -> None:
         self.wait_visible(selector + ':not([disabled]):not([aria-disabled=true])')
         text_selector = f"{selector} option[value='{value}']"

--- a/test/verify/check-shell-host-switching
+++ b/test/verify/check-shell-host-switching
@@ -439,16 +439,7 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
 
         def tab(n):
             for _ in range(n):
-                args = {"type": "keyDown", "key": "Tab"}
-                b.cdp.invoke("Input.dispatchKeyEvent", **args)
-                args["type"] = "keyUp"
-                b.cdp.invoke("Input.dispatchKeyEvent", **args)
-
-        def enter():
-            args = {"type": "keyDown", "key": "Enter"}
-            b.cdp.invoke("Input.dispatchKeyEvent", **args)
-            args["type"] = "keyUp"
-            b.cdp.invoke("Input.dispatchKeyEvent", **args)
+                b.key("Tab")
 
         # <input type="color /> is rather difficult to set with tests
         # On Firefox the popup window cannot be targeted nor with mouse nor keayboard
@@ -464,7 +455,7 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
             b.key_press("0")
             tab(1)
             b.key_press("0")
-            enter()
+            b.key("Enter")
 
         b.click('#hosts_setup_server_dialog .pf-m-primary')
         with b.wait_timeout(30):

--- a/test/verify/check-shell-menu
+++ b/test/verify/check-shell-menu
@@ -158,6 +158,58 @@ class TestMenu(testlib.MachineCase):
         b.wait_visible("#login-info-message")
         b.wait_text("#login-info-message", "You have been logged out due to inactivity.")
 
+    def testKeyboardNavigation(self):
+        b = self.browser
+        self.login_and_go()
+
+        # initially shows host switcher
+        b.wait_visible("#host-toggle")
+        self.assertEqual(b.eval_js("document.activeElement.tagName"), "BODY")
+        # conceptually we want that, but we use CSS hacks (-999 offset and 1x1 size) to hide it
+        # b.wait_not_visible(".skiplink")
+
+        # press Tab once → "Skip to content" skiplink
+        b.key("Tab")
+        b.wait_js_cond("document.activeElement.classList.contains('skiplink')")
+        self.assertEqual(b.eval_js("document.activeElement.textContent"), "Skip to content")
+        self.assertEqual(b.eval_js("document.activeElement.getAttribute('href')"), "#content")
+        b.key("Enter")
+        b.wait_js_cond("document.activeElement.getAttribute('id') === 'content'")
+        self.assertEqual(b.eval_js("document.activeElement.tagName"), "DIV")
+        self.assertEqual(b.eval_js("document.activeElement.getAttribute('id')"), "content")
+
+        # reset
+        b.reload()
+        b.wait_visible("#host-toggle")
+
+        # press Tab twice → "Skip main navigation" skiplink
+        b.key("Tab")
+        self.assertEqual(b.eval_js("document.activeElement.textContent"), "Skip to content")
+        b.key("Tab")
+        self.assertEqual(b.eval_js("document.activeElement.textContent"), "Skip main navigation")
+        b.key("Enter")
+        b.wait_js_cond("document.activeElement.tagName === 'NAV'")
+        self.assertEqual(b.eval_js("document.activeElement.getAttribute('id')"), "hosts-sel")
+
+        # actually skips the page menu and goes on to top nav bar
+        b.key("Tab")
+        b.wait_js_cond("document.activeElement.getAttribute('id') === 'host-toggle'")
+        b.key("Tab")
+        if self.machine.ostree_image:
+            b.wait_js_cond("document.activeElement.textContent === 'Help'")
+        else:
+            b.wait_js_cond("document.activeElement.textContent === 'Administrative access'")
+
+        # reset
+        b.reload()
+        b.wait_visible("#host-toggle")
+
+        # without skip links, tabbing goes through page menu
+        for _ in range(5):
+            b.key("Tab")
+        # different browsers behave a bit different here -- Firefox is at "Overview", Chromium at "Logs"
+        b.wait_js_cond("document.activeElement.classList.contains('pf-v5-c-nav__link')")
+
 
 if __name__ == '__main__':
     testlib.test_main()


### PR DESCRIPTION
We don't want the skiplinks to *actually* change the URL -- they will go
from e.g. `/system` to `/cockpit/@localhost/shell/index.html#content`.
This causes a page reload, breaks the focusing, and is also not an URL
which we actually want to expose. Fix this by stopping event
progression.

Also remove the `return false` -- event handlers don't return anything.

Introduce a `TestMenu.testKeyboardNavigation` -- skip links and tabbing
was previously not tested at all.

[1] https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#the_event_listener_callback

----

Preparation for #20553 -- let's first test skiplinks before we change them.