### PR TITLE
test: wait till some json appears

### DIFF
--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -971,6 +971,7 @@ OnCalendar=daily
 
         self.login_and_go("/playground/test")
         b.wait_visible("#user-info")
+        b.wait(lambda: "groups" in b.text("#user-info"))
         user_info = json.loads(b.text("#user-info"))
         self.assertEqual(user_info["home"], "/var/home/admin" if m.ostree_image else "/home/admin")
         # default group is first


### PR DESCRIPTION
This test flakes 27% of the time on Arch, as the test does wait until the DOM actually contains JSON data but only until the element is visible and another render might be needed to shown the actual JSON data.

---

https://cockpit-logs.us-east-1.linodeobjects.com/pull-20686-bc16cfe9-20240701-160329-arch-expensive/log.html#40-2

Silly mistake by past me!