### PR TITLE
add coverage output for qunit tests

### DIFF
--- a/build.js
+++ b/build.js
@@ -37,6 +37,7 @@ const pkgOptions = {
 
 // context options for qunit tests in qunit/
 const qunitOptions = {
+    ...!production ? { sourcemap: "linked" } : {},
     bundle: true,
     minify: false,
     nodePaths,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,10 +144,8 @@ log_cli = true
 required_plugins = ["pytest-asyncio"]
 
 [tool.pyright]
-executionEnvironments = [
-  { root = "test", extraPaths = ["test/common", "bots"] },
-  { root = "src" }
-]
+strict = ["**"]
+extraPaths = ["src", "test/common", "bots"]
 
 [tool.vulture]
 paths = [

--- a/test/common/lcov.py
+++ b/test/common/lcov.py
@@ -32,6 +32,7 @@ import re
 import shutil
 import subprocess
 import sys
+import urllib.parse
 from bisect import bisect_left
 from typing import Any, Mapping, Sequence
 
@@ -159,6 +160,12 @@ def get_dist_map(package):
 
 
 def get_distfile(url, dist_map):
+    path = urllib.parse.urlparse(url).path
+    if path.startswith('/qunit/'):
+        relpath = path[1:]
+        if os.path.exists(relpath) and os.path.exists(f'{relpath}.map'):
+            return DistFile(path[1:])
+
     parts = url.split("/")
     if len(parts) < 3 or "cockpit" not in parts:
         return None

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -239,7 +239,7 @@ class Browser:
         self.coverage_label = coverage_label
         self.machine = machine
 
-        headless = not bool(os.environ.get("TEST_SHOW_BROWSER", ""))
+        headless = os.environ.get("TEST_SHOW_BROWSER", '0') == '0'
         self.browser = os.environ.get("TEST_BROWSER", "chromium")
         if self.browser == "chromium":
             self.driver = webdriver_bidi.ChromiumBidi(headless=headless)

--- a/test/common/webdriver_bidi.py
+++ b/test/common/webdriver_bidi.py
@@ -34,7 +34,7 @@ import tempfile
 from collections.abc import AsyncIterator, Iterator
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, AsyncIterable, Iterable
+from typing import Any, AsyncIterable, Iterable, Self
 
 import aiohttp
 
@@ -155,8 +155,8 @@ def unpack_value(raw: Any) -> Any:
     raise ValueError(f"Unknown type in {raw!r}")
 
 
-# FIXME: No current way to say `[Self]`
-class WebdriverBidi(contextlib.AbstractAsyncContextManager['WebdriverBidi']):
+# FIXME: No current way to say `contextlib.AbstractAsyncContextManager[Self]`
+class WebdriverBidi:
     http_session: aiohttp.ClientSession
 
     def __init__(self, *, headless: bool = False) -> None:
@@ -223,7 +223,7 @@ class WebdriverBidi(contextlib.AbstractAsyncContextManager['WebdriverBidi']):
         else:
             raise WebdriverError("timed out waiting for default realm")
 
-    async def __aenter__(self) -> "WebdriverBidi":
+    async def __aenter__(self) -> Self:
         await self.start_session()
         return self
 

--- a/test/pytest/test_browser.py
+++ b/test/pytest/test_browser.py
@@ -41,10 +41,11 @@ async def spawn_test_server() -> AsyncIterator[URL]:  # noqa:RUF029
     address = os.read(addr_r, 1000).decode()
     os.close(addr_r)
 
-    yield URL(address)
-
-    server.kill()
-    server.wait()
+    try:
+        yield URL(address)
+    finally:
+        server.kill()
+        server.wait()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This was part of #20731 (inspired by @martinpitt's coverage-related comments there), but that PR got too big, so let's land these separately.

We need to figure out if we want this included in the overall coverage picture, and if so, find a way to make it happen.  That probably looks something like an extra `test_browser` run from `run-tests` if we're in coverage mode.  It's a bit of a weird fit, but I guess that's part of figuring out if we want to do this or not...