### PR TITLE
test: Adjust to kdump-utils split in Fedora 40

### DIFF
--- a/test/vm.updates-testing
+++ b/test/vm.updates-testing
@@ -5,4 +5,10 @@ set -eux
 exec >&2
 dnf config-manager --enable updates-testing
 dnf -y update --setopt=install_weak_deps=False
+
+# HACK: https://bodhi.fedoraproject.org/updates/FEDORA-2024-d70dfd026e
+# split the kexec-tools package; install kdump-utils manually until the next fedora-40 image refresh
+# after that bodhi update lands.
+dnf -y install kdump-utils
+
 /var/lib/download-package-sets.sh


### PR DESCRIPTION
https://bodhi.fedoraproject.org/updates/FEDORA-2024-d70dfd026e lands the kexec-tools split into Fedora 40. This temporarily breaks our "updates-testing" scenario as nothing installs kdump-utils into our image, and then the built rpms fail to install as /usr/bin/kdumpctl isn't available -- and `rpm -i` won't install it by itself.

Install it manually for now. This can be reverted after the next fedora-40 image refresh that includes that bodhi update.

Fixes #20660