### PR TITLE
lib: Always use ISO format for date picker manual input

### DIFF
--- a/pkg/base1/test-timeformat.ts
+++ b/pkg/base1/test-timeformat.ts
@@ -16,8 +16,6 @@ QUnit.test("absolute formatters, English", assert => {
     assert.equal(timeformat.dateTimeNoYear(d1), "Jan 02, 03:04 AM");
     assert.equal(timeformat.weekdayDate(d1), "Tuesday, January 2, 2024");
 
-    assert.equal(timeformat.dateShortFormat(), "MM/dd/yyyy");
-
     // all of these work with numbers as time argument
     assert.equal(timeformat.dateTimeSeconds(d1.valueOf()), "Jan 2, 2024, 3:04:05 AM");
 });
@@ -33,8 +31,6 @@ QUnit.test("absolute formatters, German", assert => {
     assert.equal(timeformat.dateTimeNoYear(d1), "02. Jan., 03:04");
     assert.equal(timeformat.weekdayDate(d1), "Dienstag, 2. Januar 2024");
 
-    assert.equal(timeformat.dateShortFormat(), "dd.MM.y");
-
     // all of these work with numbers as time argument
     assert.equal(timeformat.dateTimeSeconds(d1.valueOf()), "02.01.2024, 03:04:05");
 });
@@ -44,7 +40,6 @@ QUnit.test("absolute formatters, per-country locale", assert => {
     assert.equal(timeformat.timeSeconds(d1), "03:04:05");
     assert.equal(timeformat.date(d1), "2 January 2024");
     assert.equal(timeformat.dateShort(d1), "02/01/2024");
-    assert.equal(timeformat.dateShortFormat(), "dd/MM/yyyy");
 
     cockpit.language = "pt";
     assert.equal(timeformat.date(d1), "2 de janeiro de 2024");
@@ -122,26 +117,6 @@ QUnit.test("firstDayOfWeek", assert => {
     assert.equal(timeformat.firstDayOfWeek(), 0);
     cockpit.language = "de";
     assert.equal(timeformat.firstDayOfWeek(), 1);
-});
-
-QUnit.test("parsing", assert => {
-    cockpit.language = "en";
-    const en = timeformat.parseShortDate("1/20/2024");
-    assert.equal(en.getDate(), 20);
-    assert.equal(en.getMonth(), 0); // yes, starting from 0
-    assert.equal(en.getFullYear(), "2024");
-
-    cockpit.language = "en_GB";
-    const engb = timeformat.parseShortDate("20/01/2024");
-    assert.equal(engb.getDate(), 20);
-    assert.equal(engb.getMonth(), 0); // yes, starting from 0
-    assert.equal(engb.getFullYear(), "2024");
-
-    cockpit.language = "de";
-    const de = timeformat.parseShortDate("20.01.2024");
-    assert.equal(de.getDate(), 20);
-    assert.equal(de.getMonth(), 0); // yes, starting from 0
-    assert.equal(de.getFullYear(), "2024");
 });
 
 QUnit.start();

--- a/pkg/lib/cockpit-components-shutdown.jsx
+++ b/pkg/lib/cockpit-components-shutdown.jsx
@@ -71,9 +71,9 @@ export class ShutdownModal extends React.Component {
         this.server_time.wait()
                 .then(() => {
                     const dateObject = this.server_time.utc_fake_now;
-                    const date = timeformat.dateShort(dateObject);
-                    const hour = this.server_time.utc_fake_now.getUTCHours();
-                    const minute = this.server_time.utc_fake_now.getUTCMinutes();
+                    const date = dateObject.toISOString().split("T")[0];
+                    const hour = dateObject.getUTCHours();
+                    const minute = dateObject.getUTCMinutes();
                     this.setState({
                         dateObject,
                         date,
@@ -211,19 +211,12 @@ export class ShutdownModal extends React.Component {
                                     <DatePicker aria-label={_("Pick date")}
                                                 buttonAriaLabel={_("Toggle date picker")}
                                                 className='shutdown-date-picker'
-                                                dateFormat={timeformat.dateShort}
-                                                // https://github.com/patternfly/patternfly-react/issues/9721
-                                                dateParse={date => {
-                                                    const newDate = timeformat.parseShortDate(date);
-                                                    return Number.isNaN(newDate.valueOf()) ? false : newDate;
-                                                }}
                                                 invalidFormatText=""
                                                 isDisabled={!this.state.formFilled}
                                                 locale={timeformat.dateFormatLang()}
                                                 weekStart={timeformat.firstDayOfWeek()}
                                                 onBlur={this.calculate}
                                                 onChange={(_, d, ds) => this.updateDate(d, ds)}
-                                                placeholder={timeformat.dateShortFormat()}
                                                 validators={[this.dateRangeValidator]}
                                                 value={this.state.date}
                                                 appendTo={() => document.body} />

--- a/pkg/lib/serverTime.js
+++ b/pkg/lib/serverTime.js
@@ -97,11 +97,6 @@ export function ServerTime() {
         }
     });
 
-    self.format = function format(and_time) {
-        const options = { dateStyle: "medium", timeStyle: and_time ? "short" : undefined, timeZone: "UTC" };
-        return timeformat.formatter(options).format(self.utc_fake_now);
-    };
-
     const updateInterval = window.setInterval(emit_changed, 30000);
 
     self.wait = function wait() {
@@ -437,7 +432,7 @@ export function ServerTimeConfig() {
                 onClick={ () => change_systime_dialog(server_time, tz) }
                 data-timedated-initialized={ntp?.initialized}
                 isInline isDisabled={!superuser.allowed || !tz}>
-            { server_time.format(true) }
+            { timeformat.dateTime(server_time.utc_fake_now) }
         </Button>);
 
     let ntp_status = null;
@@ -598,12 +593,9 @@ function ChangeSystimeBody({ state, errors, change }) {
                             <DatePicker id="systime-date-input"
                                         aria-label={_("Pick date")}
                                         buttonAriaLabel={_("Toggle date picker")}
-                                        dateFormat={timeformat.dateShort}
-                                        dateParse={timeformat.parseShortDate}
                                         invalidFormatText=""
                                         locale={timeformat.dateFormatLang()}
                                         weekStart={timeformat.firstDayOfWeek()}
-                                        placeholder={timeformat.dateShortFormat()}
                                         onChange={(_, d) => change("manual_date", d)}
                                         value={manual_date}
                                         appendTo={() => document.body} />
@@ -654,7 +646,7 @@ function change_systime_dialog(server_time, timezone) {
     let errors = { };
 
     function get_current_time() {
-        state.manual_date = server_time.format();
+        state.manual_date = server_time.utc_fake_now.toISOString().split("T")[0];
 
         const minutes = server_time.utc_fake_now.getUTCMinutes();
         // normalize to two digits

--- a/pkg/lib/timeformat.ts
+++ b/pkg/lib/timeformat.ts
@@ -4,7 +4,7 @@
  * Time stamps are given in milliseconds since the epoch.
  */
 import cockpit from "cockpit";
-import { parse, formatDistanceToNow } from 'date-fns';
+import { formatDistanceToNow } from 'date-fns';
 import * as locales from 'date-fns/locale';
 
 // this needs to be dynamic, as some pages don't initialize cockpit.language right away
@@ -41,22 +41,11 @@ export const dateTimeNoYear = (t: Time): string => formatter({ month: 'short', d
 // Wednesday, June 30, 2021
 export const weekdayDate = (t: Time): string => formatter({ dateStyle: "full" }).format(t);
 
-// The following options are helpful for placeholders
-// yyyy/mm/dd
-export const dateShortFormat = (): string => dateFnsLocale().formatLong.date({ width: 'short' });
 // about 1 hour [ago]
 export const distanceToNow = (t: Time, addSuffix?: boolean): string => formatDistanceToNow(t, {
     locale: dateFnsLocale(),
     addSuffix: addSuffix ?? false
 });
-
-// Parse a string localized date like 30.06.21 to a Date Object
-export function parseShortDate(dateStr: string): Date {
-    // strip off time (i.e. set to midnight), to avoid confusing calendar widgets
-    const now = new Date();
-    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-    return parse(dateStr, dateShortFormat(), today);
-}
 
 /***
  * sorely missing from Intl: https://github.com/tc39/ecma402/issues/6

--- a/test/verify/check-system-shutdown-restart
+++ b/test/verify/check-system-shutdown-restart
@@ -125,7 +125,7 @@ class TestShutdownRestart(testlib.MachineCase):
         # Insert a date using the widget dropdown
         b.click("button[aria-label='Toggle date picker']")
         today_label = m.execute("date +'%-d %B %Y'").strip()
-        today_format = m.execute("date +'%-m/%-d/%Y'").strip()
+        today_format = m.execute("date +'%Y-%m-%d'").strip()
         b.click(f".pf-v5-c-calendar-month__dates-cell:not(.pf-m-adjacent-month) button[aria-label='{today_label}']")
         b.wait_val(".shutdown-date-picker input", today_format)
         b.blur(".shutdown-date-picker input")


### PR DESCRIPTION
PatternFly's DatePicker's textual date input defaults to ISO format
(YYYY-MM-DD), for a good reason: it's unambiguous, and localized date
input is really hard and brittle.

This is also broken for e.g. en-UK: British date format is DD/MM/YY,
while US date format is MM/DD/YY, but we don't have UI to switch between
English countries.

It was also broken for the manual time setting dialog, where the initial
formatting of the date resulted in a format that the dialog didn't
accept.

So give up, and use the default (i.e. ISO) format and parser. Also drop
the custom time/date format function in serverTime.js, and use our
standard `timeformat.dateTime()` (which has the same output format).

Fixes #19091

[1] https://www.patternfly.org/components/date-and-time/date-picker


-----

It previously looked like this in English (scheduled shutdown time):
![date-main](https://github.com/cockpit-project/cockpit/assets/200109/52521c04-4e59-42ea-8063-347e599d4a62)

And now like this, in all languages (it's not an off-by-one, I changed the day to tomorrow):
![date-pr](https://github.com/cockpit-project/cockpit/assets/200109/716b9b37-d8dd-44ff-ba26-74d6e39878a2)

When emptying the input you see the corresponding input helper:
![date-pr-template](https://github.com/cockpit-project/cockpit/assets/200109/0a76dacf-5936-44f7-a58b-cb86de581990)

And for the LOLz, the buggy default dialog value for manually setting the server date on main. With this PR, it's the same ISO format as above:

![system-time-bug](https://github.com/cockpit-project/cockpit/assets/200109/c7c7c1af-3f4d-4bd1-b15a-99084d949806)

I suppose this only didn't get a bug report because nobody actually does that..

When people say "hard times" I didn't realize what they mean.. :sweat_smile: 