### PR TITLE
unit-tests: fix json strings

### DIFF
--- a/src/bridge/test-pcp-archives.c
+++ b/src/bridge/test-pcp-archives.c
@@ -242,16 +242,16 @@ static void
 test_metrics_single_archive (TestCase *tc,
                              gconstpointer unused)
 {
-  JsonObject *options = json_obj("{ 'source': '" BUILDDIR "/mock-archives/0',"
-                                 "  'metrics': [ { 'name': 'mock.value' } ],"
-                                 "  'interval': 1000"
+  JsonObject *options = json_obj("{ \"source\": \"" BUILDDIR "/mock-archives/0\","
+                                 "  \"metrics\": [ { \"name\": \"mock.value\" } ],"
+                                 "  \"interval\": 1000"
                                  "}");
 
   setup_metrics_channel_json (tc, options);
 
   JsonObject *meta = recv_json_object (tc);
   cockpit_assert_json_eq (json_object_get_array_member (meta, "metrics"),
-                          "[ { 'name': 'mock.value', 'units': '', 'semantics': 'instant' } ]");
+                          "[ { \"name\": \"mock.value\", \"units\": \"\", \"semantics\": \"instant\" } ]");
 
   assert_sample (tc, "[[10],[11],[12]]");
 
@@ -262,17 +262,17 @@ static void
 test_metrics_archive_limit (TestCase *tc,
                             gconstpointer unused)
 {
-  JsonObject *options = json_obj("{ 'source': '" BUILDDIR "/mock-archives/0',"
-                                 "  'metrics': [ { 'name': 'mock.value' } ],"
-                                 "  'interval': 1000,"
-                                 "  'limit': 2"
+  JsonObject *options = json_obj("{ \"source\": \"" BUILDDIR "/mock-archives/0\","
+                                 "  \"metrics\": [ { \"name\": \"mock.value\" } ],"
+                                 "  \"interval\": 1000,"
+                                 "  \"limit\": 2"
                                  "}");
 
   setup_metrics_channel_json (tc, options);
 
   JsonObject *meta = recv_json_object (tc);
   cockpit_assert_json_eq (json_object_get_array_member (meta, "metrics"),
-                          "[ { 'name': 'mock.value', 'units': '', 'semantics': 'instant' } ]");
+                          "[ { \"name\": \"mock.value\", \"units\": \"\", \"semantics\": \"instant\" } ]");
 
   assert_sample (tc, "[[10],[11]]");
 
@@ -283,17 +283,17 @@ static void
 test_metrics_archive_timestamp (TestCase *tc,
                                 gconstpointer unused)
 {
-  JsonObject *options = json_obj("{ 'source': '" BUILDDIR "/mock-archives/0',"
-                                 "  'metrics': [ { 'name': 'mock.value' } ],"
-                                 "  'interval': 1000,"
-                                 "  'timestamp': 1000"
+  JsonObject *options = json_obj("{ \"source\": \"" BUILDDIR "/mock-archives/0\","
+                                 "  \"metrics\": [ { \"name\": \"mock.value\" } ],"
+                                 "  \"interval\": 1000,"
+                                 "  \"timestamp\": 1000"
                                  "}");
 
   setup_metrics_channel_json (tc, options);
 
   JsonObject *meta = recv_json_object (tc);
   cockpit_assert_json_eq (json_object_get_array_member (meta, "metrics"),
-                          "[ { 'name': 'mock.value', 'units': '', 'semantics': 'instant' } ]");
+                          "[ { \"name\": \"mock.value\", \"units\": \"\", \"semantics\": \"instant\" } ]");
 
   assert_sample (tc, "[[11],[12]]");
 
@@ -318,10 +318,10 @@ test_metrics_archive_timestamp_now (TestCase *tc,
   g_assert (pmiPutValue ("mock.now", NULL, "43") >= 0);
   g_assert (pmiWrite (now + 1, 0) >= 0);
 
-  g_autofree gchar* json = g_strdup_printf("{ 'source': '" BUILDDIR "/mock-archives/3',"
-                                           "  'metrics': [ { 'name': 'mock.now' } ],"
-                                           "  'interval': 1000,"
-                                           "  'timestamp': %lli000"
+  g_autofree gchar* json = g_strdup_printf("{ \"source\": \"" BUILDDIR "/mock-archives/3\","
+                                           "  \"metrics\": [ { \"name\": \"mock.now\" } ],"
+                                           "  \"interval\": 1000,"
+                                           "  \"timestamp\": %lli000"
                                            "}", (long long) now);
   JsonObject *options = json_obj(json);
 
@@ -329,7 +329,7 @@ test_metrics_archive_timestamp_now (TestCase *tc,
 
   JsonObject *meta = recv_json_object (tc);
   cockpit_assert_json_eq (json_object_get_array_member (meta, "metrics"),
-                          "[ { 'name': 'mock.now', 'units': '', 'semantics': 'instant' } ]");
+                          "[ { \"name\": \"mock.now\", \"units\": \"\", \"semantics\": \"instant\" } ]");
 
   assert_sample (tc, "[[42],[43]]");
 
@@ -344,20 +344,20 @@ test_metrics_archive_directory (TestCase *tc,
   expect_broken_archive_warning();
 
   JsonObject *meta;
-  JsonObject *options = json_obj("{ 'source': '" BUILDDIR "/mock-archives',"
-                                 "  'metrics': [ { 'name': 'mock.value' } ],"
-                                 "  'interval': 1000"
+  JsonObject *options = json_obj("{ \"source\": \"" BUILDDIR "/mock-archives\","
+                                 "  \"metrics\": [ { \"name\": \"mock.value\" } ],"
+                                 "  \"interval\": 1000"
                                  "}");
   setup_metrics_channel_json (tc, options);
 
   meta = recv_json_object (tc);
   cockpit_assert_json_eq (json_object_get_array_member (meta, "metrics"),
-                          "[ { 'name': 'mock.value', 'units': '', 'semantics': 'instant' } ]");
+                          "[ { \"name\": \"mock.value\", \"units\": \"\", \"semantics\": \"instant\" } ]");
   assert_sample (tc, "[[10],[11],[12]]");
 
   meta = recv_json_object (tc);
   cockpit_assert_json_eq (json_object_get_array_member (meta, "metrics"),
-                          "[ { 'name': 'mock.value', 'units': '', 'semantics': 'instant' } ]");
+                          "[ { \"name\": \"mock.value\", \"units\": \"\", \"semantics\": \"instant\" } ]");
   assert_sample (tc, "[[13],[14],[15]]");
 
   json_object_unref (options);
@@ -370,17 +370,17 @@ test_metrics_archive_directory_timestamp (TestCase *tc,
   expect_broken_archive_warning();
 
   JsonObject *meta;
-  JsonObject *options = json_obj("{ 'source': '" BUILDDIR "/mock-archives',"
-                                 "  'metrics': [ { 'name': 'mock.value' } ],"
-                                 "  'interval': 1000,"
-                                 "  'timestamp': 4000"
+  JsonObject *options = json_obj("{ \"source\": \"" BUILDDIR "/mock-archives\","
+                                 "  \"metrics\": [ { \"name\": \"mock.value\" } ],"
+                                 "  \"interval\": 1000,"
+                                 "  \"timestamp\": 4000"
                                  "}");
 
   setup_metrics_channel_json (tc, options);
 
   meta = recv_json_object (tc);
   cockpit_assert_json_eq (json_object_get_array_member (meta, "metrics"),
-                          "[ { 'name': 'mock.value', 'units': '', 'semantics': 'instant' } ]");
+                          "[ { \"name\": \"mock.value\", \"units\": \"\", \"semantics\": \"instant\" } ]");
   assert_sample (tc, "[[14],[15]]");
 
   json_object_unref (options);
@@ -394,16 +394,16 @@ test_metrics_archive_directory_late_metric (TestCase *tc,
   cockpit_expect_message ("*no such metric: mock.late: Unknown metric name*");
 
   JsonObject *meta;
-  JsonObject *options = json_obj("{ 'source': '" BUILDDIR "/mock-archives',"
-                                 "  'metrics': [ { 'name': 'mock.late' } ],"
-                                 "  'interval': 1000"
+  JsonObject *options = json_obj("{ \"source\": \"" BUILDDIR "/mock-archives\","
+                                 "  \"metrics\": [ { \"name\": \"mock.late\" } ],"
+                                 "  \"interval\": 1000"
                                  "}");
 
   setup_metrics_channel_json (tc, options);
 
   meta = recv_json_object (tc);
   cockpit_assert_json_eq (json_object_get_array_member (meta, "metrics"),
-                          "[ { 'name': 'mock.late', 'units': '', 'semantics': 'instant' } ]");
+                          "[ { \"name\": \"mock.late\", \"units\": \"\", \"semantics\": \"instant\" } ]");
   assert_sample (tc, "[[30],[31],[32]]");
 
   json_object_unref (options);

--- a/src/bridge/test-pcp.c
+++ b/src/bridge/test-pcp.c
@@ -236,9 +236,9 @@ static void
 test_metrics_compression (TestCase *tc,
                           gconstpointer unused)
 {
-  JsonObject *options = json_obj("{ 'source': 'direct',"
-                                 "  'metrics': [ { 'name': 'mock.value' } ],"
-                                 "  'interval': 1"
+  JsonObject *options = json_obj("{ \"source\": \"direct\","
+                                 "  \"metrics\": [ { \"name\": \"mock.value\" } ],"
+                                 "  \"interval\": 1"
                                  "}");
 
   setup_metrics_channel_json (tc, options);
@@ -246,7 +246,7 @@ test_metrics_compression (TestCase *tc,
 
   JsonObject *meta = recv_json_object (tc);
   cockpit_assert_json_eq (json_object_get_array_member (meta, "metrics"),
-                          "[ { 'name': 'mock.value', 'units': '', 'semantics': 'instant' } ]");
+                          "[ { \"name\": \"mock.value\", \"units\": \"\", \"semantics\": \"instant\" } ]");
 
   assert_sample (tc, "[[0]]");
   assert_sample (tc, "[[]]");
@@ -262,16 +262,16 @@ static void
 test_metrics_units (TestCase *tc,
                     gconstpointer unused)
 {
-  JsonObject *options = json_obj("{ 'source': 'direct',"
-                                 "  'metrics': [ { 'name': 'mock.seconds' } ],"
-                                 "  'interval': 1"
+  JsonObject *options = json_obj("{ \"source\": \"direct\","
+                                 "  \"metrics\": [ { \"name\": \"mock.seconds\" } ],"
+                                 "  \"interval\": 1"
                                  "}");
 
   setup_metrics_channel_json (tc, options);
 
   JsonObject *meta = recv_json_object (tc);
   cockpit_assert_json_eq (json_object_get_array_member (meta, "metrics"),
-                          "[ { 'name': 'mock.seconds', 'units': 'sec', 'semantics': 'instant' } ]");
+                          "[ { \"name\": \"mock.seconds\", \"units\": \"sec\", \"semantics\": \"instant\" } ]");
 
   assert_sample (tc, "[[60]]");
 
@@ -282,15 +282,15 @@ static void
 test_metrics_units_conv (TestCase *tc,
                          gconstpointer unused)
 {
-  JsonObject *options = json_obj("{ 'source': 'direct',"
-                                 "  'metrics': [ { 'name': 'mock.seconds', 'units': 'min' } ],"
-                                 "  'interval': 1"
+  JsonObject *options = json_obj("{ \"source\": \"direct\","
+                                 "  \"metrics\": [ { \"name\": \"mock.seconds\", \"units\": \"min\" } ],"
+                                 "  \"interval\": 1"
                                  "}");
   setup_metrics_channel_json (tc, options);
 
   JsonObject *meta = recv_json_object (tc);
   cockpit_assert_json_eq (json_object_get_array_member (meta, "metrics"),
-                          "[ { 'name': 'mock.seconds', 'units': 'min', 'semantics': 'instant' } ]");
+                          "[ { \"name\": \"mock.seconds\", \"units\": \"min\", \"semantics\": \"instant\" } ]");
 
   assert_sample (tc, "[[1]]");
 
@@ -304,9 +304,9 @@ test_metrics_units_noconv (TestCase *tc,
   cockpit_expect_log ("cockpit-protocol", G_LOG_LEVEL_MESSAGE,
                       "1234: direct: can't convert metric mock.seconds to units byte");
 
-  JsonObject *options = json_obj("{ 'source': 'direct',"
-                                 "  'metrics': [ { 'name': 'mock.seconds', 'units': 'byte' } ],"
-                                 "  'interval': 1"
+  JsonObject *options = json_obj("{ \"source\": \"direct\","
+                                 "  \"metrics\": [ { \"name\": \"mock.seconds\", \"units\": \"byte\" } ],"
+                                 "  \"interval\": 1"
                                  "}");
   setup_metrics_channel_json (tc, options);
 
@@ -320,15 +320,15 @@ static void
 test_metrics_units_funny_conv (TestCase *tc,
                                gconstpointer unused)
 {
-  JsonObject *options = json_obj("{ 'source': 'direct',"
-                                 "  'metrics': [ { 'name': 'mock.seconds', 'units': '2 min' } ],"
-                                 "  'interval': 1"
+  JsonObject *options = json_obj("{ \"source\": \"direct\","
+                                 "  \"metrics\": [ { \"name\": \"mock.seconds\", \"units\": \"2 min\" } ],"
+                                 "  \"interval\": 1"
                                  "}");
   setup_metrics_channel_json (tc, options);
 
   JsonObject *meta = recv_json_object (tc);
   cockpit_assert_json_eq (json_object_get_array_member (meta, "metrics"),
-                          "[ { 'name': 'mock.seconds', 'units': 'min*2', 'semantics': 'instant' } ]");
+                          "[ { \"name\": \"mock.seconds\", \"units\": \"min*2\", \"semantics\": \"instant\" } ]");
 
   assert_sample (tc, "[[0.5]]");
 
@@ -339,15 +339,15 @@ static void
 test_metrics_strings (TestCase *tc,
                       gconstpointer unused)
 {
-  JsonObject *options = json_obj("{ 'source': 'direct',"
-                                 "  'metrics': [ { 'name': 'mock.string' } ],"
-                                 "  'interval': 1"
+  JsonObject *options = json_obj("{ \"source\": \"direct\","
+                                 "  \"metrics\": [ { \"name\": \"mock.string\" } ],"
+                                 "  \"interval\": 1"
                                  "}");
   setup_metrics_channel_json (tc, options);
 
   JsonObject *meta = recv_json_object (tc);
   cockpit_assert_json_eq (json_object_get_array_member (meta, "metrics"),
-                          "[ { 'name': 'mock.string', 'units': '', 'semantics': 'instant' } ]");
+                          "[ { \"name\": \"mock.string\", \"units\": \"\", \"semantics\": \"instant\" } ]");
 
   assert_sample (tc, "[[false]]");
   assert_sample (tc, "[[false]]");
@@ -363,17 +363,17 @@ static void
 test_metrics_simple_instances (TestCase *tc,
                                gconstpointer unused)
 {
-  JsonObject *options = json_obj("{ 'source': 'direct',"
-                                 "  'metrics': [ { 'name': 'mock.values' } ],"
-                                 "  'interval': 1"
+  JsonObject *options = json_obj("{ \"source\": \"direct\","
+                                 "  \"metrics\": [ { \"name\": \"mock.values\" } ],"
+                                 "  \"interval\": 1"
                                  "}");
 
   setup_metrics_channel_json (tc, options);
 
   JsonObject *meta = recv_json_object (tc);
   cockpit_assert_json_eq (json_object_get_array_member (meta, "metrics"),
-                          "[ { 'name': 'mock.values', 'units': '', 'semantics': 'instant', "
-                          "    'instances': ['red', 'green', 'blue'] "
+                          "[ { \"name\": \"mock.values\", \"units\": \"\", \"semantics\": \"instant\", "
+                          "    \"instances\": [\"red\", \"green\", \"blue\"] "
                           "  } ]");
 
   assert_sample (tc, "[[[0, 0, 0]]]");
@@ -392,18 +392,18 @@ static void
 test_metrics_instance_filter_include (TestCase *tc,
                                       gconstpointer unused)
 {
-  JsonObject *options = json_obj("{ 'source': 'direct',"
-                                 "  'metrics': [ { 'name': 'mock.values' } ],"
-                                 "  'instances': [ 'red', 'blue' ],"
-                                 "  'interval': 1"
+  JsonObject *options = json_obj("{ \"source\": \"direct\","
+                                 "  \"metrics\": [ { \"name\": \"mock.values\" } ],"
+                                 "  \"instances\": [ \"red\", \"blue\" ],"
+                                 "  \"interval\": 1"
                                  "}");
 
   setup_metrics_channel_json (tc, options);
 
   JsonObject *meta = recv_json_object (tc);
   cockpit_assert_json_eq (json_object_get_array_member (meta, "metrics"),
-                          "[ { 'name': 'mock.values', 'units': '', 'semantics': 'instant', "
-                          "    'instances': ['red', 'blue'] "
+                          "[ { \"name\": \"mock.values\", \"units\": \"\", \"semantics\": \"instant\", "
+                          "    \"instances\": [\"red\", \"blue\"] "
                           "  } ]");
 
   assert_sample (tc, "[[[0, 0]]]");
@@ -417,18 +417,18 @@ static void
 test_metrics_instance_filter_omit (TestCase *tc,
                                    gconstpointer unused)
 {
-  JsonObject *options = json_obj("{ 'source': 'direct',"
-                                 "  'metrics': [ { 'name': 'mock.values' } ],"
-                                 "  'omit-instances': [ 'green' ],"
-                                 "  'interval': 1"
+  JsonObject *options = json_obj("{ \"source\": \"direct\","
+                                 "  \"metrics\": [ { \"name\": \"mock.values\" } ],"
+                                 "  \"omit-instances\": [ \"green\" ],"
+                                 "  \"interval\": 1"
                                  "}");
 
   setup_metrics_channel_json (tc, options);
 
   JsonObject *meta = recv_json_object (tc);
   cockpit_assert_json_eq (json_object_get_array_member (meta, "metrics"),
-                          "[ { 'name': 'mock.values', 'units': '', 'semantics': 'instant', "
-                          "    'instances': ['red', 'blue'] "
+                          "[ { \"name\": \"mock.values\", \"units\": \"\", \"semantics\": \"instant\", "
+                          "    \"instances\": [\"red\", \"blue\"] "
                           "  } ]");
 
   assert_sample (tc, "[[[0, 0]]]");
@@ -443,17 +443,17 @@ test_metrics_instance_dynamic (TestCase *tc,
                                gconstpointer unused)
 {
   JsonObject *meta;
-  JsonObject *options = json_obj("{ 'source': 'direct',"
-                                 "  'metrics': [ { 'name': 'mock.instances' } ],"
-                                 "  'interval': 1"
+  JsonObject *options = json_obj("{ \"source\": \"direct\","
+                                 "  \"metrics\": [ { \"name\": \"mock.instances\" } ],"
+                                 "  \"interval\": 1"
                                  "}");
 
   setup_metrics_channel_json (tc, options);
 
   meta = recv_json_object (tc);
   cockpit_assert_json_eq (json_object_get_array_member (meta, "metrics"),
-                          "[ { 'name': 'mock.instances', 'units': '', 'semantics': 'instant', "
-                          "    'instances': [] "
+                          "[ { \"name\": \"mock.instances\", \"units\": \"\", \"semantics\": \"instant\", "
+                          "    \"instances\": [] "
                           "  } ]");
 
   assert_sample (tc, "[[[]]]");
@@ -463,8 +463,8 @@ test_metrics_instance_dynamic (TestCase *tc,
 
   meta = recv_json_object (tc);
   cockpit_assert_json_eq (json_object_get_array_member (meta, "metrics"),
-                          "[ { 'name': 'mock.instances', 'units': '', 'semantics': 'instant', "
-                          "    'instances': [ 'bananas', 'milk' ] "
+                          "[ { \"name\": \"mock.instances\", \"units\": \"\", \"semantics\": \"instant\", "
+                          "    \"instances\": [ \"bananas\", \"milk\" ] "
                           "  } ]");
   assert_sample (tc, "[[[ 5, 3 ]]]");
   assert_sample (tc, "[[[ 5, 3 ]]]");
@@ -473,8 +473,8 @@ test_metrics_instance_dynamic (TestCase *tc,
 
   meta = recv_json_object (tc);
   cockpit_assert_json_eq (json_object_get_array_member (meta, "metrics"),
-                          "[ { 'name': 'mock.instances', 'units': '', 'semantics': 'instant', "
-                          "    'instances': [ 'milk' ] "
+                          "[ { \"name\": \"mock.instances\", \"units\": \"\", \"semantics\": \"instant\", "
+                          "    \"instances\": [ \"milk\" ] "
                           "  } ]");
   assert_sample (tc, "[[[ 3 ]]]");
 
@@ -489,16 +489,16 @@ static void
 test_metrics_counter (TestCase *tc,
                       gconstpointer unused)
 {
-  JsonObject *options = json_obj("{ 'source': 'direct',"
-                                 "  'metrics': [ { 'name': 'mock.counter', 'derive': 'delta' } ],"
-                                 "  'interval': 1"
+  JsonObject *options = json_obj("{ \"source\": \"direct\","
+                                 "  \"metrics\": [ { \"name\": \"mock.counter\", \"derive\": \"delta\" } ],"
+                                 "  \"interval\": 1"
                                  "}");
 
   setup_metrics_channel_json (tc, options);
 
   JsonObject *meta = recv_json_object (tc);
   cockpit_assert_json_eq (json_object_get_array_member (meta, "metrics"),
-                          "[ { 'name': 'mock.counter', 'units': '', 'semantics': 'counter', 'derive': 'delta' } ]");
+                          "[ { \"name\": \"mock.counter\", \"units\": \"\", \"semantics\": \"counter\", \"derive\": \"delta\" } ]");
 
   assert_sample (tc, "[[false]]");
   assert_sample (tc, "[[0]]");
@@ -514,16 +514,16 @@ static void
 test_metrics_counter64 (TestCase *tc,
                         gconstpointer unused)
 {
-  JsonObject *options = json_obj("{ 'source': 'direct',"
-                                 "  'metrics': [ { 'name': 'mock.counter64', 'derive': 'delta' } ],"
-                                 "  'interval': 1"
+  JsonObject *options = json_obj("{ \"source\": \"direct\","
+                                 "  \"metrics\": [ { \"name\": \"mock.counter64\", \"derive\": \"delta\" } ],"
+                                 "  \"interval\": 1"
                                  "}");
 
   setup_metrics_channel_json (tc, options);
 
   JsonObject *meta = recv_json_object (tc);
   cockpit_assert_json_eq (json_object_get_array_member (meta, "metrics"),
-                          "[ { 'name': 'mock.counter64', 'units': '', 'semantics': 'counter', 'derive': 'delta' } ]");
+                          "[ { \"name\": \"mock.counter64\", \"units\": \"\", \"semantics\": \"counter\", \"derive\": \"delta\" } ]");
 
   assert_sample (tc, "[[false]]");
   assert_sample (tc, "[[0]]");
@@ -539,26 +539,26 @@ static void
 test_metrics_counter_across_meta (TestCase *tc,
                                   gconstpointer unused)
 {
-  JsonObject *options = json_obj("{ 'source': 'direct',"
-                                 "  'metrics': [ { 'name': 'mock.counter', 'derive': 'delta' },"
-                                 "               { 'name': 'mock.instances' }"
+  JsonObject *options = json_obj("{ \"source\": \"direct\","
+                                 "  \"metrics\": [ { \"name\": \"mock.counter\", \"derive\": \"delta\" },"
+                                 "               { \"name\": \"mock.instances\" }"
                                  "             ],"
-                                 "  'interval': 1"
+                                 "  \"interval\": 1"
                                  "}");
 
   setup_metrics_channel_json (tc, options);
 
   JsonObject *meta = recv_json_object (tc);
   cockpit_assert_json_eq (json_object_get_array_member (meta, "metrics"),
-                          "[ { 'name': 'mock.counter',"
-                          "    'units': '',"
-                          "    'semantics': 'counter',"
-                          "    'derive': 'delta'"
+                          "[ { \"name\": \"mock.counter\","
+                          "    \"units\": \"\","
+                          "    \"semantics\": \"counter\","
+                          "    \"derive\": \"delta\""
                           "  },"
-                          "  { 'name': 'mock.instances',"
-                          "    'units': '',"
-                          "    'semantics': 'instant',"
-                          "    'instances': [] }"
+                          "  { \"name\": \"mock.instances\","
+                          "    \"units\": \"\","
+                          "    \"semantics\": \"instant\","
+                          "    \"instances\": [] }"
                           "]");
 
   assert_sample (tc, "[[false,[]]]");
@@ -572,15 +572,15 @@ test_metrics_counter_across_meta (TestCase *tc,
   mock_pmda_control ("add-instance", "foo", 12);
   meta = recv_json_object (tc);
   cockpit_assert_json_eq (json_object_get_array_member (meta, "metrics"),
-                          "[ { 'name': 'mock.counter',"
-                          "    'units': '',"
-                          "    'semantics': 'counter',"
-                          "    'derive': 'delta'"
+                          "[ { \"name\": \"mock.counter\","
+                          "    \"units\": \"\","
+                          "    \"semantics\": \"counter\","
+                          "    \"derive\": \"delta\""
                           "  },"
-                          "  { 'name': 'mock.instances',"
-                          "    'units': '',"
-                          "    'semantics': 'instant',"
-                          "    'instances': [ 'foo' ] }"
+                          "  { \"name\": \"mock.instances\","
+                          "    \"units\": \"\","
+                          "    \"semantics\": \"instant\","
+                          "    \"instances\": [ \"foo\" ] }"
                           "]");
   assert_sample (tc, "[[0,[12]]]");
 

--- a/src/ssh/test-sshbridge.c
+++ b/src/ssh/test-sshbridge.c
@@ -675,8 +675,8 @@ test_echo_large (TestCase *tc,
   json_object_unref (init);
 }
 
-#define MOCK_RSA_KEY "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCYzo07OA0H6f7orVun9nIVjGYrkf8AuPDScqWGzlKpAqSipoQ9oY/mwONwIOu4uhKh7FTQCq5p+NaOJ6+Q4z++xBzSOLFseKX+zyLxgNG28jnF06WSmrMsSfvPdNuZKt9rZcQFKn9fRNa8oixa+RsqEEVEvTYhGtRf7w2wsV49xIoIza/bln1ABX1YLaCByZow+dK3ZlHn/UU0r4ewpAIZhve4vCvAsMe5+6KJH8ft/OKXXQY06h6jCythLV4h18gY/sYosOa+/4XgpmBiE7fDeFRKVjP3mvkxMpxce+ckOFae2+aJu51h513S9kxY2PmKaV/JU9HBYO+yO4j+j24v\n"
-#define MOCK_RSA_KEY_INVALID  "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7YmnYAJaC579hyNFzcszH+ZFQeDuR8I2li1vCgKeM0lOIkV5TwCY4Tl1lbXI7NNffDACQnUrJfNNm6FamdhVzFEvyQAk+iQz/Wz6lHbDlY2dVvoVaJzNWyqXu/qaYs8Mb2QUmNXKtYk4IuM8PH88z5L4JwZXRbOEPOxnJNcaazP9pBhN/0TrHALaXwW29BR0SIJicJqK2r/mPuDovg/SWs8NdgY9DTAAfzdELshTigVXlc1AX6vo71x3O9NWMaPKZuy88o0BeQNI+mkVeV04Pewm3bUlDsr3VeEcd4D+Ixdyfg4+S57K1in0kHQD4PXrd/x5GoCZekxgUuBoE7HVB\n"
+#define MOCK_RSA_KEY "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCYzo07OA0H6f7orVun9nIVjGYrkf8AuPDScqWGzlKpAqSipoQ9oY/mwONwIOu4uhKh7FTQCq5p+NaOJ6+Q4z++xBzSOLFseKX+zyLxgNG28jnF06WSmrMsSfvPdNuZKt9rZcQFKn9fRNa8oixa+RsqEEVEvTYhGtRf7w2wsV49xIoIza/bln1ABX1YLaCByZow+dK3ZlHn/UU0r4ewpAIZhve4vCvAsMe5+6KJH8ft/OKXXQY06h6jCythLV4h18gY/sYosOa+/4XgpmBiE7fDeFRKVjP3mvkxMpxce+ckOFae2+aJu51h513S9kxY2PmKaV/JU9HBYO+yO4j+j24v"
+#define MOCK_RSA_KEY_INVALID  "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7YmnYAJaC579hyNFzcszH+ZFQeDuR8I2li1vCgKeM0lOIkV5TwCY4Tl1lbXI7NNffDACQnUrJfNNm6FamdhVzFEvyQAk+iQz/Wz6lHbDlY2dVvoVaJzNWyqXu/qaYs8Mb2QUmNXKtYk4IuM8PH88z5L4JwZXRbOEPOxnJNcaazP9pBhN/0TrHALaXwW29BR0SIJicJqK2r/mPuDovg/SWs8NdgY9DTAAfzdELshTigVXlc1AX6vo71x3O9NWMaPKZuy88o0BeQNI+mkVeV04Pewm3bUlDsr3VeEcd4D+Ixdyfg4+S57K1in0kHQD4PXrd/x5GoCZekxgUuBoE7HVB"
 
 static const gchar MOCK_RSA_FP[] = "SHA256:XQ8a7zGxMFstDrGecBRUP9OMnOUXd/T3vkNGtYShs2w";
 #define SSH_PUBLICKEY_HASH_NAME "SHA256"
@@ -747,7 +747,7 @@ do_hostkey_conversation (TestCase *tc,
                          gboolean add_header)
 {
   gchar *expect_json = NULL;
-  expect_json = g_strdup_printf ("{\"message\": \"The authenticity of host '127.0.0.1:%d' can't be established. Do you want to proceed this time?\", \"default\": \"%s\", \"host-key\": \"[127.0.0.1]:%d %s\", \"echo\": true }",
+  expect_json = g_strdup_printf ("{\"message\": \"The authenticity of host '127.0.0.1:%d' can't be established. Do you want to proceed this time?\", \"default\": \"%s\", \"host-key\": \"[127.0.0.1]:%d %s\\n\", \"echo\": true }",
                                  (int)tc->ssh_port, MOCK_RSA_FP,
                                  (int)tc->ssh_port, MOCK_RSA_KEY);
 
@@ -761,7 +761,7 @@ check_host_key_values (TestCase *tc,
                        JsonObject *init,
                        const char *hostname)
 {
-  gchar *knownhosts = g_strdup_printf ("[%s]:%d %s",
+  gchar *knownhosts = g_strdup_printf ("[%s]:%d %s\n",
                                        hostname ?: "127.0.0.1",
                                        (int)tc->ssh_port,
                                        MOCK_RSA_KEY);


### PR DESCRIPTION
json-glib dropped support [1] for single quote encapsulation of string values in JSON strings.

[1] https://gitlab.gnome.org/GNOME/json-glib/-/commit/c79df16fd2301f3448245387be56e69e390327f3