### PR TITLE
test: don't type check pkg/lib outside of cockpit

### DIFF
--- a/test/static-code
+++ b/test/static-code
@@ -72,7 +72,9 @@ if [ "${WITH_PARTIAL_TREE:-0}" = 0 ]; then
 	# https://github.com/microsoft/TypeScript/issues/30511
 	# We can't tell tsc to ignore the .d.ts in node_modules/ and check our
 	# own cockpit.d.ts, so we do two separate invocations as a workaround:
-	node_modules/.bin/tsc --typeRoots /dev/null --strict pkg/lib/cockpit.d.ts
+	if [ -n "$(git ls-files pkg/lib)" ]; then
+	    node_modules/.bin/tsc --typeRoots /dev/null --strict pkg/lib/cockpit.d.ts
+	fi
 	node_modules/.bin/tsc --checkJs false --skipLibCheck
     }
 fi


### PR DESCRIPTION
This is wasteful to do outside of Cockpit and leads to us needing types installed for everything in pkg/lib which is .ts and unused in the project itself. (like deep-equal for example)

---

This ofcourse doesn't fix cockpit-files... because we import `hooks.ts`. But if someone ports the terminal component to typescript then CI in cockpit-files should not fail because we lack the types for xterm.js.

```
not ok 10 /static-code/test-typescript
# pkg/lib/hooks.ts(22,24): error TS7016: Could not find a declaration file for module 'deep-equal'. '/home/jelle/projects/cockpit-files/node_modules/deep-equal/index.js' implicitly has an 'any' type.
#   Try `npm i --save-dev @types/deep-equal` if it exists or add a new declaration (.d.ts) file containing `declare module 'deep-equal';`
```