### PR TITLE
test: Wipe lastlog db for TestSystemInfo.testBasic pixel test

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1917,7 +1917,7 @@ class MachineCase(unittest.TestCase):
                                     ".*couldn't create polkit session subject: No session for pid.*",
                                     "We are no longer a registered authentication agent.",
                                     ".*: failed to retrieve resource: terminated",
-                                    ".*: external channel failed: (terminated|protocol-error)",
+                                    ".*: external channel failed:.*",
                                     ".*: truncated data in external channel",
                                     'audit:.*denied.*comm="systemd-user-se".*nologin.*',
                                     ".*No session for cookie",

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -83,6 +83,8 @@ class TestSystemInfo(testlib.MachineCase):
         # set static machine ID, as they have different lengths which disturbs the pixel test
         m.execute("mv /etc/machine-id /etc/machine-id.orig")
         m.write("/etc/machine-id", "123456789abcdef123456789abcdef00")
+        # avoid "Last logged in" health card message, it breaks pixel tests and is too unpredictable
+        m.execute("rm -f /var/log/lastlog /var/lib/lastlog/lastlog2.db /var/lib/wtmpdb/wtmp.db")
 
         self.login_and_go("/system")
 


### PR DESCRIPTION
On the recent Fedora 40 image refresh [1] the "admin" user has a past
login, which unexpectedly appears in the Health card as "Last logged in".
As that data is too unpredictable, wipe the lastlog database first.
    
[1] https://github.com/cockpit-project/bots/pull/6605

----

Plus a flake fix for [this](https://cockpit-logs.us-east-1.linodeobjects.com/pull-6605-f678fe28-20240711-050210-fedora-40-devel-cockpit-project-cockpit/log.html), which is also on the weather report.

