### PR TITLE
shell: Enable host switcher also on Fedora 40

### DIFF
--- a/pkg/shell/manifest.json
+++ b/pkg/shell/manifest.json
@@ -35,6 +35,7 @@
     "config": {
         "host_switcher": {
             "platform:f39": true,
+            "platform:f40": true,
             "platform:el9": true,
             "bookworm": true,
             "jammy": true,

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1623,8 +1623,8 @@ class MachineCase(unittest.TestCase):
                 self.sshd_socket = 'sshd.socket'
         self.restart_sshd = f'systemctl try-restart {self.sshd_service}'
 
-        # only enabled by default on stable LTS OSes; see pkg/shell/manifest.json
-        self.multihost_enabled = image.startswith(("rhel-9", "centos-9")) or image in ["ubuntu-2204", "ubuntu-stable", "debian-stable", "fedora-39"]
+        # only enabled by default on released OSes; see pkg/shell/manifest.json
+        self.multihost_enabled = image.startswith(("rhel-9", "centos-9")) or image in ["ubuntu-2204", "ubuntu-stable", "debian-stable", "fedora-39", "fedora-40", "fedora-coreos"]
 
     def nonDestructiveSetup(self) -> None:
         """generic setUp/tearDown for @nondestructive tests"""


### PR DESCRIPTION
We don't want to change behavior for released OSes.