### PR TITLE
flatpak: add cockpit-files to packages list

### DIFF
--- a/containers/flatpak/prepare
+++ b/containers/flatpak/prepare
@@ -23,6 +23,7 @@ RELEASES_XML = f'{FLATPAK_ID}.releases.xml'
 
 # Constants related to extra packages
 UPSTREAM_REPOS = [
+    'cockpit-project/cockpit-files',
     'cockpit-project/cockpit-machines',
     'cockpit-project/cockpit-ostree',
     'cockpit-project/cockpit-podman',


### PR DESCRIPTION
This will result in cockpit-files being included the next time we sync up with flathub (in the release workflow).