### PR TITLE
clean up pytest warning messages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,6 +157,7 @@ ignore_decorators = [
    "@*.getter",
    "@*.register_function",
    "@bus.Interface.Method",
+   "@pytest.fixture",
    "@pytest.hookimpl",
 ]
 

--- a/test/pytest/test_bridge.py
+++ b/test/pytest/test_bridge.py
@@ -928,7 +928,7 @@ async def test_flow_control(transport: MockTransport, tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_large_upload(event_loop: asyncio.AbstractEventLoop, transport: MockTransport, tmp_path: Path) -> None:
+async def test_large_upload(transport: MockTransport, tmp_path: Path) -> None:
     fifo = str(tmp_path / 'pipe')
     os.mkfifo(fifo)
 
@@ -947,7 +947,7 @@ async def test_large_upload(event_loop: asyncio.AbstractEventLoop, transport: Mo
 
     # start draining now, and make sure we get everything we sent.
     with open(fifo, 'rb') as receiver:
-        received = await event_loop.run_in_executor(None, receiver.read)
+        received = await asyncio.get_running_loop().run_in_executor(None, receiver.read)
         assert len(received) == loops * Channel.BLOCK_SIZE
 
     # and now our done and close messages should come

--- a/test/pytest/test_peer.py
+++ b/test/pytest/test_peer.py
@@ -168,10 +168,10 @@ async def test_await_cancellable_connect_init(bridge):
 
 
 @pytest.mark.asyncio
-async def test_await_cancellable_connect_close(monkeypatch, event_loop, bridge):
+async def test_await_cancellable_connect_close(monkeypatch, bridge):
     monkeypatch.setenv('INIT_TYPE', 'silence')  # make sure we never get "init"
     peer = CancellableConnect(bridge, PEER_CONFIG)
-    event_loop.call_later(0.1, peer.close)  # call peer.close() after .start() is running
+    asyncio.get_running_loop().call_later(0.1, peer.close)  # call peer.close() after .start() is running
     with pytest.raises(asyncio.CancelledError):
         await peer.start()
     # we already called .close()

--- a/test/pytest/test_transport.py
+++ b/test/pytest/test_transport.py
@@ -21,6 +21,7 @@ import errno
 import os
 import signal
 import subprocess
+import sys
 import unittest.mock
 from typing import Any, List, Optional, Tuple
 
@@ -297,6 +298,9 @@ class TestSubprocessTransport:
 
     @pytest.mark.asyncio
     async def test_safe_watcher_ENOSYS(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        if sys.version_info >= (3, 12, 0):
+            pytest.skip()
+
         monkeypatch.setattr(asyncio, 'PidfdChildWatcher', unittest.mock.Mock(side_effect=OSError), raising=False)
         protocol, transport = self.subprocess(['true'])
         watcher = transport._get_watcher(asyncio.get_running_loop())

--- a/test/pytest/test_transport.py
+++ b/test/pytest/test_transport.py
@@ -304,14 +304,6 @@ class TestSubprocessTransport:
         await protocol.eof_and_exited_with_code(0)
 
     @pytest.mark.asyncio
-    async def test_safe_watcher_oldpy(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delattr(asyncio, 'PidfdChildWatcher', raising=False)
-        protocol, transport = self.subprocess(['true'])
-        watcher = transport._get_watcher(asyncio.get_running_loop())
-        assert isinstance(watcher, asyncio.SafeChildWatcher)
-        await protocol.eof_and_exited_with_code(0)
-
-    @pytest.mark.asyncio
     async def test_true_pty(self) -> None:
         loop = asyncio.get_running_loop()
         protocol = Protocol()


### PR DESCRIPTION
We've been long-ignoring a block of warnings at the bottom of our pytest output, mostly about various asyncio-related deprecations and churn.

Let's clean that up — it's distracting, and it makes it easier to miss legitimate issues when they arise.