### PR TITLE
lib: import Flex from the Flex directory

### DIFF
--- a/pkg/lib/cockpit-components-password.jsx
+++ b/pkg/lib/cockpit-components-password.jsx
@@ -27,11 +27,11 @@ import { Popover } from "@patternfly/react-core/dist/esm/components/Popover/inde
 import { Progress, ProgressMeasureLocation, ProgressSize } from "@patternfly/react-core/dist/esm/components/Progress/index.js";
 import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput/index.js";
 import { EyeIcon, EyeSlashIcon, HelpIcon } from '@patternfly/react-icons';
+import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex/index.js";
 
 import { FormHelper } from "cockpit-components-form-helper";
 
 import './cockpit-components-password.scss';
-import { Flex, FlexItem } from '@patternfly/react-core';
 
 const _ = cockpit.gettext;
 


### PR DESCRIPTION
Importing it via the global barrel file means we import the CSS of all patternfly components. This won't reduce our bundle for now as PatternFly table and other components still import via `@patternfly/react-core`.