### PR TITLE
fmf: Force-update firewalld on CentOS 10

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -17,10 +17,10 @@ mkdir -p /root/.ssh
 curl https://raw.githubusercontent.com/cockpit-project/bots/main/machine/identity.pub >> /root/.ssh/authorized_keys
 chmod 600 /root/.ssh/authorized_keys
 
-# HACK: broken shadow-utils
-if grep -q 'platform:f41' /etc/os-release; then
-    rpm -q shadow-utils
-    dnf update -y shadow-utils
+# HACK: broken firewalld in latest c10s image, and no new images for > 1 week
+if grep -q 'platform:el10' /etc/os-release; then
+    rpm -q firewalld
+    dnf update -y firewalld
 fi
 
 # HACK: setroubleshoot-server crashes/times out randomly (breaking TestServices),


### PR DESCRIPTION
There have been no new C10S images for two weeks and counting [1], and the latest one has a broken firewalld [2]. Update it.

Drop the obsolete shadow-utils hack, the current version is fine.

[1] https://issues.redhat.com/browse/CS-2358
[2] https://issues.redhat.com/browse/RHEL-50339

---

Fixes [this failure](https://artifacts.dev.testing-farm.io/6416217f-93ca-44c7-bb2a-a5fff2f12de2/) which has been plaguing it for a long time.