### PR TITLE
test: unexpected whitespace after decorator

### DIFF
--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -469,7 +469,7 @@ machine         : 8561
         b.wait_text('#memory-listing tbody:nth-of-type(2) td[data-label=Rank]', "Single rank")
         b.wait_in_text('#memory-listing tbody:nth-of-type(2) td[data-label=Speed]', "2400 MT/s")
 
-    @ testlib.nondestructive
+    @testlib.nondestructive
     def testCPUSecurityMitigationsDetect(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
So this was legal? :exploding_head:  well ruff now detects this which is great!