### PR TITLE
Omit instances historical metrics

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -1142,7 +1142,7 @@ The general open options are:
    * "direct": PCP metrics from plugins that are loaded into the
      Cockpit bridge directly.  Use this when in doubt.
 
-   * "pcmd": PCP metrics from the local PCP daemon.
+   * "pmcd": PCP metrics from the local PCP daemon.
 
    * A string starting with "/": PCP metrics from one or more
      archives.

--- a/pkg/metrics/metrics.jsx
+++ b/pkg/metrics/metrics.jsx
@@ -200,7 +200,7 @@ const HISTORY_METRICS = [
     { name: "disk.all.total_bytes", derive: "rate" },
 
     // network utilization
-    { name: "network.interface.total.bytes", derive: "rate", "omit-instances": ["lo"] },
+    { name: "network.interface.total.bytes", derive: "rate" },
 ];
 
 function debug() {
@@ -1710,6 +1710,7 @@ class MetricsHistory extends React.Component {
             timestamp: load_timestamp,
             limit,
             metrics: HISTORY_METRICS,
+            "omit-instances": ["lo"],
         });
 
         metrics.addEventListener("message", (event, message) => {


### PR DESCRIPTION
I can be convinced to change the protocol but not now while I am rewriting this into Python :)

```
[jelle@t14s][~/projects/cockpit/main]%cpf open metrics1 source="/tmp/disk" metrics='[{"name":"network.interface.total.bytes","derive":"rate","omit-instances":["lo"]}]
' limit=5  : wait | G_MESSAGES_DEBUG=none ./cockpit-pcp | /usr/bin/cat
36

{ "command": "init", "version": 1 }36

{"command":"ready","channel":"ch1"}188
ch1
{"timestamp":1597663539413,"now":1720517012231,"interval":1000,"metrics":[{"name":"network.interface.total.bytes","derive":"rate","instances":[],"units":"byte","semantics":"counter"}]}10
ch1
[[[]]]228
ch1
{"timestamp":1597663540413,"now":1720517012231,"interval":1000,"metrics":[{"name":"network.interface.total.bytes","derive":"rate","instances":["lo","eth0","eth1","virbr0","virbr0-nic"],"units":"byte","semantics":"counter"}]}84
ch1
[[[false,false,false,false,false]],[[343707,199192,0,0,0]],[[null,199193]],[[]]]36

{"command":"close","channel":"ch1"}
```

Versus:

```
[jelle@t14s][~/projects/cockpit/main]%cpf open metrics1 source="/tmp/disk" metrics='[{"name":"network.interface.total.bytes","derive":"rate"}]' omit_instances='["lo"]' limit=5  : wait | G_MESSAGES_DEBUG=none ./cockpit-pcp | /usr/bin/cat
36

{ "command": "init", "version": 1 }36

{"command":"ready","channel":"ch1"}188
ch1
{"timestamp":1597663539413,"now":1720517247774,"interval":1000,"metrics":[{"name":"network.interface.total.bytes","derive":"rate","instances":[],"units":"byte","semantics":"counter"}]}10
ch1
[[[]]]228
ch1
{"timestamp":1597663540413,"now":1720517247775,"interval":1000,"metrics":[{"name":"network.interface.total.bytes","derive":"rate","instances":["lo","eth0","eth1","virbr0","virbr0-nic"],"units":"byte","semantics":"counter"}]}84
ch1
[[[false,false,false,false,false]],[[343707,199192,0,0,0]],[[null,199193]],[[]]]36

{"command":"close","channel":"ch1"}
```

Super confused...