### PR TITLE
Centos 10 timeout flakes

### DIFF
--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -723,8 +723,8 @@ password=foobar
         m.execute("while [ ! -e /tmp/hogged ]; do sleep 1; done")
         # bars update every 5s
         time.sleep(8)
+        testlib.wait(lambda: progressValue(2) >= initial_usage + 10)
         hog_usage = progressValue(2)
-        self.assertGreater(hog_usage, initial_usage + 10)
 
         m.execute("kill %d" % mem_hog)
         # Should go back to initial_usage, but it doesn't always, for example on fedora.


### PR DESCRIPTION
It can take a few renders until the percentage is exactly bigger or equal to the new expected value.

---

https://cockpit-logs.us-east-1.linodeobjects.com/pull-20671-cb251b6c-20240629-061927-centos-10-other/log.html
https://cockpit-logs.us-east-1.linodeobjects.com/pull-20017-1db13b92-20240627-175830-centos-10-other/log.html