### PR TITLE
systemd: openssh 9.8 disabled DSA by default

### DIFF
--- a/pkg/systemd/overview-cards/ssh-list-host-keys.sh
+++ b/pkg/systemd/overview-cards/ssh-list-host-keys.sh
@@ -45,7 +45,7 @@ echo "$systemd" | while IFS='=' read -r name value; do
     fi
 done
 
-keys=$(ssh-keyscan -t dsa,ecdsa,ed25519,rsa -p "$port" "$host" || true)
+keys=$(ssh-keyscan -t dsa,ecdsa,ed25519,rsa -p "$port" "$host" || ssh-keyscan -t ecdsa,ed25519,rsa -p "$port" "$host" || true)
 if [ -n "$keys" ]; then
     # Some versions of ssh-keygen don't support -f reading from stdin
     # so write a tmpfile


### PR DESCRIPTION
Arch Linux compiles openssh with the default flags which now disables DSA keygen and thus listing / parsing now errors out.

Fix for https://github.com/cockpit-project/bots/pull/6570

---

Honestly a bit annoying that `ssh-keyscan` just errors out, maybe we should drop showing DSA keys in the future for older operating systems.

---

Side note: `ssh-keygen -l` can now read from stdin since [openssh 7.2](https://www.openssh.com/txt/release-7.2) and the ssh on RHEL 8 is new enough!

So: `ssh-add -L | ssh-keygen -l -f -` now works, but I didn't feel like removing tempfiles everywhere also as we invoke `ssh-keygen` for md5 and sha256.