### PR TITLE
test: Disable SSH PerSourcePenalties

### DIFF
--- a/test/vm.install
+++ b/test/vm.install
@@ -14,6 +14,7 @@ if ! type rpm-ostree >/dev/null 2>&1; then
     systemctl disable cockpit.socket
 fi
 
+
 # OS specific hacks
 
 if [ "$ID" = "debian" ] || [ "$ID" = "ubuntu" ]; then
@@ -49,6 +50,11 @@ fi
 if [ "$PLATFORM_ID" = "platform:el10" ]; then
     # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=2273078
     printf  '[network]\nfirewall_driver = "nftables"\n' > /etc/containers/containers.conf
+fi
+
+if [ "$ID" = "arch" ]; then
+    # Disable PerSourcePenalties, our CI is too fast
+    echo "PerSourcePenalties no" >>/etc/ssh/sshd_config
 fi
 
 # start cockpit once to ensure it works, and generate the certificate (to avoid re-doing that for each test)


### PR DESCRIPTION
They interfere with our tests, especially the multi-host tests that do a lot of failed password logins.