### PR TITLE
css: Shuffle some code around to make SASS happy

### DIFF
--- a/pkg/lib/patternfly/patternfly-5-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-5-overrides.scss
@@ -212,10 +212,11 @@ select.pf-v5-c-form-control {
   gap: var(--pf-v5-l-flex--spacer-base);
 
   &:not([class*="pf-m-space-items-"]) {
+    gap: var(--pf-v5-l-flex--spacer--md);
+
     > * {
       --pf-v5-l-flex--spacer--column: 0;
     }
-    gap: var(--pf-v5-l-flex--spacer--md);
   }
 
   // Negate the margin hack used by immediate flex children

--- a/pkg/metrics/metrics.scss
+++ b/pkg/metrics/metrics.scss
@@ -221,12 +221,13 @@ html {
   // Shrink percentage column to allow for more service text
   th[data-label="%"],
   td[data-label="%"] {
+    inline-size: 2rem;
+    min-inline-size: 0;
+
     .pf-v5-c-table__text {
       --pf-v5-c-table--cell--MinWidth: 0;
       display: inline;
     }
-    inline-size: 2rem;
-    min-inline-size: 0;
   }
 
   .pf-m-grid-lg.pf-v5-c-table {
@@ -340,6 +341,12 @@ $graphs: cpu, memory, disks, network;
   --network-color: var(--pf-v5-chart-color-black-300);
   --network-color-extreme: var(--pf-v5-chart-color-black-400);
 
+  --column-size: 10vw;
+  --half-column-size: 8vw;
+  --data-min-height: 5px;
+
+  --graph-column-size: 60%;
+
   .pf-v5-theme-dark & {
     --cpu-color: var(--pf-v5-chart-color-purple-500);
     --cpu-color-extreme: var(--pf-v5-chart-color-purple-300);
@@ -353,12 +360,6 @@ $graphs: cpu, memory, disks, network;
     --network-color: var(--pf-v5-chart-color-black-400);
     --network-color-extreme: var(--pf-v5-chart-color-black-300);
   }
-
-  --column-size: 10vw;
-  --half-column-size: 8vw;
-  --data-min-height: 5px;
-
-  --graph-column-size: 60%;
 
   &-hour-compressed {
     --data-min-height: 1px;
@@ -389,11 +390,12 @@ $graphs: cpu, memory, disks, network;
   }
 
   &-sublabels.pf-v5-c-content {
+    display: flex;
+
     small {
       font-size: var(--pf-v5-global--FontSize--xs);
       margin-block-end: var(--pf-v5-global--spacer--xs) !important;
     }
-    display: flex;
   }
 
   &-label-graph {

--- a/pkg/shell/nav.scss
+++ b/pkg/shell/nav.scss
@@ -206,11 +206,11 @@ $desktop: $phone + 1px;
     inset: 0;
     background: var(--pf-v5-global--BackgroundColor--dark-200);
 
+    z-index: 399; // Modals have 400 and modals should be in front of host switcher
+
     .pf-v5-theme-dark & {
       background: var(--pf-v5-global--BackgroundColor--dark-300);
     }
-
-    z-index: 399; // Modals have 400 and modals should be in front of host switcher
 
     &.edit-hosts {
       .pf-v5-c-nav__list {

--- a/pkg/systemd/overview.scss
+++ b/pkg/systemd/overview.scss
@@ -7,6 +7,9 @@
 .ct-limited-access-alert {
   --pf-v5-c-alert--GridTemplateColumns: auto auto 1fr;
 
+  // Set the right padding so that the button aligns with the other alerts in the page on the side
+  padding-inline-end: var(--pf-v5-c-page__main-section--PaddingRight);
+
   // Fix vertical alignment
   // Unset the H4 line-height (as PF3/Bootstrap/etc. sets it; PF4 doesn't)
   > .pf-v5-c-alert__title {
@@ -32,9 +35,6 @@
     // Allow the action button to have a bit more space on iPhone SE sized phones
     grid-template-areas: "icon title" ". content" "action action";
   }
-
-  // Set the right padding so that the button aligns with the other alerts in the page on the side
-  padding-inline-end: var(--pf-v5-c-page__main-section--PaddingRight);
 
   > .pf-v5-c-alert__action {
     margin-inline: var(--pf-v5-global--spacer--md) 0;

--- a/pkg/systemd/terminal.scss
+++ b/pkg/systemd/terminal.scss
@@ -70,7 +70,6 @@
         min-inline-size: 5rem;
       }
     }
-    padding: 0;
   }
 }
 


### PR DESCRIPTION
We're supposed to have CSS related to the top level at the top anyway, but SASS is getting picky about it.

I've fixed the issues in the code, and this makes the SASS compiler happy with our SCSS.

This *shouldn't* change anything.

The warning from SASS was:

> ▲ [WARNING] Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming version. To keep the existing behavior, move the declaration above the nested rule. To opt into the new behavior, wrap the declaration in `& {}`.