### PR TITLE
test: Clean up Browser.select_PF[45](), avoid :contains() in testlib.py

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -940,14 +940,17 @@ class Browser:
             user = "root" if "suse" in self.machine.image else "admin"
 
         if passwordless:
-            self.wait_in_text("div[role=dialog]:contains('Administrative access')", "You now have administrative access.")
-            self.click("div[role=dialog] button:contains('Close')")
-            self.wait_not_present("div[role=dialog]:contains('You now have administrative access.')")
+            self.wait_text("div[role=dialog] .pf-v5-c-modal-box__title", "Administrative access")
+            self.wait_in_text("div[role=dialog] .pf-v5-c-modal-box__body", "You now have administrative access.")
+            # there should be only one ("Close") button
+            self.click("div[role=dialog] .pf-v5-c-modal-box__footer button")
         else:
-            self.wait_in_text("div[role=dialog]:contains('Switch to administrative access')", f"Password for {user}:")
-            self.set_input_text("div[role=dialog]:contains('Switch to administrative access') input", password or "foobar")
-            self.click("div[role=dialog] button:contains('Authenticate')")
-            self.wait_not_present("div[role=dialog]:contains('Switch to administrative access')")
+            self.wait_text("div[role=dialog] .pf-v5-c-modal-box__title", "Switch to administrative access")
+            self.wait_in_text("div[role=dialog]", f"Password for {user}:")
+            self.set_input_text("div[role=dialog] input", password or "foobar")
+            self.click("div[role=dialog] button.pf-m-primary")
+
+        self.wait_not_present("div[role=dialog]")
 
         self.check_superuser_indicator("Administrative access")
         self.switch_to_frame(cur_frame)
@@ -957,8 +960,9 @@ class Browser:
         self.switch_to_top()
 
         self.open_superuser_dialog()
-        self.click("div[role=dialog]:contains('Switch to limited access') button:contains('Limit access')")
-        self.wait_not_present("div[role=dialog]:contains('Switch to limited access')")
+        self.wait_text("div[role=dialog] .pf-v5-c-modal-box__title", "Switch to limited access")
+        self.click("div[role=dialog] button.pf-m-primary")
+        self.wait_not_present("div[role=dialog]")
         self.check_superuser_indicator("Limited access")
 
         self.switch_to_frame(cur_frame)
@@ -996,15 +1000,18 @@ class Browser:
 
         self.wait_visible('#hosts_setup_server_dialog')
         if new:
-            self.click('#hosts_setup_server_dialog button:contains(Add)')
+            self.wait_text("#hosts_setup_server_dialog button.pf-m-primary", "Add")
+            self.click("#hosts_setup_server_dialog button.pf-m-primary")
             if not known_host:
                 self.wait_in_text('#hosts_setup_server_dialog', "You are connecting to")
                 self.wait_in_text('#hosts_setup_server_dialog', "for the first time.")
-                self.click("#hosts_setup_server_dialog button:contains('Trust and add host')")
+                self.wait_text("#hosts_setup_server_dialog button.pf-m-primary", "Trust and add host")
+                self.click("#hosts_setup_server_dialog button.pf-m-primary")
         if password:
             self.wait_in_text('#hosts_setup_server_dialog', "Unable to log in")
             self.set_input_text('#login-custom-password', password)
-            self.click('#hosts_setup_server_dialog button:contains(Log in)')
+            self.wait_text("#hosts_setup_server_dialog button.pf-m-primary", "Log in")
+            self.click("#hosts_setup_server_dialog button.pf-m-primary")
         if expect_closed_dialog:
             self.wait_not_present('#hosts_setup_server_dialog')
 

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -556,25 +556,31 @@ class Browser:
             self.cdp.invoke("Input.dispatchKeyEvent", type="keyUp", key=name, modifiers=modifiers, **args)
 
     def select_from_dropdown(self, selector: str, value: object) -> None:
+        """For an actual <select> HTML component"""
+
         self.wait_visible(selector + ':not([disabled]):not([aria-disabled=true])')
         text_selector = f"{selector} option[value='{value}']"
         self._wait_present(text_selector)
         self.set_val(selector, value)
         self.wait_val(selector, value)
 
-    def select_PF4(self, selector: str, value: str) -> None:
-        self.click(f"{selector}:not([disabled]):not([aria-disabled=true])")
-        select_entry = f"{selector} + ul button:contains('{value}')"
-        self.click(select_entry)
-        if self.is_present(f"{selector}.pf-m-typeahead"):
-            self.wait_val(f"{selector} > div input[type=text]", value)
-        else:
-            self.wait_text(f"{selector} .pf-v5-c-select__toggle-text", value)
+    def select_PF(self, selector: str, value: str, menu_class: str = ".pf-v5-c-menu") -> None:
+        """For a PatternFly Select-like component
 
-    def select_PF5(self, selector_button: str, selector: str, value: object) -> None:
-        self.click(f"{selector_button}:not([disabled]):not([aria-disabled=true])")
-        select_entry = f"{selector} ul button:contains('{value}')"
-        self.click(select_entry)
+        For things like <Select> or <TimePicker>. Unfortunately none of them render as an actual <select>, but a
+        <button> or <div> with a detached menu div (which can even be in the parent).
+
+        For similar components like the deprecated <Select> you can specify a different menu class.
+        """
+        self.click(selector)
+        # SelectOption's value does not render to an actual "value" attribute, just a <li> text
+        self.click(f"{menu_class} button:contains('{value}')")
+        self.wait_not_present(menu_class)
+
+    def select_PF_deprecated(self, selector: str, value: str) -> None:
+        """For the deprecated PatternFly Select component"""
+
+        self.select_PF(selector, value, menu_class=".pf-v5-c-select__menu")
 
     def set_input_text(
         self, selector: str, val: str, append: bool = False, value_check: bool = True, blur: bool = True

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -369,7 +369,7 @@ class TestHistoryMetrics(testlib.MachineCase):
         # self.waitStream(3) # FIXME: wait for new data - pcp does not handle time change greatly
         b.wait_text("#date-picker-select-toggle .pf-v5-c-select__toggle-text", "Today")
 
-        b.select_PF4("#date-picker-select-toggle", "Wednesday, September 16, 2020")
+        b.select_PF_deprecated("#date-picker-select-toggle", "Wednesday, September 16, 2020")
         self.assertGreater(getMaximumSpike(test=self, g_type="memory", saturation=False, hour=1600236000000, minute=51), 0.5)
         self.assertIn("Memory", events_at(1600236000000, 51))
 
@@ -678,7 +678,7 @@ class TestHistoryMetrics(testlib.MachineCase):
                   """)
         self.addCleanup(m.execute, "nmcli con delete fake; firewall-cmd --permanent --delete-zone comeandgo || true; firewall-cmd  --reload")
         checkEnable(firewalld_alert=True)
-        b.select_PF4("#firewalld-request-pmproxy", "comeandgo")
+        b.select_PF_deprecated("#firewalld-request-pmproxy", "comeandgo")
         m.execute("firewall-cmd --permanent --delete-zone comeandgo; firewall-cmd  --reload")
         b.click(".pf-v5-c-alert button.pf-m-primary")
         self.allow_browser_errors("Failed to enable pmproxy in firewalld:.*INVALID_ZONE: comeandgo.*")

--- a/test/verify/check-system-journal
+++ b/test/verify/check-system-journal
@@ -206,17 +206,17 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         wait_log_present("JUST ERROR")
 
         # We cannot open this select with tests but we need to wait until it gets loaded
-        b.select_PF4("#journal-identifier-menu .pf-v5-c-select__toggle", "just-a-service")
+        b.select_PF_deprecated("#journal-identifier-menu .pf-v5-c-select__toggle", "just-a-service")
         wait_log_not_present("JUST ERROR")
         wait_log_present("THE SERVICE")
-        b.select_PF4("#journal-identifier-menu .pf-v5-c-select__toggle", "All")
+        b.select_PF_deprecated("#journal-identifier-menu .pf-v5-c-select__toggle", "All")
         wait_log_present("JUST ERROR")
         wait_log_present("THE SERVICE")
 
-        self.browser.select_PF4("#journal-prio-menu", "Error and above")
+        b.select_PF_deprecated("#journal-prio-menu", "Error and above")
         wait_log_not_present("THE SERVICE")
         wait_log_present("JUST ERROR")
-        b.select_PF4("#journal-identifier-menu .pf-v5-c-select__toggle", "check-journal")
+        b.select_PF_deprecated("#journal-identifier-menu .pf-v5-c-select__toggle", "check-journal")
         b.wait_not_present("#journal-identifier-menu + ul button:contains('just-a-service')")
 
         b.go("#/?tag=test-stream&priority=notice")
@@ -295,16 +295,16 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         b.wait_visible("#journal-box .cockpit-logline .cockpit-log-message:contains('Message 5')")
 
         # Test filters
-        b.select_PF4("#logs-predefined-filters", "Current boot")
+        b.select_PF_deprecated("#logs-predefined-filters", "Current boot")
         b.wait_val("#journal-grep input", "priority:err identifier:logger boot:0 [5-6]")
 
-        b.select_PF4("#logs-predefined-filters", "Previous boot")
+        b.select_PF_deprecated("#logs-predefined-filters", "Previous boot")
         b.wait_val("#journal-grep input", "priority:err identifier:logger boot:-1 [5-6]")
 
-        b.select_PF4("#logs-predefined-filters", "Last 24 hours")
+        b.select_PF_deprecated("#logs-predefined-filters", "Last 24 hours")
         b.wait_val("#journal-grep input", "priority:err identifier:logger since:-24hours [5-6]")
 
-        b.select_PF4("#logs-predefined-filters", "Last 7 days")
+        b.select_PF_deprecated("#logs-predefined-filters", "Last 7 days")
         b.wait_val("#journal-grep input", "priority:err identifier:logger since:-7days [5-6]")
 
         # Check that 'until' qualifier keeps streaming until given time
@@ -340,21 +340,21 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         b.go(f"#/?priority=err&since=@{self.test_start_time}")
         b.wait_visible(f"#journal-box .cockpit-logline .cockpit-log-message:contains('{tag_error.upper()}')")
         b.wait_not_present(f"#journal-box .cockpit-logline .cockpit-log-message:contains('{tag_info.upper()}')")
-        b.select_PF4("#journal-identifier-menu .pf-v5-c-select__toggle", tag_error)
+        b.select_PF_deprecated("#journal-identifier-menu .pf-v5-c-select__toggle", tag_error)
         b.wait_not_present(f"#journal-identifier-menu + ul button:contains('{tag_info}')")
 
-        self.browser.select_PF4("#journal-prio-menu", "Debug and above")
-        b.select_PF4("#journal-identifier-menu .pf-v5-c-select__toggle", "All")
+        b.select_PF_deprecated("#journal-prio-menu", "Debug and above")
+        b.select_PF_deprecated("#journal-identifier-menu .pf-v5-c-select__toggle", "All")
         b.wait_visible(f"#journal-box .cockpit-logline .cockpit-log-message:contains('{tag_error.upper()}')")
         b.wait_visible(f"#journal-box .cockpit-logline .cockpit-log-message:contains('{tag_info.upper()}')")
-        b.select_PF4("#journal-identifier-menu .pf-v5-c-select__toggle", tag_error)
-        b.select_PF4("#journal-identifier-menu .pf-v5-c-select__toggle", tag_info)
+        b.select_PF_deprecated("#journal-identifier-menu .pf-v5-c-select__toggle", tag_error)
+        b.select_PF_deprecated("#journal-identifier-menu .pf-v5-c-select__toggle", tag_info)
 
-        self.browser.select_PF4("#journal-prio-menu", "Error and above")
-        b.select_PF4("#journal-identifier-menu .pf-v5-c-select__toggle", "All")
+        b.select_PF_deprecated("#journal-prio-menu", "Error and above")
+        b.select_PF_deprecated("#journal-identifier-menu .pf-v5-c-select__toggle", "All")
         b.wait_visible(f"#journal-box .cockpit-logline .cockpit-log-message:contains('{tag_error.upper()}')")
         b.wait_not_present(f"#journal-box .cockpit-logline .cockpit-log-message:contains('{tag_info.upper()}')")
-        b.select_PF4("#journal-identifier-menu .pf-v5-c-select__toggle", tag_error)
+        b.select_PF_deprecated("#journal-identifier-menu .pf-v5-c-select__toggle", tag_error)
         b.wait_not_present(f"#journal-identifier-menu + ul button:contains('{tag_info}')")
 
     def testRebootAndTime(self):
@@ -542,17 +542,17 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
 
         journal_line_selector = "#journal-box .cockpit-logline:has(span:contains({0}))"
 
-        self.browser.select_PF4("#journal-prio-menu", "Only emergency")
+        b.select_PF_deprecated("#journal-prio-menu", "Only emergency")
         b.wait_visible(journal_line_selector.format("EMERGENCY_MESSAGE"))
         b.wait_not_present(journal_line_selector.format("WARNING_MESSAGE"))
         b.wait_not_present(journal_line_selector.format("INFO_MESSAGE"))
 
-        self.browser.select_PF4("#journal-prio-menu", "Warning and above")
+        b.select_PF_deprecated("#journal-prio-menu", "Warning and above")
         b.wait_visible(journal_line_selector.format("EMERGENCY_MESSAGE"))
         b.wait_visible(journal_line_selector.format("WARNING_MESSAGE"))
         b.wait_not_present(journal_line_selector.format("INFO_MESSAGE"))
 
-        self.browser.select_PF4("#journal-prio-menu", "Info and above")
+        b.select_PF_deprecated("#journal-prio-menu", "Info and above")
         b.wait_visible(journal_line_selector.format("EMERGENCY_MESSAGE"))
         b.wait_visible(journal_line_selector.format("WARNING_MESSAGE"))
         b.wait_visible(journal_line_selector.format("INFO_MESSAGE"))
@@ -569,13 +569,13 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
 
         self.login_and_go("/system/logs#/?since=@" + self.test_start_time)
 
-        self.browser.select_PF4("#journal-prio-menu", "Critical and above")
+        b.select_PF_deprecated("#journal-prio-menu", "Critical and above")
         b.wait_visible(sleep_crash_list_sel)
 
-        self.browser.select_PF4("#journal-prio-menu", "Alert and above")
+        b.select_PF_deprecated("#journal-prio-menu", "Alert and above")
         b.wait_not_present(sleep_crash_list_sel)
 
-        self.browser.select_PF4("#journal-prio-menu", "Critical and above")
+        b.select_PF_deprecated("#journal-prio-menu", "Critical and above")
         b.click(sleep_crash_list_sel)
 
         def wait_field(name, value):

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -1490,8 +1490,8 @@ class TestTimers(testlib.MachineCase):
         b.wait_visible("[data-index='0'] .week-days")
         b.click("[data-index='0'] [aria-label='Add']")
         b.select_from_dropdown("[data-index='0'] .week-days select", "fri")
-        # select time from dropdown with mouse
-        b.select_PF5("#timer-dialog [data-index='0'] .create-timer-time-picker input", ".pf-v5-c-menu", "12:30")
+        # select time in TimePicker with mouse
+        b.select_PF("#timer-dialog [data-index='0'] .create-timer-time-picker input", "12:30")
         # type time with keyboard
         b.select_from_dropdown("[data-index='1'] .week-days select", "sun")
         b.set_input_text("[data-index='1'] .create-timer-time-picker input", "20:12")


### PR DESCRIPTION
After that we can drop sizzle from cockpit-ostree, and potentially other projects.