### PR TITLE
test: Make ignore_ssl_certificate_errors() implicit; some small test fixes

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1366,7 +1366,7 @@ class Browser:
 
         if self.cdp and self.cdp.valid:
             self.switch_to_top()
-            if self.is_present("#navbar-oops"):
+            if self.eval_js("!!document.getElementById('navbar-oops')"):
                 assert not self.is_visible("#navbar-oops"), "Cockpit shows an Oops"
 
 

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -235,6 +235,11 @@ class Browser:
             self.layouts = [layout for layout in self.layouts if layout["theme"] != "dark"]
         self.current_layout = None
 
+        # we don't have a proper SSL certificate for our tests, ignore it
+        # Firefox does not support this, tests which rely on it need to skip it
+        if self.cdp.browser.name == "chromium":
+            self.cdp.command("setSSLBadCertificateAction('continue')")
+
     def allow_download(self) -> None:
         """Allow browser downloads"""
         if self.cdp.browser.name == "chromium":
@@ -1020,12 +1025,6 @@ class Browser:
         self.go(f"/@{address}")
         self.start_machine_troubleshoot(new=True, known_host=known_host, password=password)
         self.enter_page("/system", host=address)
-
-    def ignore_ssl_certificate_errors(self, ignore: bool) -> None:
-        action = "continue" if ignore else "cancel"
-        if opts.trace:
-            print("-> Setting SSL certificate error policy to %s" % action)
-        self.cdp.command(f"setSSLBadCertificateAction('{action}')")
 
     def grant_permissions(self, *args: str) -> None:
         """Grant permissions to the browser"""

--- a/test/verify/check-client
+++ b/test/verify/check-client
@@ -97,6 +97,7 @@ Command = /usr/bin/env python3 -m cockpit.beiboot
 
     def checkLoginScenarios(self, *, local_bridge=True):
         self.m_client.spawn(f"runuser -u admin -- {self.libexecdir}/cockpit-ws --no-tls", "ws.log")
+        self.m_client.wait_for_cockpit_running()
 
         b = self.browser
         b.open("/")

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -1293,7 +1293,6 @@ ProtocolHeader = X-Forwarded-Proto
             # check that we show up in the system logs from the browser's IP, not the proxy's
             self.assertIn('(172.27.0.2)', self.machine.execute('who'))
         b.logout()
-        b.cdp.invoke("Browser.close")
 
     @testlib.skipImage("nginx not installed", "centos-*", "rhel-*", "debian-*", "ubuntu-*", "arch")
     @testlib.skipOstree("nginx not installed")

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -497,7 +497,6 @@ class TestConnection(testlib.MachineCase):
         m.upload(["../tools/debian/tests/smoke"], "/tmp")
         m.execute("/tmp/smoke")
 
-        b.ignore_ssl_certificate_errors(ignore=True)
         self.login_and_go("/system", tls=True)
         cookie = b.cookie("cockpit")
         # cookie should be marked as secure
@@ -1000,7 +999,6 @@ until pgrep -f '^(/usr/[^ ]+/[^ /]*python[^ /]* )?/usr/bin/cockpit-bridge'; do s
                 "ws-notls.log")
         m.wait_for_cockpit_running(tls=True)
 
-        b.ignore_ssl_certificate_errors(ignore=True)
         b.open(f"https://{b.address}:{b.port}/system")
         b.wait_visible("#login")
         b.set_val("#login-user-input", "admin")
@@ -1277,7 +1275,6 @@ ProtocolHeader = X-Forwarded-Proto
         self.assertIn(b"subject: CN=alice; DC=COCKPIT", out)
 
         # works with browser (but we can't set our CA)
-        b.ignore_ssl_certificate_errors(ignore=True)
         (https_host, https_port) = self.machine.forward["443"].split(':')
         b.open(f"https://{https_host}:{https_port}{urlroot}/system")
         if login:
@@ -1359,7 +1356,6 @@ server {
 
         # embedding
         b = self.browser
-        b.ignore_ssl_certificate_errors(ignore=True)
         (https_host, https_port) = self.machine.forward["443"].split(':')
         b.open(f"https://{https_host}:{https_port}/embed-cockpit/index.html")
         b.set_val("#embed-address", f"https://{https_host}:{https_port}/cockpit-root")

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1516,6 +1516,8 @@ class TestGrafanaClient(testlib.MachineCase):
         except Exception:
             bg.snapshot("FAIL-grafana")
             raise
+        finally:
+            bg.kill()
 
 
 if __name__ == '__main__':

--- a/test/verify/check-ws-bastion
+++ b/test/verify/check-ws-bastion
@@ -44,7 +44,6 @@ class TestWsBastionContainer(testlib.MachineCase):
         m.execute("podman run -d --name cockpit-bastion -p 9090:9090 localhost/cockpit/ws")
         m.execute("until curl --fail --head -k https://localhost:9090/; do sleep 1; done")
 
-        b.ignore_ssl_certificate_errors(ignore=True)
         b.open("/", tls=True)
 
         b.wait_visible("#login")
@@ -92,7 +91,6 @@ class TestWsBastionContainer(testlib.MachineCase):
 
         m.execute(f"ssh-keyscan localhost | sed 's/^localhost/{HOST}/' > /root/known_hosts")
         self.addCleanup(m.execute, "rm /root/known_hosts")
-        b.ignore_ssl_certificate_errors(ignore=True)
 
         def check_login():
             m.execute("until curl --fail --head -k https://localhost:9090/; do sleep 1; done")
@@ -140,7 +138,6 @@ class TestWsBastionContainer(testlib.MachineCase):
                   "localhost/cockpit/ws")
         m.execute("until curl --fail --head -k https://localhost:9090/; do sleep 1; done")
 
-        b.ignore_ssl_certificate_errors(ignore=True)
         b.open("/", tls=True)
 
         b.wait_visible("#login")
@@ -180,7 +177,6 @@ class TestWsBastionContainer(testlib.MachineCase):
                   "localhost/cockpit/ws")
         m.execute("until curl --fail --head -k https://localhost:9090/; do sleep 1; done")
 
-        b.ignore_ssl_certificate_errors(ignore=True)
         b.open("/", tls=True)
         b.set_val("#login-user-input", "admin")
         b.set_val("#server-field", HOST)


### PR DESCRIPTION
With the webdriver and BiDi APIs you have to set the "bad SSL certificate" policy at the browser instantiation time, and can't switch at runtime (not even through the CDP protocol).
    
We don't have any "real" browser test for denying a bad SSL certificate -- `check-connectinon` does that with `curl`, and otherwise we are not testing how browsers configure SSL trust. So just implicitly ignore bad SSL certificates.
    
This is formally an API break, but no external project uses that API.

---

Plus a few random test cleanups which I came across in #20832.

This is a prerequisite for #20832.

The advantage of this: Once we port this over to bidi, we can enable all the skipped TestConnection for firefox, as that works there as well. The CDP command never did.