### PR TITLE
build.js: support outputting esbuild metadata file

### DIFF
--- a/build.js
+++ b/build.js
@@ -50,8 +50,12 @@ const qunitOptions = {
 const parser = (await import('argparse')).default.ArgumentParser();
 parser.add_argument('-r', '--rsync', { help: "rsync bundles to ssh target after build", metavar: "HOST" });
 parser.add_argument('-w', '--watch', { action: 'store_true', help: "Enable watch mode" });
+parser.add_argument('-m', '--metafile', { help: "Enable bund size information file", metavar: "FILE" });
 parser.add_argument('onlydir', { nargs: '?', help: "The pkg/<DIRECTORY> to build (eg. base1, shell, ...)", metavar: "DIRECTORY" });
 const args = parser.parse_args();
+
+if (args.metafile)
+    pkgOptions.metafile = true;
 
 if (args.onlydir?.includes('/'))
     parser.error("Directory must not contain '/'");
@@ -201,7 +205,9 @@ async function build() {
         });
 
         try {
-            await Promise.all([pkgContext.rebuild(), qunitContext.rebuild()]);
+            const results = await Promise.all([pkgContext.rebuild(), qunitContext.rebuild()]);
+            if (args.metafile)
+                fs.writeFileSync(args.metafile, JSON.stringify(results[0].metafile));
         } catch (e) {
             if (!args.watch)
                 process.exit(1);


### PR DESCRIPTION
ESbuild supports outputting a metadata file which can be used to view bundle size information using https://esbuild.github.io/analyze/

Closes: #18267

---

This is a bit funny as it includes *everything* by default, but imo a useful exercise is `./build.js --metafile meta.json storaged`.