### PR TITLE
storaged: support creating btrfs snapshots

### DIFF
--- a/pkg/storaged/btrfs/get-path-uuid.py
+++ b/pkg/storaged/btrfs/get-path-uuid.py
@@ -1,0 +1,30 @@
+import os
+import os.path
+import subprocess
+import sys
+
+
+def main(path):
+    # If the path does not exist, we will create but need to verify it lives on the same volume
+    if not os.path.exists(path):
+        if path.endswith('/'):
+            path = path.rstrip('/')
+        path = os.path.dirname(path)
+
+        # bail out if the parent path is not found
+        if not os.path.exists(path):
+            sys.exit(2)
+
+    try:
+        sys.stdout.write(subprocess.check_output(["findmnt", "--output", "UUID,fstype", "--json", "--target", path]).decode().strip())
+    except subprocess.SubprocessError as exc:
+        print(exc, file=sys.stderr)
+        sys.exit(3)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        sys.stderr.write("Path not provided\n")
+        sys.exit(1)
+
+    main(sys.argv[1])

--- a/pkg/storaged/btrfs/get-path-uuid.py
+++ b/pkg/storaged/btrfs/get-path-uuid.py
@@ -1,4 +1,6 @@
-import os
+# Copyright (C) 2026 Red Hat, Inc.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 import os.path
 import subprocess
 import sys
@@ -16,7 +18,9 @@ def main(path):
             sys.exit(2)
 
     try:
-        sys.stdout.write(subprocess.check_output(["findmnt", "--output", "UUID,fstype", "--json", "--target", path]).decode().strip())
+        sys.stdout.write(subprocess.check_output(["findmnt", "--output",
+                                                  "UUID,fstype", "--json",
+                                                  "--target", path]).decode().strip())
     except subprocess.SubprocessError as exc:
         print(exc, file=sys.stderr)
         sys.exit(3)

--- a/pkg/storaged/btrfs/subvolume.jsx
+++ b/pkg/storaged/btrfs/subvolume.jsx
@@ -22,11 +22,12 @@ import {
     get_fstab_config_with_client, reload_systemd,
     flatten, teardown_active_usage,
 } from "../utils.js";
-import { btrfs_usage, validate_subvolume_name, parse_subvol_from_options, validate_snapshot_path } from "./utils.jsx";
+import { btrfs_usage, validate_subvolume_name, parse_subvol_from_options, validate_snapshots_location } from "./utils.jsx";
 import { at_boot_input, update_at_boot_input, mounting_dialog, mount_options } from "../filesystem/mounting-dialog.jsx";
 import {
     dialog_open, TextInput, CheckBoxes,
     TeardownMessage, init_teardown_usage,
+    SelectOneRadioVerticalTextInput,
 } from "../dialog.jsx";
 import { check_mismounted_fsys, MismountAlert } from "../filesystem/mismounting.jsx";
 import {
@@ -261,60 +262,111 @@ function subvolume_delete(volume, subvol, mount_point_in_parent, card) {
     });
 }
 
-function snapshot_create(volume, subvol, parent_dir) {
+async function snapshot_create(volume, subvol, parent_dir) {
     const block = client.blocks[volume.path];
-
-    let action_variants = [
-        { tag: null, Title: _("Create and mount") },
-        { tag: "nomount", Title: _("Create only") }
+    console.log(volume, subvol);
+    const action_variants = [
+        { tag: null, Title: _("Create snapshot") },
     ];
 
-    if (client.in_anaconda_mode()) {
-        action_variants = [
-            { tag: "nomount", Title: _("Create") }
-        ];
-    }
+    const getCurrentDate = async () => {
+        const out = await cockpit.spawn(["date", "+%s"]);
+        const now = parseInt(out.trim()) * 1000;
+        const d = new Date(now);
+        d.setSeconds(0);
+        d.setMilliseconds(0);
+        return d;
+    };
+
+    const folder_exists = async (path) => {
+        // Check if path does not exist and can be created
+        try {
+            await cockpit.spawn(["test", "-d", path]);
+            return true;
+        } catch {
+            return false;
+        }
+    };
+
+    const date = await getCurrentDate();
+    const current_date = date.toISOString().split("T")[0];
+    const current_date_time = date.toISOString().replace(":00.000Z", "");
+    const choices = [
+        {
+            value: "current_date",
+            title: cockpit.format(_("Current date $0"), current_date),
+        },
+        {
+            value: "current_date_time",
+            title: cockpit.format(_("Current date and time $0"), current_date_time),
+        },
+        {
+            value: "custom_name",
+            title: _("Custom name"),
+            type: "radioWithInput",
+        },
+    ];
 
     dialog_open({
         Title: _("Create snapshot"),
         Fields: [
-            TextInput("path", _("Path"),
+            TextInput("subvolume", _("Subvolume"),
                       {
-                          validate: path => validate_snapshot_path(path)
+                          value: subvol.pathname,
+                          disabled: true,
                       }),
-            CheckBoxes("readonly", _("Read-only"),
+            TextInput("snapshots_location", _("Snapshots location"),
+                      {
+                          placeholder: cockpit.format(_("Example, $0"), "/.snapshots"),
+                          explanation: _("Snapshots must reside within their subvolume."),
+                          validate: path => validate_snapshots_location(path, volume),
+                      }),
+            SelectOneRadioVerticalTextInput("snapshot_name", _("Snapshot name"),
+                                            {
+                                                value: { checked: "current_date", inputs: { } },
+                                                choices,
+                                                validate: (val, _values, _variant) => {
+                                                    if (val.checked === "custom_name")
+                                                        return validate_subvolume_name(val.inputs.custom_name);
+                                                }
+                                            }),
+
+            CheckBoxes("readonly", _("Option"),
                        {
                            fields: [
-                               { tag: "on", title: _("Make the new snapshot readonly") }
+                               { tag: "on", title: _("Read-only") }
                            ],
                        }),
-            TextInput("mount_point", _("Mount Point"),
-                      {
-                          validate: (val, _values, variant) => {
-                              return is_valid_mount_point(client,
-                                                          block,
-                                                          client.add_mount_point_prefix(val),
-                                                          variant == "nomount");
-                          }
-                      }),
-            mount_options(false, false),
-            at_boot_input(),
         ],
-        update: update_at_boot_input,
         Action: {
             Variants: action_variants,
             action: async function (vals) {
+                // Create snapshot location if it does not exists
+                console.log("values", vals);
+                const exists = await folder_exists(vals.snapshots_location);
+                if (!exists) {
+                    await cockpit.spawn(["btrfs", "subvolume", "create", vals.snapshots_location], { superuser: "require", err: "message" });
+                }
+
                 // HACK: cannot use block_btrfs.CreateSnapshot as it always creates a subvolume relative to MountPoints[0] which
                 // makes it impossible to handle a situation where we have multiple subvolumes mounted.
                 // https://github.com/storaged-project/udisks/issues/1242
                 const cmd = ["btrfs", "subvolume", "snapshot"];
-                if (vals.readonly)
+                if (vals.readonly?.on)
                     cmd.push("-r");
-                await cockpit.spawn([...cmd, parent_dir, vals.path], { superuser: "require", err: "message" });
-                await btrfs_poll();
-                if (vals.mount_point !== "") {
-                    await set_mount_options(subvol, block, vals);
+                let snapshot_name = "";
+                if (vals.snapshot_name.checked == "current_date") {
+                    snapshot_name = current_date;
+                } else if (vals.snapshot_name.checked === "current_date_time") {
+                    snapshot_name = current_date_time;
+                } else if (vals.snapshot_name.checked === "custom_name") {
+                    snapshot_name = vals.snapshot_name.inputs.custom_name;
                 }
+                console.log([...cmd, `/${subvol.pathname}`, `${vals.snapshots_location}/${snapshot_name}`]);
+                // TODO: need full path to subvolume
+                // ERROR: cannot snapshot '/home': Read-only file system
+                // This happens when a snapshot already exists!
+                await cockpit.spawn([...cmd, `/${subvol.pathname}`, `${vals.snapshots_location}/${snapshot_name}`], { superuser: "require", err: "message" });
             }
         }
     });

--- a/pkg/storaged/btrfs/subvolume.jsx
+++ b/pkg/storaged/btrfs/subvolume.jsx
@@ -262,10 +262,10 @@ function subvolume_delete(volume, subvol, mount_point_in_parent, card) {
     });
 }
 
-async function snapshot_create(volume, subvol, parent_dir) {
+async function snapshot_create(volume, subvol, subvolume_path) {
     const block = client.blocks[volume.path];
     const localstorage_key = "storage:snapshot-locations";
-    console.log(volume, subvol);
+    console.log(volume, subvol, subvolume_path);
     const action_variants = [
         { tag: null, Title: _("Create snapshot") },
     ];
@@ -394,9 +394,9 @@ async function snapshot_create(volume, subvol, parent_dir) {
                     cmd.push("-r");
 
                 const snapshot_name = get_snapshot_name(vals);
-                console.log([...cmd, `/${subvol.pathname}`, `${vals.snapshots_location}/${snapshot_name}`]);
+                console.log([...cmd, subvolume_path, `${vals.snapshots_location}/${snapshot_name}`]);
                 const snapshot_location = `${vals.snapshots_location}/${snapshot_name}`;
-                await cockpit.spawn([...cmd, `/${subvol.pathname}`, snapshot_location], { superuser: "require", err: "message" });
+                await cockpit.spawn([...cmd, subvolume_path, snapshot_location], { superuser: "require", err: "message" });
                 localStorage.setItem(localstorage_key, JSON.stringify({ ...getLocalStorageSnapshotLocs(), [subvol.id]: vals.snapshots_location }));
 
                 // Re-trigger btrfs poll so the users sees the created snapshot in the overview or subvolume detail page

--- a/pkg/storaged/btrfs/subvolume.jsx
+++ b/pkg/storaged/btrfs/subvolume.jsx
@@ -264,10 +264,31 @@ function subvolume_delete(volume, subvol, mount_point_in_parent, card) {
 
 async function snapshot_create(volume, subvol, parent_dir) {
     const block = client.blocks[volume.path];
+    const localstorage_key = "storage:snapshot-locations";
     console.log(volume, subvol);
     const action_variants = [
         { tag: null, Title: _("Create snapshot") },
     ];
+
+    const getLocalStorageSnapshotLocs = () => {
+        const localstorage_snapshot_data = localStorage.getItem(localstorage_key);
+        if (localstorage_snapshot_data === null)
+            return null;
+
+        try {
+            return JSON.parse(localstorage_snapshot_data);
+        } catch (err) {
+            console.warn("localstorage btrfs snapshot locations data malformed", localstorage_snapshot_data);
+            return null;
+        }
+    };
+
+    const getSavedSnapshotLocation = subvol => {
+        const snapshot_locations = getLocalStorageSnapshotLocs();
+        if (snapshot_locations != null)
+            return snapshot_locations[subvol.id] || null;
+        return snapshot_locations;
+    };
 
     const getCurrentDate = async () => {
         const out = await cockpit.spawn(["date", "+%s"]);
@@ -279,7 +300,7 @@ async function snapshot_create(volume, subvol, parent_dir) {
     };
 
     const folder_exists = async (path) => {
-        // Check if path does not exist and can be created
+        // Check if path exist and can be created
         try {
             await cockpit.spawn(["test", "-d", path]);
             return true;
@@ -289,6 +310,7 @@ async function snapshot_create(volume, subvol, parent_dir) {
     };
 
     const date = await getCurrentDate();
+    // Convert dates to ISO-8601
     const current_date = date.toISOString().split("T")[0];
     const current_date_time = date.toISOString().replace(":00.000Z", "");
     const choices = [
@@ -307,6 +329,18 @@ async function snapshot_create(volume, subvol, parent_dir) {
         },
     ];
 
+    const get_snapshot_name = (vals) => {
+        let snapshot_name = "";
+        if (vals.snapshot_name.checked == "current_date") {
+            snapshot_name = current_date;
+        } else if (vals.snapshot_name.checked === "current_date_time") {
+            snapshot_name = current_date_time;
+        } else if (vals.snapshot_name.checked === "custom_name") {
+            snapshot_name = vals.snapshot_name.inputs.custom_name;
+        }
+        return snapshot_name;
+    };
+
     dialog_open({
         Title: _("Create snapshot"),
         Fields: [
@@ -317,8 +351,12 @@ async function snapshot_create(volume, subvol, parent_dir) {
                       }),
             TextInput("snapshots_location", _("Snapshots location"),
                       {
+                          value: getSavedSnapshotLocation(subvol),
                           placeholder: cockpit.format(_("Example, $0"), "/.snapshots"),
-                          explanation: _("Snapshots must reside within their subvolume."),
+                          explanation: (<>
+                              <p>{_("Snapshots must reside within the same btrfs volume.")}</p>
+                              <p>{_("When the snapshot location does not exist, it will be created as btrfs subvolume automatically.")}</p>
+                          </>),
                           validate: path => validate_snapshots_location(path, volume),
                       }),
             SelectOneRadioVerticalTextInput("snapshot_name", _("Snapshot name"),
@@ -354,19 +392,15 @@ async function snapshot_create(volume, subvol, parent_dir) {
                 const cmd = ["btrfs", "subvolume", "snapshot"];
                 if (vals.readonly?.on)
                     cmd.push("-r");
-                let snapshot_name = "";
-                if (vals.snapshot_name.checked == "current_date") {
-                    snapshot_name = current_date;
-                } else if (vals.snapshot_name.checked === "current_date_time") {
-                    snapshot_name = current_date_time;
-                } else if (vals.snapshot_name.checked === "custom_name") {
-                    snapshot_name = vals.snapshot_name.inputs.custom_name;
-                }
+
+                const snapshot_name = get_snapshot_name(vals);
                 console.log([...cmd, `/${subvol.pathname}`, `${vals.snapshots_location}/${snapshot_name}`]);
-                // TODO: need full path to subvolume
-                // ERROR: cannot snapshot '/home': Read-only file system
-                // This happens when a snapshot already exists!
-                await cockpit.spawn([...cmd, `/${subvol.pathname}`, `${vals.snapshots_location}/${snapshot_name}`], { superuser: "require", err: "message" });
+                const snapshot_location = `${vals.snapshots_location}/${snapshot_name}`;
+                await cockpit.spawn([...cmd, `/${subvol.pathname}`, snapshot_location], { superuser: "require", err: "message" });
+                localStorage.setItem(localstorage_key, JSON.stringify({ ...getLocalStorageSnapshotLocs(), [subvol.id]: vals.snapshots_location }));
+
+                // Re-trigger btrfs poll so the users sees the created snapshot in the overview or subvolume detail page
+                await btrfs_poll();
             }
         }
     });

--- a/pkg/storaged/btrfs/subvolume.jsx
+++ b/pkg/storaged/btrfs/subvolume.jsx
@@ -270,7 +270,7 @@ async function snapshot_create(volume, subvol, subvolume_path) {
         { tag: null, Title: _("Create snapshot") },
     ];
 
-    const getLocalStorageSnapshotLocs = () => {
+    const get_local_storage_snapshots_locs = () => {
         const localstorage_snapshot_data = localStorage.getItem(localstorage_key);
         if (localstorage_snapshot_data === null)
             return null;
@@ -283,14 +283,14 @@ async function snapshot_create(volume, subvol, subvolume_path) {
         }
     };
 
-    const getSavedSnapshotLocation = subvol => {
-        const snapshot_locations = getLocalStorageSnapshotLocs();
+    const get_localstorage_snapshot_location = subvol => {
+        const snapshot_locations = get_local_storage_snapshots_locs();
         if (snapshot_locations != null)
             return snapshot_locations[subvol.id] || null;
         return snapshot_locations;
     };
 
-    const getCurrentDate = async () => {
+    const get_current_date = async () => {
         const out = await cockpit.spawn(["date", "+%s"]);
         const now = parseInt(out.trim()) * 1000;
         const d = new Date(now);
@@ -309,7 +309,7 @@ async function snapshot_create(volume, subvol, subvolume_path) {
         }
     };
 
-    const date = await getCurrentDate();
+    const date = await get_current_date();
     // Convert dates to ISO-8601
     const current_date = date.toISOString().split("T")[0];
     const current_date_time = date.toISOString().replace(":00.000Z", "");
@@ -351,7 +351,7 @@ async function snapshot_create(volume, subvol, subvolume_path) {
                       }),
             TextInput("snapshots_location", _("Snapshots location"),
                       {
-                          value: getSavedSnapshotLocation(subvol),
+                          value: get_localstorage_snapshot_location(subvol),
                           placeholder: cockpit.format(_("Example, $0"), "/.snapshots"),
                           explanation: (<>
                               <p>{_("Snapshots must reside within the same btrfs volume.")}</p>
@@ -397,7 +397,7 @@ async function snapshot_create(volume, subvol, subvolume_path) {
                 console.log([...cmd, subvolume_path, `${vals.snapshots_location}/${snapshot_name}`]);
                 const snapshot_location = `${vals.snapshots_location}/${snapshot_name}`;
                 await cockpit.spawn([...cmd, subvolume_path, snapshot_location], { superuser: "require", err: "message" });
-                localStorage.setItem(localstorage_key, JSON.stringify({ ...getLocalStorageSnapshotLocs(), [subvol.id]: vals.snapshots_location }));
+                localStorage.setItem(localstorage_key, JSON.stringify({ ...get_local_storage_snapshots_locs(), [subvol.id]: vals.snapshots_location }));
 
                 // Re-trigger btrfs poll so the users sees the created snapshot in the overview or subvolume detail page
                 await btrfs_poll();

--- a/pkg/storaged/btrfs/subvolume.jsx
+++ b/pkg/storaged/btrfs/subvolume.jsx
@@ -22,10 +22,10 @@ import {
     get_fstab_config_with_client, reload_systemd,
     flatten, teardown_active_usage,
 } from "../utils.js";
-import { btrfs_usage, validate_subvolume_name, parse_subvol_from_options } from "./utils.jsx";
+import { btrfs_usage, validate_subvolume_name, parse_subvol_from_options, validate_snapshot_path } from "./utils.jsx";
 import { at_boot_input, update_at_boot_input, mounting_dialog, mount_options } from "../filesystem/mounting-dialog.jsx";
 import {
-    dialog_open, TextInput,
+    dialog_open, TextInput, CheckBoxes,
     TeardownMessage, init_teardown_usage,
 } from "../dialog.jsx";
 import { check_mismounted_fsys, MismountAlert } from "../filesystem/mismounting.jsx";
@@ -180,7 +180,7 @@ function subvolume_create(volume, subvol) {
     });
 }
 
-function subvolume_delete(volume, subvol, card) {
+function subvolume_delete(volume, subvol, mount_point_in_parent, card) {
     const block = client.blocks[volume.path];
     const subvols = client.uuids_btrfs_subvols[volume.data.uuid];
     const mount_point_in_parent = get_rw_mount_point_in_parent(volume, subvol);
@@ -258,6 +258,65 @@ function subvolume_delete(volume, subvol, card) {
         Inits: [
             init_teardown_usage(client, usage)
         ]
+    });
+}
+
+function snapshot_create(volume, subvol, parent_dir) {
+    const block = client.blocks[volume.path];
+
+    let action_variants = [
+        { tag: null, Title: _("Create and mount") },
+        { tag: "nomount", Title: _("Create only") }
+    ];
+
+    if (client.in_anaconda_mode()) {
+        action_variants = [
+            { tag: "nomount", Title: _("Create") }
+        ];
+    }
+
+    dialog_open({
+        Title: _("Create snapshot"),
+        Fields: [
+            TextInput("path", _("Path"),
+                      {
+                          validate: path => validate_snapshot_path(path)
+                      }),
+            CheckBoxes("readonly", _("Read-only"),
+                       {
+                           fields: [
+                               { tag: "on", title: _("Make the new snapshot readonly") }
+                           ],
+                       }),
+            TextInput("mount_point", _("Mount Point"),
+                      {
+                          validate: (val, _values, variant) => {
+                              return is_valid_mount_point(client,
+                                                          block,
+                                                          client.add_mount_point_prefix(val),
+                                                          variant == "nomount");
+                          }
+                      }),
+            mount_options(false, false),
+            at_boot_input(),
+        ],
+        update: update_at_boot_input,
+        Action: {
+            Variants: action_variants,
+            action: async function (vals) {
+                // HACK: cannot use block_btrfs.CreateSnapshot as it always creates a subvolume relative to MountPoints[0] which
+                // makes it impossible to handle a situation where we have multiple subvolumes mounted.
+                // https://github.com/storaged-project/udisks/issues/1242
+                const cmd = ["btrfs", "subvolume", "snapshot"];
+                if (vals.readonly)
+                    cmd.push("-r");
+                await cockpit.spawn([...cmd, parent_dir, vals.path], { superuser: "require", err: "message" });
+                await btrfs_poll();
+                if (vals.mount_point !== "") {
+                    await set_mount_options(subvol, block, vals);
+                }
+            }
+        }
     });
 }
 
@@ -377,6 +436,12 @@ function make_btrfs_subvolume_page(parent, volume, subvol, path_prefix, subvols)
         title: _("Create subvolume"),
         excuse: create_excuse,
         action: () => subvolume_create(volume, subvol),
+    });
+
+    actions.push({
+        title: _("Create snapshot"),
+        excuse: create_excuse,
+        action: () => snapshot_create(volume, subvol, (mounted && !opt_ro) ? mount_point : mount_point_in_parent),
     });
 
     // Don't show deletion for the root subvolume as it can never be deleted.

--- a/pkg/storaged/btrfs/utils.jsx
+++ b/pkg/storaged/btrfs/utils.jsx
@@ -5,6 +5,8 @@
 import cockpit from "cockpit";
 
 import { decode_filename } from "../utils.js";
+import * as python from "python.js";
+import get_path_uuid from "./get-path-uuid.py";
 
 const _ = cockpit.gettext;
 
@@ -75,7 +77,45 @@ export function validate_subvolume_name(name) {
         return cockpit.format(_("Name cannot contain the character '/'."));
 }
 
-export function validate_snapshot_path(path) {
+export async function validate_snapshots_location(path, volume) {
     if (path === "")
-        return _("Path cannot be empty.");
+        return _("Location cannot be empty.");
+
+    try {
+        const output = await python.spawn([get_path_uuid], [path],
+                                          { environ: ["LANGUAGE=" + (cockpit.language || "en")] });
+        console.log(output);
+        const path_info = JSON.parse(output);
+        if (path_info.filesystems.length !== 1)
+            return _("Unable to detect filesystem for given path");
+
+        const fs = path_info.filesystems[0];
+        if (fs.fstype !== "btrfs")
+            return _("Provided path is not btrfs");
+
+        if (fs.uuid !== volume.data.uuid)
+            return _("Snapshot location needs to be on the same btrfs volume");
+    } catch (err) {
+        if (err.exit_status == 2)
+            return _("Parent of snapshot location does not exist");
+        console.warn("Unable to detect UUID of snapshot location", err);
+    }
+    // const path_exists = await folder_exists(path);
+    // // Verify that the parent is in the same btrfs volume
+    // if (!path_exists) {
+    // }
+    //
+    // try {
+    //     const output = await cockpit.spawn(["findmnt", "-o", "UUID", "-n", "-T", path], { err: "message" });
+    //     const uuid = output.trim();
+    //     if (uuid !== volume.data.uuid) {
+    //         return _("Snapshot location needs to be on the same btrfs volume");
+    //     }
+    // } catch (err) {
+    //     console.log(err);
+    //     if (err?.message === "") {
+    //         return _("Given path does not exist");
+    //     }
+    //     console.warn("Unable to detect UUID of snapshot location", err);
+    // }
 }

--- a/pkg/storaged/btrfs/utils.jsx
+++ b/pkg/storaged/btrfs/utils.jsx
@@ -74,3 +74,8 @@ export function validate_subvolume_name(name) {
     if (name.includes('/'))
         return cockpit.format(_("Name cannot contain the character '/'."));
 }
+
+export function validate_snapshot_path(path) {
+    if (path === "")
+        return _("Path cannot be empty.");
+}

--- a/pkg/storaged/btrfs/verify-btrfs-snapshot-location.py
+++ b/pkg/storaged/btrfs/verify-btrfs-snapshot-location.py
@@ -1,0 +1,30 @@
+import os
+import os.path
+import subprocess
+import sys
+
+
+def main(path):
+    # If the path does not exist, we will create but need to verify it lives on the same volume
+    if not os.path.exists(path):
+        if path.endswith('/'):
+            path = path.rstrip('/')
+        path = os.path.dirname(path)
+
+        # bail out if the parent path is not found
+        if not os.path.exists(path):
+            sys.exit(2)
+
+    try:
+        print(subprocess.check_output(["findmnt", "--output", "UUID", "--no-heading", "--target", path]))
+    except subprocess.SubprocessError as exc:
+        print(exc, file=sys.stderr)
+        sys.exit(3)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        sys.stdout.write("Path not provided\n")
+        sys.exit(1)
+
+    main(sys.argv[1])

--- a/pkg/storaged/btrfs/verify-btrfs-snapshot-location.py
+++ b/pkg/storaged/btrfs/verify-btrfs-snapshot-location.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2026 Red Hat, Inc.
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-import os
 import os.path
 import subprocess
 import sys

--- a/pkg/storaged/btrfs/verify-btrfs-snapshot-location.py
+++ b/pkg/storaged/btrfs/verify-btrfs-snapshot-location.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2026 Red Hat, Inc.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 import os
 import os.path
 import subprocess

--- a/pkg/storaged/dialog.jsx
+++ b/pkg/storaged/dialog.jsx
@@ -306,7 +306,7 @@ const Row = ({ field, values, errors, onChange }) => {
         );
     } else if (!field.bare) {
         return (
-            <FormGroup hasNoPaddingTop={field.hasNoPaddingTop}>
+            <FormGroup isInline={field.isInline || false} hasNoPaddingTop={field.hasNoPaddingTop}>
                 { field_elts }
                 { nested_elts }
             </FormGroup>
@@ -645,6 +645,7 @@ export const TextInput = (tag, title, options) => {
         title,
         options,
         initial_value: options.value || "",
+        isInline: options.isInline || false,
 
         render: (val, change, validated) =>
             <TextInputPF4 data-field={tag} data-field-type="text-input"
@@ -773,6 +774,48 @@ export const SelectOneRadio = (tag, title, options) => {
                         {fields}
                     </Split>);
             }
+        }
+    };
+};
+
+export const SelectOneRadioVerticalTextInput = (tag, title, options) => {
+    return {
+        tag,
+        title,
+        options,
+        initial_value: options.value || { checked: {}, inputs: {} },
+        hasNoPaddingTop: true,
+
+        render: (val, change) => {
+            const fieldset = options.choices.map(c => {
+                const ftag = tag + "." + c.value;
+                const fval = val.checked === c.value;
+                const tval = val.inputs[c.value] || '';
+                function fchange(newval) {
+                    val.checked = newval;
+                    change(val);
+                }
+
+                function tchange(newval) {
+                    val.inputs[c.value] = newval;
+                    change(val);
+                }
+
+                return (
+                    <React.Fragment key={c.value}>
+                        <Radio isChecked={fval} data-data={fval}
+                            id={ftag}
+                            onChange={() => fchange(c.value)} label={c.title} />
+                        {fval !== false && c?.type === "radioWithInput" && <TextInputPF4 id={ftag + "-input"} value={tval} onChange={(_event, value) => tchange(value)} />}
+                    </React.Fragment>
+                );
+            });
+
+            return (
+                <div data-field={tag} data-field-type="select-radio">
+                    {fieldset}
+                </div>
+            );
         }
     };
 };

--- a/pkg/storaged/dialog.jsx
+++ b/pkg/storaged/dialog.jsx
@@ -653,6 +653,7 @@ export const TextInput = (tag, title, options) => {
                           aria-label={title}
                           value={val}
                           isDisabled={options.disabled}
+                          placeholder={options.placeholder}
                           onChange={(_event, value) => change(value)} />
     };
 };


### PR DESCRIPTION
Btrfs supports creating a snapshot of a subvolume, either readonly or write-able. Unlike creating subvolumes, it doesn't make sense to put a snapshot of a subvolume in the subvolume itself users likely have a special `snapshots` subvolume where they collect their snapshots.

Open questions:
* Unlike subvolumes we don't want to create a snapshot in the parent directory, I have given the UI an option to specify a full path, this is good and bad. Good because it is flexible, bad because it would allow you to specify a path to a NFS mount, xfs partition or something else weird. Then again it isn't too bad, note that snapshots can be created under a subvolume or normal directory in btrfs. (Users usually have a snapshot subvolume directory where they put them either `/snapshots or `/.snapshots`, this is not a well-known directory)
* Do we offer mount options? You can obviously mount them like subvolumes as they are one, so we can offer that flexibility


Follow up / issues:
* We don't identify snapshots, we just show it as subvolume
* We don't and likely can't identify read only snapshots, this requires major udisks work.

---

# Support creating btrfs snapshots


![Screenshot from 2024-06-07 11-36-05](https://github.com/cockpit-project/cockpit/assets/67428/7fe17494-3f9a-47bc-8ad1-e0c8e5132425)

Snapshot creation dialog:

![image](https://github.com/cockpit-project/cockpit/assets/67428/af02c72e-125a-4bcd-8e4f-a519e9c11a5a)
