### PR TITLE
lastlog2 fixes

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1804,6 +1804,7 @@ class MachineCase(unittest.TestCase):
 
         # btmp tracking
         "cockpit-session: pam: Last failed login:.*",
+        "cockpit-session: pam: Last login: .*",
         "cockpit-session: pam: There .* failed login attempts? since the last successful login.",
 
         # pam_lastlog complaints

--- a/test/verify/check-system-journal
+++ b/test/verify/check-system-journal
@@ -179,16 +179,8 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         wait_journal_empty()
 
         def wait_slow10():
-            systemd_version = int(m.execute("systemctl --version | awk '{print $2; exit}'").strip())
-
-            if systemd_version >= 248:
-                # changed in https://github.com/systemd/systemd/commit/f5ec78e503
-                stop_message = "Deactivated successfully."
-            else:
-                stop_message = "Succeeded."
-
             with b.wait_timeout(30):
-                wait_log_lines([["systemd", "slow10.service: " + stop_message, ""], ["sh", "SLOW", "10"],
+                wait_log_lines([["systemd", "slow10.service: Deactivated successfully.", ""], ["sh", "SLOW", "10"],
                                 ["systemd", "Started.*Slowly log 10 identical lines.", ""]])
 
         def wait_log_present(message):

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -402,6 +402,7 @@ class TestAccounts(testlib.MachineCase):
 
         # Clean out the relevant logfiles
         m.execute("truncate -s0 /var/log/{[bw]tmp,lastlog} /var/run/utmp")
+        m.execute("rm -f /var/lib/lastlog/lastlog2.db /var/lib/wtmpdb/wtmp.db")
 
         self.login_and_go("/users")
         # Create a locked user with weak password
@@ -1072,6 +1073,7 @@ class TestAccounts(testlib.MachineCase):
 
         # Clean out the relevant logfiles
         m.execute("truncate -s0 /var/log/{[bw]tmp,lastlog} /var/run/utmp")
+        m.execute("rm -f /var/lib/lastlog/lastlog2.db /var/lib/wtmpdb/wtmp.db")
 
         # Login once to create an entry
         self.login_and_go("/users")


### PR DESCRIPTION
Spotted by https://github.com/cockpit-project/bots/pull/6491 . The [failures](https://cockpit-logs.us-east-1.linodeobjects.com/pull-6491-b6cc24bb-20240612-091310-debian-testing-other-cockpit-project-cockpit/log.html)  pass for me locally now and also [in CI](https://cockpit-logs.us-east-1.linodeobjects.com/pull-20579-6e46779f-20240612-145132-debian-testing-other-bots%236491/log.html).

~This still has a TODO item, the `passwd -S --all` fallback is a bit tricky to do here. See [failures](https://cockpit-logs.us-east-1.linodeobjects.com/pull-20579-6e46779f-20240612-145019-rhel-9-5-other/log.html)~ Fixed.