### PR TITLE
tsconfig: Disable checking .js[x] files by default

### DIFF
--- a/test/static-code
+++ b/test/static-code
@@ -73,7 +73,7 @@ if [ "${WITH_PARTIAL_TREE:-0}" = 0 ]; then
 	# We can't tell tsc to ignore the .d.ts in node_modules/ and check our
 	# own cockpit.d.ts, so we do two separate invocations as a workaround:
 	node_modules/.bin/tsc --typeRoots /dev/null --strict pkg/lib/cockpit.d.ts
-	node_modules/.bin/tsc --checkJs false --skipLibCheck
+	node_modules/.bin/tsc --skipLibCheck
     }
 fi
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
 {
     "compilerOptions": {
         "allowJs": true,
-        "checkJs": true,
+        "checkJs": false,
         "baseUrl": "./pkg/lib",
         "esModuleInterop": true,
         "exactOptionalPropertyTypes": true,


### PR DESCRIPTION
Pretending that all our *.js[x] files are meant to satisfy type checks is very annoying with vim/ALE, as it is now littered with e.g. "Parameter 'conn_to' implicitly has an 'any' type." in function declarations. It isn't possible to add annotations in .tsx files, and we are not going to port all our existing code anytime soon. Let's restrict the checks to .ts[x] files and drop the config override in test/static-code.

---

I don't understand the full ramifications of this change and don't know why it was introduced that way. Commit 9f7bd38b61cfc3b555e12568f0cd8bb6960f5d6e only talks about tsx files, not jsx. I confirmed that I still get typechecking errors in both ALE and test/static-code when I change/drop the annotations in e.g. pkg/lib/cockpit-components-context-menu.tsx