### PR TITLE
lib: Fix server time

### DIFF
--- a/pkg/base1/test-timeformat.ts
+++ b/pkg/base1/test-timeformat.ts
@@ -3,7 +3,10 @@ import QUnit from 'qunit-tests';
 import cockpit from "cockpit";
 import * as timeformat from "timeformat";
 
+// this is a date for the current time zone
 const d1 = new Date("2024-01-02 03:04:05");
+// same date in UTC
+const d1_utc = 1704164645000;
 
 QUnit.test("absolute formatters, English", assert => {
     cockpit.language = "en";
@@ -15,6 +18,9 @@ QUnit.test("absolute formatters, English", assert => {
     assert.equal(timeformat.dateTimeSeconds(d1), "Jan 2, 2024, 3:04:05 AM");
     assert.equal(timeformat.dateTimeNoYear(d1), "Jan 02, 03:04 AM");
     assert.equal(timeformat.weekdayDate(d1), "Tuesday, January 2, 2024");
+
+    const utc_offset = (new Date()).getTimezoneOffset();
+    assert.equal(timeformat.dateTimeUTC(d1_utc + utc_offset), "Jan 2, 2024, 3:04 AM");
 
     // all of these work with numbers as time argument
     assert.equal(timeformat.dateTimeSeconds(d1.valueOf()), "Jan 2, 2024, 3:04:05 AM");

--- a/pkg/lib/serverTime.js
+++ b/pkg/lib/serverTime.js
@@ -432,7 +432,7 @@ export function ServerTimeConfig() {
                 onClick={ () => change_systime_dialog(server_time, tz) }
                 data-timedated-initialized={ntp?.initialized}
                 isInline isDisabled={!superuser.allowed || !tz}>
-            { timeformat.dateTime(server_time.utc_fake_now) }
+            { timeformat.dateTimeUTC(server_time.utc_fake_now) }
         </Button>);
 
     let ntp_status = null;

--- a/pkg/lib/timeformat.ts
+++ b/pkg/lib/timeformat.ts
@@ -26,6 +26,8 @@ export const date = (t: Time): string => formatter({ dateStyle: "long" }).format
 export const dateShort = (t: Time): string => formatter().format(t);
 // Jun 30, 2021, 7:41 AM
 export const dateTime = (t: Time): string => formatter({ dateStyle: "medium", timeStyle: "short" }).format(t);
+// Jun 30, 2021, 7:41 AM if `t` is in UTC format
+export const dateTimeUTC = (t: Time): string => formatter({ dateStyle: "medium", timeStyle: "short", timeZone: "UTC" }).format(t);
 // Jun 30, 2021, 7:41:23 AM
 export const dateTimeSeconds = (t: Time): string => formatter({ dateStyle: "medium", timeStyle: "medium" }).format(t);
 // Jun 30, 7:41 AM


### PR DESCRIPTION
In commit 846552219 I got rid of the `ServerTime.format()` wrapper, and missed the `timeZone: "UTC"` option. This resulted in the Overview's "System time:" being wrong.

Bring this back, but as that is generally useful, introduce a `timeformat.dateTimeUTC()` helper and add a unit test.

Fixes #20710