### PR TITLE
[r8] test: Drop Grafana selector class names

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1525,9 +1525,9 @@ class TestGrafanaClient(testlib.MachineCase):
 
             bg.wait_in_text("#var-host", "grafana-client")
 
-            # expect a "Load average" panel with a sensible number
-            max_load = bg.text("div:contains('Load average') .graph-legend-series:contains('1 minute') .max")
-            self.assertGreater(float(max_load), 0)
+            # expect a "Load average" panel with sensible numbers
+            bg.wait_in_text("div[data-testid*='Load average']", "minute")
+            self.assertRegex(bg.text("div[data-testid*='Load average']"), r"[0-9]\.[0-9]")
         except Exception:
             bg.snapshot("FAIL-grafana")
             raise


### PR DESCRIPTION
The latest Grafana version in the services refresh [1] replaced all human readable and sensible CSS classes with unpredictable junk like "css-140ea9t". So stop relying on the classes and just ensure that the "Load average" panel contains "minute" and any floating point number. This works with both the current and the new image.

[1] https://github.com/cockpit-project/bots/pull/6483

Cherry-picked from main commit f004e993ae56.