### PR TITLE
package.json: Add modules for type checking

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "xterm-addon-canvas": "0.5.0"
   },
   "devDependencies": {
+    "@types/node": "20.14.10",
     "@types/qunit": "^2.19.10",
     "@types/react": "18.3.3",
     "@types/react-dom": "18.3.0",
@@ -48,6 +49,7 @@
     "gettext-parser": "8.0.0",
     "htmlparser": "1.7.7",
     "jed": "1.1.1",
+    "postcss-modules": "6.0.0",
     "qunit": "2.21.0",
     "qunit-tap": "1.5.1",
     "sass": "1.77.6",
@@ -57,7 +59,7 @@
     "stylelint-config-standard-scss": "13.1.0",
     "stylelint-formatter-pretty": "4.0.0",
     "stylelint-use-logical-spec": "5.0.1",
-    "typescript": "^5.3.3"
+    "typescript": "5.3.3"
   },
   "scripts": {
     "eslint": "eslint --ext .js --ext .jsx pkg/ test/common/",


### PR DESCRIPTION
`@types/node` fixes type checking errors like

> node_modules/sass/types/legacy/render.d.ts:26:8 - error TS2580: Cannot find name 'Buffer'.

`postcss-modules` is apparently an undeclared dependency of esbuild-sass-plugin:

> node_modules/esbuild-sass-plugin/lib/utils.d.ts:3:34 - error TS2307:
> Cannot find module 'postcss-modules' or its corresponding type declarations.

Also pin down the typescript version, the `^` slipped in there inadvertently.

----

Right now, if `test/static-code` fails on any type check, it spews out a bunch of errors which are not ours: all except for the last one (which triggers printing all of this).

```
# node_modules/@patternfly/react-core/dist/esm/components/MenuToggle/MenuToggleCheckbox.d.ts:4:18 - error TS2430: Interface 'MenuToggleCheckboxProps' incorrectly extends interface 'Omit<HTMLProps<HTMLInputElement>, "disabled" | "type" | "onChange" | "checked">'.
#   Types of property 'defaultChecked' are incompatible.
#     Type 'boolean | null' is not assignable to type 'boolean | undefined'.
#       Type 'null' is not assignable to type 'boolean | undefined'.
#
# 4 export interface MenuToggleCheckboxProps extends Omit<React.HTMLProps<HTMLInputElement>, 'type' | 'onChange' | 'disabled' | 'checked'>, OUIAProps {
#                    ~~~~~~~~~~~~~~~~~~~~~~~
#
# node_modules/@patternfly/react-core/dist/esm/components/NotificationDrawer/NotificationDrawerListItemHeader.d.ts:4:35 - error TS2304: Cannot find name 'SVGIconProps'.
#
# 4     success: React.ComponentClass<SVGIconProps, any>;
#                                     ~~~~~~~~~~~~
#
# node_modules/@patternfly/react-core/dist/esm/components/NotificationDrawer/NotificationDrawerListItemHeader.d.ts:5:34 - error TS2304: Cannot find name 'SVGIconProps'.
#
# 5     danger: React.ComponentClass<SVGIconProps, any>;
#                                    ~~~~~~~~~~~~
#
# node_modules/@patternfly/react-core/dist/esm/components/NotificationDrawer/NotificationDrawerListItemHeader.d.ts:6:35 - error TS2304: Cannot find name 'SVGIconProps'.
#
# 6     warning: React.ComponentClass<SVGIconProps, any>;
#                                     ~~~~~~~~~~~~
#
# node_modules/@patternfly/react-core/dist/esm/components/NotificationDrawer/NotificationDrawerListItemHeader.d.ts:7:32 - error TS2304: Cannot find name 'SVGIconProps'.
#
# 7     info: React.ComponentClass<SVGIconProps, any>;
#                                  ~~~~~~~~~~~~
#
# node_modules/@patternfly/react-core/dist/esm/components/NotificationDrawer/NotificationDrawerListItemHeader.d.ts:8:34 - error TS2304: Cannot find name 'SVGIconProps'.
#
# 8     custom: React.ComponentClass<SVGIconProps, any>;
#                                    ~~~~~~~~~~~~
#
# node_modules/@patternfly/react-core/dist/esm/components/Tabs/Tabs.d.ts:1:23 - error TS2688: Cannot find type definition file for 'node'.
#
# 1 /// <reference types="node" />
#                         ~~~~
#
# node_modules/@patternfly/react-core/dist/esm/components/Tabs/Tabs.d.ts:127:20 - error TS2503: Cannot find namespace 'NodeJS'.
#
# 127     scrollTimeout: NodeJS.Timeout;
#                        ~~~~~~
#
# node_modules/@patternfly/react-core/dist/esm/helpers/Popper/thirdparty/popper-core/types.d.ts:118:34 - error TS2344: Type 'Options' does not satisfy the constraint 'Obj'.
#
# 118     fn: (arg0: ModifierArguments<Options>) => State | void;
#                                      ~~~~~~~
#
#   node_modules/@patternfly/react-core/dist/esm/helpers/Popper/thirdparty/popper-core/types.d.ts:112:33
#     112 export interface Modifier<Name, Options> {
#                                         ~~~~~~~
#     This type parameter might need an `extends Obj` constraint.
#
# node_modules/@patternfly/react-core/dist/esm/helpers/Popper/thirdparty/popper-core/types.d.ts:119:39 - error TS2344: Type 'Options' does not satisfy the constraint 'Obj'.
#
# 119     effect?: (arg0: ModifierArguments<Options>) => () => void | void;
#                                           ~~~~~~~
#
#   node_modules/@patternfly/react-core/dist/esm/helpers/Popper/thirdparty/popper-core/types.d.ts:112:33
#     112 export interface Modifier<Name, Options> {
#                                         ~~~~~~~
#     This type parameter might need an `extends Obj` constraint.
#
# node_modules/esbuild-sass-plugin/lib/utils.d.ts:3:34 - error TS2307: Cannot find module 'postcss-modules' or its corresponding type declarations.
#
# 3 import PostcssModulesPlugin from 'postcss-modules';
#                                    ~~~~~~~~~~~~~~~~~
#
# node_modules/sass/types/legacy/render.d.ts:26:8 - error TS2580: Cannot find name 'Buffer'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
#
# 26   css: Buffer;
#           ~~~~~~
#
# node_modules/sass/types/legacy/render.d.ts:56:9 - error TS2580: Cannot find name 'Buffer'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
#
# 56   map?: Buffer;
#            ~~~~~~
#
# pkg/playground/remote.tsx:55:13 - error TS2339: Property 'translate' does not exist on type 'typeof import("cockpit")'.
#
# 55     cockpit.translate();
#                ~~~~~~~~~
#
#
# Found 14 errors in 7 files.
#
# Errors  Files
#      1  node_modules/@patternfly/react-core/dist/esm/components/MenuToggle/MenuToggleCheckbox.d.ts:4
#      5  node_modules/@patternfly/react-core/dist/esm/components/NotificationDrawer/NotificationDrawerListItemHeader.d.ts:4
#      2  node_modules/@patternfly/react-core/dist/esm/components/Tabs/Tabs.d.ts:1
#      2  node_modules/@patternfly/react-core/dist/esm/helpers/Popper/thirdparty/popper-core/types.d.ts:118
#      1  node_modules/esbuild-sass-plugin/lib/utils.d.ts:3
#      2  node_modules/sass/types/legacy/render.d.ts:26
#      1  pkg/playground/remote.tsx:55
```

After this PR, it's down to "9 errors in 4 files", and they are all in PF.