### PR TITLE
pkg/sosreport: Generate sos reports in /var/tmp to display them

### DIFF
--- a/pkg/sosreport/sosreport.jsx
+++ b/pkg/sosreport/sosreport.jsx
@@ -149,7 +149,7 @@ function sosCreate(args, setProgress, setError, setErrorDetail) {
     const starting_regex = /Starting ([0-9]+)\/([0-9]+).*\[Running: (.*)\]/;
 
     // TODO - Use a real API instead of scraping stdout once such an API exists
-    const task = cockpit.spawn(["sos", "report", "--batch"].concat(args),
+    const task = cockpit.spawn(["sos", "report", "--batch", "--tmp-dir", "/var/tmp"].concat(args),
                                { superuser: "require", err: "out", pty: true });
 
     task.stream(text => {


### PR DESCRIPTION
In this plugin, the static path "/var/tmp" is used to search for SOS reports. Due to configurations in the "sos" program, the path for creating the reports may differ from this path. In order to create the reports for this plugin findable, the "sos" call is passed the parameters "--tmp-dir" with the value "/var/tmp" in order to generate the reports in the right place.

fix: #19617