### PR TITLE
apps: drop custom content-security-policy

### DIFF
--- a/pkg/apps/manifest.json
+++ b/pkg/apps/manifest.json
@@ -10,8 +10,6 @@
         }
     },
 
-    "content-security-policy": "img-src *",
-
     "config": {
         "appstream_config_packages": {
             "debian": ["appstream"]


### PR DESCRIPTION
The apps content-security-policy allows more the our default policy which is unneeded as images are loaded via `fsread1` and thus the same origin.

---

Before
```
// default-src 'self'; connect-src wss://127.0.0.2:9091 'self'; form-action 'self'; base-uri 'self'; object-src 'none'; font-src 'self' data:; img-src *; block-all-mixed-content
```

After
```
// default-src 'self'; connect-src wss://127.0.0.2:9091 'self'; form-action 'self'; base-uri 'self'; object-src 'none'; font-src 'self' data:; img-src 'self' data:; block-all-mixed-content
```