### PR TITLE
networkmanager: drop preventDefault code

### DIFF
--- a/pkg/networkmanager/ip-settings.jsx
+++ b/pkg/networkmanager/ip-settings.jsx
@@ -108,7 +108,7 @@ export const IpSettingsDialog = ({ topic, connection, dev, settings }) => {
             setRoutes([]);
     }, [method, addresses.length, canHaveExtra, isOff]);
 
-    const onSubmit = (ev) => {
+    const onSubmit = (_ev) => {
         const createSettingsObj = () => ({
             ...settings,
             [topic]: {
@@ -131,12 +131,6 @@ export const IpSettingsDialog = ({ topic, connection, dev, settings }) => {
             setDialogError,
             onClose: Dialogs.close,
         });
-
-        // Prevent dialog from closing because of <form> onsubmit event
-        if (event)
-            event.preventDefault();
-
-        return false;
     };
     const addressIpv4Helper = (address) => {
         const config = { address, netmask: '', gateway: '' };


### PR DESCRIPTION
This was introduced in 234a6672af, where the IpSettingsDialog got ported to React and PF4. This now started to flake on ubuntu-stable, where the dialog is closed in the tests just after it was opened.

---

Amplified here, and it does fail a ton :) https://github.com/cockpit-project/cockpit/pull/20692

I accidentally fixed up this `preventDefault` and then it didn't reproduce anymore in commit https://github.com/cockpit-project/cockpit/pull/20692/commits/5828f45aece9ed878231b459c033e0266807b1e2