### PR TITLE
test/static-code: Ignore pkg/lib for non-Cockpit projects; Ignore `machine.image_file` type check failure

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -32,6 +32,7 @@ jobs:
             git reset --hard ${GITHUB_SHA}
 
             vendor/checkout
+            test/common/make-bots
             ./autogen.sh
             make -j$(nproc) '${{ matrix.target }}'
           EOF

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1437,8 +1437,9 @@ class MachineCase(unittest.TestCase):
                 self.network = network
             networking = self.network.host(restrict=restrict, forward=forward or {})
             machine = machine_class(verbose=opts.trace, networking=networking, image=image, **kwargs)
-            if opts.fetch and not os.path.exists(machine.image_file):
-                machine.pull(machine.image_file)
+            image_file = machine.image_file  # type: ignore[attr-defined]
+            if opts.fetch and not os.path.exists(image_file):
+                machine.pull(image_file)
             if cleanup:
                 self.addCleanup(machine.kill)
         return machine

--- a/test/static-code
+++ b/test/static-code
@@ -69,9 +69,11 @@ if [ "${WITH_PARTIAL_TREE:-0}" = 0 ]; then
 
     test_typescript() {
         test -x node_modules/.bin/tsc -a -x /usr/bin/node || skip 'no tsc'
-        # Only display tsc output if it contains errors about something other than node_modules/
+        # Only display tsc output if it contains errors about something other than node_modules/,
+        # and pkg/lib for non-cockpit projects
+        [ -d pkg/base1 ] || ignore="pkg/lib|"
         # https://github.com/microsoft/TypeScript/issues/30511
-        if node_modules/.bin/tsc --checkJs false --pretty false | grep -Eqv '^(node_modules| )'; then
+        if node_modules/.bin/tsc --checkJs false --pretty false | grep -Eqv "^(node_modules|${ignore:-} )"; then
             node_modules/.bin/tsc ${FORCE_COLOR:+--pretty true} --checkJs false
         fi
     }


### PR DESCRIPTION
This unblocks https://github.com/cockpit-project/starter-kit/pull/937 . I validated that introducing a type error into starter-kit proper still fails as expected, but it's clean/passes with the lib update in that PR. I also validated that introducing a type error into cockpit's pkg/lib still fails.

While at it, I also fixed this:
```
❱❱❱ test/static-code 
not ok 6 /static-code/test-mypy
# test/common/testlib.py:1440: error: "Machine" has no attribute "image_file"  [attr-defined]
# test/common/testlib.py:1441: error: "Machine" has no attribute "image_file"  [attr-defined]
```