### PR TITLE
Drop date-fns usage

### DIFF
--- a/pkg/base1/test-timeformat.ts
+++ b/pkg/base1/test-timeformat.ts
@@ -65,6 +65,7 @@ QUnit.test("relative formatter, English", assert => {
     const minutes = now - 4 * MIN - 5 * SEC;
     const halfhour = now - 32 * MIN;
     const hours = now - 3 * HOUR - 57 * MIN;
+    const yesterday = now - 25 * HOUR;
     const days4short = now - 4 * DAY + 2 * HOUR;
     const days4long = now - 4 * DAY - 2 * HOUR;
     const week3short = now - 20 * DAY + 2 * HOUR;
@@ -85,6 +86,9 @@ QUnit.test("relative formatter, English", assert => {
 
     assert.equal(timeformat.distanceToNow(hours), "about 4 hours");
     assert.equal(timeformat.distanceToNow(hours, true), "about 4 hours ago");
+
+    assert.equal(timeformat.distanceToNow(yesterday), "1 day");
+    assert.equal(timeformat.distanceToNow(yesterday, true), "1 day ago");
 
     assert.equal(timeformat.distanceToNow(days4short), "4 days");
     assert.equal(timeformat.distanceToNow(days4long), "4 days");
@@ -107,6 +111,7 @@ QUnit.test("relative formatter, German", assert => {
     assert.equal(timeformat.distanceToNow(seconds), "weniger als 1 Minute");
     assert.equal(timeformat.distanceToNow(seconds, true), "vor weniger als 1 Minute");
 
+    assert.equal(timeformat.distanceToNow(now - 25 * HOUR), "1 Tag");
     assert.equal(timeformat.distanceToNow(now - 4 * DAY), "4 Tage");
     assert.equal(timeformat.distanceToNow(now - 21 * DAY), "21 Tage");
     assert.equal(timeformat.distanceToNow(now - 62 * DAY), "2 Monate");

--- a/pkg/base1/test-timeformat.ts
+++ b/pkg/base1/test-timeformat.ts
@@ -61,60 +61,54 @@ const DAY = 24 * HOUR;
 
 QUnit.test("relative formatter, English", assert => {
     const now = Date.now();
-    const seconds = now - 4.5 * SEC;
-    const minutes = now - 4 * MIN - 5 * SEC;
-    const halfhour = now - 32 * MIN;
-    const hours = now - 3 * HOUR - 57 * MIN;
-    const yesterday = now - 25 * HOUR;
-    const days4short = now - 4 * DAY + 2 * HOUR;
-    const days4long = now - 4 * DAY - 2 * HOUR;
-    const week3short = now - 20 * DAY + 2 * HOUR;
-    const week3long = now - 21 * DAY - 2 * HOUR;
-    const month2short = now - 2 * 30 * DAY + 5 * DAY;
-    const month2long = now - 2 * 30 * DAY - 5 * DAY;
 
     cockpit.language = "en";
-    assert.equal(timeformat.distanceToNow(seconds), "less than a minute");
-    assert.equal(timeformat.distanceToNow(seconds, false), "less than a minute");
-    assert.equal(timeformat.distanceToNow(seconds, true), "less than a minute ago");
+    assert.equal(timeformat.distanceToNow(now + 4.5 * SEC), "in less than a minute");
+    assert.equal(timeformat.distanceToNow(now - 4.5 * SEC), "less than a minute ago");
 
-    assert.equal(timeformat.distanceToNow(minutes), "4 minutes");
-    assert.equal(timeformat.distanceToNow(minutes, true), "4 minutes ago");
+    assert.equal(timeformat.distanceToNow(now + 4 * MIN - 5 * SEC), "in 4 minutes");
+    assert.equal(timeformat.distanceToNow(now - 4 * MIN - 5 * SEC), "4 minutes ago");
+    assert.equal(timeformat.distanceToNow(now - 4 * MIN + 5 * SEC), "4 minutes ago");
 
-    assert.equal(timeformat.distanceToNow(halfhour), "32 minutes");
-    assert.equal(timeformat.distanceToNow(halfhour, true), "32 minutes ago");
+    assert.equal(timeformat.distanceToNow(now - 32 * MIN), "32 minutes ago");
+    assert.equal(timeformat.distanceToNow(now + 32 * MIN), "in 32 minutes");
 
-    assert.equal(timeformat.distanceToNow(hours), "about 4 hours");
-    assert.equal(timeformat.distanceToNow(hours, true), "about 4 hours ago");
+    assert.equal(timeformat.distanceToNow(now + 3 * HOUR + 57 * MIN), "in 4 hours");
+    assert.equal(timeformat.distanceToNow(now - 3 * HOUR - 57 * MIN), "4 hours ago");
 
-    assert.equal(timeformat.distanceToNow(yesterday), "1 day");
-    assert.equal(timeformat.distanceToNow(yesterday, true), "1 day ago");
+    assert.equal(timeformat.distanceToNow(now + 25 * HOUR), "tomorrow");
+    assert.equal(timeformat.distanceToNow(now - 25 * HOUR), "yesterday");
 
-    assert.equal(timeformat.distanceToNow(days4short), "4 days");
-    assert.equal(timeformat.distanceToNow(days4long), "4 days");
-    assert.equal(timeformat.distanceToNow(days4short, true), "4 days ago");
+    assert.equal(timeformat.distanceToNow(now + 4 * DAY - 2 * HOUR), "in 4 days");
+    assert.equal(timeformat.distanceToNow(now + 4 * DAY + 2 * HOUR), "in 4 days");
+    assert.equal(timeformat.distanceToNow(now - 4 * DAY - 2 * HOUR), "4 days ago");
+    assert.equal(timeformat.distanceToNow(now - 4 * DAY + 2 * HOUR), "4 days ago");
 
-    assert.equal(timeformat.distanceToNow(week3short), "20 days");
-    assert.equal(timeformat.distanceToNow(week3long), "21 days");
-    assert.equal(timeformat.distanceToNow(week3long, true), "21 days ago");
+    assert.equal(timeformat.distanceToNow(now + 20 * DAY), "in 3 weeks");
+    assert.equal(timeformat.distanceToNow(now + 21 * DAY), "in 3 weeks");
+    assert.equal(timeformat.distanceToNow(now - 21 * DAY), "3 weeks ago");
 
-    assert.equal(timeformat.distanceToNow(month2short), "about 2 months");
-    assert.equal(timeformat.distanceToNow(month2long), "2 months");
+    assert.equal(timeformat.distanceToNow(now + 60 * DAY), "in 2 months");
+    assert.equal(timeformat.distanceToNow(now - 60 * DAY), "2 months ago");
+
+    assert.equal(timeformat.distanceToNow(now + 1200 * DAY), "in 3 years");
+    assert.equal(timeformat.distanceToNow(now - 1200 * DAY), "3 years ago");
 });
 
 QUnit.test("relative formatter, German", assert => {
     const now = Date.now();
-    const seconds = now - 4.5 * SEC;
 
     // no need to be as thorough as with English, just spot check that it's translated
     cockpit.language = "de";
-    assert.equal(timeformat.distanceToNow(seconds), "weniger als 1 Minute");
-    assert.equal(timeformat.distanceToNow(seconds, true), "vor weniger als 1 Minute");
+    /* TODO: this first needs to be translated in po/de.po
+    assert.equal(timeformat.distanceToNow(now + 4.5 * SEC), "in weniger als 1 Minute");
+    assert.equal(timeformat.distanceToNow(now - 4.5 * SEC), "vor weniger als 1 Minute");
+    */
 
-    assert.equal(timeformat.distanceToNow(now - 25 * HOUR), "1 Tag");
-    assert.equal(timeformat.distanceToNow(now - 4 * DAY), "4 Tage");
-    assert.equal(timeformat.distanceToNow(now - 21 * DAY), "21 Tage");
-    assert.equal(timeformat.distanceToNow(now - 62 * DAY), "2 Monate");
+    assert.equal(timeformat.distanceToNow(now + 25 * HOUR), "morgen");
+    assert.equal(timeformat.distanceToNow(now - 25 * HOUR), "gestern");
+    assert.equal(timeformat.distanceToNow(now - 4 * DAY), "vor 4 Tagen");
+    assert.equal(timeformat.distanceToNow(now + 21 * DAY), "in 3 Wochen");
 });
 
 QUnit.test("firstDayOfWeek", assert => {

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -780,7 +780,7 @@ const UpdatesStatus = ({ updates, highestSeverity, timeSinceRefresh, tracerPacka
     let lastChecked;
     // PackageKit returns G_MAXUINT if the db was never checked.
     if (timeSinceRefresh !== null && timeSinceRefresh !== 2 ** 32 - 1)
-        lastChecked = cockpit.format(_("Last checked: $0"), timeformat.distanceToNow(new Date().valueOf() - timeSinceRefresh * 1000, true));
+        lastChecked = cockpit.format(_("Last checked: $0"), timeformat.distanceToNow(new Date().valueOf() - timeSinceRefresh * 1000));
 
     const notifications = [];
     if (numUpdates > 0) {

--- a/pkg/sosreport/sosreport.jsx
+++ b/pkg/sosreport/sosreport.jsx
@@ -473,7 +473,7 @@ const SOSBody = () => {
             props: { key: path },
             columns: [
                 report.name,
-                timeformat.distanceToNow(new Date(report.date * 1000), true),
+                timeformat.distanceToNow(new Date(report.date * 1000)),
                 { title: <LabelGroup>{labels}</LabelGroup> },
                 {
                     title: <>{action}{menu}</>,

--- a/pkg/storaged/dialog.jsx
+++ b/pkg/storaged/dialog.jsx
@@ -1401,7 +1401,7 @@ export const StopProcessesMessage = ({ mount_point, users }) => {
                 u.pid,
                 { title: u.cmd.substr(0, 100), props: { modifier: "breakWord" } },
                 u.user || "-",
-                { title: format_delay(-u.since * 1000, true), props: { modifier: "nowrap" } }
+                { title: format_delay(-u.since * 1000), props: { modifier: "nowrap" } }
             ]
         };
     });
@@ -1412,7 +1412,7 @@ export const StopProcessesMessage = ({ mount_point, users }) => {
                 { title: u.unit.replace(/\.service$/, ""), props: { modifier: "breakWord" } },
                 { title: u.cmd.substr(0, 100), props: { modifier: "breakWord" } },
                 { title: u.desc || "", props: { modifier: "breakWord" } },
-                { title: format_delay(-u.since * 1000, true), props: { modifier: "nowrap" } }
+                { title: format_delay(-u.since * 1000), props: { modifier: "nowrap" } }
             ]
         };
     });

--- a/pkg/storaged/dialog.jsx
+++ b/pkg/storaged/dialog.jsx
@@ -1401,7 +1401,7 @@ export const StopProcessesMessage = ({ mount_point, users }) => {
                 u.pid,
                 { title: u.cmd.substr(0, 100), props: { modifier: "breakWord" } },
                 u.user || "-",
-                { title: format_delay(-u.since * 1000), props: { modifier: "nowrap" } }
+                { title: format_delay(-u.since * 1000, true), props: { modifier: "nowrap" } }
             ]
         };
     });
@@ -1412,7 +1412,7 @@ export const StopProcessesMessage = ({ mount_point, users }) => {
                 { title: u.unit.replace(/\.service$/, ""), props: { modifier: "breakWord" } },
                 { title: u.cmd.substr(0, 100), props: { modifier: "breakWord" } },
                 { title: u.desc || "", props: { modifier: "breakWord" } },
-                { title: format_delay(-u.since * 1000), props: { modifier: "nowrap" } }
+                { title: format_delay(-u.since * 1000, true), props: { modifier: "nowrap" } }
             ]
         };
     });
@@ -1432,7 +1432,7 @@ export const StopProcessesMessage = ({ mount_point, users }) => {
                                           { title: _("PID"), props: colprops },
                                           { title: _("Command"), props: colprops },
                                           { title: _("User"), props: colprops },
-                                          { title: _("Runtime"), props: colprops }
+                                          { title: _("Started"), props: colprops }
                                       ]
                                   }
                                       rows={process_rows} />
@@ -1452,7 +1452,7 @@ export const StopProcessesMessage = ({ mount_point, users }) => {
                                           { title: _("Service"), props: colprops },
                                           { title: _("Command"), props: colprops },
                                           { title: _("Description"), props: colprops },
-                                          { title: _("Runtime"), props: colprops }
+                                          { title: _("Started"), props: colprops }
                                       ]
                                   }
                                   rows={service_rows} />

--- a/pkg/storaged/test-util.js
+++ b/pkg/storaged/test-util.js
@@ -22,9 +22,9 @@ import QUnit, { f } from "qunit-tests";
 
 QUnit.test("format_delay", function (assert) {
     const checks = [
-        [3000, "less than a minute"],
-        [60000, "1 minute"],
-        [15550000, "about 4 hours"],
+        [3000, "in less than a minute"],
+        [60000, "in 1 minute"],
+        [15550000, "in 4 hours"],
     ];
 
     assert.expect(checks.length);

--- a/pkg/storaged/utils.js
+++ b/pkg/storaged/utils.js
@@ -191,8 +191,8 @@ export function format_fsys_usage(used, total) {
     return parts[0] + text;
 }
 
-export function format_delay(d) {
-    return timeformat.distanceToNow(new Date().valueOf() + d);
+export function format_delay(d, addSuffix) {
+    return timeformat.distanceToNow(new Date().valueOf() + d, addSuffix);
 }
 
 export function format_size_and_text(size, text) {

--- a/pkg/storaged/utils.js
+++ b/pkg/storaged/utils.js
@@ -191,8 +191,8 @@ export function format_fsys_usage(used, total) {
     return parts[0] + text;
 }
 
-export function format_delay(d, addSuffix) {
-    return timeformat.distanceToNow(new Date().valueOf() + d, addSuffix);
+export function format_delay(d) {
+    return timeformat.distanceToNow(new Date().valueOf() + d);
 }
 
 export function format_size_and_text(size, text) {

--- a/pkg/systemd/overview-cards/systemInformationCard.jsx
+++ b/pkg/systemd/overview-cards/systemInformationCard.jsx
@@ -95,7 +95,7 @@ export class SystemInformationCard extends React.Component {
                 .then(content => {
                     const uptime = parseFloat(content.split(' ')[0]);
                     const bootTime = new Date().valueOf() - uptime * 1000;
-                    this.setState({ systemUptime: timeformat.distanceToNow(bootTime, true) });
+                    this.setState({ systemUptime: timeformat.distanceToNow(bootTime) });
                 })
                 .catch(ex => console.error("Error reading system uptime", ex.toString())); // not-covered: OS error
     }

--- a/pkg/systemd/overview-cards/systemInformationCard.jsx
+++ b/pkg/systemd/overview-cards/systemInformationCard.jsx
@@ -95,7 +95,7 @@ export class SystemInformationCard extends React.Component {
                 .then(content => {
                     const uptime = parseFloat(content.split(' ')[0]);
                     const bootTime = new Date().valueOf() - uptime * 1000;
-                    this.setState({ systemUptime: timeformat.distanceToNow(bootTime) });
+                    this.setState({ systemUptime: timeformat.distanceToNow(bootTime, true) });
                 })
                 .catch(ex => console.error("Error reading system uptime", ex.toString())); // not-covered: OS error
     }
@@ -126,7 +126,7 @@ export class SystemInformationCard extends React.Component {
                                 </td>
                             </tr>
                             <tr className="pf-v5-c-table__tr">
-                                <th className="pf-v5-c-table__th system-information-uptime" scope="row">{_("Uptime")}</th>
+                                <th className="pf-v5-c-table__th system-information-uptime" scope="row">{_("Up since")}</th>
                                 <td className="pf-v5-c-table__td">
                                     <div id="system_uptime">{this.state.systemUptime}</div>
                                 </td>

--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -94,7 +94,7 @@ ExecStart=/usr/bin/sleep infinity
         b.wait_in_text("#dialog", "The listed processes and services will be forcefully stopped.")
         if fstype != "btrfs":
             b.assert_pixels("#dialog", "busy-unmount", mock={"td[data-label='PID']": "1234",
-                                                             "td[data-label='Runtime']": "a little while"})
+                                                             "td[data-label='Started']": "a little while ago"})
         self.confirm()
         b.wait_in_text(self.card_desc(filesystem, "Mount point"), "The filesystem is not mounted")
 

--- a/test/verify/check-storage-nfs
+++ b/test/verify/check-storage-nfs
@@ -264,7 +264,7 @@ class TestStorageNfs(storagelib.StorageCase):
         b.wait_in_text("#dialog", "The listed processes will be forcefully stopped.")
         b.wait_in_text("#dialog", "Stop and unmount")
         b.assert_pixels("#dialog", "unmount", mock={"td[data-label='PID']": "1234",
-                                                    "td[data-label='Runtime']": "a little while"})
+                                                    "td[data-label='Started']": "a little while ago"})
         self.dialog_apply()
         self.dialog_wait_close()
 

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -193,11 +193,11 @@ class TestSystemInfo(testlib.MachineCase):
         m.execute("mount -o bind /tmp/fake_uptime /proc/uptime")
         self.addCleanup(m.execute, "umount /proc/uptime")
         with b.wait_timeout(70):
-            b.wait_text("#system_uptime", "33 minutes")
+            b.wait_text("#system_uptime", "33 minutes ago")
         # 4 months and a bit, timeformat rounds quite aggressively; also, test a slightly different format
         m.write("/tmp/fake_uptime", "10370000 12345.30\n")
         with b.wait_timeout(70):
-            b.wait_text("#system_uptime", "4 months")
+            b.wait_text("#system_uptime", "4 months ago")
 
         self.allow_journal_messages("error loading contents of os-release: .*",  # C bridge
                                     ".* Neither /etc/os-release nor /usr/lib/os-release exists",  # py bridge


### PR DESCRIPTION
For technical reasons this also does some minor grammar changes on the  "Uptime" on the overview:

![image](https://github.com/cockpit-project/cockpit/assets/200109/5b4183ea-3bc8-487d-9223-1f5a755c0467)

and in the "process/services which keep a block device busy". Before:

![proc-runtime-main](https://github.com/cockpit-project/cockpit/assets/200109/284b020a-1135-47ad-84f9-004ea24ea747)

After:

![proc-runtime-pr](https://github.com/cockpit-project/cockpit/assets/200109/884f1ad9-aaf0-4568-b3d5-ac32d74567bd)

See the commit descriptions for details, and the corresponding pixel ref changes.

Fixes #20653

Note: this does *not* yet drop date-fns from package.json. I'll do that as a follow-up after this lands, as node_module rebuilds bitrot in hours.