### PR TITLE
cockpit.d.ts: fix some `cockpit.file()` annotations

### DIFF
--- a/pkg/lib/cockpit.d.ts
+++ b/pkg/lib/cockpit.d.ts
@@ -225,9 +225,9 @@ declare module 'cockpit' {
 
     interface FileHandle<T> {
         read(): Promise<T>;
-        replace(content: T): Promise<FileTag>;
+        replace(new_content: T, expected_tag?: FileTag): Promise<FileTag>;
         watch(callback: FileWatchCallback<T>, options?: { read?: boolean }): FileWatchHandle;
-        modify(callback: (data: T) => T): Promise<[T, FileTag]>;
+        modify(callback: (data: T) => T, initial_content?: string, initial_tag?: FileTag): Promise<[T, FileTag]>;
         close(): void;
         path: string;
     }


### PR DESCRIPTION
These things take optional arguments to change their behaviour.

There is another issue in the binding that will be more difficult to fix: our non-standard promise type supports multiple arguments to the .then() callback.  We can't describe that using the `Promise` API which we've subclassed.  We leave that alone for now.