### PR TITLE
pam-ssh-add: Fix insecure killing of session ssh-agent [CVE-2024-6126]

### DIFF
--- a/test/verify/check-session
+++ b/test/verify/check-session
@@ -86,6 +86,39 @@ class TestSession(testlib.MachineCase):
         b.logout()
         wait_session(should_exist=False)
 
+        # try to pwn $SSH_AGENT_PID via pam_env's user_readenv=1 (CVE-2024-6126)
+
+        if m.image in ["fedora-39", "fedora-40", "centos-10", "rhel-10-0"]:
+            # pam_env user_readenv crashes in Fedora/RHEL 10, skip the test
+            # https://bugzilla.redhat.com/show_bug.cgi?id=2293045
+            return
+        if m.ostree_image:
+            # not using cockpit's PAM config
+            return
+
+        # this is enabled by default in tools/cockpit.debian.pam, as well as
+        # Debian/Ubuntu's /etc/pam.d/sshd; but not in Fedora/RHEL
+        if "debian" not in m.image and "ubuntu" not in m.image:
+            self.write_file("/etc/pam.d/cockpit", "session required pam_env.so user_readenv=1\n", append=True)
+        victim_pid = m.spawn("sleep infinity", "sleep.log")
+        self.addCleanup(m.execute, f"kill {victim_pid} || true")
+        self.write_file("/home/admin/.pam_environment", f"SSH_AGENT_PID={victim_pid}\n", owner="admin")
+
+        b.login_and_go()
+        wait_session(should_exist=True)
+        # starts ssh-agent in session
+        m.execute("pgrep -u admin ssh-agent")
+        # but the session has the modified SSH_AGENT_PID
+        bridge = m.execute("pgrep -u admin cockpit-bridge").strip()
+        agent = m.execute(f"grep --null-data SSH_AGENT_PID /proc/{bridge}/environ | xargs -0 | sed 's/.*=//'").strip()
+        self.assertEqual(agent, str(victim_pid))
+
+        # logging out still kills the actual ssh-agent, not the victim pid
+        b.logout()
+        wait_session(should_exist=False)
+        m.execute("while pgrep -u admin ssh-agent; do sleep 1; done", timeout=10)
+        m.execute(f"test -e /proc/{victim_pid}")
+
 
 if __name__ == '__main__':
     testlib.test_main()


### PR DESCRIPTION
Some distributions like Debian 12, or possibly some administrators enable pam_env's deprecated `user_readenv` option [1]. The user session can change the `$SSH_AGENT_PID`, so that it can pass an arbitrary pid to `pam_sm_close_session()`. This is a local authenticated DoS.

Avoid this by storing the agent pid in a global variable. The cockpit-session process stays around for the entire session time, so we don't need to put the pid into the PAM data.

It can also happen that the user session's ssh-agent gets killed, and some other process later on recycles the PID. Temporarily drop privileges to the target user so that we at least don't kill anyone else's process.

Add an integration test which checks that changing the env variable works, pointing it to a different process doesn't kill that, and ssh-agent (the original pid) is still cleaned up correctly. However, as pam_so.env in Fedora crashes hard, skip the test there.

Many thanks to Paolo Perego <paolo.perego@suse.com> for discovering, and Luna Dragon <luna.dragon@suse.com> for reporting this issue!

[1] https://man7.org/linux/man-pages/man8/pam_env.8.html

CVE-2024-6126
https://bugzilla.redhat.com/show_bug.cgi?id=2290859

-----
## pam-ssh-add: Fix insecure killing of session ssh-agent [CVE-2024-6126]

### Affected systems
* **Debian, Ubuntu, and other Debian-derived distributions**: These distributions enable the deprecated `user_readenv` option by default in [the `pam_env` PAM module](https://man7.org/linux/man-pages/man8/pam_env.8.html).
* **Fedora, CentOS, RHEL, Arch, OpenSUSE**: Not affected by default. Only systems where the `user_readenv` option has been manually enabled.
* **Other Linux distributions**: Check `grep -r user_readenv /etc/pam.d`. If there is no output, you are not affected. Otherwise check if the "cockpit" PAM module directly or indirectly uses that option.

This is tracked as [CVE-2024-2947](https://www.cve.org/CVERecord?id=CVE-2024-2947).

### Impact

Cockpit's `pam_ssh_add` module had a vulnerability when `user_readenv` is enabled on the system, as it inherits the settings from the system in `/etc/pam.d/cockpit`.

This could cause a Denial of Service if a locally-authenticated user could craft a `~/.pam_environment` file which would kill an arbitrary process on the system with root privileges when logging out of a Cockpit session. 

### Fix

- Upgrade to **Cockpit version 320** to fix this issue.
- For older Cockpit versions, a backport patch is available: <https://github.com/cockpit-project/cockpit/commit/XXXTODO>.

### Workaround

If you cannot upgrade to Cockpit 320 or use the patch linked above, and may have potentially malicious local users on a system running Cockpit, you can mitigate this vulnerability:

- Remove the `user_readenv=1` option from the `pam_env.so` line in `/etc/pam.d/cockpit`.

This will disable reading any extra environment variables in user's `~/.pam_environment` files, which is most commonly used to set a local environment different from the system default.

### Acknowledgments

Many thanks to [Paolo Perego](https://github.com/thesp0nge) for discovering, and [Luna Dragon](https://github.com/Lunarequest/) for reporting this issue!
