### PR TITLE
Add `fsinfo` client library and QUnit tests

### DIFF
--- a/files.js
+++ b/files.js
@@ -56,6 +56,7 @@ const info = {
         "base1/test-format.ts",
         "base1/test-framed-cache.js",
         "base1/test-framed.js",
+        "base1/test-fsinfo.ts",
         "base1/test-http.js",
         "base1/test-journal-renderer.js",
         "base1/test-locale.js",

--- a/pkg/base1/test-fsinfo.ts
+++ b/pkg/base1/test-fsinfo.ts
@@ -1,0 +1,160 @@
+import QUnit, { f } from "qunit-tests";
+
+import cockpit from "cockpit";
+import { FsInfoClient, FsInfoState, fsinfo } from "fsinfo";
+
+function fsinfo_err(errno: "ENOENT" | "EPERM" | "EACCES" | "ENOTDIR" | "ELOOP") {
+    const problems = {
+        ENOENT: 'not-found',
+        EPERM: 'access-denied',
+        EACCES: 'access-denied',
+        ENOTDIR: 'not-directory',
+        ELOOP: 'internal-error',
+    };
+    const strerr = {
+        ENOENT: 'No such file or directory',
+        EPERM: 'Access denied',
+        EACCES: 'Permission denied',
+        ENOTDIR: 'Not a directory',
+        ELOOP: 'Too many levels of symbolic links',
+    };
+
+    return { error: { errno, problem: problems[errno], message: strerr[errno] } };
+}
+
+QUnit.test("fsinfo trivial", async assert => {
+    // Make sure that it's not an error to open with no attributes requested
+    assert.deepEqual(await fsinfo("/", []), {}, "Yup, '/' is still there.");
+});
+
+QUnit.test("fsinfo errors", async assert => {
+    assert.timeout(5000);
+
+    // Just test that errors are reported correctly in general.  The unit test
+    // is more explicit about the specific error conditions that need to be
+    // checked for.
+    let thrown: string = '';
+    try {
+        await fsinfo("rel", []);
+        assert.ok(false, "fsinfo() error checking");
+    } catch (exc: any) { // eslint-disable-line @typescript-eslint/no-explicit-any
+        thrown = exc.problem;
+    }
+    assert.equal(thrown, 'protocol-error', "fsinfo() error checking");
+});
+
+QUnit.test("FsInfoClient errors", async assert => {
+    const client = new FsInfoClient("rel", []);
+    try {
+        // We want to get 'close' with a problem code, and no 'change'
+        const expected = await new Promise((resolve, reject) => {
+            client.on('close', (msg) => resolve(msg.problem));
+            client.on('change', reject);
+        });
+        assert.equal(expected, 'protocol-error', "FsInfoClient error checking");
+    } finally {
+        // Calling .close() after we got 'close' event is still OK.
+        client.close();
+    }
+});
+
+QUnit.test("fsinfo cases", async assert => {
+    assert.timeout(5000);
+
+    const dir = await cockpit.spawn([
+        'sh', '-c',
+        `
+           cd "$(mktemp -d)"
+           echo -n "$(pwd)"
+
+           # a normal directory
+           mkdir dir
+           echo dir file > dir/dir-file.txt
+           echo do not read this > dir-file.xtx
+
+           # a directory without +x (search)
+           mkdir no-x-dir
+           echo file > no-x-dir/no-x-dir-file.txt
+           chmod 644 no-x-dir
+
+           # a directory without +r (read)
+           mkdir no-r-dir
+           echo file > no-r-dir/no-r-dir-file.txt
+           chmod 311 no-r-dir
+
+           # a normal file
+           echo normal file > file
+
+           # a non-readable file
+           echo inaccessible file > no-r-file
+           chmod 0 no-r-file
+
+           # a device
+           ln -sf /dev/null dev
+
+           # a dangling symlink
+           ln -sf does-not-exist dangling
+
+           # a symlink pointing to itself
+           ln -sf loopy loopy
+        `
+    ]);
+
+    const cases: Record<string, FsInfoState> = {
+        dir: { info: { type: 'dir', entries: { 'dir-file.txt': { type: 'reg' } } } },
+
+        // can't stat() the file
+        'no-x-dir': { info: { type: "dir", entries: { "no-x-dir-file.txt": {} } } },
+
+        // can't read the directory, so no entries
+        'no-r-dir': { info: { type: "dir" } },
+
+        // normal file, can read its contents
+        file: { info: { type: "reg" } },
+
+        // can't read file, so no contents
+        'no-r-file': { info: { type: "reg" } },
+
+        // a device
+        dev: { info: { type: "chr" } },
+
+        // a dangling symlink
+        dangling: fsinfo_err('ENOENT'),
+
+        // a link pointing at itself
+        loopy: fsinfo_err('ELOOP'),
+    } as const;
+
+    try {
+        // Check the async one-shot non-watching API first
+        for (const [name, expected_state] of Object.entries(cases)) {
+            try {
+                const state = await fsinfo(`${dir}/${name}`, ['type', 'entries']);
+                assert.deepEqual(state, expected_state.info, f`fsinfo(${name})`);
+            } catch (exc) {
+                assert.deepEqual(exc, expected_state.error, f`fsinfo(${name})`);
+            }
+        }
+
+        // Now test the client (watcher)
+        for (let [name, expected_state] of Object.entries(cases)) {
+            const client = new FsInfoClient(`${dir}/${name}`, ['type', 'entries']);
+
+            // Watching requires read access to the directory
+            if (name.includes('no-r')) {
+                expected_state = fsinfo_err('EACCES');
+            }
+
+            // await the first state change: it's guaranteed to be the complete data
+            const value = await new Promise<FsInfoState>(resolve => { client.on('change', resolve) });
+            assert.deepEqual(value, expected_state, f`FsInfoClient(${name})`);
+
+            client.close();
+        }
+    } finally {
+        await cockpit.spawn(["chmod", "-R", "u+rwX", dir]);
+        await cockpit.spawn(["rm", "-rf", dir]);
+    }
+});
+
+QUnit.start();

--- a/pkg/lib/event.ts
+++ b/pkg/lib/event.ts
@@ -1,0 +1,36 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+export class EventEmitter<EM extends { [E in keyof EM]: (...args: never[]) => void }> {
+    #listeners: { [E in keyof EM]?: EM[E][] } = {};
+
+    public on<E extends keyof EM>(event: E, listener: EM[E]) {
+        const listeners = this.#listeners[event] ||= [];
+        listeners.push(listener);
+        return () => {
+            listeners.splice(listeners.indexOf(listener), 1);
+        };
+    }
+
+    protected emit<E extends keyof EM>(event: E, ...args: Parameters<EM[E]>) {
+        for (const listener of this.#listeners[event] || []) {
+            listener(...args);
+        }
+    }
+}

--- a/pkg/lib/fsinfo.ts
+++ b/pkg/lib/fsinfo.ts
@@ -1,0 +1,150 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+'use strict';
+
+import cockpit from 'cockpit';
+
+import { EventEmitter } from './event';
+
+function is_json_dict(value: cockpit.JsonValue): value is cockpit.JsonObject {
+    return value?.constructor === Object;
+}
+
+/* RFC 7396 — JSON Merge Patch — functional */
+function json_merge(current: cockpit.JsonValue, patch: cockpit.JsonValue): cockpit.JsonValue {
+    if (is_json_dict(patch)) {
+        const updated = is_json_dict(current) ? { ...current } : { };
+
+        for (const [key, value] of Object.entries(patch)) {
+            if (value === null) {
+                delete updated[key];
+            } else {
+                updated[key] = json_merge(updated[key], value);
+            }
+        }
+
+        return updated;
+    } else {
+        return patch;
+    }
+}
+
+export interface FileInfo {
+    type?: string;
+    tag?: string;
+    mode?: number;
+    size?: number;
+    uid?: number;
+    user?: string | number;
+    gid?: number;
+    group?: string | number;
+    mtime?: number;
+    target?: string;
+    entries?: Record<string, FileInfo>;
+    targets?: Record<string, FileInfo>;
+}
+
+export interface FsInfoError {
+    problem: string;
+    message: string;
+    errno: string;
+}
+
+export interface FsInfoState {
+    info?: FileInfo;
+    error?: FsInfoError;
+    loading?: true;
+}
+
+export interface FsInfoEvents {
+    change(state: FsInfoState): void;
+    close(message: cockpit.JsonObject): void;
+}
+
+export class FsInfoClient extends EventEmitter<FsInfoEvents> {
+    state: FsInfoState = { loading: true };
+
+    private partial_state: cockpit.JsonValue = null;
+    private channel: cockpit.Channel<string>;
+
+    constructor(path: string, attrs: (keyof FileInfo)[], options?: cockpit.JsonObject) {
+        super();
+
+        this.channel = cockpit.channel({
+            payload: "fsinfo",
+            path,
+            attrs,
+            watch: true,
+            ...options
+        });
+
+        this.channel.addEventListener("message", (_event, payload) => {
+            this.partial_state = json_merge(this.partial_state, JSON.parse(payload));
+
+            if (is_json_dict(this.partial_state) && !this.partial_state.partial) {
+                this.state = { ...this.partial_state };
+                this.emit('change', this.state);
+            }
+        });
+
+        this.channel.addEventListener("close", (_event, message) => {
+            this.emit('close', message);
+        });
+    }
+
+    close() {
+        this.channel.close();
+    }
+
+    static entry(info: FileInfo, name: string): FileInfo | null {
+        return info.entries?.[name] ?? null;
+    }
+
+    static target(info: FileInfo, name: string): FileInfo | null {
+        const entries = info.entries ?? {};
+        const targets = info.targets ?? {};
+
+        let entry = entries[name] ?? null;
+        for (let i = 0; i < 40; i++) {
+            const target = entry?.target;
+            if (!target)
+                return entry;
+            if (target === '.')
+                return info;
+            entry = entries[target] ?? targets[target] ?? null;
+        }
+        return null; // ELOOP
+    }
+}
+
+export function fsinfo(path: string, attrs: (keyof FileInfo)[], options?: cockpit.JsonObject): Promise<FileInfo> {
+    return new Promise((resolve, reject) => {
+        const client = new FsInfoClient(path, attrs, { ...options, watch: false });
+        client.on('close', (message) => {
+            if (message.problem) {
+                reject(message);
+            } else if (client.state.info) {
+                resolve(client.state.info);
+            } else {
+                reject(client.state.error);
+            }
+        });
+    });
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,9 +19,11 @@
             "dom",
             "es2020"
         ],
+        "moduleResolution": "node",
         "noEmit": true,  // we only use `tsc` for type checking
         "skipLibCheck": true,  // don't check node_modules
         "strict": true,
+        "target": "es2020",
     },
     "include": [
         "pkg/**/*"


### PR DESCRIPTION
This is almost exactly what's in Cockpit Files today.  I made a few small adjustments around the `loading` parameter (to make it easier to test) and I made the `close` event return the message so we can query the problem code (which is important for throwing exceptions from the async interface).