### PR TITLE
test: wait till /mnt is properly unmounted

### DIFF
--- a/test/verify/check-storage-anaconda
+++ b/test/verify/check-storage-anaconda
@@ -627,14 +627,16 @@ AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
         # A filesystem with just directories should not show the
         # warning.
 
-        m.execute(f"mkfs.ext4 {disk}; mount {disk} /mnt; mkdir -p /mnt/dir/ect/ory; umount /mnt")
-
+        m.execute(f"mkfs.ext4 {disk}; mount {disk} /mnt; mkdir -p /mnt/dir/ect/ory")
+        m.execute("while mountpoint -q /mnt && ! umount /mnt; do sleep 0.2; done;")
         b.wait_text(self.card_row_col("Storage", 1, 3), "ext4 filesystem")
-        self.click_dropdown(self.card_row("Storage", 1), "Create partition table")
-        self.dialog_wait_open()
+
+        self.dialog_open_with_retry(lambda: self.click_dropdown(self.card_row("Storage", 1), "Create partition table"),
+                                    lambda: "Initialize" in b.text("#dialog"))
         self.dialog_set_val("type", "empty")
         self.dialog_apply()
         self.dialog_wait_close()
+        b.wait_text(self.card_row_col("Storage", 1, 3), "Unformatted data")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In our tests the format dialog opens while /mnt is still mounted, so ensure it is really unmounted before trying to create a partition table.