### PR TITLE
test: Stop failing on SELinux messages in rawhide and CentOS 10

### DIFF
--- a/test/run
+++ b/test/run
@@ -65,6 +65,11 @@ case "${TEST_SCENARIO:=}" in
 
 esac
 
+# these are too volatile/ungated, we can't keep up with reporting issues
+if [ "$TEST_OS" = "fedora-rawhide" ] || [ "$TEST_OS" = "centos-10" ]; then
+    export TEST_AUDIT_NO_SELINUX=1
+fi
+
 if [ -n "$TEST_SCENARIO" ] && [ -z "$RUN_OPTS" ]; then
     echo "Unknown test scenario: $TEST_SCENARIO"
     exit 1


### PR DESCRIPTION
There's a new firehose of SELinux violations in these distros. They are just too messy, ungated, and we can't keep up with reporting all the issues any more.

Fixes #20542

----

See the issue and its tons of duplicates, plus the centos-10 refresh. I give up, and the rest of the team is even less keen on piloting. 🏳️