### PR TITLE
tests: updates of mock-insights from subscription-manager-cockpit

### DIFF
--- a/test/verify/files/mock-insights
+++ b/test/verify/files/mock-insights
@@ -52,13 +52,14 @@ class handler(BaseHTTPRequestHandler):
         m = self.match("/r/insights/v1/systems/([^/]+)")
         if m:
             machine_id = m[1]
-            if machine_id not in systems:
-                self.send_response(404)
-                self.end_headers()
-                return
-            self.send_response(200)
+            for system in systems.values():
+                if system["machine_id"] == machine_id:
+                    self.send_response(200)
+                    self.end_headers()
+                    self.wfile.write(json.dumps(system).encode() + b"\n")
+                    return
+            self.send_response(404)
             self.end_headers()
-            self.wfile.write(json.dumps(systems[machine_id]).encode() + b"\n")
             return
 
         m = self.match("/r/insights/v1/branch_info")
@@ -77,9 +78,10 @@ class handler(BaseHTTPRequestHandler):
                 "total": 0,
                 "results": [],
             }
-            if insights_id in systems:
-                res["total"] += 1
-                res["results"].append({"id": "123-nice-id"})
+            for system in systems.values():
+                if system["insights_id"] == insights_id:
+                    res["total"] += 1
+                    res["results"].append(system)
             self.wfile.write(json.dumps(res).encode("utf-8") + b"\n")
             return
 
@@ -88,7 +90,7 @@ class handler(BaseHTTPRequestHandler):
             inventory_id = m[1]
             self.send_response(200)
             self.end_headers()
-            if inventory_id == "123-nice-id":
+            if inventory_id in systems:
                 self.wfile.write(b'[ { "rule": { "total_risk": 3 } }, { "rule": { "total_risk": 2 } }, { "rule": { "total_risk": 1 } }]\n')
             else:
                 self.wfile.write(b'[ ]\n')
@@ -106,8 +108,10 @@ class handler(BaseHTTPRequestHandler):
             s = json.loads(data)
             s["unregistered_at"] = None
             s["account_number"] = "123456"
+            s["insights_id"] = s["machine_id"]
+            s["id"] = "123-nice-id"
             print(s)
-            systems[s["machine_id"]] = s
+            systems[s["id"]] = s
             self.send_response(200)
             self.end_headers()
             self.wfile.write(data)

--- a/test/verify/files/mock-insights
+++ b/test/verify/files/mock-insights
@@ -17,6 +17,7 @@
 # username=admin
 # password=foobar
 
+import email
 import json
 import os
 import re
@@ -124,6 +125,51 @@ class handler(BaseHTTPRequestHandler):
             self.wfile.write(b'{ "reports": [ "foo", "bar" ] }\n')
             return
 
+        m = self.match("/r/insights/platform/ingress/v1/upload")
+        if m:
+            # The metadata of the system is in the multipart MIME data
+            # sent by the system for the upload; to pick it and use it
+            # we need to unpack the multipart MIME data.
+
+            # First, create prologue to the data, so it can be recognized
+            # as multipart MIME.
+            multipart_data = (
+                b"""MIME-Version: 1.0
+Content-Type: """
+                + self.headers.get("content-type").encode("utf-8")
+                + b"""
+
+"""
+            )
+            multipart_data += data
+
+            # Parse the multipart MIME data, and then look for a "metadata"
+            # file part which contains the system metadata as JSON.
+            message = email.message_from_bytes(multipart_data)
+            for part in message.walk():
+                if part.get_filename() == "metadata":
+                    s = json.loads(part.get_payload())
+                    s["id"] = "123-nice-id"
+                    print(s)
+                    systems[s["id"]] = s
+
+                    self.send_response(202)
+                    self.end_headers()
+                    self.wfile.write(
+                        b"{"
+                        b'  "request_id": "some-upload", '
+                        b'  "upload": { '
+                        b'    "account": "123456", '
+                        b'    "org_id": "123456" '
+                        b"  }"
+                        b"}\n"
+                    )
+                    return
+
+            self.send_response(400)
+            self.end_headers()
+            return
+
         self.send_response(404)
         self.end_headers()
 
@@ -136,6 +182,18 @@ class handler(BaseHTTPRequestHandler):
             self.end_headers()
             if machine_id in systems:
                 del systems[machine_id]
+            return
+
+        m = self.match("/r/insights/platform/inventory/v1/hosts/([^/]+)")
+        if m:
+            inventory_id = m[1]
+            if inventory_id in systems:
+                del systems[inventory_id]
+                self.send_response(200)
+                self.end_headers()
+                return
+            self.send_response(404)
+            self.end_headers()
             return
 
         self.send_response(404)

--- a/test/verify/files/mock-insights
+++ b/test/verify/files/mock-insights
@@ -52,12 +52,13 @@ class handler(BaseHTTPRequestHandler):
         m = self.match("/r/insights/v1/systems/([^/]+)")
         if m:
             machine_id = m[1]
+            if machine_id not in systems:
+                self.send_response(404)
+                self.end_headers()
+                return
             self.send_response(200)
             self.end_headers()
-            if machine_id in systems:
-                self.wfile.write(json.dumps(systems[machine_id]).encode() + b"\n")
-            else:
-                self.wfile.write(b"{ }\n")
+            self.wfile.write(json.dumps(systems[machine_id]).encode() + b"\n")
             return
 
         m = self.match("/r/insights/v1/branch_info")

--- a/test/verify/files/mock-insights
+++ b/test/verify/files/mock-insights
@@ -70,21 +70,25 @@ class handler(BaseHTTPRequestHandler):
 
         m = self.match("/r/insights/platform/inventory/v1/hosts\\?insights_id=(.*)")
         if m:
-            machine_id = m[1]
+            insights_id = m[1]
             self.send_response(200)
             self.end_headers()
-            if machine_id in systems:
-                self.wfile.write(b'{ "total": 1, "results": [ { "id": "123-nice-id" } ] }\n')
-            else:
-                self.wfile.write(b'{ "total": 0, "results": [ ] }\n')
+            res = {
+                "total": 0,
+                "results": [],
+            }
+            if insights_id in systems:
+                res["total"] += 1
+                res["results"].append({"id": "123-nice-id"})
+            self.wfile.write(json.dumps(res).encode("utf-8") + b"\n")
             return
 
         m = self.match("/r/insights/platform/insights/v1/system/([^/]+)/reports/")
         if m:
-            platform_id = m[1]
+            inventory_id = m[1]
             self.send_response(200)
             self.end_headers()
-            if platform_id == "123-nice-id":
+            if inventory_id == "123-nice-id":
                 self.wfile.write(b'[ { "rule": { "total_risk": 3 } }, { "rule": { "total_risk": 2 } }, { "rule": { "total_risk": 1 } }]\n')
             else:
                 self.wfile.write(b'[ ]\n')


### PR DESCRIPTION
This forwards various updates to `mock-insights` as done in subscription-manager-cockpit, where it is stressed/used a bit more; in particular, the changes come from:
- https://github.com/candlepin/subscription-manager-cockpit/pull/66 (one commit)
- https://github.com/candlepin/subscription-manager-cockpit/pull/72 (all the commits)

This should hopefully avoid failures in case `insights-client` (or better, insights-core) switches the default value of `legacy_upload` from true to false; no ETA planned for that, although that's what we are trying to work on.

See the message of each commit for longer explanations.