### PR TITLE
systemd: Use binary channel for Terminal

### DIFF
--- a/pkg/base1/test-http.js
+++ b/pkg/base1/test-http.js
@@ -163,6 +163,18 @@ QUnit.test("truncated UTF8 frame", assert => {
             .finally(done);
 });
 
+QUnit.test("binary data", async assert => {
+    const data = await cockpit.http({ ...test_server, binary: true }).get("/mock/binary-data");
+    assert.deepEqual(data, new Uint8Array([255, 1, 255, 2]));
+});
+
+QUnit.test("invalid UTF-8", assert => {
+    assert.rejects(
+        cockpit.http(test_server).get("/mock/binary-data"),
+        ex => ex.problem == "protocol-error" && ex.message.includes("can't decode byte 0xff"),
+        "rejects non-UTF-8 data on text channel");
+});
+
 QUnit.test("close", assert => {
     const done = assert.async();
     assert.expect(3);

--- a/pkg/systemd/terminal.jsx
+++ b/pkg/systemd/terminal.jsx
@@ -34,7 +34,8 @@ const _ = cockpit.gettext;
                     "TERM=xterm-256color",
                 ],
                 directory: user.home || "/",
-                pty: true
+                pty: true,
+                binary: true,
             });
         }
 

--- a/src/cockpit/channel.py
+++ b/src/cockpit/channel.py
@@ -427,8 +427,11 @@ class ProtocolChannel(Channel, asyncio.Protocol):
 
     def data_received(self, data: bytes) -> None:
         assert self._transport is not None
-        if not self.send_data(data):
-            self._transport.pause_reading()
+        try:
+            if not self.send_data(data):
+                self._transport.pause_reading()
+        except ChannelError as exc:
+            self.close(exc.get_attrs())
 
     def do_resume_send(self) -> None:
         assert self._transport is not None

--- a/src/ws/test-server.c
+++ b/src/ws/test-server.c
@@ -226,6 +226,16 @@ send_truncated_utf8 (gpointer data)
 }
 
 static gboolean
+send_binary_data (gpointer data)
+{
+  CockpitWebResponse *response = data;
+  g_autoptr(GBytes) bytes = g_bytes_new_static ("\xFF\x01\xFF\x02", 4);
+  cockpit_web_response_queue (response, bytes);
+  cockpit_web_response_complete (response);
+  return FALSE;
+}
+
+static gboolean
 mock_http_stream (CockpitWebResponse *response, GSourceFunc func)
 {
   cockpit_web_response_headers (response, 200, "OK", -1, NULL);
@@ -356,6 +366,8 @@ on_handle_mock (CockpitWebServer *server,
     return mock_http_stream (response, send_split_utf8);
   if (g_str_equal (path, "/truncated-utf8"))
     return mock_http_stream (response, send_truncated_utf8);
+  if (g_str_equal (path, "/binary-data"))
+    return mock_http_stream (response, send_binary_data);
   if (g_str_equal (path, "/headers"))
     return mock_http_headers (response, headers);
   if (g_str_equal (path, "/host"))

--- a/test/verify/check-system-terminal
+++ b/test/verify/check-system-terminal
@@ -91,6 +91,13 @@ PROMPT_COMMAND='printf "\033]0;%s@%s:%s\007" "${USER}" "${HOSTNAME%%.*}" "${PWD/
 
         b.input_text('echo -e "1\\u0041"\n')
         wait_line(n + 3, '1A')
+        wait_line(n + 4, prompt)
+
+        # non-UTF8 data
+        m.execute(r"echo -e 'hello\xFF\x01\xFF\x02world' > " + self.vm_tmpdir + "/garbage.txt")
+        b.input_text(f'cat {self.vm_tmpdir}/garbage.txt\n')
+        wait_line(n + 5, 'helloworld')
+        wait_line(n + 6, prompt)
 
         # The '@' sign is in the default prompt
         b.wait_in_text(".terminal-title", '@')


### PR DESCRIPTION
Terminals are not defined/required to be UTF-8 only. Sometimes people
cat binary data to the terminal, or possibly files in other encodings.
These cannot be sent through `TEXT` websocket channels, and will also
trigger the additional checks from commit 1b15dcb94fe834.

Use a binary channel to avoid all that. XTerm.js gets along with this
just fine, and it ignores invalid data.

With this you can now even `cat /bin/true` and get something moderately
sensible, instead of no output at all.

Fixes #20791