### PR TITLE
pkg/lib: add reference from cockpit.d.ts to cockpit.js

### DIFF
--- a/pkg/lib/cockpit.d.ts
+++ b/pkg/lib/cockpit.d.ts
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+import '_internal/common'; // side-effecting import (`window` augmentations)
+
 declare module 'cockpit' {
     type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
     type JsonObject = Record<string, JsonValue>;


### PR DESCRIPTION
For projects that import TypeScript modules from pkg/lib which reach into the _internal/ directory, all of those files get included in the compilation.  For projects that only import `'cockpit'`, though, the TypeScript compiler files our `cockpit.d.ts` and stops there.

Add a reference to tell it to pull in everything that `cockpit.js` imports.  This is needed to get the type declarations of the `.ts` files in `_internal/` — particularly the `window` augmentations in `common.ts`.


I tested manually making this change to cockpit-project/starter-kit#917 and it fixed the issues there.