### PR TITLE
test: Re-relax the `{become,drop}_superuser()` checks

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -940,12 +940,12 @@ class Browser:
             user = "root" if "suse" in self.machine.image else "admin"
 
         if passwordless:
-            self.wait_text("div[role=dialog] .pf-v5-c-modal-box__title", "Administrative access")
+            self.wait_in_text("div[role=dialog]", "Administrative access")
             self.wait_in_text("div[role=dialog] .pf-v5-c-modal-box__body", "You now have administrative access.")
             # there should be only one ("Close") button
             self.click("div[role=dialog] .pf-v5-c-modal-box__footer button")
         else:
-            self.wait_text("div[role=dialog] .pf-v5-c-modal-box__title", "Switch to administrative access")
+            self.wait_in_text("div[role=dialog]", "Switch to administrative access")
             self.wait_in_text("div[role=dialog]", f"Password for {user}:")
             self.set_input_text("div[role=dialog] input", password or "foobar")
             self.click("div[role=dialog] button.pf-m-primary")
@@ -960,7 +960,7 @@ class Browser:
         self.switch_to_top()
 
         self.open_superuser_dialog()
-        self.wait_text("div[role=dialog] .pf-v5-c-modal-box__title", "Switch to limited access")
+        self.wait_in_text("div[role=dialog]", "Switch to limited access")
         self.click("div[role=dialog] button.pf-m-primary")
         self.wait_not_present("div[role=dialog]")
         self.check_superuser_indicator("Limited access")


### PR DESCRIPTION
The stricter checks introduced in commit 0b215006ec don't yet work on older cockpit Shell versions on debian-stable and ubuntu-2204. There the class is still called `.pf-c-modal-box__title`, and so the selectors don't match.

This also isn't important for this helper function. Leave the detailled dialog checks to TestSuperuser and pixel tests, and go back to just ensuring that the expected title text is somewhere in the dialog.

---

This fixes/unblocks https://github.com/cockpit-project/cockpit-machines/pull/1733