### PR TITLE
test: Fix type of MachineCase.machine_class

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1332,7 +1332,7 @@ class MachineCase(unittest.TestCase):
     runner = None
     machine: testvm.Machine
     machines: Mapping[str, testvm.Machine]
-    machine_class = None
+    machine_class: type | None = None
     browser: Browser
     network = None
     journal_start: str | None = None


### PR DESCRIPTION
It's not NoneType. anaconda-webui sets a different class, and mypy complains:

> test/anacondalib.py:38: error: Incompatible types in assignment (expression has type "type[VirtInstallMachine]", variable has type "None")  [assignment]

---

Found as part of https://github.com/rhinstaller/anaconda-webui/pull/322 -- I locally applied the change and mypy is happy now.