### PR TITLE
debian: Enable DynamicUser for cockpit-ws

### DIFF
--- a/tools/debian/cockpit-ws.postinst
+++ b/tools/debian/cockpit-ws.postinst
@@ -3,12 +3,6 @@ set -e
 
 #DEBHELPER#
 
-# HACK: This is normally a DynamicUser=, but Debian's default nsswitch doesn't include `passwd: systemd`
-if ! grep 'passwd:.*\bsystemd\b' /etc/nsswitch.conf; then
-    echo "nss-systemd not configured, so DynamicUser= does not work. Creating static cockpit-ws user"
-    adduser --system --group --home /nonexistent --no-create-home --quiet cockpit-ws
-fi
-
 if ! dpkg-statoverride --list /usr/lib/cockpit/cockpit-session >/dev/null; then
     dpkg-statoverride --update --add root cockpit-wsinstance 4750 /usr/lib/cockpit/cockpit-session
 fi

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -174,6 +174,7 @@ Depends: ${misc:Depends},
          adduser,
          openssl,
          systemd (>= 235),
+         libnss-systemd,
 Suggests: sssd-dbus (>= 2.6.2),
          python3,
 Description: Cockpit Web Service

--- a/tools/debian/tests/control
+++ b/tools/debian/tests/control
@@ -1,5 +1,6 @@
 Tests: smoke
 Depends: cockpit,
          curl,
+         adduser,
 Restrictions: isolation-container,
               needs-sudo,

--- a/tools/debian/tests/smoke
+++ b/tools/debian/tests/smoke
@@ -4,8 +4,10 @@ set -e
 trap 'if [ "$?" -ne 0 ]; then id cockpit-ws || true; systemctl --all | grep cockpit; sudo journalctl -b; fi' EXIT
 
 # HACK: debian stable kernel+LXC (running on ci.d.n) breaks DynamicUser=
-if uname -r | grep -q ^6.1; then
+# https://bugs.debian.org/1073815
+if uname -r | grep -q ^6.1 && systemd-detect-virt --container; then
     echo " * working around broken DynamicUser= support on Debian 12 kernel+LXC"
+    sudo adduser --system --group --home /nonexistent --no-create-home --quiet cockpit-ws
     sudo mkdir -p /etc/systemd/system/cockpit-ws-user.service.d
     printf '[Service]\nDynamicUser=no\n' | sudo tee /etc/systemd/system/cockpit-ws-user.service.d/no-dynamic.conf
     sudo systemctl daemon-reload


### PR DESCRIPTION
Depend on libnss-systemd to ensure that the "cockpit-ws" dynamic user can be resolved. With that we don't need to create a static system user any more.

Adjust the autopkgtest workaround to create that user instead, and add a bug reference. Restrict the hack to running inside of a container, as it works fine on the host.

Taken from downstream:
  https://salsa.debian.org/utopia-team/cockpit/-/commit/f9e34e9b6ea4630
  https://salsa.debian.org/utopia-team/cockpit/-/commit/87d81351f0f3eb6
  https://salsa.debian.org/utopia-team/cockpit/-/commit/7ad393cee5a212d