### PR TITLE
pkg/lib: remove wasOutside check from context menu

### DIFF
--- a/pkg/lib/cockpit-components-context-menu.tsx
+++ b/pkg/lib/cockpit-components-context-menu.tsx
@@ -47,12 +47,8 @@ export const ContextMenu = ({ parentId, children } : {
         };
 
         const _handleClick = (event: MouseEvent) => {
-            if (event && event.button === 0 && event.target instanceof HTMLElement) {
-                const wasOutside = root.current && !root.current.contains(event.target);
-
-                if (wasOutside)
-                    setVisible(false);
-            }
+            if (event.button === 0)
+                setVisible(false);
         };
 
         const parent = document.getElementById(parentId)!;


### PR DESCRIPTION
In f9b01663060c and d599d625e149 we've been trying to fix this code to make the `wasOutside` check "more correct".  The problem is that we actually always depended on it being broken.

The original version of the code before we started making changes would always close the menu on any click at all (because the comparison was broken).  This is actually the behaviour we need, because otherwise nothing will close the menu when we click on an item inside of it.

This is all sort of unfortunate, but let's just put it back to the way it effectively was by removing all of this `wasOutside` logic entirely. That means we're going to pop-down when the user clicks on a divider, but otherwise we have no way to tell the difference between dividers or other menu items (without making this all significantly more complex).