### PR TITLE
tools: arch: add glib2-devel as makedependency

### DIFF
--- a/tools/arch/PKGBUILD
+++ b/tools/arch/PKGBUILD
@@ -11,7 +11,7 @@ pkgdesc='A systemd web based user interface for Linux servers'
 arch=('x86_64')
 url='https://cockpit-project.org/'
 license=(LGPL)
-makedepends=(krb5 libssh accountsservice json-glib glib-networking
+makedepends=(krb5 libssh accountsservice json-glib glib-networking glib2-devel
              git intltool gtk-doc gobject-introspection networkmanager xmlto npm pcp
              python-build python-installer python-wheel)
 source=("cockpit-${pkgver}.tar.xz"


### PR DESCRIPTION
glib2 has been split up into glib2-devel since 2.80.3-2.

https://lists.archlinux.org/archives/list/arch-dev-public@lists.archlinux.org/thread/FLUDH7DXL5CJNZPX4NAWKQO2QJF3PZCD/