### PR TITLE
shell: Deprecate host switcher in current OS releases

### DIFF
--- a/doc/guide/authentication.xml
+++ b/doc/guide/authentication.xml
@@ -61,11 +61,35 @@
 
   </section>
 
+  <section id="direct-secondary-auth">
+    <title>Directly logging into a secondary server without a primary session</title>
+
+    <para>It is also possible to log into a secondary server without
+    opening a session on the primary server. This is useful if you
+    are not actually interested in the primary server and would only
+    use it because you do not have direct network access to the
+    secondary server.</para>
+
+    <para>In this case, <filename>cockpit-ws</filename> still runs on
+    the primary server, but the credentials from the login screen are
+    directly used with SSH to log into the secondary server given in
+    the "Connect To" field of the login screen.</para>
+
+    <para>Thus, the PAM configuration and accounts on the primary
+    server don't matter at all. Often, the only purpose of the primary
+    server is to sit on the boundary of your network and forward
+    connections to internal machines.</para>
+
+    <para>In this case, the login page will prompt you to verify
+    unknown SSH keys. Accepted keys will be remembered in the local
+    storage of your browser.</para>
+  </section>
+
   <section id="secondary-auth">
     <title>Logging into a secondary server from the primary session</title>
 
-    <para>Once you have a session on the primary server you will be
-    able to connect to additional servers by using the host switching
+    <para>Once you have a session on the primary server, it is possible
+    connect to additional servers by using the host switching
     UI of the Cockpit Shell. This is useful if you have direct network
     access to the primary server, but not to the secondary server.</para>
 
@@ -75,8 +99,25 @@
     of running a interactive shell there, however, it starts a
     <filename>cockpit-bridge</filename> process.</para>
 
-    <para>Thus, these servers will need to be running an SSH server on
-    port 22 and be configured to support one of the following
+    <para><emphasis>Warning:</emphasis> Unlike with SSH on the command line
+    though, this will also load and use the Cockpit pages (i.e. JavaScript)
+    from the remote machine, which means that the remote machine can execute
+    arbitrary code on your primary and all other connected secondary machines.
+    Hence, only connect to <emphasis>machines which you trust</emphasis>.</para>
+
+    <para>Due to this security risk, this host switcher functionality is disabled
+    by default, except on long-term stable Linux distributions (Red Hat
+    Enterprise Linux 9, Debian 12, and Ubuntu 22.04/24.04 LTS). If you are
+    comfortable with the security implications, you can enable it manually by
+    creating a file <filename>/etc/cockpit/shell.override.json</filename> with
+    the following content:</para>
+
+<programlisting>
+{ "config": { "host_switcher": true } }
+</programlisting>
+
+    <para>These servers will need to be running an SSH server
+    and be configured to support one of the following
     authentication methods.</para>
 
     <section id="password">
@@ -119,30 +160,6 @@
       keys, and will write accepted host keys into
       <filename>~/.ssh/known_hosts</filename>.</para>
     </section>
-  </section>
-
-  <section id="direct-secondary-auth">
-    <title>Directly logging into a secondary server without a primary session</title>
-
-    <para>It is also possible to log into a secondary server without
-    opening a session on the primary server. This is useful if you
-    are not actually interested in the primary server and would only
-    use it because you do not have direct network access to the
-    secondary server.</para>
-
-    <para>In this case, <filename>cockpit-ws</filename> still runs on
-    the primary server, but the credentials from the login screen are
-    directly used with SSH to log into the secondary server given in
-    the "Connect To" field of the login screen.</para>
-
-    <para>Thus, the PAM configuration and accounts on the primary
-    server don't matter at all. Often, the only purpose of the primary
-    server is to sit on the boundary of your network and forward
-    connections to internal machines.</para>
-
-    <para>In this case, the login page will prompt you to verify
-    unknown SSH keys. Accepted keys will be remembered in the local
-    storage of your browser.</para>
   </section>
 
 </chapter>

--- a/pkg/shell/hosts.jsx
+++ b/pkg/shell/hosts.jsx
@@ -3,14 +3,24 @@ import cockpit from "cockpit";
 import React from 'react';
 import ReactDOM from "react-dom";
 import PropTypes from 'prop-types';
-import { PageSidebar } from "@patternfly/react-core/dist/esm/components/Page/index.js";
-import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
-import { Tooltip } from "@patternfly/react-core/dist/esm/components/Tooltip/index.js";
-import { EditIcon, MinusIcon, CaretUpIcon, CaretDownIcon } from '@patternfly/react-icons';
+import { Button } from "@patternfly/react-core/dist/esm/components/Button";
+import {
+    CaretDownIcon,
+    CaretUpIcon,
+    EditIcon,
+    ExclamationCircleIcon,
+    ExternalLinkAltIcon,
+    MinusIcon,
+} from '@patternfly/react-icons';
+import { Label } from "@patternfly/react-core/dist/esm/components/Label";
+import { PageSidebar } from "@patternfly/react-core/dist/esm/components/Page";
+import { Popover } from "@patternfly/react-core/dist/esm/components/Popover";
+import { Tooltip } from "@patternfly/react-core/dist/esm/components/Tooltip";
 
 import 'polyfills';
 import { CockpitNav, CockpitNavItem } from "./nav.jsx";
 import { HostModal } from "./hosts_dialog.jsx";
+import { useLoggedInUser } from "hooks";
 
 const _ = cockpit.gettext;
 const hosts_sel = document.getElementById("nav-hosts");
@@ -46,6 +56,18 @@ function HostLine({ host, user }) {
     );
 }
 
+// top left navigation element when host switching is disabled
+export const CockpitCurrentHost = ({ machine }) => {
+    const user_info = useLoggedInUser();
+
+    return (
+        <div className="ct-switcher ct-switcher-localonly pf-m-dark">
+            <HostLine user={machine.user || user_info?.name || ""} host={machine.label || ""} />
+        </div>
+    );
+};
+
+// full host switcher
 export class CockpitHosts extends React.Component {
     constructor(props) {
         super(props);
@@ -174,6 +196,24 @@ export class CockpitHosts extends React.Component {
         />;
         const label = this.props.machine.label || "";
         const user = this.props.machine.user || this.state.current_user;
+
+        let add_host_action;
+
+        if (this.props.enable_add_host) {
+            add_host_action = <Button variant="secondary" onClick={this.onAddNewHost}>{_("Add new host")}</Button>;
+        } else {
+            const footer = <a href="https://cockpit-project.org/blog/cockpit-322.html" target="_blank" rel="noreferrer">
+                <ExternalLinkAltIcon /> {_("Read more...")}
+            </a>;
+            add_host_action = (
+                <Popover id="disabled-add-host-help"
+                         headerContent={_("Host switching is not supported")}
+                         bodyContent={_("Connecting to remote hosts inside of a web console session is deprecated and will be removed in the future. You can still connect to your existing hosts for now.")}
+                         footerContent={footer}>
+                    <Label className="deprecated-add-host" color="blue" icon={<ExclamationCircleIcon />}>{_("Deprecated")}</Label>
+                </Popover>);
+        }
+
         return (
             <>
                 <div className="ct-switcher">
@@ -213,7 +253,7 @@ export class CockpitHosts extends React.Component {
                             />
                             <div className="nav-hosts-actions">
                                 {this.props.machines.list.length > 1 && <Button variant="secondary" onClick={this.onEditHosts}>{this.state.editing ? _("Stop editing hosts") : _("Edit hosts")}</Button>}
-                                <Button variant="secondary" onClick={this.onAddNewHost}>{_("Add new host")}</Button>
+                                {add_host_action}
                             </div>
                         </PageSidebar>
                     </HostsSelector>
@@ -245,4 +285,5 @@ CockpitHosts.propTypes = {
     selector: PropTypes.string.isRequired,
     hostAddr: PropTypes.func.isRequired,
     jump: PropTypes.func.isRequired,
+    enable_add_host: PropTypes.bool.isRequired,
 };

--- a/pkg/shell/indexes.jsx
+++ b/pkg/shell/indexes.jsx
@@ -24,10 +24,12 @@ import { createRoot } from "react-dom/client";
 
 import { CockpitNav, CockpitNavItem, SidebarToggle } from "./nav.jsx";
 import { TopNav } from ".//topnav.jsx";
-import { CockpitHosts } from "./hosts.jsx";
+import { CockpitHosts, CockpitCurrentHost } from "./hosts.jsx";
 import { codes, HostModal } from "./hosts_dialog.jsx";
 import { EarlyFailure, EarlyFailureReady } from './failures.jsx';
 import { WithDialogs } from "dialogs.jsx";
+import { read_os_release } from "os-release";
+import { get_manifest_config_matchlist } from "utils";
 
 import * as base_index from "./base_index";
 
@@ -98,6 +100,18 @@ function MachinesIndex(index_options, machines, loader) {
     cockpit.user().then(user => {
         current_user = user.name || "";
     }).catch(exc => console.log(exc));
+
+    /* Host switcher enabled? */
+    let host_switcher_enabled = false;
+    read_os_release().then(os_release => {
+        const enabled = os_release && get_manifest_config_matchlist(
+            "shell", "host_switcher", false,
+            [os_release.PLATFORM_ID, os_release.VERSION_CODENAME]);
+        if (enabled) {
+            host_switcher_enabled = true;
+            update_machines();
+        }
+    });
 
     /* Navigation */
     let ready = false;
@@ -374,14 +388,20 @@ function MachinesIndex(index_options, machines, loader) {
         if (!machine)
             machine = machines.lookup(state.host);
 
-        hosts_sel_root.render(
-            React.createElement(CockpitHosts, {
-                machine: machine || {},
-                machines,
-                selector: "nav-hosts",
-                hostAddr: index.href,
-                jump: index.jump,
-            }));
+        // deprecation transition period: show existing remote hosts, but disable adding new ones
+        if (host_switcher_enabled || machines.list.length > 1) {
+            hosts_sel_root.render(
+                React.createElement(CockpitHosts, {
+                    machine: machine || {},
+                    machines,
+                    selector: "nav-hosts",
+                    hostAddr: index.href,
+                    jump: index.jump,
+                    enable_add_host: host_switcher_enabled,
+                }));
+        } else {
+            hosts_sel_root.render(React.createElement(CockpitCurrentHost, { machine: machine || {} }));
+        }
     }
 
     function update_title(label, machine) {

--- a/pkg/shell/manifest.json
+++ b/pkg/shell/manifest.json
@@ -32,6 +32,15 @@
             "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_systems_using_the_rhel_9_web_console/index"
         }
     ],
+    "config": {
+        "host_switcher": {
+            "platform:f39": true,
+            "platform:el9": true,
+            "bookworm": true,
+            "jammy": true,
+            "noble": true
+        }
+    },
     "bridges": [
         {
             "privileged": true,

--- a/pkg/shell/nav.scss
+++ b/pkg/shell/nav.scss
@@ -397,6 +397,12 @@ $desktop: $phone + 1px;
   }
 }
 
+.ct-switcher-localonly {
+  padding-inline-start: var(--pf-v5-global--spacer--lg);
+  padding-block-start: var(--pf-v5-global--spacer--sm);
+  color: var(--pf-v5-global--Color--light-100);
+}
+
 .pf-v5-theme-dark {
   .pf-v5-c-select__toggle {
     > * {
@@ -667,6 +673,11 @@ $desktop: $phone + 1px;
   // Hide border from navigation items for mobile
   .pf-v5-c-menu-toggle::before {
     border: none;
+  }
+
+  // Hide local-only host switcher (i.e. when only showing the current user name)
+  .ct-switcher-localonly {
+    display: none !important;
   }
 }
 

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1623,6 +1623,9 @@ class MachineCase(unittest.TestCase):
                 self.sshd_socket = 'sshd.socket'
         self.restart_sshd = f'systemctl try-restart {self.sshd_service}'
 
+        # only enabled by default on stable LTS OSes; see pkg/shell/manifest.json
+        self.multihost_enabled = image.startswith(("rhel-9", "centos-9")) or image in ["ubuntu-2204", "ubuntu-stable", "debian-stable", "fedora-39"]
+
     def nonDestructiveSetup(self) -> None:
         """generic setUp/tearDown for @nondestructive tests"""
 

--- a/test/verify/check-shell-host-switching
+++ b/test/verify/check-shell-host-switching
@@ -115,6 +115,11 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
         self.allow_restart_journal_messages()
         self.allow_hostkey_messages()
 
+    def enable_multihost(self, machine):
+        if not self.multihost_enabled:
+            machine.write("/etc/cockpit/shell.override.json",
+                          '{ "config": { "host_switcher": true } }')
+
     def testBasic(self):
         b = self.browser
         m1 = self.machines["machine1"]
@@ -126,6 +131,33 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
 
         # This should all work without being admin on machine1
         self.login_and_go(superuser=False)
+
+        # on recent OSes, switcher is disabled by default
+        if not self.multihost_enabled:
+            b.wait_text("#hosts-sel .ct-switcher-localonly", "admin@localhost")
+            self.assertFalse(b.is_present("#hosts-sel button"))
+            b.assert_pixels("#hosts-sel", "no-switching", skip_layouts=["mobile"])
+            b.logout()
+
+            # transition period: Existing remote hosts are still shown
+            m1.write("/etc/cockpit/machines.d/99-webui.json",
+                     '{"srv": { "address": "my.srv", "visible": true }}')
+            b.login_and_go(superuser=False)
+            b.click("#hosts-sel button")
+            self.wait_host_addresses(b, ["localhost", "my.srv"])
+            b.wait_in_text(".deprecated-add-host", "Deprecated")
+            b.assert_pixels(".nav-hosts-actions", "deprecated", skip_layouts=["mobile"])
+            # clicking on it shows popover with help
+            b.click(".deprecated-add-host")
+            b.wait_text("#popover-disabled-add-host-help-header", "Host switching is not supported")
+            b.click(".pf-v5-c-popover__close button")
+            b.wait_not_present("#popover-disabled-add-host-help-header")
+            b.logout()
+            m1.execute("rm /etc/cockpit/machines.d/99-webui.json")
+
+            # enable host switcher for this test
+            self.enable_multihost(m1)
+            b.login_and_go(superuser=False)
 
         b.assert_pixels("#nav-system", "nav-system", skip_layouts=["mobile"])
         b.set_layout("mobile")
@@ -321,6 +353,7 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
 
     def testBasicAsAdmin(self):
         b = self.browser
+        self.enable_multihost(self.machine)
 
         # When being admin, changes in the host switcher are supposed
         # to be reflected in all browser sessions.
@@ -402,6 +435,8 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
         m1 = self.machines['machine1']
         m2 = self.machines['machine2']
         m3 = self.machines['machine3']
+
+        self.enable_multihost(m1)
 
         m2.execute("hostnamectl set-hostname machine2")
         m3.execute("hostnamectl set-hostname machine3")
@@ -496,6 +531,7 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
         b = self.browser
         m2 = self.machines["machine2"]
 
+        self.enable_multihost(self.machine)
         self.login_and_go(None)
 
         # And and connect to a second machine

--- a/test/verify/check-shell-menu
+++ b/test/verify/check-shell-menu
@@ -191,14 +191,21 @@ class TestMenu(testlib.MachineCase):
         b.wait_js_cond("document.activeElement.tagName === 'NAV'")
         self.assertEqual(b.eval_js("document.activeElement.getAttribute('id')"), "hosts-sel")
 
-        # actually skips the page menu and goes on to top nav bar
+        # actually skips the page menu and goes on to top nav bar; where exactly depends on whether
+        # the host switcher is enabled, and whether the privilege button is visible (not with ws container)
         b.key("Tab")
-        b.wait_js_cond("document.activeElement.getAttribute('id') === 'host-toggle'")
-        b.key("Tab")
-        if self.machine.ostree_image:
-            b.wait_js_cond("document.activeElement.textContent === 'Help'")
+        if self.multihost_enabled:
+            b.wait_js_cond("document.activeElement.getAttribute('id') === 'host-toggle'")
+            b.key("Tab")
+            if self.machine.ostree_image:
+                b.wait_js_cond("document.activeElement.textContent === 'Help'")
+            else:
+                b.wait_js_cond("document.activeElement.textContent === 'Administrative access'")
         else:
-            b.wait_js_cond("document.activeElement.textContent === 'Administrative access'")
+            if self.machine.ostree_image:
+                b.wait_js_cond("document.activeElement.textContent === 'Help'")
+            else:
+                b.wait_js_cond("document.activeElement.textContent === 'Administrative access'")
 
         # reset
         b.reload()

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -287,7 +287,6 @@ class TestMultiMachine(testlib.MachineCase):
         b.switch_to_top()
 
         b.wait_js_cond(f'window.location.pathname == "{root}=10.111.113.2/system"')
-
         b.wait_in_text("#hosts-sel", "machine2")
 
         # This is a primary session, we can also ssh onwards to other machines

--- a/test/verify/check-shell-multi-machine-key
+++ b/test/verify/check-shell-multi-machine-key
@@ -115,6 +115,11 @@ class TestMultiMachineKeyAuth(testlib.MachineCase):
         if self.is_devel_build():
             self.disable_preload("packagekit", "playground", "systemd", machine=self.machine2)
 
+        # enable multi-host
+        if not self.multihost_enabled:
+            self.machine.write("/etc/cockpit/shell.override.json",
+                               '{ "config": { "host_switcher": true } }')
+
     # Possible workaround - ssh as `admin` and just do `m.execute()`
     @testlib.skipBrowser("Firefox cannot do `cockpit.spawn`", "firefox")
     @testlib.todoPybridgeRHEL8()

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -31,11 +31,12 @@ class TestLogin(testlib.MachineCase):
         b = self.browser
         b.wait_visible("#content")
         b.wait_text('#current-username', 'admin')
-        b.set_layout("mobile")
-        b.click("#hosts-sel button")
-        b.wait_in_text(".view-hosts .pf-m-current", "admin @")
-        b.click("#hosts-sel button")
-        b.set_layout("desktop")
+        if self.multihost_enabled:
+            b.set_layout("mobile")
+            b.click("#hosts-sel button")
+            b.wait_in_text(".view-hosts .pf-m-current", "admin @")
+            b.click("#hosts-sel button")
+            b.set_layout("desktop")
 
     def testBasic(self):
         m = self.machine


### PR DESCRIPTION
Connecting to multiple remote machines within one Cockpit session and
executing arbitrary JavaScript from them means that connecting to an
untrustworthy machine can do arbitrary damage to *all other* connected
machines. [1][2][3]

For many years, nobody has found a solution how to isolate the per-host
iframes from one another with still being authenticated "enough" to get
reliably mapped to a particular session and remote host, and it's
currently deemed impossible.

To avoid this, gradually phase out the shell's host switcher. Start with
disabling the host switcher in current development releases (Fedora,
RHEL 10, Debian testing, Arch, and so on), but keep it enabled in stable
long-term supported releases (RHEL 9, Debian 12, Ubuntu 22.04/24.04
LTS). Use our manifest `config` mechanism for that. This also provides a
short-term escape hatch to turn it back on with a manifest override [4].

Also, if the user has any existing remote hosts defined, still show the
host switcher with the existing hosts, and just disable the "Add new
host" button. Put a label in its place with an explanation and a link to
the blog post. We don't need this for users without existing remote host
definitions, as there's no breakage for them. This special case is the
next thing that we will deprecate.

Note: Directly logging into a remote host from the login page or the
flatpak is fine, and continued to be supported. Also, remote bridge
channels with the `host` option are supported for now, as they don't
load remote JavaScript code by themselves; PR #20726 provides a
replacement API for pages which want to do that.

Document that in the guide's Authentication page. Move the "direct
remote login" up, as that's continued to be supported.

Fixes https://issues.redhat.com/browse/COCKPIT-1149

[1] https://issues.redhat.com/browse/COCKPIT-870
[2] https://issues.redhat.com/browse/RHEL-4032
[3] https://issues.redhat.com/browse/RHEL-4037
[4] https://cockpit-project.org/blog/cockpit-322.html


-----

TODO:
 - [x] Builds on top of #20747
 - [x] Preferably, land after #20726 to have a working replacement
 - [x] Discuss: Add cockpit.conf option for this? Result: no
 - [x] Update the secondary auth in the guide
 - [x] Keep host switcher for Ubuntu 24.04 LTS and Fedora 39
 - [x] update the blog post TODO link once this is ready to land (currently aiming at 322)
 - [x] Add pixel test for "local only" host selector
 - [x] Add release note

## Shell: Deprecate host switching

The navigation menu's "Host switcher" allows the user to connect to further machines over SSH, get a Cockpit session for these machines, and switch between them within the primary session. However, all these parallel Cockpit sessions can do arbitrary changes to all other sessions via [direct remote channels](https://issues.redhat.com/browse/COCKPIT-870), [iframe traversal](https://issues.redhat.com/browse/RHEL-4032), [cache poisoning](https://issues.redhat.com/browse/RHEL-4037), and other means. This breaks the trust boundaries which normally exist with command-line SSH: When connecting from a host A to an untrusted host B, it is expected that B is notable to do anything on A.

Despite several months of research of current web technologies, we did not find a design which avoids this flaw. Therefore Cockpit will gradually deprecate the host switcher feature. As a first step, it will be disabled by default in Fedora ≥ 40, Debian unstable/testing, CentOS/RHEL 10, and Arch. However, if you already have existing remote host definitions, you can continue to connect to them for now, you just cannot add new remote connections any more.

The host switcher will stay as is in stable/Enterprise Linux distributions. Currently these are Red Hat Enterprise Linux/CentOS Stream 9, Debian 12 "bookworm", and Ubuntu 22.04 LTS and 24.04 LTS.

### Alternatives

 * The login page offers a "Connect to:" field which will directly connect to the given host with SSH. This is safe and will always be supported. However, this only supports user/password or Kerberos authentication, not SSH keys.

 * If you use a Linux desktop, consider  using the [Cockpit Client flatpak](https://flathub.org/apps/details/org.cockpit_project.CockpitClient). That can use password and SSH key authentication to any SSH target, and gives you a Cockpit session even for machines which don't have *any* Cockpit related packages installed.

 * If you have a custom page which wants to use channels (commands, file operations, D-Bus calls, etc.) on a remote machine, then please use the [cockpit-connect-ssh](https://github.com/cockpit-project/cockpit/blob/main/pkg/lib/cockpit-connect-ssh.tsx) library to set up the SSH connection instead of relying on the host switcher.

### Mitigation

In the short term, you can re-enable the host switcher by creating a `/etc/cockpit/shell.override.json` [manifest override file](https://cockpit-project.org/guide/latest/packages.html#package-manifest-override) with the following contents:

```json
{ "config": { "host_switcher": true } }
```
