### PR TITLE
new async `Dialogs` interface, add `transport` to `cockpit.d.ts`

### DIFF
--- a/pkg/lib/cockpit.d.ts
+++ b/pkg/lib/cockpit.d.ts
@@ -32,6 +32,19 @@ declare module 'cockpit' {
 
     export let language: string;
 
+    interface Transport {
+        csrf_token: string;
+        origin: string;
+        host: string;
+        options: JsonObject;
+        uri(suffix?: string): string;
+        wait(callback: (transport: Transport) => void): void;
+        close(problem?: string): void;
+        application(): string;
+    }
+
+    export const transport: Transport;
+
     /* === jQuery compatible promise ============== */
 
     interface DeferredPromise<T> extends Promise<T> {

--- a/pkg/lib/cockpit.js
+++ b/pkg/lib/cockpit.js
@@ -324,8 +324,7 @@ function calculate_url(suffix) {
     } else if (window_loc.indexOf('https:') === 0) {
         return "wss://" + window.location.host + "/" + prefix + "/" + suffix;
     } else {
-        transport_debug("Cockpit must be used over http or https");
-        return null;
+        throw new Error("Cockpit must be used over http or https");
     }
 }
 

--- a/pkg/shell/active-pages-modal.jsx
+++ b/pkg/shell/active-pages-modal.jsx
@@ -25,12 +25,11 @@ import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.
 import { Label } from "@patternfly/react-core/dist/esm/components/Label/index.js";
 import { Split, SplitItem } from "@patternfly/react-core/dist/esm/layouts/Split/index.js";
 import { Modal } from "@patternfly/react-core/dist/esm/components/Modal/index.js";
-import { useDialogs } from "dialogs.jsx";
 import { useInit } from "hooks";
 
 const _ = cockpit.gettext;
 
-export const ActivePagesDialog = ({ frames }) => {
+export const ActivePagesDialog = ({ dialogResult, frames }) => {
     function get_pages() {
         const result = [];
         for (const address in frames.iframes) {
@@ -57,7 +56,6 @@ export const ActivePagesDialog = ({ frames }) => {
         return result;
     }
 
-    const Dialogs = useDialogs();
     const init_pages = useInit(get_pages, [frames]);
     const [pages, setPages] = useState(init_pages);
 
@@ -66,7 +64,7 @@ export const ActivePagesDialog = ({ frames }) => {
             if (element.selected)
                 frames.remove(element.host, element.component);
         });
-        Dialogs.close();
+        dialogResult.resolve();
     }
 
     const rows = pages.map(page => {
@@ -93,11 +91,11 @@ export const ActivePagesDialog = ({ frames }) => {
     return (
         <Modal isOpen position="top" variant="small"
                id="active-pages-dialog"
-               onClose={Dialogs.close}
+               onClose={() => dialogResult.resolve()}
                title={_("Active pages")}
                footer={<>
                    <Button variant='primary' onClick={onRemove}>{_("Close selected pages")}</Button>
-                   <Button variant='link' onClick={Dialogs.close}>{_("Cancel")}</Button>
+                   <Button variant='link' onClick={() => dialogResult.resolve()}>{_("Cancel")}</Button>
                </>}
         >
             <ListingTable showHeader={false}

--- a/pkg/shell/credentials.jsx
+++ b/pkg/shell/credentials.jsx
@@ -39,14 +39,12 @@ import { ListingPanel } from 'cockpit-components-listing-panel.jsx';
 import { ListingTable } from 'cockpit-components-table.jsx';
 import { ModalError } from 'cockpit-components-inline-notification.jsx';
 import { useEvent, useObject } from 'hooks';
-import { useDialogs } from "dialogs.jsx";
 
 import "./credentials.scss";
 
 const _ = cockpit.gettext;
 
-export const CredentialsModal = () => {
-    const Dialogs = useDialogs();
+export const CredentialsModal = ({ dialogResult }) => {
     const keys = useObject(() => credentials.keys_instance(), null, []);
     const [addNewKey, setAddNewKey] = useState(false);
     const [dialogError, setDialogError] = useState();
@@ -75,10 +73,10 @@ export const CredentialsModal = () => {
     return (
         <>
             <Modal isOpen position="top" variant="medium"
-                   onClose={Dialogs.close}
+                   onClose={() => dialogResult.resolve()}
                    title={_("SSH keys")}
                    id="credentials-modal"
-                   footer={<Button variant='secondary' onClick={Dialogs.close}>{_("Close")}</Button>}
+                   footer={<Button variant='secondary' onClick={() => dialogResult.resolve()}>{_("Close")}</Button>}
             >
                 <Stack hasGutter>
                     {dialogError && <ModalError dialogError={dialogError} />}

--- a/pkg/shell/shell-modals.jsx
+++ b/pkg/shell/shell-modals.jsx
@@ -30,14 +30,12 @@ import { Text, TextContent, TextList, TextListItem, TextVariants } from "@patter
 import { SearchIcon } from '@patternfly/react-icons';
 
 import { useInit } from "hooks";
-import { useDialogs } from "dialogs.jsx";
 
 import "menu-select-widget.scss";
 
 const _ = cockpit.gettext;
 
-export const AboutCockpitModal = () => {
-    const Dialogs = useDialogs();
+export const AboutCockpitModal = ({ dialogResult }) => {
     const [packages, setPackages] = useState(null);
 
     useInit(() => {
@@ -58,7 +56,7 @@ export const AboutCockpitModal = () => {
     return (
         <AboutModal
             isOpen
-            onClose={Dialogs.close}
+            onClose={() => dialogResult.resolve()}
             id="about-cockpit-modal"
             trademark={_("Licensed under GNU LGPL version 2.1")}
             productName={_("Web Console")}
@@ -88,10 +86,9 @@ export const AboutCockpitModal = () => {
     );
 };
 
-export const LangModal = () => {
+export const LangModal = ({ dialogResult }) => {
     const language = document.cookie.replace(/(?:(?:^|.*;\s*)CockpitLang\s*=\s*([^;]*).*$)|^.*$/, "$1") || "en-us";
 
-    const Dialogs = useDialogs();
     const [selected, setSelected] = useState(language);
     const [searchInput, setSearchInput] = useState("");
 
@@ -111,11 +108,11 @@ export const LangModal = () => {
         <Modal isOpen position="top" variant="small"
                id="display-language-modal"
                className="display-language-modal"
-               onClose={Dialogs.close}
+               onClose={() => dialogResult.resolve()}
                title={_("Display language")}
                footer={<>
                    <Button variant='primary' onClick={onSelect}>{_("Select")}</Button>
-                   <Button variant='link' onClick={Dialogs.close}>{_("Cancel")}</Button>
+                   <Button variant='link' onClick={() => dialogResult.resolve()}>{_("Cancel")}</Button>
                </>}
         >
             <Flex direction={{ default: 'column' }}>
@@ -183,13 +180,12 @@ export function TimeoutModal(props) {
     );
 }
 
-export function OopsModal(props) {
-    const Dialogs = useDialogs();
+export function OopsModal({ dialogResult }) {
     return (
         <Modal isOpen position="top" variant="medium"
-               onClose={Dialogs.close}
+               onClose={() => dialogResult.resolve()}
                title={_("Unexpected error")}
-               footer={<Button variant='secondary' onClick={Dialogs.close}>{_("Close")}</Button>}
+               footer={<Button variant='secondary' onClick={() => dialogResult.resolve()}>{_("Close")}</Button>}
         >
             {_("Cockpit had an unexpected internal error.")}
             <br />

--- a/pkg/shell/topnav.jsx
+++ b/pkg/shell/topnav.jsx
@@ -172,7 +172,7 @@ export class TopNav extends React.Component {
 
         docItems.push(<Divider key="separator1" />);
         docItems.push(<DropdownItem key="about" component="button"
-                                    onClick={() => Dialogs.show(<AboutCockpitModal />)}>
+                                    onClick={() => Dialogs.run(AboutCockpitModal, {})}>
             {_("About Web Console")}
         </DropdownItem>);
 
@@ -212,20 +212,20 @@ export class TopNav extends React.Component {
 
         if (manifest.locales)
             main_menu.push(<DropdownItem key="languages" className="display-language-menu"
-                                         onClick={() => Dialogs.show(<LangModal />)}>
+                                         onClick={() => Dialogs.run(LangModal, {})}>
                 {_("Display language")}
             </DropdownItem>);
 
         if (this.state.showActivePages)
             main_menu.push(
                 <DropdownItem key="frames" id="active-pages" component="button"
-                              onClick={() => Dialogs.show(<ActivePagesDialog frames={this.props.index.frames} />)}>
+                              onClick={() => Dialogs.run(ActivePagesDialog, { frames: this.props.index.frames })}>
                     {_("Active pages")}
                 </DropdownItem>);
 
         main_menu.push(
             <DropdownItem key="creds" id="sshkeys" component="button"
-                          onClick={() => Dialogs.show(<CredentialsModal />)}>
+                          onClick={() => Dialogs.run(CredentialsModal, {})}>
                 {_("SSH keys")}
             </DropdownItem>,
             <Divider key="separator3" />,
@@ -252,7 +252,7 @@ export class TopNav extends React.Component {
                             { this.props.index.has_oops &&
                                 <ToolbarItem>
                                     <Button id="navbar-oops" variant="link" size="lg" isDanger
-                                            onClick={() => Dialogs.show(<OopsModal />)}>{_("Ooops!")}</Button>
+                                            onClick={() => Dialogs.run(OopsModal, {})}>{_("Ooops!")}</Button>
                                 </ToolbarItem>
                             }
                             <ToolbarItem>


### PR DESCRIPTION
 - simplify the implementation of `<WithDialogs/>`/`useDialogs()` by dropping the `await Dialogs.show()` mode and replacing it with a simpler `await Dialogs.run()`.  Port it to TypeScript.
 - add `cockpit.transport` to the stub, making a very minor change to `cockpit.js` (on a path that should be essentially dead code).