### PR TITLE
Shell: Extra warnings when connecting to remote hosts

### DIFF
--- a/doc/guide/Makefile-guide.am
+++ b/doc/guide/Makefile-guide.am
@@ -21,6 +21,7 @@ GUIDE_INCLUDES = \
 	doc/guide/cockpit-session.xml \
 	doc/guide/cockpit-spawn.xml \
 	doc/guide/cockpit-util.xml \
+	doc/guide/multi-host.xml \
 	doc/guide/authentication.xml \
 	doc/guide/embedding.xml \
 	doc/guide/feature-firewall.xml \

--- a/doc/guide/cockpit-guide.xml
+++ b/doc/guide/cockpit-guide.xml
@@ -27,6 +27,7 @@
     <xi:include href="https.xml"/>
     <xi:include href="listen.xml"/>
     <xi:include href="startup.xml"/>
+    <xi:include href="multi-host.xml"/>
     <xi:include href="authentication.xml"/>
     <xi:include href="sso.xml"/>
     <xi:include href="cert-authentication.xml"/>

--- a/doc/guide/multi-host.xml
+++ b/doc/guide/multi-host.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
+	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
+<chapter id="multi-host">
+  <title>
+    Managing multiple hosts at the same time
+  </title>
+
+  <para>
+    Cockpit allows you to access multiple hosts in a single session,
+    by establishing SSH connections to other hosts. This is quite
+    similar to logging into these other hosts using the
+    <command>ssh</command> command on the command line, with one very
+    important difference:
+  </para>
+  <para>
+    Code from the local host and all the remote hosts run at the same
+    time, in the same browser context.  They are not isolated from
+    each other in the browser. All code effectively has the same
+    privileges as the primary session on the local host.
+  </para>
+  <para>
+    Thus, <emphasis>you should only only connect to remote hosts that
+    you trust</emphasis>. You must be sure that none of the hosts that
+    you connect to will cause Cockpit to load malicious JavaScript
+    code into your browser.
+  </para>
+  <para>
+    Therefore, Cockpit will warn you before connecting to more than
+    one host. It is also possible to disable multiple hosts entirely,
+    and some operating systems do this already by default.
+  </para>
+  <para>
+    You can prevent loading of JavaScript, HTML, etc from more than
+    one host by adding this to <filename>cockpit.conf</filename>:
+  </para>
+  <programlisting>
+    [WebService]
+    AllowMultiHost=false
+  </programlisting>
+  <para>
+    When you allow multiple hosts in a single Cockpit session by
+    setting <code>AllowMultiHost</code> to true, then the user will be
+    warned once per session, before connecting to the second host.  If
+    that is still too much, you can switch the warning off completely
+    by adding the following to <filename>cockpit.conf</filename>:
+  </para>
+  <programlisting>
+    [Session]
+    WarnBeforeConnecting=false
+  </programlisting>
+</chapter>

--- a/doc/man/cockpit.conf.xml
+++ b/doc/man/cockpit.conf.xml
@@ -272,6 +272,18 @@ IdleTimeout=15
           <para>When not specified, there is no idle timeout by default.</para>
         </listitem>
       </varlistentry>
+      <varlistentry>
+        <term><option>WarnBeforeConnecting</option></term>
+        <listitem>
+          <para>Whether to warn before connecting to remote hosts from the Shell. Defaults to true.</para>
+          <informalexample>
+<programlisting language="ini">
+[Session]
+WarnBeforeConnecting=false
+</programlisting>
+          </informalexample>
+        </listitem>
+      </varlistentry>
     </variablelist>
   </refsect1>
 

--- a/pkg/shell/hosts.jsx
+++ b/pkg/shell/hosts.jsx
@@ -16,7 +16,7 @@ import { Tooltip } from "@patternfly/react-core/dist/esm/components/Tooltip";
 import 'polyfills';
 import { CockpitNav, CockpitNavItem } from "./nav.jsx";
 import { build_href, split_connection_string } from "./util.jsx";
-import { add_host, edit_host } from "./hosts_dialog.jsx";
+import { add_host, edit_host, connect_host } from "./hosts_dialog.jsx";
 
 const _ = cockpit.gettext;
 
@@ -122,17 +122,14 @@ export class CockpitHosts extends React.Component {
     }
 
     async onHostSwitch(machine) {
-        const { state } = this.props;
+        const { state, host_modal_state } = this.props;
 
-        // We could launch the connection dialogs here and not jump at
-        // all when the login fails (or is cancelled), but the
-        // traditional behavior is to jump and then try to connect.
-
-        const connection_string = machine.connection_string;
-        const parts = split_connection_string(connection_string);
-        const addr = build_href({ host: parts.address });
-        state.jump(addr);
-        state.ensure_connection();
+        const connection_string = await connect_host(host_modal_state, state, machine);
+        if (connection_string) {
+            const parts = split_connection_string(connection_string);
+            const addr = build_href({ host: parts.address });
+            state.jump(addr);
+        }
     }
 
     onEditHosts() {

--- a/pkg/shell/hosts.jsx
+++ b/pkg/shell/hosts.jsx
@@ -114,7 +114,7 @@ export class CockpitHosts extends React.Component {
     }
 
     async onAddNewHost() {
-        await add_host(this.props.host_modal_state);
+        await add_host(this.props.host_modal_state, this.props.state);
     }
 
     async onHostEdit(event, machine) {

--- a/pkg/shell/hosts_dialog.jsx
+++ b/pkg/shell/hosts_dialog.jsx
@@ -78,20 +78,32 @@ export const HostModalState = () => {
     return self;
 };
 
-export async function add_host(state) {
-    await state.show_modal({ });
+/* Activate and jump to a newly added machine, identified by its
+   connection string.
+ */
+function jump_to_new_connection_string(shell_state, connection_string) {
+    // Get the address of the machine from its connection string
+    const addr = split_connection_string(connection_string).address;
+    // Tell the Loader that now is the time to start monitoring the
+    // manifests.
+    shell_state.loader.connect(addr);
+    // Navigate to it.
+    shell_state.jump(build_href({ host: addr }));
+}
+
+export async function add_host(state, shell_state) {
+    const connection_string = await state.show_modal({ });
+    if (connection_string)
+        jump_to_new_connection_string(shell_state, connection_string);
 }
 
 export async function edit_host(state, shell_state, machine) {
     const { current_machine } = shell_state;
     const connection_string = await state.show_modal({ address: machine.address });
     if (connection_string) {
-        const parts = split_connection_string(connection_string);
-        const addr = build_href({ host: parts.address });
-        if (machine == current_machine && parts.address != machine.address) {
-            shell_state.loader.connect(parts.address);
-            shell_state.jump(addr);
-        }
+        const addr = split_connection_string(connection_string).address;
+        if (machine == current_machine && addr != machine.address)
+            jump_to_new_connection_string(shell_state, connection_string);
     }
 }
 

--- a/pkg/shell/hosts_dialog.jsx
+++ b/pkg/shell/hosts_dialog.jsx
@@ -38,10 +38,13 @@ import { Popover } from "@patternfly/react-core/dist/esm/components/Popover/inde
 import { Radio } from "@patternfly/react-core/dist/esm/components/Radio/index.js";
 import { Stack } from "@patternfly/react-core/dist/esm/layouts/Stack/index.js";
 import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput/index.js";
-import { OutlinedQuestionCircleIcon } from "@patternfly/react-icons";
+import { OutlinedQuestionCircleIcon, ExternalLinkAltIcon } from "@patternfly/react-icons";
+import { HelperText, HelperTextItem } from "@patternfly/react-core/dist/esm/components/HelperText/index.js";
+import { Text, TextContent, TextVariants } from "@patternfly/react-core/dist/esm/components/Text";
 
 import { FormHelper } from "cockpit-components-form-helper";
 import { ModalError } from "cockpit-components-inline-notification.jsx";
+import { fmt_to_fragments } from "utils.js";
 
 import { build_href, split_connection_string, generate_connection_string } from "./util.jsx";
 
@@ -119,6 +122,12 @@ export async function connect_host(state, shell_state, machine) {
             address: machine.address,
             template: codes[machine.problem],
         });
+    } else if (!window.sessionStorage.getItem("connection-warning-shown")) {
+        // connect by launching into the "Connection warning" dialog.
+        connection_string = await state.show_modal({
+            address: machine.address,
+            template: "connect"
+        });
     } else {
         // Try to connect without any dialog
         try {
@@ -145,6 +154,7 @@ export async function connect_host(state, shell_state, machine) {
 }
 
 export const codes = {
+    danger: "connect",
     "no-cockpit": "not-supported",
     "not-supported": "not-supported",
     "protocol-error": "not-supported",
@@ -195,6 +205,74 @@ class NotSupported extends React.Component {
                     { this.props.dialogError && <ModalError dialogError={this.props.dialogError} />}
                     <p>{cockpit.format(_("A compatible version of Cockpit is not installed on $0."), this.props.full_address)}</p>
                 </Stack>
+            </Modal>
+        );
+    }
+}
+
+class Connect extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            inProgress: false,
+        };
+    }
+
+    onConnect() {
+        window.sessionStorage.setItem("connection-warning-shown", true);
+        this.setState({ inProgress: true });
+        this.props.run(try2Connect(this.props.machines_ins, this.props.full_address), ex => {
+            let keep_message = false;
+            if (ex.problem === "no-host") {
+                let host_id_port = this.props.full_address;
+                let port = "22";
+                const port_index = host_id_port.lastIndexOf(":");
+                if (port_index === -1) {
+                    host_id_port = this.props.full_address + ":22";
+                } else {
+                    port = host_id_port.substr(port_index + 1);
+                }
+
+                ex.message = cockpit.format(_("Unable to contact the given host $0. Make sure it has ssh running on port $1, or specify another port in the address."), host_id_port, port);
+                ex.problem = "not-found";
+                keep_message = true;
+            }
+            this.setState({ inProgress: false });
+            this.props.setError(ex, keep_message);
+        });
+    }
+
+    render() {
+        return (
+            <Modal id="hosts_connect_server_dialog" isOpen
+                   position="top" variant="small"
+                   onClose={this.props.onClose}
+                   title={fmt_to_fragments(_("Connect to $0?"), <b>{this.props.host}</b>)}
+                   titleIconVariant="warning"
+                   footer={<>
+                       <HelperText>
+                           <HelperTextItem>{_("You will be reminded once per session.")}</HelperTextItem>
+                       </HelperText>
+                       <Button variant="warning" isLoading={this.state.inProgress}
+                                       onClick={() => this.onConnect()}>
+                           {_("Connect")}
+                       </Button>
+                       <Button variant="link" className="btn-cancel" onClick={this.props.onClose}>
+                           { _("Cancel") }
+                       </Button>
+                   </>}
+            >
+                <TextContent>
+                    <Text component={TextVariants.p}>
+                        {_("Connected hosts can fully control each other. This includes running programs that could harm your system or steal data. Only connect to trusted machines.")}
+                    </Text>
+                    <Text component={TextVariants.p}>
+                        <a href="https://cockpit-project.org/guide/latest/multi-host.html" target="blank" rel="noopener noreferrer">
+                            <ExternalLinkAltIcon /> {_("Read more")}
+                        </a>
+                    </Text>
+                </TextContent>
             </Modal>
         );
     }
@@ -323,23 +401,27 @@ class AddMachine extends React.Component {
             });
         });
 
-        this.props.run(try2Connect(this.props.machines_ins, address), ex => {
-            if (ex.problem === "no-host") {
-                let host_id_port = address;
-                let port = "22";
-                const port_index = host_id_port.lastIndexOf(":");
-                if (port_index === -1) {
-                    host_id_port = address + ":22";
-                } else {
-                    port = host_id_port.substr(port_index + 1);
-                }
+        if (!window.sessionStorage.getItem("connection-warning-shown")) {
+            this.props.setError({ problem: "danger", command: "close" });
+        } else {
+            this.props.run(try2Connect(this.props.machines_ins, address), ex => {
+                if (ex.problem === "no-host") {
+                    let host_id_port = address;
+                    let port = "22";
+                    const port_index = host_id_port.lastIndexOf(":");
+                    if (port_index === -1) {
+                        host_id_port = address + ":22";
+                    } else {
+                        port = host_id_port.substr(port_index + 1);
+                    }
 
-                ex.message = cockpit.format(_("Unable to contact the given host $0. Make sure it has ssh running on port $1, or specify another port in the address."), host_id_port, port);
-                ex.problem = "not-found";
-            }
-            this.setState({ inProgress: false });
-            this.props.setError(ex);
-        });
+                    ex.message = cockpit.format(_("Unable to contact the given host $0. Make sure it has ssh running on port $1, or specify another port in the address."), host_id_port, port);
+                    ex.problem = "not-found";
+                }
+                this.setState({ inProgress: false });
+                this.props.setError(ex);
+            });
+        }
     }
 
     render() {
@@ -1157,7 +1239,9 @@ class HostModalInner extends React.Component {
             complete: this.complete,
         };
 
-        if (template === "add-machine")
+        if (template === "connect")
+            return <Connect {...props} />;
+        else if (template === "add-machine")
             return <AddMachine {...props} />;
         else if (template === "unknown-hostkey" || template === "unknown-host" || template === "invalid-hostkey")
             return <HostKey {...props} />;

--- a/pkg/shell/shell.jsx
+++ b/pkg/shell/shell.jsx
@@ -66,10 +66,7 @@ const Shell = () => {
     useEvent(host_modal_state, "changed");
 
     useEvent(state, "connect", () => {
-        // We could launch some dialogs here, but the traditional
-        // behavior is to just connect the loader and open the dialogs
-        // from the troubleshoot button.
-        state.loader.connect(state.current_machine.address);
+        connect_host(host_modal_state, state, state.current_machine);
     });
 
     const {

--- a/pkg/shell/state.jsx
+++ b/pkg/shell/state.jsx
@@ -45,6 +45,24 @@ export function ShellState() {
     if (meta_multihost instanceof HTMLMetaElement && meta_multihost.content == "yes")
         config.host_switcher_enabled = true;
 
+    /* Should show warning before connecting? */
+    let config_ready = false;
+    cockpit.dbus(null, { bus: "internal" }).call("/config", "cockpit.Config", "GetString",
+                                                 ["Session", "WarnBeforeConnecting"], [])
+            .then(([result]) => {
+                if (result == "false" || result == "no") {
+                    window.sessionStorage.setItem("connection-warning-shown", "yes");
+                }
+            })
+            .catch(e => {
+                if (e.name != "cockpit.Config.KeyError")
+                    console.warn("Error reading WarnBeforeConnecting configuration:", e.message);
+            })
+            .finally(() => {
+                config_ready = true;
+                on_ready();
+            });
+
     /* MACHINES DATABASE AND MANIFEST LOADER
      *
      * These are part of the machinery in the basement that maintains
@@ -74,7 +92,7 @@ export function ShellState() {
         on_ready();
 
     function on_ready() {
-        if (machines.ready) {
+        if (machines.ready && config_ready) {
             self.ready = true;
             window.addEventListener("popstate", ev => {
                 update();
@@ -500,7 +518,6 @@ export function ShellState() {
 
         // Methods
         jump,
-        ensure_connection,
         remove_frame,
         most_recent_path_for_host,
 

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1141,13 +1141,23 @@ class Browser:
         known_host: bool = False,
         password: str | None = None,
         expect_closed_dialog: bool = True,
+        expect_warning: bool = True,
+        expect_curtain: bool = True
     ) -> None:
-        self.click('#machine-troubleshoot')
+        if expect_curtain:
+            self.click('#machine-troubleshoot')
+
+        if not new and expect_warning:
+            self.wait_visible('#hosts_connect_server_dialog')
+            self.click("#hosts_connect_server_dialog button.pf-m-warning")
 
         self.wait_visible('#hosts_setup_server_dialog')
         if new:
             self.wait_text("#hosts_setup_server_dialog button.pf-m-primary", "Add")
             self.click("#hosts_setup_server_dialog button.pf-m-primary")
+            if expect_warning:
+                self.wait_visible('#hosts_connect_server_dialog')
+                self.click("#hosts_connect_server_dialog button.pf-m-warning")
             if not known_host:
                 self.wait_in_text('#hosts_setup_server_dialog', "You are connecting to")
                 self.wait_in_text('#hosts_setup_server_dialog', "for the first time.")
@@ -1161,10 +1171,14 @@ class Browser:
         if expect_closed_dialog:
             self.wait_not_present('#hosts_setup_server_dialog')
 
-    def add_machine(self, address: str, known_host: bool = False, password: str = "foobar") -> None:
+    def add_machine(self, address: str, known_host: bool = False, password: str = "foobar",
+                    expect_warning: bool = True) -> None:
         self.switch_to_top()
         self.go(f"/@{address}")
-        self.start_machine_troubleshoot(new=True, known_host=known_host, password=password)
+        self.start_machine_troubleshoot(new=True,
+                                        known_host=known_host,
+                                        password=password,
+                                        expect_warning=expect_warning)
         self.enter_page("/system", host=address)
 
     def grant_permissions(self, *args: str) -> None:

--- a/test/verify/check-shell-host-switching
+++ b/test/verify/check-shell-host-switching
@@ -37,7 +37,12 @@ class HostSwitcherHelpers:
         for address in expected:
             b._wait_present(f"#hosts_setup_server_dialog datalist option[value='{address}']")
 
-    def wait_host_addresses(self, b, expected):
+    def wait_host_addresses(self, b, expected, host_switcher_is_open=True):
+        if not host_switcher_is_open:
+            # wait for host switcher to close
+            b.wait_not_present("#nav-hosts.interact")
+            # open it again
+            b.click("#hosts-sel button")
         b.wait_js_cond(f'ph_select("#nav-hosts .nav-item a").length == {len(expected)}')
         for address in expected:
             if address == "localhost":
@@ -91,6 +96,14 @@ class HostSwitcherHelpers:
         with b.wait_timeout(30):
             b.wait_not_present('#hosts_setup_server_dialog')
 
+    def wait_connected(self, b, address, expected_user=None):
+        b.wait_visible(f".connected a[href='/@{address}']")
+        if expected_user:
+            b.wait_text("#current-username", expected_user)
+        # Switch back to localhost, since the rest of the test expects that
+        b.click("a[href='/']")
+        b.click("#hosts-sel button")
+
     def connect_and_wait(self, b, address, expected_user=None, expect_warning=False):
         b.click(f"a[href='/@{address}']")
         if expect_warning:
@@ -101,12 +114,7 @@ class HostSwitcherHelpers:
         b.wait_not_present("#nav-hosts.interact")
         # open it again
         b.click("#hosts-sel button")
-        b.wait_visible(f".connected a[href='/@{address}']")
-        if expected_user:
-            b.wait_text("#current-username", expected_user)
-        # Switch back to localhost, since the rest of the test expects that
-        b.click("a[href='/']")
-        b.click("#hosts-sel button")
+        self.wait_connected(b, address, expected_user)
 
 
 @testlib.skipBeiboot("host switching disabled in beiboot mode")
@@ -212,9 +220,9 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
         b.click('#hosts_setup_server_dialog .pf-m-primary')
         b.wait_not_present('#hosts_setup_server_dialog')
 
-        self.wait_host_addresses(b, ["localhost", "10.111.113.2"])
+        self.wait_host_addresses(b, ["localhost", "10.111.113.2"], host_switcher_is_open=False)
         # defaults to current host user name "admin"
-        self.connect_and_wait(b, "10.111.113.2", "admin")
+        self.wait_connected(b, "10.111.113.2", "admin")
 
         # Main host should have both buttons disabled, the second both enabled
         b.click("button:contains('Edit hosts')")
@@ -230,8 +238,8 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
         b.wait_not_present(".nav-item a[href='/@10.111.113.2'] .nav-status")
 
         self.add_new_machine(b, "10.111.113.3")
-        self.wait_host_addresses(b, ["localhost", "10.111.113.3", "10.111.113.2"])
-        self.connect_and_wait(b, "10.111.113.3", "admin")
+        self.wait_host_addresses(b, ["localhost", "10.111.113.3", "10.111.113.2"], host_switcher_is_open=False)
+        self.wait_connected(b, "10.111.113.3", "admin")
 
         b.assert_pixels("#nav-hosts", "nav-hosts-2-remotes")
 
@@ -247,16 +255,16 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
 
         # Add one back, check addresses on both browsers
         self.add_new_machine(b, "10.111.113.2", known_host=True)
-        self.wait_host_addresses(b, ["localhost", "10.111.113.2"])
-        self.connect_and_wait(b, "10.111.113.2")
+        self.wait_host_addresses(b, ["localhost", "10.111.113.2"], host_switcher_is_open=False)
+        self.wait_connected(b, "10.111.113.2")
         self.check_discovered_addresses(b, ["10.111.113.3"])
 
         b.wait_not_present(".nav-item a[href='/@10.111.113.2'] .nav-status")
 
         # And the second one, check addresses
         self.add_new_machine(b, "10.111.113.3", known_host=True)
-        self.wait_host_addresses(b, ["localhost", "10.111.113.2", "10.111.113.3"])
-        self.connect_and_wait(b, "10.111.113.3")
+        self.wait_host_addresses(b, ["localhost", "10.111.113.2", "10.111.113.3"], host_switcher_is_open=False)
+        self.wait_connected(b, "10.111.113.3")
         self.check_discovered_addresses(b, [])
 
         # Test change user, not doing in edit to reuse machines
@@ -324,14 +332,14 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
 
         # plain address and separate "User name:" field
         self.add_new_machine(b, "10.111.113.2", known_host=True, user="someone", expect_password_auth=True)
-        self.wait_host_addresses(b, ["localhost", "10.111.113.2"])
-        self.connect_and_wait(b, "10.111.113.2", "someone")
+        self.wait_host_addresses(b, ["localhost", "10.111.113.2"], host_switcher_is_open=False)
+        self.wait_connected(b, "10.111.113.2", "someone")
         self.machine_remove(b, "10.111.113.2", second_to_last=True)
 
         # address with user and different "User name:" field, latter wins
         self.add_new_machine(b, "admin@10.111.113.2", known_host=True, user="someone", expect_password_auth=True)
-        self.wait_host_addresses(b, ["localhost", "10.111.113.2"])
-        self.connect_and_wait(b, "10.111.113.2", "someone")
+        self.wait_host_addresses(b, ["localhost", "10.111.113.2"], host_switcher_is_open=False)
+        self.wait_connected(b, "10.111.113.2", "someone")
         self.machine_remove(b, "10.111.113.2", second_to_last=True)
 
         # switch off warnings for the rest of this test (nneds the
@@ -346,37 +354,37 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
 
         # ssh:// prefix and implied user, no warning because we switched it off above
         self.add_new_machine(b, "ssh://10.111.113.2", known_host=True, expect_warning=False)
-        self.wait_host_addresses(b, ["localhost", "10.111.113.2"])
-        self.connect_and_wait(b, "10.111.113.2", "admin")
+        self.wait_host_addresses(b, ["localhost", "10.111.113.2"], host_switcher_is_open=False)
+        self.wait_connected(b, "10.111.113.2", "admin")
         self.machine_remove(b, "10.111.113.2", second_to_last=True)
 
         # ssh:// prefix and separate "User name:" field
         self.add_new_machine(b, "ssh://10.111.113.2", known_host=True, user="admin")
-        self.wait_host_addresses(b, ["localhost", "10.111.113.2"])
-        self.connect_and_wait(b, "10.111.113.2", "admin")
+        self.wait_host_addresses(b, ["localhost", "10.111.113.2"], host_switcher_is_open=False)
+        self.wait_connected(b, "10.111.113.2", "admin")
         self.machine_remove(b, "10.111.113.2", second_to_last=True)
 
         self.add_new_machine(b, "ssh://10.111.113.2", known_host=True, user="someone", expect_password_auth=True)
-        self.wait_host_addresses(b, ["localhost", "10.111.113.2"])
-        self.connect_and_wait(b, "10.111.113.2", "someone")
+        self.wait_host_addresses(b, ["localhost", "10.111.113.2"], host_switcher_is_open=False)
+        self.wait_connected(b, "10.111.113.2", "someone")
         self.machine_remove(b, "10.111.113.2", second_to_last=True)
 
         # ssh:// prefix with user name
         self.add_new_machine(b, "ssh://someone@10.111.113.2", known_host=True, expect_password_auth=True)
-        self.wait_host_addresses(b, ["localhost", "10.111.113.2"])
-        self.connect_and_wait(b, "10.111.113.2", "someone")
+        self.wait_host_addresses(b, ["localhost", "10.111.113.2"], host_switcher_is_open=False)
+        self.wait_connected(b, "10.111.113.2", "someone")
         self.machine_remove(b, "10.111.113.2", second_to_last=True)
 
         # ssh:// prefix with user and different "User name:" field, latter wins
         self.add_new_machine(b, "ssh://admin@10.111.113.2", known_host=True, user="someone", expect_password_auth=True)
-        self.wait_host_addresses(b, ["localhost", "10.111.113.2"])
-        self.connect_and_wait(b, "10.111.113.2", "someone")
+        self.wait_host_addresses(b, ["localhost", "10.111.113.2"], host_switcher_is_open=False)
+        self.wait_connected(b, "10.111.113.2", "someone")
         self.machine_remove(b, "10.111.113.2", second_to_last=True)
 
         # ssh:// prefix with user name and port in the connection target
         self.add_new_machine(b, "ssh://admin@10.111.113.2:22", known_host=True)
-        self.wait_host_addresses(b, ["localhost", "10.111.113.2"])
-        self.connect_and_wait(b, "10.111.113.2")
+        self.wait_host_addresses(b, ["localhost", "10.111.113.2"], host_switcher_is_open=False)
+        self.wait_connected(b, "10.111.113.2")
         self.machine_remove(b, "10.111.113.2", second_to_last=True)
 
         self.allow_journal_messages(".*server offered unsupported authentication methods: password public-key.*")
@@ -410,9 +418,9 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
         self.wait_host_addresses(b2, ["localhost"])
 
         self.add_new_machine(b, "10.111.113.2", expect_warning=True)
-        self.wait_host_addresses(b, ["localhost", "10.111.113.2"])
+        self.wait_host_addresses(b, ["localhost", "10.111.113.2"], host_switcher_is_open=False)
         self.wait_host_addresses(b2, ["localhost", "10.111.113.2"])
-        self.connect_and_wait(b, "10.111.113.2")
+        self.wait_connected(b, "10.111.113.2")
         self.connect_and_wait(b2, "10.111.113.2", expect_warning=True)
 
         # Main host should have both buttons disabled, the second both enabled
@@ -428,9 +436,9 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
         b.wait_not_present(".nav-item a[href='/@10.111.113.2'] .nav-status")
 
         self.add_new_machine(b, "10.111.113.3")
-        self.wait_host_addresses(b, ["localhost", "10.111.113.3", "10.111.113.2"])
+        self.wait_host_addresses(b, ["localhost", "10.111.113.3", "10.111.113.2"], host_switcher_is_open=False)
         self.wait_host_addresses(b2, ["localhost", "10.111.113.3", "10.111.113.2"])
-        self.connect_and_wait(b, "10.111.113.3")
+        self.wait_connected(b, "10.111.113.3")
         self.connect_and_wait(b2, "10.111.113.3")
 
         # Remove two
@@ -449,9 +457,9 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
 
         # Add one back, check addresses on both browsers
         self.add_new_machine(b, "10.111.113.2", known_host=True)
-        self.wait_host_addresses(b, ["localhost", "10.111.113.2"])
+        self.wait_host_addresses(b, ["localhost", "10.111.113.2"], host_switcher_is_open=False)
         self.wait_host_addresses(b2, ["localhost", "10.111.113.2"])
-        self.connect_and_wait(b, "10.111.113.2")
+        self.wait_connected(b, "10.111.113.2")
         self.check_discovered_addresses(b, ["10.111.113.3"])
         self.check_discovered_addresses(b2, ["10.111.113.3"])
 
@@ -459,9 +467,9 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
 
         # And the second one, check addresses on both browsers
         self.add_new_machine(b, "10.111.113.3", known_host=True)
-        self.wait_host_addresses(b, ["localhost", "10.111.113.2", "10.111.113.3"])
+        self.wait_host_addresses(b, ["localhost", "10.111.113.2", "10.111.113.3"], host_switcher_is_open=False)
         self.wait_host_addresses(b2, ["localhost", "10.111.113.2", "10.111.113.3"])
-        self.connect_and_wait(b, "10.111.113.3")
+        self.wait_connected(b, "10.111.113.3")
         self.check_discovered_addresses(b, [])
         self.check_discovered_addresses(b2, [])
 
@@ -490,8 +498,8 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
 
         b.click("#hosts-sel button")
         self.add_new_machine(b, "10.111.113.3", expect_warning=True)
-        self.wait_host_addresses(b, ["localhost", "10.111.113.3"])
-        self.connect_and_wait(b, "10.111.113.3")
+        self.wait_host_addresses(b, ["localhost", "10.111.113.3"], host_switcher_is_open=False)
+        self.wait_connected(b, "10.111.113.3")
 
         b.click("button:contains('Edit hosts')")
         b.click("#nav-hosts .nav-item a[href='/@10.111.113.3'] + span button.nav-action.pf-m-secondary")
@@ -573,7 +581,6 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
         # Add and connect to a second machine
         b.click("#hosts-sel button")
         self.add_new_machine(b, "10.111.113.2", expect_warning=True)
-        b.click("a[href='/@10.111.113.2']")
         b.wait_visible("iframe.container-frame[name='cockpit1:10.111.113.2/system']")
         self.assertIn("admin", m2.execute("loginctl"))
         b.click("#hosts-sel button")

--- a/test/verify/check-shell-host-switching
+++ b/test/verify/check-shell-host-switching
@@ -66,7 +66,8 @@ class HostSwitcherHelpers:
         # HACK: Dropping the machine does not terminate SSH connection; https://github.com/cockpit-project/cockpit/issues/19672
         self.machine.execute(f"pkill -f [s]sh.*{address}; while pgrep -f [s]sh.*{address}; do sleep 1; done")
 
-    def add_new_machine(self, b, address, known_host=False, pixel_label=None, user=None, expect_password_auth=False):
+    def add_new_machine(self, b, address, known_host=False, pixel_label=None, user=None, expect_password_auth=False,
+                        expect_warning=False):
         b.click("button:contains('Add new host')")
         b.wait_visible('#hosts_setup_server_dialog')
         b.set_input_text('#add-machine-address', address)
@@ -75,6 +76,10 @@ class HostSwitcherHelpers:
         if pixel_label:
             b.assert_pixels("#hosts_setup_server_dialog", pixel_label)
         b.click('#hosts_setup_server_dialog .pf-m-primary:contains("Add")')
+        if expect_warning:
+            b.wait_visible('#hosts_connect_server_dialog')
+            b.click('#hosts_connect_server_dialog button.pf-m-warning')
+            b.wait_not_present('#hosts_connect_server_dialog')
         if not known_host:
             b.wait_in_text('#hosts_setup_server_dialog',
                            f"You are connecting to {address.removeprefix('ssh://')} for the first time")
@@ -86,8 +91,15 @@ class HostSwitcherHelpers:
         with b.wait_timeout(30):
             b.wait_not_present('#hosts_setup_server_dialog')
 
-    def connect_and_wait(self, b, address, expected_user=None):
+    def connect_and_wait(self, b, address, expected_user=None, expect_warning=False):
         b.click(f"a[href='/@{address}']")
+        if expect_warning:
+            b.wait_visible('#hosts_connect_server_dialog')
+            b.click('#hosts_connect_server_dialog button.pf-m-warning')
+            b.wait_not_present('#hosts_connect_server_dialog')
+        # wait for host switcher to close after connecting
+        b.wait_not_present("#nav-hosts.interact")
+        # open it again
         b.click("#hosts-sel button")
         b.wait_visible(f".connected a[href='/@{address}']")
         if expected_user:
@@ -176,7 +188,30 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
         b.wait_in_text("#nav-hosts .nav-item a", "mydhcpname")
         m1.execute("hostnamectl set-hostname 'localhost'")
 
-        self.add_new_machine(b, "10.111.113.2", pixel_label="host-add-dialog")
+        # Add a host with a couple of mistakes on the way
+        b.click("button:contains('Add new host')")
+        b.wait_visible('#hosts_setup_server_dialog')
+        b.set_input_text('#add-machine-address', "10.111.113.2:1234")
+        b.click('#hosts_setup_server_dialog .pf-m-primary:contains("Add")')
+        # Port is wrong but we first have to confirm that we really want to connect
+        b.wait_visible('#hosts_connect_server_dialog')
+        b.assert_pixels("#hosts_connect_server_dialog", "host-connect-dialog")
+        b.click('#hosts_connect_server_dialog button.pf-m-warning')
+        # Now we are back in the "Add host" dialog with the error
+        b.wait_in_text('#hosts_setup_server_dialog', "Unable to contact the given host 10.111.113.2:1234. Make sure it has ssh running on port 1234, or specify another port in the address.")
+        # Give another wrong address
+        b.set_input_text('#add-machine-address', "10.111.113.2:4321")
+        b.click('#hosts_setup_server_dialog .pf-m-primary:contains("Add")')
+        # Error happens immediatly now.
+        b.wait_in_text('#hosts_setup_server_dialog', "Unable to contact the given host 10.111.113.2:4321. Make sure it has ssh running on port 4321, or specify another port in the address.")
+        # Now do it right
+        b.set_input_text('#add-machine-address', "10.111.113.2")
+        b.assert_pixels("#hosts_setup_server_dialog", "host-add-dialog")
+        b.click('#hosts_setup_server_dialog .pf-m-primary:contains("Add")')
+        b.wait_in_text('#hosts_setup_server_dialog', "You are connecting to 10.111.113.2 for the first time")
+        b.click('#hosts_setup_server_dialog .pf-m-primary')
+        b.wait_not_present('#hosts_setup_server_dialog')
+
         self.wait_host_addresses(b, ["localhost", "10.111.113.2"])
         # defaults to current host user name "admin"
         self.connect_and_wait(b, "10.111.113.2", "admin")
@@ -299,12 +334,18 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
         self.connect_and_wait(b, "10.111.113.2", "someone")
         self.machine_remove(b, "10.111.113.2", second_to_last=True)
 
+        # switch off warnings for the rest of this test (nneds the
+        # relogin below to take effect)
+        m1.write("/etc/cockpit/cockpit.conf",
+                 '[Session]\nWarnBeforeConnecting=false\n',
+                 append=True)
+
         # reset session store to forget previous user/host connections
         b.relogin()
         b.click("#hosts-sel button")
 
-        # ssh:// prefix and implied user
-        self.add_new_machine(b, "ssh://10.111.113.2", known_host=True)
+        # ssh:// prefix and implied user, no warning because we switched it off above
+        self.add_new_machine(b, "ssh://10.111.113.2", known_host=True, expect_warning=False)
         self.wait_host_addresses(b, ["localhost", "10.111.113.2"])
         self.connect_and_wait(b, "10.111.113.2", "admin")
         self.machine_remove(b, "10.111.113.2", second_to_last=True)
@@ -368,11 +409,11 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
         b2.click("#hosts-sel button")
         self.wait_host_addresses(b2, ["localhost"])
 
-        self.add_new_machine(b, "10.111.113.2")
+        self.add_new_machine(b, "10.111.113.2", expect_warning=True)
         self.wait_host_addresses(b, ["localhost", "10.111.113.2"])
         self.wait_host_addresses(b2, ["localhost", "10.111.113.2"])
         self.connect_and_wait(b, "10.111.113.2")
-        self.connect_and_wait(b2, "10.111.113.2")
+        self.connect_and_wait(b2, "10.111.113.2", expect_warning=True)
 
         # Main host should have both buttons disabled, the second both enabled
         b.click("button:contains('Edit hosts')")
@@ -448,7 +489,7 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
         self.login_and_go(superuser=False)
 
         b.click("#hosts-sel button")
-        self.add_new_machine(b, "10.111.113.3")
+        self.add_new_machine(b, "10.111.113.3", expect_warning=True)
         self.wait_host_addresses(b, ["localhost", "10.111.113.3"])
         self.connect_and_wait(b, "10.111.113.3")
 
@@ -529,9 +570,9 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
         self.enable_multihost(self.machine)
         self.login_and_go(None)
 
-        # And and connect to a second machine
+        # Add and connect to a second machine
         b.click("#hosts-sel button")
-        self.add_new_machine(b, "10.111.113.2")
+        self.add_new_machine(b, "10.111.113.2", expect_warning=True)
         b.click("a[href='/@10.111.113.2']")
         b.wait_visible("iframe.container-frame[name='cockpit1:10.111.113.2/system']")
         self.assertIn("admin", m2.execute("loginctl"))

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -149,7 +149,7 @@ class TestMultiMachineAdd(testlib.MachineCase):
 
         self.login_and_go(None)
         b.add_machine("10.111.113.2", password=None)
-        b.add_machine(m3_host, password=None)
+        b.add_machine(m3_host, password=None, expect_warning=False)
 
         b.switch_to_top()
         b.click("#hosts-sel button")
@@ -226,7 +226,7 @@ class TestMultiMachineAdd(testlib.MachineCase):
 
         self.login_and_go(None)
         b.add_machine("m2", password=None)
-        b.add_machine("m3", password=None)
+        b.add_machine("m3", password=None, expect_warning=False)
 
         b.switch_to_top()
         b.click("#hosts-sel button")
@@ -561,8 +561,11 @@ class TestMultiMachine(testlib.MachineCase):
         # navigating there again will fail
         b.go(m2_path)
         with b.wait_timeout(30):
-            b.wait_text(".curtains-ct h1", "Not connected to host")
-        b.wait_text("#machine-troubleshoot", "Log in")
+            b.wait_visible("#hosts_setup_server_dialog")
+        b.start_machine_troubleshoot(expect_curtain=False, password="foobar",
+                                     expect_closed_dialog=False, expect_warning=False)
+        b.wait_in_text("#hosts_setup_server_dialog .pf-v5-c-alert", "Login failed")
+        b.click("#hosts_setup_server_dialog button:contains(Cancel)")
 
         # wait for system to load
         b.go("/system")
@@ -577,8 +580,8 @@ class TestMultiMachine(testlib.MachineCase):
         b.reload()
         b.go(m2_path)
         with b.wait_timeout(30):
-            b.wait_text(".curtains-ct h1", "Not connected to host")
-        b.start_machine_troubleshoot(password="foobar")
+            b.wait_visible("#hosts_setup_server_dialog")
+        b.start_machine_troubleshoot(expect_curtain=False, password="foobar", expect_warning=False)
 
         b.enter_page("/playground/test", "10.111.113.2", reconnect=True)
         # image is back because it page was reloaded after disconnection
@@ -678,21 +681,21 @@ class TestMultiMachine(testlib.MachineCase):
         m1.execute("mkdir -p /home/admin/.ssh/")
         break_hostkey(m1, "10.111.113.2")
 
-        b.start_machine_troubleshoot(new=True, known_host=True, expect_closed_dialog=False)
+        b.start_machine_troubleshoot(new=True, known_host=True, expect_closed_dialog=False, expect_warning=False)
         b.wait_in_text('#hosts_setup_server_dialog', "10.111.113.2 key changed")
         b.click("#hosts_setup_server_dialog button:contains(Cancel)")
         fix_hostkey(m1)
 
         # Bad cockpit
         break_bridge(m2)
-        b.start_machine_troubleshoot(new=True, password="foobar", expect_closed_dialog=False)
+        b.start_machine_troubleshoot(new=True, password="foobar", expect_closed_dialog=False, expect_warning=False)
         check_failed_state(b, "Cockpit is not installed")
         fix_bridge(m2)
 
         # Troubleshoot existing
         # Properly add machine
         fix_hostkey(m1)
-        b.add_machine("10.111.113.2")
+        b.add_machine("10.111.113.2", expect_warning=False)
         b.logout()
         b.wait_visible("#login")
 
@@ -700,16 +703,17 @@ class TestMultiMachine(testlib.MachineCase):
         break_bridge(m2)
         self.login_and_go(None)
         b.go(machine_path)
-        with b.wait_timeout(240):
-            b.start_machine_troubleshoot(password="foobar", expect_closed_dialog=False)
+        with b.wait_timeout(20):
+            b.start_machine_troubleshoot(expect_curtain=False, password="foobar", expect_closed_dialog=False)
 
         check_failed_state(b, "Cockpit is not installed")
-        b.wait_visible("#machine-troubleshoot")
+        b.wait_visible("#machine-reconnect")
         fix_bridge(m2)
 
         # Clear host key
         fix_hostkey(m1)
-        b.start_machine_troubleshoot(expect_closed_dialog=False)
+        b.click("#machine-reconnect")
+        b.start_machine_troubleshoot(expect_curtain=False, expect_closed_dialog=False, expect_warning=False)
         b.wait_in_text('#hosts_setup_server_dialog', "You are connecting to 10.111.113.2 for the first time.")
 
         # show fingerprint validation
@@ -743,13 +747,10 @@ class TestMultiMachine(testlib.MachineCase):
         self.login_and_go(None)
         b.go(machine_path)
 
-        with b.wait_timeout(120):
-            b.wait_visible("#machine-troubleshoot")
-        b.start_machine_troubleshoot(expect_closed_dialog=False)
+        with b.wait_timeout(20):
+            b.wait_visible("#hosts_connect_server_dialog")
+        b.start_machine_troubleshoot(expect_curtain=False, expect_closed_dialog=False)
         b.wait_in_text('#hosts_setup_server_dialog', "Unable to log in")
-        b.set_input_text('#login-custom-password', "")
-        fail_login(b)
-
         b.set_input_text("#login-custom-password", "bad")
         fail_login(b)
         b.set_input_text("#login-custom-password", "alt-password")
@@ -768,11 +769,11 @@ class TestMultiMachine(testlib.MachineCase):
 
         self.login_and_go(None)
         b.go(machine_path)
-        with b.wait_timeout(120):
-            b.wait_visible("#machine-troubleshoot")
-        b.start_machine_troubleshoot(expect_closed_dialog=False)
-        b.wait_in_text('#hosts_setup_server_dialog h1', "Could not contact")
-        b.set_input_text("#edit-machine-port", "2222")
+        with b.wait_timeout(20):
+            b.wait_visible("#hosts_connect_server_dialog")
+        b.start_machine_troubleshoot(expect_curtain=False, expect_closed_dialog=False)
+        b.wait_in_text('#hosts_setup_server_dialog', "Unable to contact")
+        b.set_input_text("#add-machine-address", "10.111.113.2:2222")
         b.click(f'#hosts_setup_server_dialog {self.primary_btn_class}')
         # ssh(1) tracks known hosts by name/IP, not by port; so not expecting a host key prompt here
         b.wait_in_text('#hosts_setup_server_dialog h1', "Log in to")
@@ -811,12 +812,13 @@ class TestMultiMachine(testlib.MachineCase):
 
         self.login_and_go(None)
         b.go("/@10.111.113.2")
-        b.start_machine_troubleshoot(expect_closed_dialog=False)
         b.click('#machine-troubleshoot')
         b.wait_visible('#hosts_setup_server_dialog')
         b.wait_in_text('#hosts_setup_server_dialog', "new host")
         b.set_input_text('#add-machine-user', "fred")
         b.click('#hosts_setup_server_dialog button:contains(Add)')
+        b.wait_visible('#hosts_connect_server_dialog')
+        b.click("#hosts_connect_server_dialog button.pf-m-warning")
         b.wait_in_text('#hosts_setup_server_dialog', "You are connecting to 10.111.113.2 for the first time.")
         b.click("#hosts_setup_server_dialog button:contains('Trust and add host')")
         b.wait_in_text('#hosts_setup_server_dialog', "Unable to log in")
@@ -842,14 +844,17 @@ class TestMultiMachine(testlib.MachineCase):
         self.assertEqual(m1.execute("cat /home/admin/.ssh/id_rsa.pub"),
                          m2.execute("cat /home/fred/.ssh/authorized_keys"))
 
-        # Relogin.  This should now work seamlessly.
+        # Relogin.  This should now work seamlessly (except for the warning).
         b.relogin(None, wait_remote_session_machine=m1)
+        b.wait_visible('#hosts_connect_server_dialog')
+        b.click("#hosts_connect_server_dialog button.pf-m-warning")
         b.enter_page("/system", host="fred@10.111.113.2")
 
         # De-authorize key and relogin, then re-authorize.
         m2.execute("rm /home/fred/.ssh/authorized_keys")
         b.relogin(None, wait_remote_session_machine=m1)
-        b.click('#machine-troubleshoot')
+        b.wait_visible('#hosts_connect_server_dialog')
+        b.click("#hosts_connect_server_dialog button.pf-m-warning")
         b.wait_visible('#hosts_setup_server_dialog')
         b.wait_in_text('#hosts_setup_server_dialog', "Unable to log in")
         b.wait_in_text("#hosts_setup_server_dialog", "Authorize SSH key")
@@ -865,7 +870,8 @@ class TestMultiMachine(testlib.MachineCase):
         # change the passphrase back to the login password
         m1.execute("ssh-keygen -q -f /home/admin/.ssh/id_rsa -p -P foobar -N foobarfoo")
         b.relogin(None, wait_remote_session_machine=m1)
-        b.click('#machine-troubleshoot')
+        b.wait_visible('#hosts_connect_server_dialog')
+        b.click("#hosts_connect_server_dialog button.pf-m-warning")
         b.wait_visible('#hosts_setup_server_dialog')
         b.wait_in_text('#hosts_setup_server_dialog', "The SSH key for logging in")
         b.set_checked('#hosts_setup_server_dialog input[value=key]', val=True)
@@ -881,6 +887,8 @@ class TestMultiMachine(testlib.MachineCase):
         # which don't have pam-ssh-add in its PAM stack.)
         if not m1.ostree_image:
             b.relogin(None, wait_remote_session_machine=m1)
+            b.wait_visible('#hosts_connect_server_dialog')
+            b.click("#hosts_connect_server_dialog button.pf-m-warning")
             b.enter_page("/system", host="fred@10.111.113.2")
 
         # The authorized_keys files should still only have a single key
@@ -913,6 +921,8 @@ class TestMultiMachine(testlib.MachineCase):
         b.click('#machine-troubleshoot')
         b.wait_visible('#hosts_setup_server_dialog')
         b.click('#hosts_setup_server_dialog button:contains(Add)')
+        b.wait_visible('#hosts_connect_server_dialog')
+        b.click('#hosts_connect_server_dialog button:contains(Connect)')
         b.wait_in_text('#hosts_setup_server_dialog', "You are connecting to 10.111.113.2 for the first time.")
         b.click("#hosts_setup_server_dialog button:contains('Trust and add host')")
         b.wait_in_text('#hosts_setup_server_dialog', "The SSH key")

--- a/test/verify/check-shell-multi-machine-key
+++ b/test/verify/check-shell-multi-machine-key
@@ -152,6 +152,8 @@ class TestMultiMachineKeyAuth(testlib.MachineCase):
 
         b.wait_text(f'#hosts_setup_server_dialog {self.primary_btn_class}', "Add")
         b.click(f'#hosts_setup_server_dialog {self.primary_btn_class}')
+        b.wait_visible('#hosts_connect_server_dialog')
+        b.click('#hosts_connect_server_dialog button.pf-m-warning')
         b.wait_in_text('#hosts_setup_server_dialog', "You are connecting to 10.111.113.2 for the first time.")
         b.click(f'#hosts_setup_server_dialog {self.primary_btn_class}')
         b.wait_in_text('#hosts_setup_server_dialog h1', "Log in to")
@@ -181,6 +183,8 @@ class TestMultiMachineKeyAuth(testlib.MachineCase):
             self.load_key('id_rsa', 'foobar')
 
         b.go("/@10.111.113.2")
+        b.wait_visible('#hosts_connect_server_dialog')
+        b.click('#hosts_connect_server_dialog button.pf-m-warning')
         b.wait_visible("iframe.container-frame[name='cockpit1:10.111.113.2/system']")
 
         # Change user
@@ -248,6 +252,8 @@ Host 10.111.113.2
         b.wait_visible('#hosts_setup_server_dialog')
         b.set_input_text('#add-machine-address', "10.111.113.2")
         b.click("#hosts_setup_server_dialog .pf-m-primary")
+        b.wait_visible('#hosts_connect_server_dialog')
+        b.click('#hosts_connect_server_dialog button.pf-m-warning')
         b.wait_in_text("#hosts_setup_server_dialog", "You are connecting to 10.111.113.2 for the first time.")
         b.click("#hosts_setup_server_dialog .pf-m-primary")
         b.wait_in_text("#hosts_setup_server_dialog", "/home/admin/.ssh/id_ed25519")
@@ -282,6 +288,8 @@ Host 10.111.113.2
         b.wait_visible('#hosts_setup_server_dialog')
         b.set_input_text("#add-machine-address", "10.111.113.2")
         b.click("#hosts_setup_server_dialog .pf-m-primary")
+        b.wait_visible('#hosts_connect_server_dialog')
+        b.click('#hosts_connect_server_dialog button.pf-m-warning')
         b.wait_in_text("#hosts_setup_server_dialog", "You are connecting to 10.111.113.2 for the first time.")
         b.click("#hosts_setup_server_dialog .pf-m-primary")
         b.wait_in_text("#hosts_setup_server_dialog", "/home/admin/.ssh/id_rsa")

--- a/test/verify/check-shell-multi-machine-key
+++ b/test/verify/check-shell-multi-machine-key
@@ -259,7 +259,7 @@ Host 10.111.113.2
         b.wait_in_text("#hosts_setup_server_dialog", "/home/admin/.ssh/id_ed25519")
         b.set_input_text("#locked-identity-password", "locked")
         b.click("#hosts_setup_server_dialog .pf-m-primary")
-        b.wait_visible("a[href='/@10.111.113.2']")
+        b.enter_page("/system", "10.111.113.2")
         self.allow_hostkey_messages()
 
     def testLockedDefaultIdentity(self):
@@ -295,7 +295,7 @@ Host 10.111.113.2
         b.wait_in_text("#hosts_setup_server_dialog", "/home/admin/.ssh/id_rsa")
         b.set_input_text("#locked-identity-password", "foobarfoo")
         b.click("#hosts_setup_server_dialog .pf-m-primary")
-        b.wait_visible("a[href='/@10.111.113.2']")
+        b.enter_page("/system", "10.111.113.2")
         self.allow_hostkey_messages()
 
 

--- a/test/verify/check-shell-multi-os
+++ b/test/verify/check-shell-multi-os
@@ -79,7 +79,7 @@ class TestRHEL8(testlib.MachineCase):
 
         # stock → dev: via shell Add host
         stock_b.login_and_go()
-        stock_b.add_machine("10.111.113.1")
+        stock_b.add_machine("10.111.113.1", expect_warning=False)
         stock_b.wait_in_text(".ct-overview-header-hostname", dev_hostname)
 
 

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -428,6 +428,8 @@ class TestSuperuserDashboard(testlib.MachineCase):
         b.wait_visible('#hosts_setup_server_dialog')
         b.wait_visible('#hosts_setup_server_dialog button:contains("Add")')
         b.click('#hosts_setup_server_dialog button:contains("Add")')
+        b.wait_visible('#hosts_connect_server_dialog')
+        b.click('#hosts_connect_server_dialog button.pf-m-warning')
         b.wait_in_text('#hosts_setup_server_dialog', "You are connecting to 10.111.113.2 for the first time.")
         b.click('#hosts_setup_server_dialog button.pf-m-primary')
         b.wait_in_text('#hosts_setup_server_dialog', "Unable to log in")
@@ -457,7 +459,8 @@ class TestSuperuserDashboard(testlib.MachineCase):
         # superuser on m2 (once we have logged in there).
         self.allow_restart_journal_messages()
         b.relogin()
-        b.click('#machine-troubleshoot')
+        b.wait_visible('#hosts_connect_server_dialog')
+        b.click('#hosts_connect_server_dialog button.pf-m-warning')
         b.wait_visible('#hosts_setup_server_dialog')
         b.set_input_text("#login-custom-password", "foobar")
         b.click('#hosts_setup_server_dialog button:contains("Log in")')

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -815,6 +815,8 @@ ipa-advise enable-admins-sudo | sh -ex
         b.wait_visible('#hosts_setup_server_dialog')
         b.click('#hosts_setup_server_dialog button:contains(Add)')
         b.wait_not_present('#hosts_setup_server_dialog')
+        b.wait_visible('#hosts_connect_server_dialog')
+        b.click('#hosts_connect_server_dialog button.pf-m-warning')
 
         # Getting root privs through sudo with kerberos in the remote SSH session does not currently work.
         # ssh -K is supposed to forward the credentials cache, but doesn't; klist in the ssh session is empty
@@ -1074,6 +1076,8 @@ class TestKerberos(testlib.MachineCase):
         b.wait_visible('#hosts_setup_server_dialog')
         b.click('#hosts_setup_server_dialog button:contains(Add)')
         b.wait_not_present('#hosts_setup_server_dialog')
+        b.wait_visible('#hosts_connect_server_dialog')
+        b.click('#hosts_connect_server_dialog button.pf-m-warning')
 
         b.enter_page("/system/terminal", host="x0.cockpit.lan")
         b.wait_visible(".terminal")

--- a/test/verify/check-system-shutdown-restart
+++ b/test/verify/check-system-shutdown-restart
@@ -92,7 +92,7 @@ class TestShutdownRestart(testlib.MachineCase):
 
         with b2.wait_timeout(30):
             b2.wait_visible("#machine-troubleshoot")
-        b2.start_machine_troubleshoot(password="foobar")
+        b2.start_machine_troubleshoot(password="foobar", expect_warning=False)
 
         b2.enter_page("/system", host="10.111.113.1", reconnect=False)
 


### PR DESCRIPTION
### Shell: Extra warnings when connecting to remote hosts

Connecting to multiple hosts in a single Cockpit session allows all these hosts to access each other freely. Eventually Cockpit will not allow multiple connections, but in the mean time, we want to educate people better.

![image](https://github.com/user-attachments/assets/b2be2acf-3e2d-44ce-80b4-9c6d98d0f5a1)

This warning can be disabled by including the following in `/etc/cockpit/cockpit.conf`:

```
[Session] 
WarnBeforeConnecting=false
```

-----------------------

Demo: https://youtu.be/Un6k3DiukOg
