### PR TITLE
fmf: Force-upgrade shadow-utils in rawhide

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -17,6 +17,12 @@ mkdir -p /root/.ssh
 curl https://raw.githubusercontent.com/cockpit-project/bots/main/machine/identity.pub >> /root/.ssh/authorized_keys
 chmod 600 /root/.ssh/authorized_keys
 
+# HACK: broken shadow-utils
+if grep -q 'platform:f41' /etc/os-release; then
+    rpm -q shadow-utils
+    dnf update -y shadow-utils
+fi
+
 # HACK: setroubleshoot-server crashes/times out randomly (breaking TestServices),
 # and is hard to disable as it does not use systemd
 if rpm -q setroubleshoot-server; then


### PR DESCRIPTION
The current TMT images have a broken version which breaks `chpasswd`.

----

Fixes this failure: https://artifacts.dev.testing-farm.io/a5437486-fcf7-459a-8ba2-75a7ad827049/

This currently breaks all our own cockpit PRs, as well as stratis and selinux-policy upstream PRs. Same hack as in https://github.com/cockpit-project/cockpit-podman/pull/1801