### PR TITLE
Warn about/prevent multiple direct remote connections

### DIFF
--- a/pkg/static/login.html
+++ b/pkg/static/login.html
@@ -21,6 +21,14 @@
     <span id="banner-message" class="pf-v5-c-alert__title"></span>
   </div>
 
+  <div id="multihost-warning" class="pf-v5-c-alert pf-m-info pf-m-inline dialog-error" aria-label="inline danger alert" hidden="true">
+    <svg fill="currentColor" viewBox="0 0 448 512" aria-hidden="true">
+      <path d="M224 512c35.32 0 63.97-28.65 63.97-64H160.03c0 35.35 28.65 64 63.97 64zm215.39-149.71c-19.32-20.76-55.47-51.99-55.47-154.29 0-77.7-54.48-139.9-127.94-155.16V32c0-17.67-14.32-32-31.98-32s-31.98 14.33-31.98 32v20.84C118.56 68.1 64.08 130.3 64.08 208c0 102.3-36.15 133.53-55.47 154.29-6 6.45-8.66 14.16-8.61 21.71.11 16.4 12.98 32 32.1 32h383.8c19.12 0 32-15.6 32.1-32 .05-7.55-2.61-15.27-8.61-21.71z" />
+    </svg>
+    <p id="multihost-message" class="pf-v5-c-alert__title"></p>
+    <button id="multihost-get-me-there" class="pf-v5-c-button">Go there</button>
+  </div>
+
   <span id="badge"></span>
 
   <div class="container" id="main">

--- a/pkg/static/login.js
+++ b/pkg/static/login.js
@@ -343,28 +343,22 @@ import "./login.scss";
         // end up on the login page, we are about to load resources
         // from two machines into the same browser origin.
 
-        const cur_machine = window.localStorage.getItem("current-machine");
-
-        // Protect against outdated cur_machine values.
-        if (cur_machine == "localhost" && !window.location.pathname.startsWith("/="))
-            return;
-        if (cur_machine && cur_machine != "localhost" && window.location.pathname.startsWith("/=" + cur_machine))
-            return;
+        const logged_into = environment["logged-into"];
+        const cur_machine = logged_into.length > 0 ? logged_into[0] : null;
 
         function redirect_to_current_machine() {
-            if (cur_machine == "localhost")
+            if (cur_machine === ".")
                 login_reload("/");
             else
                 login_reload("/=" + cur_machine);
         }
 
-        environment.page.allow_multi_host = true; // XXX
-
         if (cur_machine) {
             if (!environment.page.allow_multi_host)
                 redirect_to_current_machine();
             else {
-                id("multihost-message").textContent = format(_("You are already connected to '$0' in this browser session. Connecting to other hosts will allow them to execute arbitrary code on each other. Please be careful."), cur_machine);
+                id("multihost-message").textContent = format(_("You are already connected to '$0' in this browser session. Connecting to other hosts will allow them to execute arbitrary code on each other. Please be careful."),
+                                                             cur_machine == "." ? "localhost" : cur_machine);
                 id("multihost-get-me-there").addEventListener("click", redirect_to_current_machine);
                 show('#multihost-warning');
             }
@@ -442,7 +436,6 @@ import "./login.scss";
                 oauth_auto_login();
             }
         } else if (logout_intent) {
-            window.localStorage.removeItem("current-machine");
             show_login(logout_reason);
         } else if (need_host()) {
             show_login();
@@ -1018,7 +1011,7 @@ import "./login.scss";
         }
     }
 
-    function setup_localstorage (response, machine) {
+    function setup_localstorage (response) {
         /* Clear anything not prefixed with
          * different application from sessionStorage
          */
@@ -1051,8 +1044,6 @@ import "./login.scss";
         const ca_cert_url = environment.CACertUrl;
         if (ca_cert_url)
             window.sessionStorage.setItem('CACertUrl', ca_cert_url);
-
-        window.localStorage.setItem('current-machine', machine || "localhost");
     }
 
     function run(response) {
@@ -1079,7 +1070,7 @@ import "./login.scss";
          */
         clear_storage(window.sessionStorage, application, false);
 
-        setup_localstorage(response, machine);
+        setup_localstorage(response);
         login_reload(wanted);
     }
 

--- a/pkg/static/login.js
+++ b/pkg/static/login.js
@@ -338,21 +338,41 @@ import "./login.scss";
         event.stopPropagation();
     }
 
-    function boot() {
-        window.onload = null;
+    function deal_with_multihost() {
+        // If we are currently logged in to some machine, but still
+        // end up on the login page, we are about to load resources
+        // from two machines into the same browser origin.
 
-        if (!environment.page.allow_multi_host) {
-            // If we are currently logged in, we do not want to allow
-            // another login to a different machine. So we redirect to
-            // the current login.
+        const cur_machine = window.localStorage.getItem("current-machine");
 
-            const cur_machine = window.localStorage.getItem("current-machine");
-            if (cur_machine == "localhost" && window.location.pathname.startsWith("/=")) {
+        // Protect against outdated cur_machine values.
+        if (cur_machine == "localhost" && !window.location.pathname.startsWith("/="))
+            return;
+        if (cur_machine && cur_machine != "localhost" && window.location.pathname.startsWith("/=" + cur_machine))
+            return;
+
+        function redirect_to_current_machine() {
+            if (cur_machine == "localhost")
                 login_reload("/");
-            } else if (cur_machine && !window.location.pathname.startsWith("/=" + cur_machine)) {
+            else
                 login_reload("/=" + cur_machine);
+        }
+
+        environment.page.allow_multi_host = true; // XXX
+
+        if (cur_machine) {
+            if (!environment.page.allow_multi_host)
+                redirect_to_current_machine();
+            else {
+                id("multihost-message").textContent = format(_("You are already connected to '$0' in this browser session. Connecting to other hosts will allow them to execute arbitrary code on each other. Please be careful."), cur_machine);
+                id("multihost-get-me-there").addEventListener("click", redirect_to_current_machine);
+                show('#multihost-warning');
             }
         }
+    }
+
+    function boot() {
+        window.onload = null;
 
         translate();
         if (window.cockpit_po && window.cockpit_po[""]) {
@@ -360,6 +380,8 @@ import "./login.scss";
             if (window.cockpit_po[""]["language-direction"])
                 document.documentElement.dir = window.cockpit_po[""]["language-direction"];
         }
+
+        deal_with_multihost();
 
         setup_path_globals(window.location.pathname);
 
@@ -420,6 +442,7 @@ import "./login.scss";
                 oauth_auto_login();
             }
         } else if (logout_intent) {
+            window.localStorage.removeItem("current-machine");
             show_login(logout_reason);
         } else if (need_host()) {
             show_login();

--- a/pkg/static/login.js
+++ b/pkg/static/login.js
@@ -341,6 +341,19 @@ import "./login.scss";
     function boot() {
         window.onload = null;
 
+        if (!environment.page.allow_multi_host) {
+            // If we are currently logged in, we do not want to allow
+            // another login to a different machine. So we redirect to
+            // the current login.
+
+            const cur_machine = window.localStorage.getItem("current-machine");
+            if (cur_machine == "localhost" && window.location.pathname.startsWith("/=")) {
+                login_reload("/");
+            } else if (cur_machine && !window.location.pathname.startsWith("/=" + cur_machine)) {
+                login_reload("/=" + cur_machine);
+            }
+        }
+
         translate();
         if (window.cockpit_po && window.cockpit_po[""]) {
             document.documentElement.lang = window.cockpit_po[""].language;
@@ -948,6 +961,8 @@ import "./login.scss";
     }
 
     function login_reload (wanted) {
+        console.log("RELOAD", wanted);
+
         // Force a reload if not triggered below
         // because only the hash part of the url
         // changed
@@ -980,7 +995,7 @@ import "./login.scss";
         }
     }
 
-    function setup_localstorage (response) {
+    function setup_localstorage (response, machine) {
         /* Clear anything not prefixed with
          * different application from sessionStorage
          */
@@ -1013,6 +1028,8 @@ import "./login.scss";
         const ca_cert_url = environment.CACertUrl;
         if (ca_cert_url)
             window.sessionStorage.setItem('CACertUrl', ca_cert_url);
+
+        window.localStorage.setItem('current-machine', machine || "localhost");
     }
 
     function run(response) {
@@ -1039,7 +1056,7 @@ import "./login.scss";
          */
         clear_storage(window.sessionStorage, application, false);
 
-        setup_localstorage(response);
+        setup_localstorage(response, machine);
         login_reload(wanted);
     }
 

--- a/pkg/static/login.scss
+++ b/pkg/static/login.scss
@@ -354,14 +354,14 @@ label.checkbox {
   display: none;
 }
 
-.login-pf #banner {
+.login-pf #banner, .login-pf #multihost-warning {
   margin-block: 1rem 0.5rem;
   margin-inline: 0;
   grid-area: banner;
   inline-size: 100%;
 }
 
-#banner-message {
+#banner-message, #multihost-message  {
   white-space: pre-wrap;
   max-block-size: 12em;
   overflow: auto;

--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -1706,3 +1706,13 @@ cockpit_auth_empty_cookie_value (const gchar *path, gboolean secure)
 
   return cookie_line;
 }
+
+gchar *
+cockpit_auth_cookie_name (const gchar *path)
+{
+  gchar *application = cockpit_auth_parse_application (path, NULL);
+  gchar *cookie = application_cookie_name (application);
+  g_free (application);
+
+  return cookie;
+}

--- a/src/ws/cockpitauth.h
+++ b/src/ws/cockpitauth.h
@@ -108,6 +108,8 @@ gchar *         cockpit_auth_parse_application    (const gchar *path,
 gchar *         cockpit_auth_empty_cookie_value       (const gchar *path,
                                                        gboolean secure);
 
+gchar *         cockpit_auth_cookie_name      (const gchar *path);
+
 G_END_DECLS
 
 #endif


### PR DESCRIPTION
Demo: https://youtu.be/lvR2youiY4M

- [x] don't rely on logout resetting local storage. instead, let cockpit-ws report host addresses of valid cookies to login.html
- [x] config option
- [ ] design
- [ ] tests
- [ ] coverage
