### PR TITLE
test: Allow different panel HTML elements in Grafana

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1511,8 +1511,8 @@ class TestGrafanaClient(testlib.MachineCase):
             bg.wait_in_text("#var-host", "grafana-client")
 
             # expect a "Load average" panel with sensible numbers
-            bg.wait_in_text("div[data-testid*='Load average']", "minute")
-            self.assertRegex(bg.text("div[data-testid*='Load average']"), r"[0-9]\.[0-9]")
+            bg.wait_in_text("section[data-testid*='Load average'],div[data-testid*='Load average']", "minute")
+            self.assertRegex(bg.text("section[data-testid*='Load average'],div[data-testid*='Load average']"), r"[0-9]\.[0-9]")
         except Exception:
             bg.snapshot("FAIL-grafana")
             raise


### PR DESCRIPTION
The current service image refresh [1] brings a new Grafana which changes the panel containers from `<div>` to `<section>`. Accept both.

Note: There is also a nested `<button>` with the same `data-testid` attribute, so we have to specify the tag name.

[1] https://github.com/cockpit-project/bots/pull/6644