### PR TITLE
systemd: don't show dsa host keys

### DIFF
--- a/pkg/systemd/overview-cards/ssh-list-host-keys.sh
+++ b/pkg/systemd/overview-cards/ssh-list-host-keys.sh
@@ -45,7 +45,7 @@ echo "$systemd" | while IFS='=' read -r name value; do
     fi
 done
 
-keys=$(ssh-keyscan -t dsa,ecdsa,ed25519,rsa -p "$port" "$host" || ssh-keyscan -t ecdsa,ed25519,rsa -p "$port" "$host" || true)
+keys=$(ssh-keyscan -t ecdsa,ed25519,rsa -p "$port" "$host" || true)
 if [ -n "$keys" ]; then
     # Some versions of ssh-keygen don't support -f reading from stdin
     # so write a tmpfile


### PR DESCRIPTION
Since OpenSSH 9.8 DSA support is not compiled in by default and since OpenSSH 7.0 DSA is already deprecated and not recommended. Don't show it anymore on the SSH host key dialog.