### PR TITLE
test: Generalize tracer failure message on logout

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1926,6 +1926,9 @@ class MachineCase(unittest.TestCase):
                                     'which: no python in .*'
                                     )
 
+        # happens when logging out quickly while tracer is running
+        self.allow_browser_errors("Tracer failed:.*internal-error")
+
     def check_journal_messages(self, machine: testvm.Machine | None = None) -> None:
         """Check for unexpected journal entries."""
         machine = machine or self.machine

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1880,10 +1880,6 @@ class MachineCase(unittest.TestCase):
         "error: Could not determine kpatch packages:.*PackageKit crashed",
     ]
 
-    if testvm.DEFAULT_IMAGE.startswith('rhel-8'):
-        # old occasional bugs in tracer, don't happen in newer versions any more
-        default_allowed_console_errors.append('Tracer failed:.*Traceback')
-
     env_allow = os.environ.get("TEST_ALLOW_BROWSER_ERRORS")
     if env_allow:
         default_allowed_console_errors += env_allow.split(",")

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -319,8 +319,7 @@ OnCalendar=daily
             })""", language)
             b.wait_attr(".index-page", "lang", language)
 
-        # the quick iteration starts/stops tracer in quick succession, before it can finish
-        self.allow_browser_errors("Tracer failed:.*internal-error")
+        self.allow_restart_journal_messages()
 
     def testPtBRLocale(self):
         m = self.machine


### PR DESCRIPTION
This isn't specific to CheckPages - any test which logs out relatively quickly
after logging in (and preloading the updates page) may run into this.

In particular, this happens quite often in TestAD.testUnqualifiedUsers.

----

This fixes this common failure:
 - https://cockpit-logs.us-east-1.linodeobjects.com/pull-20772-0c309400-20240718-032729-fedora-39-networking/log.html#56
 - https://cockpit-logs.us-east-1.linodeobjects.com/pull-20772-0c309400-20240718-032731-fedora-40-firefox-networking/log.html#56

That's the one and only unexpected message on the [weather report](https://ci-weather-cockpit.apps.ocp.cloud.ci.centos.org/tests.html?repo=cockpit-project%2Fcockpit&days=7).