### PR TITLE
cockpit.js: Add fsinfo fallback to fswatch1

### DIFF
--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -17,7 +17,8 @@
     - firewalld
     - glibc-all-langpacks
     - libvirt-daemon-config-network
-    - firewalld
+    # for semanage
+    - policycoreutils-python-utils
     - rpm-build
     - sssd
     - sssd-dbus


### PR DESCRIPTION
Commit 00d7e1dcac2a moved `cockpit.file().watch()` to use the `fsinfo` channel. But this is only available with cockpit-bridge >= 310. This breaks e.g. cockpit-podman which is supported on Debian stable, but also bundles cockpit.js via cockpit's pkg/lib.

Add back the fswatch1 implementation as a fallback if fsinfo is not supported.

----

This will unblock https://github.com/cockpit-project/cockpit-podman/pull/1779 . I tested it locally and it works fine. I triggered a test run against this PR in the podman PR, and it succeeded.