### PR TITLE
lib: Declare window.debugging type

### DIFF
--- a/pkg/lib/cockpit.d.ts
+++ b/pkg/lib/cockpit.d.ts
@@ -16,6 +16,11 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+// a lot of libraries and applications use `window.debugging`, see HACKING.md
+interface Window {
+    debugging?: string;
+}
+
 declare module 'cockpit' {
     type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
     type JsonObject = Record<string, JsonValue>;


### PR DESCRIPTION
We use this throughout cockpit.js and library modules. This fixes a TypeScript error:

> pkg/lib/cockpit-dark-theme.ts(21,16): error TS2339:
> Property 'debugging' does not exist on type 'Window & typeof globalThis'.

It's not clear why this doesn't break cockpit-files, but it does break starter-kit.

----

This blocks https://github.com/cockpit-project/starter-kit/pull/917