### PR TITLE
users: Fix crash on nonexisting lastlog

### DIFF
--- a/pkg/users/users.js
+++ b/pkg/users/users.js
@@ -176,8 +176,6 @@ async function getLogins(logind_client) {
         LastLogPath = "lastlog";
     }
 
-    const lastlog = await cockpit.spawn([LastLogPath], { environ: ["LC_ALL=C"] });
-
     const currentLogins = [];
     try {
         // out args: uso (uid, name, logind object)
@@ -213,6 +211,13 @@ async function getLogins(logind_client) {
         if (err.message && !err.message.includes("bad argument --all")) {
             console.warn("Unexpected error when getting locked account information", err);
         }
+    }
+
+    let lastlog = "";
+    try {
+        lastlog = await cockpit.spawn([LastLogPath], { environ: ["LC_ALL=C"] });
+    } catch (ex) {
+        console.warn(`Failed to run ${LastLogPath}: ${ex.toString()}`);
     }
 
     // drop header and last empty line with slice

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -140,6 +140,7 @@ Depends: ${misc:Depends},
          openssl,
 # policykit-1 was split into multiple packages; keep old name for Debian 11 and Ubuntu
 Recommends: sudo | pkexec | policykit-1
+Suggests: lastlog2
 Provides: cockpit-shell,
           cockpit-systemd,
           cockpit-tuned,


### PR DESCRIPTION
If `lastlog` is not installed, and neither is `lastlog2`, `getLogins()` ran into an uncaught "not-found" exception due to the spawn failure. The page then never finished loading.

Move the lastlog call closer to where the output is parsed, and handle failure.

----

Spotted in https://github.com/cockpit-project/bots/pull/6491 . This makes the tests mostly work (other than of course the actual "last login" checks)