### PR TITLE
test: Widen pasta hack for newer podman versions

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -744,8 +744,8 @@ class TestCurrentMetrics(testlib.MachineCase):
         self.busybox_image = m.execute("podman images --format '{{.Repository}}' | grep busybox").strip()
         self.login_and_go("/metrics")
 
-        # hack around https://github.com/containers/podman/issues/21896 for our offline test VMs
-        if not m.execute("ip route show default").strip() and "5.0" in m.execute("podman version"):
+        # hack around https://bugzilla.redhat.com/show_bug.cgi?id=2277954 for our offline test VMs
+        if not m.execute("ip route show default").strip():
             m.execute("nmcli con add type dummy con-name fake ifname fake0 ip4 1.2.3.4/24 gw4 1.2.3.1")
             self.addCleanup(m.execute, "nmcli con delete fake")
 


### PR DESCRIPTION
podman 5.x trickles into more and more images, and and that point we just accept defeat. The issue still exists in current 5.1 and is tricky to "fix", see discussion on bugzilla.

Adjust the URL, as the upstream issue is closed.

---

Blocks https://github.com/cockpit-project/bots/pull/6501 , I trigger an extra run against that refreshed image.