### PR TITLE
test/static-code: make mypy deps configurable

### DIFF
--- a/test/mypy-deps
+++ b/test/mypy-deps
@@ -1,0 +1,3 @@
+src/cockpit/_vendor/bei/__init__.py
+src/cockpit/_vendor/ferny/__init__.py
+src/cockpit/_vendor/systemd_ctypes/__init__.py

--- a/test/static-code
+++ b/test/static-code
@@ -41,8 +41,8 @@ test_ruff() {
 if [ "${WITH_PARTIAL_TREE:-0}" = 0 ]; then
     test_mypy() {
         command -v mypy >/dev/null || skip 'no mypy'
-        for pkg in systemd_ctypes ferny bei; do
-            test -e "src/cockpit/_vendor/${pkg}/__init__.py" || skip "no ${pkg}"
+        for file in $(cat test/mypy-deps 2>/dev/null || true); do
+            test -e "${file}" || skip "no ${file}"
         done
         find_python_files | xargs -r -0 mypy --no-error-summary
     }


### PR DESCRIPTION
We hardcode a check for systemd_ctypes, ferny, and beiboot in test/static-code and skip running mypy if they're not checked out, but that doesn't make sense for the other projects which use this script.

Move the configuration to a separate file, so each package can provide their own.  If no file is present, there are no dependencies: this is expected to be the normal case for starter-kit-based projects.