### PR TITLE
test: Stop failing on SELinux messages for all Fedoras

### DIFF
--- a/test/run
+++ b/test/run
@@ -66,7 +66,7 @@ case "${TEST_SCENARIO:=}" in
 esac
 
 # these are too volatile/ungated, we can't keep up with reporting issues
-if [ "$TEST_OS" = "fedora-rawhide" ] || [ "$TEST_OS" = "centos-10" ]; then
+if [ "${TEST_OS#fedora}" != "$TEST_OS" ] || [ "$TEST_OS" = "centos-10" ]; then
     export TEST_AUDIT_NO_SELINUX=1
 fi
 


### PR DESCRIPTION
Fedora 40 pending updates also cause all kinds of new errors.

Extends commit 86e2b69e8b.

Fixes #20542

----

See the two most recent duplicates from last night, #20603 and #20604. :exploding_head: 