### PR TITLE
Allow EmptyStatePanel actions to be of a different variant

### DIFF
--- a/pkg/lib/cockpit-components-empty-state.jsx
+++ b/pkg/lib/cockpit-components-empty-state.jsx
@@ -24,7 +24,7 @@ import { EmptyStateActions, EmptyState, EmptyStateBody, EmptyStateFooter, EmptyS
 import { Spinner } from "@patternfly/react-core/dist/esm/components/Spinner/index.js";
 import "./cockpit-components-empty-state.css";
 
-export const EmptyStatePanel = ({ title, paragraph, loading, icon, action, isActionInProgress = false, onAction, actionVariant = "primary", secondary, headingLevel = "h1" }) => {
+export const EmptyStatePanel = ({ title, paragraph, loading = false, icon, action, isActionInProgress = false, onAction, actionVariant = "primary", secondary, headingLevel = "h1" }) => {
     const slimType = title || paragraph ? "" : "slim";
     return (
         <EmptyState variant={EmptyStateVariant.full}>

--- a/pkg/lib/cockpit-components-empty-state.jsx
+++ b/pkg/lib/cockpit-components-empty-state.jsx
@@ -24,7 +24,7 @@ import { EmptyStateActions, EmptyState, EmptyStateBody, EmptyStateFooter, EmptyS
 import { Spinner } from "@patternfly/react-core/dist/esm/components/Spinner/index.js";
 import "./cockpit-components-empty-state.css";
 
-export const EmptyStatePanel = ({ title, paragraph, loading, icon, action, isActionInProgress = false, onAction, secondary, headingLevel = "h1" }) => {
+export const EmptyStatePanel = ({ title, paragraph, loading, icon, action, isActionInProgress = false, onAction, actionVariant = "primary", secondary, headingLevel = "h1" }) => {
     const slimType = title || paragraph ? "" : "slim";
     return (
         <EmptyState variant={EmptyStateVariant.full}>
@@ -34,7 +34,7 @@ export const EmptyStatePanel = ({ title, paragraph, loading, icon, action, isAct
             </EmptyStateBody>
             {(action || secondary) && <EmptyStateFooter>
                 { action && (typeof action == "string"
-                    ? <Button variant="primary" className={slimType}
+                    ? <Button variant={actionVariant} className={slimType}
                           isLoading={isActionInProgress}
                           isDisabled={isActionInProgress}
                           onClick={onAction}>{action}</Button>
@@ -51,6 +51,7 @@ EmptyStatePanel.propTypes = {
     title: PropTypes.string,
     paragraph: PropTypes.node,
     action: PropTypes.node,
+    actionVariant: PropTypes.string,
     isActionInProgress: PropTypes.bool,
     onAction: PropTypes.func,
     secondary: PropTypes.node,

--- a/pkg/lib/cockpit.d.ts
+++ b/pkg/lib/cockpit.d.ts
@@ -321,4 +321,7 @@ declare module 'cockpit' {
     /** @deprecated */ function format_bytes(n: MaybeNumber, factor: unknown, options?: object | boolean): string | string[];
     /** @deprecated */ function format_bytes_per_sec(n: MaybeNumber, factor: unknown, options?: object | boolean): string | string[];
     /** @deprecated */ function format_bits_per_sec(n: MaybeNumber, factor: unknown, options?: object | boolean): string | string[];
+
+    /* === Session ====================== */
+    function logout(reload: boolean, reason?: string): void;
 }

--- a/pkg/metrics/metrics.jsx
+++ b/pkg/metrics/metrics.jsx
@@ -1818,7 +1818,8 @@ class MetricsHistory extends React.Component {
             return <EmptyStatePanel
                         icon={ExclamationCircleIcon}
                         title={_("You need to relogin to be able to see metrics history")}
-                        action={<Button onClick={() => cockpit.logout(true)}>{_("Log out")}</Button>}
+                        action={_("Log out")}
+                        onAction={() => cockpit.logout(true)}
             />;
 
         // on a single machine, cockpit-pcp depends on pcp; but this may not be the case in the beiboot scenario,

--- a/pkg/networkmanager/networkmanager.jsx
+++ b/pkg/networkmanager/networkmanager.jsx
@@ -75,7 +75,7 @@ const App = () => {
                 <div id="networking-nm-crashed">
                     <EmptyStatePanel icon={ ExclamationCircleIcon }
                                      title={ _("NetworkManager is not running") }
-                                     action={ name ? _("Start service") : null }
+                                     action={nmService.exists ? _("Start service") : null}
                                      onAction={ nmService.start }
                                      secondary={
                                          <Button component="a"
@@ -99,7 +99,7 @@ const App = () => {
                 <div id="networking-nm-disabled">
                     <EmptyStatePanel icon={ ExclamationCircleIcon }
                                      title={ _("Network devices and graphs require NetworkManager") }
-                                     action={ name ? _("Enable service") : null }
+                                     action={nmService.exists ? _("Enable service") : null}
                                      onAction={() => {
                                          nmService.enable();
                                          nmService.start();

--- a/pkg/systemd/logsJournal.jsx
+++ b/pkg/systemd/logsJournal.jsx
@@ -288,7 +288,6 @@ export class JournalBox extends React.Component {
             /* Show 'Load earlier entries' button if we didn't reach start yet */
             this.state.didntReachStart
                 ? <EmptyStatePanel action={_("Load earlier entries")}
-                             actionInProgressText={_("Loading earlier entries")}
                              icon={noLogs ? ExclamationCircleIcon : undefined}
                              isActionInProgress={this.state.loading}
                              onAction={() => {
@@ -323,7 +322,7 @@ export class JournalBox extends React.Component {
                              }}
                              paragraph={noLogs ? _("You may try to load older entries.") : ""}
                              title={noLogs ? _("No logs found") : ""}
-                             loading={false} />
+                             loading={this.state.loading} />
                 : null
         );
 

--- a/pkg/systemd/logsJournal.jsx
+++ b/pkg/systemd/logsJournal.jsx
@@ -280,7 +280,7 @@ export class JournalBox extends React.Component {
                                      onAction={() => cockpit.location.go('/')}
                                      paragraph={_("Can not find any logs using the current combination of filters.")}
                                      title={_("No logs found")}
-                                     loading={false} />
+                    />
                 </div>
             );
         }

--- a/pkg/systemd/logsJournal.jsx
+++ b/pkg/systemd/logsJournal.jsx
@@ -276,6 +276,7 @@ export class JournalBox extends React.Component {
                     {error}
                     <EmptyStatePanel action={_("Clear all filters")}
                                      icon={ExclamationCircleIcon}
+                                     actionVariant="link"
                                      onAction={() => cockpit.location.go('/')}
                                      paragraph={_("Can not find any logs using the current combination of filters.")}
                                      title={_("No logs found")}

--- a/pkg/systemd/service-details.jsx
+++ b/pkg/systemd/service-details.jsx
@@ -536,13 +536,9 @@ export class ServiceDetails extends React.Component {
                 icon={ExclamationCircleIcon}
                 title={title}
                 paragraph={this.props.unitId}
-                action={
-                    <Button variant="link"
-                            component="a"
-                            onClick={() => cockpit.jump(path, cockpit.transport.host)}>
-                        {_("View all services")}
-                    </Button>
-                }
+                action={_("View all services")}
+                actionVariant="link"
+                onAction={() => cockpit.jump(path, cockpit.transport.host)}
             />;
         }
 

--- a/pkg/users/accounts-list.js
+++ b/pkg/users/accounts-list.js
@@ -338,7 +338,8 @@ const GroupsList = ({ groups, accounts, isExpanded, setIsExpanded, min_gid, max_
                     rows={ filtered_groups.map(a => getGroupRow(a, accounts)) }
                     loading={ groups.length && accounts.length ? '' : _("Loading...") }
                     sortMethod={sortRows}
-                    emptyComponent={<EmptyStatePanel title={_("No matching results")} icon={SearchIcon} />}
+                    emptyComponent={<EmptyStatePanel title={_("No matching results")} icon={SearchIcon} action={_("Clear filter")}
+                                                     onAction={() => setCurrentTextFilter('')} actionVariant="link" />}
                     variant="compact" sortBy={{ index: 2, direction: SortByDirection.asc }} />
             </CardExpandableContent>
         </Card>
@@ -451,7 +452,8 @@ const AccountsList = ({ accounts, current_user, groups, min_uid, max_uid, shells
                           rows={ filtered_accounts.map(a => getAccountRow(a, current_user === a.name, groups)) }
                           loading={ accounts.length ? '' : _("Loading...") }
                           sortMethod={sortRows}
-                          emptyComponent={<EmptyStatePanel title={_("No matching results")} icon={SearchIcon} />}
+                          emptyComponent={<EmptyStatePanel title={_("No matching results")} icon={SearchIcon} action={_("Clear filter")}
+                                                           onAction={() => setCurrentTextFilter('')} actionVariant="link" />}
                           variant="compact" sortBy={{ index: 0, direction: SortByDirection.asc }} />
         </Card>
 

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -261,7 +261,7 @@ WantedBy=default.target
         # Check empty state error for nonexistent unit with valid name
         b.go(f'/system/services#/nonexistent.service{suffix}')
         b.wait_in_text(".pf-v5-c-empty-state", "Unit nonexistent.service not found")
-        b.click("a:contains('View all services')")
+        b.click("button:contains('View all services')")
         b.switch_to_top()
         b.wait_js_cond('window.location.pathname == "/system/services"')
         if user:
@@ -1190,7 +1190,7 @@ Where=/fail
         self.do_action("Stop")
 
         b.wait_in_text(".pf-v5-c-empty-state", "Unit test-transient.service not found")
-        b.click("a:contains('View all services')")
+        b.click("button:contains('View all services')")
         b.switch_to_top()
         b.wait_js_cond('window.location.pathname == "/system/services"')
 

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -345,6 +345,16 @@ class TestAccounts(testlib.MachineCase):
         b.set_input_text("#accounts-filter input", "spooky")
         b.wait_visible("#accounts div.pf-v5-c-empty-state")
 
+        # clear text filters
+        b.click("#accounts-filter button[aria-label='Reset']")
+        b.wait_not_present("#accounts div.pf-v5-c-empty-state")
+
+        # clear via empty-state action
+        b.set_input_text("#accounts-filter input", "spooky")
+        b.wait_visible("#accounts div.pf-v5-c-empty-state")
+        b.click("div.pf-v5-c-empty-state button.pf-m-link")
+        b.wait_not_present("#accounts div.pf-v5-c-empty-state")
+
         b.inject_js("""
                     function getTextColumn(query_selector) {
                         const values = [];
@@ -374,9 +384,7 @@ class TestAccounts(testlib.MachineCase):
             b.set_input_text("#accounts-filter input", "users")
             names = b.eval_js("getTextColumn(\"[data-label='Username'] a\")")
             b.wait(lambda: "robert" in names)
-
-        # clear text filters
-        b.click("#accounts-filter button[aria-label='Reset']")
+            b.click("#accounts-filter button[aria-label='Reset']")
 
         # check alphabetical order of Username
         check_column_sort("[data-label='Username'] a")


### PR DESCRIPTION
This changes the EmptyStatePanel action to a link by default, retaining the primary button where the action is almost always guaranteed to be clicked (starting networkmanager for example).

Adds an action to the user/groups emptystate:

![image](https://github.com/user-attachments/assets/973d8ddc-57bd-4d2f-9e53-113016b04e55)

Makes the logs `load earlier data` show a spinner after clicking:

[Screencast from 2024-07-15 16-30-12.webm](https://github.com/user-attachments/assets/65f1a8df-af09-44b6-8c6b-04025ce40939)

And further cleans up API usage, and a small typing improvement.

Empty state now shows a link

![image](https://github.com/user-attachments/assets/75feffd8-dedb-4b57-ae74-82dff59a8da3)


No logs found now shows:

![image](https://github.com/user-attachments/assets/d14a868e-5336-4b4c-963a-6f450af7f8ec)
