### PR TITLE
plans: add cockpit-files reverse dependency testing

### DIFF
--- a/plans/files.fmf
+++ b/plans/files.fmf
@@ -1,0 +1,19 @@
+# reverse dependency test
+enabled: false
+
+adjust+:
+  when: revdeps == yes
+  enabled: true
+
+discover:
+    how: fmf
+    url: https://github.com/cockpit-project/cockpit-files
+    ref: "main"
+execute:
+    how: tmt
+
+# This has to duplicate cockpit-files's plan structure; see https://github.com/teemtee/tmt/issues/1770
+/files:
+    summary: Run cockpit-files tests
+    discover+:
+        test: /test/browser


### PR DESCRIPTION
Cockpit-files is the only user of fsinfo so far, so testing if it Cockpit pull requests do not break Cockpit-files main is beneficial for the Cockpit project.


---

Not entirely sure if this is just it, as we have no test separation in cockpit-files like podman but this seems correct?

```
[jelle@t14s][~/projects/cockpit-files]%toolbox enter rhel-developer-toolbox-latest
[jelle@⬢ rhel-developer-toolbox-latest][~/projects/cockpit-files]%tmt
Found 1 test: /test/browser.
Found 1 plan: /plans/all.
Found 0 stories.
```

It would be good to only trigger this on src/cockpit and pkg/lib changes but I am not sure if fmf can support that.