### PR TITLE
test: Tolerate absent /home

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1605,11 +1605,15 @@ class MachineCase(unittest.TestCase):
         self.restore_file("/etc/subuid")
         self.restore_file("/etc/subgid")
         self.restore_file("/var/log/wtmp")
-        home_dirs = m.execute("ls /home").strip().split()
+
+        def get_home_dirs() -> Sequence[str]:
+            return m.execute("if [ -d /home ]; then ls /home; fi").strip().split()
+
+        initial_home_dirs = get_home_dirs()
 
         def cleanup_home_dirs() -> None:
-            for d in m.execute("ls /home").strip().split():
-                if d not in home_dirs:
+            for d in get_home_dirs():
+                if d not in initial_home_dirs:
                     m.execute("rm -r /home/" + d)
         self.addCleanup(cleanup_home_dirs)
 


### PR DESCRIPTION
systemd recently dropped creating /home via tmpfiles [1]. Thus in the Anaconda environment there is no /home any more, which tripped up our nondestructive setup.

Also rename `home_dirs` to `initial_home_dirs` to clarify its purpose.

[1] https://src.fedoraproject.org/rpms/systemd/c/a76669ee222fc

----

See https://github.com/cockpit-project/bots/pull/6544 and [these lovely failures](https://cockpit-logs.us-east-1.linodeobjects.com/pull-6544-c740e50f-20240625-081141-fedora-rawhide-boot-rhinstaller-anaconda-webui/log.html)