### PR TITLE
tsconfig.json: don't typecheck esbuild plugins

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,4 +28,10 @@
     "include": [
         "pkg/**/*"
     ],
+    "exclude": [
+        // these are part of the build system, not the app
+        "pkg/lib/esbuild-*.js",
+        "pkg/lib/cockpit-*-plugin.js",
+        "pkg/lib/*2po.js"
+    ],
 }


### PR DESCRIPTION
Our TypeScript config is setup to check our code that will be bundled and run in the browser.  It shouldn't be running on esbuild plugins that are run inside of node, and we never intended for it to. Unfortunately, we mix our esbuild plugins into pkg/lib/ alongside browser-based code, so it gets lumped in.

Add some excludes.  Fortunately, we don't have to copy this to other projects (like Cockpit Files) because they only check `src/*` in the first place (and only include files in other directories if they are explicitly imported).