### PR TITLE
zh: fix translation for "Add team" in Chinese

### DIFF
--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -821,7 +821,7 @@ msgstr "添加系统服务到安全区域 $0"
 
 #: pkg/networkmanager/team.jsx:154 pkg/networkmanager/network-main.jsx:143
 msgid "Add team"
-msgstr "添加绑定"
+msgstr "添加组合"
 
 #: pkg/networkmanager/firewall.jsx:806 pkg/networkmanager/firewall.jsx:811
 msgid "Add zone"


### PR DESCRIPTION
Changed from `添加绑定`(bond) to `添加组合`(team).

refer to:
https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/blob/main/po/zh_CN.po?ref_type=heads#L634

and

https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/blob/main/po/zh_CN.po?ref_type=heads#L641