### PR TITLE
test: improve subscription-manager handling & registration

### DIFF
--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1208,10 +1208,8 @@ class TestUpdatesSubscriptions(packagelib.PackageCase):
     }
 
     def register(self):
-        # this fails with "Unable to find available subscriptions for all your installed products", but works anyway
         self.machine.execute(
-            "LC_ALL=C.UTF-8 subscription-manager register --serverurl https://services.cockpit.lan:8443/candlepin --org=admin --activationkey=awesome_os_pool || true")
-        self.machine.execute("LC_ALL=C.UTF-8 subscription-manager attach --auto")
+            "LC_ALL=C.UTF-8 subscription-manager register --org=donaldduck --activationkey=awesome_os_pool")
 
     def setUp(self):
         super().setUp()
@@ -1229,8 +1227,8 @@ class TestUpdatesSubscriptions(packagelib.PackageCase):
         self.candlepin.download("/home/admin/candlepin/generated_certs/88888.pem", product_file)
 
         # # upload product info to the test machine
-        m.execute("mkdir -p /etc/pki/product")
-        m.upload([product_file], "/etc/pki/product")
+        m.execute("mkdir -p /etc/pki/product-default")
+        m.upload([product_file], "/etc/pki/product-default")
 
         # set up CA
         ca = self.candlepin.execute("cat /home/admin/candlepin/certs/candlepin-ca.crt")
@@ -1244,6 +1242,14 @@ class TestUpdatesSubscriptions(packagelib.PackageCase):
         self.update_icon = "#page_status_notification_updates svg"
         self.update_text = "#page_status_notification_updates"
         self.update_text_action = "#page_status_notification_updates a"
+
+        # setup the repositories properly using the candlepin RPM GPG key
+        m.execute("curl -o /etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin http://services.cockpit.lan:8080/RPM-GPG-KEY-candlepin")
+        m.execute("subscription-manager config --rhsm.baseurl http://services.cockpit.lan:8080")
+
+        # perform the additional configuration of subscription-manager
+        m.execute(
+            "subscription-manager config --server.hostname services.cockpit.lan --server.port 8443 --server.prefix /candlepin")
 
     def testNoUpdates(self):
         b = self.browser


### PR DESCRIPTION
Improve the registration using subscription-manager to setup things better, and switch to SCA (which will be the only option soon).

First, ensure that subscription-manager is configured so that the package manager can properly receive content from the repositories of the self-deployed Candlepin. This should have been done in the past, and it will be critical for switching to SCA for testing: in SCA mode, all the content of the organization is available by default, and some repositories are also automatically enabled. This means:
- installing the GPG key for RPM packages
- setting the `baseurl` in `rhsm.conf`

Second, set the server details using `subscription-manager config` during the test setup, so it matches more what is the recommended procedure, and it makes the registration command shorter.

Third, upload the product certificates to `/etc/pki/product-default`, which is the proper location for them rather than `/etc/pki/product`.

Forth, switch the account to an SCA one, i.e. the `donaldduck` organization; since the registration ought to always succeed, drop the `|| true` hack and the associated comment about products, which should not happen anymore. Also drop the auto-attach command, which is a no-op in SCA, and it will be dropped in future versions of subscription-manager.