### PR TITLE
Adjust for dropping pcp and sssd from debian-testing

### DIFF
--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -1230,8 +1230,8 @@ UnixPath=/run/cockpit/session
         self.assertGreater(len(bridges), 0)
         self.assertIn('sudo', bridge_names)
 
-        # OStree has no PCP bridge
-        if not m.ostree_image:
+        # OStree has no PCP bridge; it's temporarily gone from Debian testing as well
+        if not m.ostree_image and m.image != "debian-testing":
             self.assertIn(f'{self.libexecdir}/cockpit-pcp', bridge_names)
 
 

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -79,6 +79,7 @@ def applySettings(browser, dialog_selector):
         browser.wait_not_present(dialog_selector)
 
 
+@testlib.skipOstree("no PCP support")
 class TestHistoryMetrics(testlib.MachineCase):
     def setUp(self):
         super().setUp()
@@ -113,7 +114,6 @@ class TestHistoryMetrics(testlib.MachineCase):
         })""")
         self.assertLessEqual(leading_empty, 4)
 
-    @testlib.skipOstree("no PCP support")
     def testBasic(self):
         b = self.browser
         m = self.machine
@@ -179,7 +179,6 @@ class TestHistoryMetrics(testlib.MachineCase):
         b.enter_page("/system")
         b.wait_visible('.system-information')
 
-    @testlib.skipOstree("no PCP support")
     def testEvents(self):
         b = self.browser
         m = self.machine
@@ -451,7 +450,6 @@ class TestHistoryMetrics(testlib.MachineCase):
         self.assertIn("until=2021-3-8%2010%3A39%3A45", url)
 
     @testlib.nondestructive
-    @testlib.skipOstree("no PCP support")
     def testNoDataEnable(self):
         b = self.browser
         m = self.machine
@@ -487,7 +485,6 @@ class TestHistoryMetrics(testlib.MachineCase):
         b.logout()
 
     @testlib.nondestructive
-    @testlib.skipOstree("no PCP support")
     def testNoDataFailed(self):
         b = self.browser
         m = self.machine
@@ -513,7 +510,6 @@ class TestHistoryMetrics(testlib.MachineCase):
         b.wait_in_text("#service-details", "pmlogger.service")
 
     @testlib.nondestructive
-    @testlib.skipOstree("no PCP support")
     def testLoggerSettings(self):
         b = self.browser
         m = self.machine
@@ -547,7 +543,6 @@ class TestHistoryMetrics(testlib.MachineCase):
         self.assertEqual(m.execute("systemctl is-enabled pmlogger").strip(), "enabled")
 
     @testlib.nondestructive
-    @testlib.skipOstree("no PCP support")
     def testPmProxySettings(self, customRedisService=None):
         b = self.browser
         m = self.machine
@@ -718,7 +713,6 @@ class TestHistoryMetrics(testlib.MachineCase):
         checkEnabled(expected=True)
 
     @testlib.nondestructive
-    @testlib.skipOstree("no PCP support")
     @testlib.onlyImage("valkey is the default only in Fedora", "fedora*")
     def testPmProxySettingsRedis(self):
         self.machine.execute("systemctl mask valkey")
@@ -1369,13 +1363,13 @@ class TestMetricsPackages(packagelib.PackageCase):
         self.assertIn(redis_service, m.execute("systemctl show -p Wants --value pmproxy").strip())
 
 
+@testlib.skipOstree("no PCP support")
 class TestMultiCPU(testlib.MachineCase):
 
     provision = {
         "0": {"cpus": 2}
     }
 
-    @testlib.skipOstree("no PCP support")
     def testCPUUsage(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -80,6 +80,7 @@ def applySettings(browser, dialog_selector):
 
 
 @testlib.skipOstree("no PCP support")
+@testlib.skipImage("pcp not currently in testing", "debian-testing")
 class TestHistoryMetrics(testlib.MachineCase):
     def setUp(self):
         super().setUp()
@@ -1364,6 +1365,7 @@ class TestMetricsPackages(packagelib.PackageCase):
 
 
 @testlib.skipOstree("no PCP support")
+@testlib.skipImage("pcp not currently in testing", "debian-testing")
 class TestMultiCPU(testlib.MachineCase):
 
     provision = {
@@ -1409,6 +1411,7 @@ class TestMultiCPU(testlib.MachineCase):
 
 
 @testlib.skipOstree("no PCP support")
+@testlib.skipImage("pcp not currently in testing", "debian-testing")
 class TestGrafanaClient(testlib.MachineCase):
 
     provision = {

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -657,6 +657,7 @@ OnCalendar=daily
             b.wait_in_text(f"#file-autocomplete-widget-preselected li:nth-of-type({i + 1}) button", paths[i])
 
     @testlib.skipOstree("No PCP available")
+    @testlib.skipImage("pcp not currently in testing", "debian-testing")
     def testPlots(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -750,6 +750,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         self.allow_journal_messages(r"cockpit-session: user account access failed.*root.*")
 
     @testlib.skipOstree("sssd not available")
+    @testlib.skipImage("sssd not currently in testing", "debian-testing")
     def testClientCertAuthentication(self):
         m = self.machine
 

--- a/test/verify/check-storage-swap
+++ b/test/verify/check-storage-swap
@@ -27,6 +27,10 @@ import testlib
 class TestStorageswap(storagelib.StorageCase):
 
     def checkSwapUsed(self):
+        # this relies on PCP, which is not currently in testing
+        if self.machine.image == "debian-testing":
+            return
+
         self.browser.wait_text(self.card_desc("Swap", "Used"), "0 B")
 
     def testBasic(self):

--- a/test/verify/check-storage-swap
+++ b/test/verify/check-storage-swap
@@ -50,17 +50,17 @@ class TestStorageswap(storagelib.StorageCase):
         # It should have been started and have a fstab entry
         self.click_card_row("GPT partitions", 1)
         self.checkSwapUsed()
-        self.assertIn("defaults", m.execute(f"findmnt --fstab -n -o OPTIONS {disk}1"))
+        testlib.wait(lambda: "defaults" in m.execute(f"findmnt --fstab -n -o OPTIONS {disk}1"))
 
         # Stopping should set it to noauto
         b.click(self.card_button("Swap", "Stop"))
         b.wait_text(self.card_desc("Swap", "Used"), "-")
-        self.assertIn("noauto", m.execute(f"findmnt --fstab -n -o OPTIONS {disk}1"))
+        testlib.wait(lambda: "noauto" in m.execute(f"findmnt --fstab -n -o OPTIONS {disk}1"))
 
         # Start it again to test teardown below
         b.click(self.card_button("Swap", "Start"))
         self.checkSwapUsed()
-        self.assertIn("defaults", m.execute(f"findmnt --fstab -n -o OPTIONS {disk}1"))
+        testlib.wait(lambda: "defaults" in m.execute(f"findmnt --fstab -n -o OPTIONS {disk}1"))
 
         # It should have the right partition type
         b.wait_visible(self.card("Swap"))

--- a/test/verify/check-storage-swap
+++ b/test/verify/check-storage-swap
@@ -26,6 +26,9 @@ import testlib
 @testlib.nondestructive
 class TestStorageswap(storagelib.StorageCase):
 
+    def checkSwapUsed(self):
+        self.browser.wait_text(self.card_desc("Swap", "Used"), "0 B")
+
     def testBasic(self):
         b = self.browser
         m = self.machine
@@ -46,7 +49,7 @@ class TestStorageswap(storagelib.StorageCase):
 
         # It should have been started and have a fstab entry
         self.click_card_row("GPT partitions", 1)
-        b.wait_text(self.card_desc("Swap", "Used"), "0 B")
+        self.checkSwapUsed()
         self.assertIn("defaults", m.execute(f"findmnt --fstab -n -o OPTIONS {disk}1"))
 
         # Stopping should set it to noauto
@@ -56,7 +59,7 @@ class TestStorageswap(storagelib.StorageCase):
 
         # Start it again to test teardown below
         b.click(self.card_button("Swap", "Start"))
-        b.wait_text(self.card_desc("Swap", "Used"), "0 B")
+        self.checkSwapUsed()
         self.assertIn("defaults", m.execute(f"findmnt --fstab -n -o OPTIONS {disk}1"))
 
         # It should have the right partition type
@@ -88,7 +91,7 @@ class TestStorageswap(storagelib.StorageCase):
         # fstab entry
         m.execute(f"mkswap -f {disk}")
         b.click(self.card_button("Swap", "Start"))
-        b.wait_text(self.card_desc("Swap", "Used"), "0 B")
+        self.checkSwapUsed()
         testlib.wait(lambda: "defaults" in m.execute(f"findmnt --fstab -n -o OPTIONS {disk}"))
 
     def testEncrypted(self):
@@ -113,7 +116,7 @@ class TestStorageswap(storagelib.StorageCase):
 
         # It should have been started and have a fstab entry
         self.click_card_row("Storage", name=disk)
-        b.wait_text(self.card_desc("Swap", "Used"), "0 B")
+        self.checkSwapUsed()
         dev = b.text(self.card_desc("Encryption", "Cleartext device"))
         testlib.wait(lambda: "defaults" in m.execute(f"findmnt --fstab -n -o OPTIONS {dev}"))
 

--- a/test/vm.updates-testing
+++ b/test/vm.updates-testing
@@ -5,10 +5,4 @@ set -eux
 exec >&2
 dnf config-manager --enable updates-testing
 dnf -y update --setopt=install_weak_deps=False
-
-# HACK: https://bodhi.fedoraproject.org/updates/FEDORA-2024-d70dfd026e
-# split the kexec-tools package; install kdump-utils manually until the next fedora-40 image refresh
-# after that bodhi update lands.
-dnf -y install kdump-utils
-
 /var/lib/download-package-sets.sh

--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -5,6 +5,12 @@ DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 # we need an apparmor profile for >= 4.0; this exists in Ubuntu >= 24.04, but not in Debian yet
 PRE4AA = $(filter $(shell . /etc/os-release; echo $${VERSION_ID:-unstable}),22.04 11 12 unstable)
 
+# pcp isn't in Debian testing right now
+ifeq ($(shell . /etc/os-release; echo $${VERSION_CODENAME}),trixie)
+    export DH_OPTIONS = -Ncockpit-pcp
+    CONFIG_OPTIONS = --disable-pcp
+endif
+
 # riscv is an emulated architecture for now, and too slow to run expensive unit tests
 # hppa's threading is absurdly slow (#981127)
 SLOW_ARCHES = $(filter $(shell dpkg-architecture -qDEB_BUILD_ARCH),riscv64 hppa)


### PR DESCRIPTION
See https://github.com/cockpit-project/bots/pull/6579

I locally went through all the failures and confirmed that they are working against the new image. I also triggered tests against that updated bots image, and they all passed.