### PR TITLE
hosts: Use a cockpit.conf option to disable the host switcher

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -302,6 +302,21 @@ fi
 
 AM_CONDITIONAL([ENABLE_DOC], [test "$enable_doc" = "yes"])
 
+# Default for AllowMultiHost
+
+AC_MSG_CHECKING([for AllowMultiHost default])
+AC_ARG_ENABLE(multihost,
+              AS_HELP_STRING([--enable-multihost],
+                             [Set AllowMultiHost to true by default]),
+              [], [enable_multihost=no])
+AC_MSG_RESULT($enable_multihost)
+if test "$enable_multihost" = "no"; then
+   multihost_def=0
+else
+   multihost_def=1
+fi
+AC_DEFINE_UNQUOTED(ALLOW_MULTIHOST_DEFAULT, [$multihost_def], [default for AllowMultiHost configuration setting])
+
 # cockpit-client
 AC_MSG_CHECKING([whether to install cockpit-client])
 AC_ARG_ENABLE([cockpit-client],

--- a/doc/guide/authentication.xml
+++ b/doc/guide/authentication.xml
@@ -105,16 +105,13 @@
     arbitrary code on your primary and all other connected secondary machines.
     Hence, only connect to <emphasis>machines which you trust</emphasis>.</para>
 
-    <para>Due to this security risk, this host switcher functionality is disabled
-    by default, except on long-term stable Linux distributions (Red Hat
-    Enterprise Linux 9, Debian 12, and Ubuntu 22.04/24.04 LTS). If you are
-    comfortable with the security implications, you can enable it manually by
-    creating a file <filename>/etc/cockpit/shell.override.json</filename> with
-    the following content:</para>
-
-<programlisting>
-{ "config": { "host_switcher": true } }
-</programlisting>
+    <para>Due to this security risk, this host switcher functionality
+    is disabled by default, except on long-term stable Linux
+    distributions (Red Hat Enterprise Linux 9, Debian 12, and Ubuntu
+    22.04/24.04 LTS). If you are comfortable with the security
+    implications, you can enable it manually with the
+    <code>AllowMultiHost</code> option in
+    <filename>cockpit.conf</filename>.</para>
 
     <para>These servers will need to be running an SSH server
     and be configured to support one of the following

--- a/doc/man/cockpit.conf.xml
+++ b/doc/man/cockpit.conf.xml
@@ -124,6 +124,23 @@ ForwardedForHeader = X-Forwarded-For
         </listitem>
       </varlistentry>
       <varlistentry>
+        <term><option>AllowMultiHost</option></term>
+        <listitem>
+          <para>
+            When set to <literal>true</literal>, cockpit will allow
+            users to connect to multiple hosts in one session. The
+            default is OS specific.
+          </para>
+          <para>
+            When connecting to multiple servers, JavaScript runs
+            without isolation. All systems will be vulnerable to
+            potential attacks from other connected hosts. Enable this
+            option <emphasis>only</emphasis> when all hosts are
+            trusted.
+          </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
         <term><option>MaxStartups</option></term>
         <listitem><para>Same as the <command>sshd</command> configuration option by the same name.
             Specifies the maximum number of concurrent login attempts

--- a/pkg/shell/indexes.jsx
+++ b/pkg/shell/indexes.jsx
@@ -28,8 +28,6 @@ import { CockpitHosts, CockpitCurrentHost } from "./hosts.jsx";
 import { codes, HostModal } from "./hosts_dialog.jsx";
 import { EarlyFailure, EarlyFailureReady } from './failures.jsx';
 import { WithDialogs } from "dialogs.jsx";
-import { read_os_release } from "os-release";
-import { get_manifest_config_matchlist } from "utils";
 
 import * as base_index from "./base_index";
 
@@ -103,15 +101,9 @@ function MachinesIndex(index_options, machines, loader) {
 
     /* Host switcher enabled? */
     let host_switcher_enabled = false;
-    read_os_release().then(os_release => {
-        const enabled = os_release && get_manifest_config_matchlist(
-            "shell", "host_switcher", false,
-            [os_release.PLATFORM_ID, os_release.VERSION_CODENAME]);
-        if (enabled) {
-            host_switcher_enabled = true;
-            update_machines();
-        }
-    });
+    const meta_multihost = document.head.querySelector("meta[name='allow-multihost']");
+    if (meta_multihost instanceof HTMLMetaElement && meta_multihost.content == "yes")
+        host_switcher_enabled = true;
 
     /* Navigation */
     let ready = false;

--- a/pkg/shell/manifest.json
+++ b/pkg/shell/manifest.json
@@ -32,16 +32,6 @@
             "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_systems_using_the_rhel_9_web_console/index"
         }
     ],
-    "config": {
-        "host_switcher": {
-            "platform:f39": true,
-            "platform:f40": true,
-            "platform:el9": true,
-            "bookworm": true,
-            "jammy": true,
-            "noble": true
-        }
-    },
     "bridges": [
         {
             "privileged": true,

--- a/src/ws/cockpitchannelresponse.c
+++ b/src/ws/cockpitchannelresponse.c
@@ -22,6 +22,7 @@
 #include "cockpitchannelresponse.h"
 
 #include "common/cockpitchannel.h"
+#include "common/cockpitconf.h"
 #include "common/cockpitflow.h"
 #include "common/cockpitwebinject.h"
 #include "common/cockpitwebserver.h"
@@ -102,6 +103,13 @@ cockpit_channel_inject_perform (CockpitChannelInject *inject,
     {
       prefixed_application = g_strdup_printf ("/%s", cockpit_creds_get_application (creds));
     }
+
+  {
+    const gboolean allow_multihost = cockpit_conf_bool ("WebService", "AllowMultiHost",
+                                                        ALLOW_MULTIHOST_DEFAULT);
+    g_string_append_printf (str, "\n    <meta name=\"allow-multihost\" content=\"%s\">",
+                            allow_multihost ? "yes" : "no");
+  }
 
   if (inject->base_path)
     {

--- a/src/ws/cockpithandlers.c
+++ b/src/ws/cockpithandlers.c
@@ -251,6 +251,7 @@ add_page_to_environment (JsonObject *object,
 {
   static gint page_login_to = -1;
   gboolean require_host = FALSE;
+  gboolean allow_multihost;
   JsonObject *page;
   const gchar *value;
 
@@ -268,9 +269,11 @@ add_page_to_environment (JsonObject *object,
     }
 
   require_host = is_cockpit_client || cockpit_conf_bool ("WebService", "RequireHost", FALSE);
+  allow_multihost = cockpit_conf_bool ("WebService", "AllowMultiHost", ALLOW_MULTIHOST_DEFAULT);
 
   json_object_set_boolean_member (page, "connect", page_login_to);
   json_object_set_boolean_member (page, "require_host", require_host);
+  json_object_set_boolean_member (page, "allow_multihost", allow_multihost);
   json_object_set_object_member (object, "page", page);
 }
 

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1776,6 +1776,12 @@ class MachineCase(unittest.TestCase):
 
         shutil.rmtree(self.tmpdir, ignore_errors=True)
 
+    def enable_multihost(self, machine: testvm.Machine) -> None:
+        if not self.multihost_enabled:
+            machine.write("/etc/cockpit/cockpit.conf",
+                          '[WebService]\nAllowMultiHost=yes\n')
+            machine.restart_cockpit()
+
     def login_and_go(
         self,
         path: str | None = None,

--- a/test/verify/check-shell-host-switching
+++ b/test/verify/check-shell-host-switching
@@ -115,11 +115,6 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
         self.allow_restart_journal_messages()
         self.allow_hostkey_messages()
 
-    def enable_multihost(self, machine):
-        if not self.multihost_enabled:
-            machine.write("/etc/cockpit/shell.override.json",
-                          '{ "config": { "host_switcher": true } }')
-
     def testBasic(self):
         b = self.browser
         m1 = self.machines["machine1"]

--- a/test/verify/check-shell-multi-machine-key
+++ b/test/verify/check-shell-multi-machine-key
@@ -116,9 +116,7 @@ class TestMultiMachineKeyAuth(testlib.MachineCase):
             self.disable_preload("packagekit", "playground", "systemd", machine=self.machine2)
 
         # enable multi-host
-        if not self.multihost_enabled:
-            self.machine.write("/etc/cockpit/shell.override.json",
-                               '{ "config": { "host_switcher": true } }')
+        self.enable_multihost(self.machine)
 
     # Possible workaround - ssh as `admin` and just do `m.execute()`
     @testlib.skipBrowser("Firefox cannot do `cockpit.spawn`", "firefox")

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -65,6 +65,11 @@ ExcludeArch: %{ix86}
 %endif
 %endif
 
+%define enable_multihost 1
+%if 0%{?fedora} >= 41 || 0%{?rhel} >= 10
+%define enable_multihost 0
+%endif
+
 # Ship custom SELinux policy
 %define selinuxtype targeted
 %define selinux_configure_arg --enable-selinux-policy=%{selinuxtype}
@@ -164,6 +169,9 @@ BuildRequires:  python3-tox-current-env
     --with-pamdir='%{pamdir}' \
 %if %{build_pcp} == 0
     --disable-pcp \
+%endif
+%if %{enable_multihost}
+    --enable-multihost \
 %endif
 
 %make_build

--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -8,7 +8,13 @@ PRE4AA = $(filter $(shell . /etc/os-release; echo $${VERSION_ID:-unstable}),22.0
 # pcp isn't in Debian testing right now
 ifeq ($(shell . /etc/os-release; echo $${VERSION_CODENAME}),trixie)
     export DH_OPTIONS = -Ncockpit-pcp
-    CONFIG_OPTIONS = --disable-pcp
+    CONFIG_OPTIONS := --disable-pcp
+endif
+
+# keep the host switcher on in currently supported stable releases
+STABLE = $(filter $(shell . /etc/os-release; echo $${VERSION_CODENAME}),bookworm jammy noble)
+ifneq ($(STABLE),)
+    CONFIG_OPTIONS := $(CONFIG_OPTIONS) --enable-multihost
 endif
 
 # riscv is an emulated architecture for now, and too slow to run expensive unit tests


### PR DESCRIPTION
We will want to refer to that setting in more places than the shell, so it's good to be prepared for that. At least the login page will also need it.

The default for the setting is now a ./configure option, with a default default of "host switcher is off".
