### PR TITLE
Fix TestKdumpNFSAnsible with current Fedora 40

### DIFF
--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -78,9 +78,14 @@ class KdumpHelpers(testlib.MachineCase):
         browser.click("#kdump-automation-script")
         ansible_script_sel = ".automation-script-modal .pf-v5-c-modal-box__body section:nth-child(2) textarea"
         machine.execute("mkdir -p roles/kdump/tasks")
-        machine.write("roles/kdump/tasks/main.yml", browser.text(ansible_script_sel))
-        # Redirect to stderr as this can fail, if so we want logs
-        machine.execute("ansible -m include_role -a name=kdump localhost", check=not allow_failure, stdout=None)
+        ansible_script = browser.text(ansible_script_sel)
+        # show role for debugging
+        print("---- generated Ansible role -----")
+        print(ansible_script)
+        print("---------------------------------")
+        machine.write("roles/kdump/tasks/main.yml", ansible_script)
+        # Show stdout as this can fail, if so we want logs
+        machine.execute("ansible -vv -m include_role -a name=kdump localhost", check=not allow_failure, stdout=None)
         browser.click(".pf-v5-c-modal-box__footer button:contains('Close')")
         browser.wait_not_present(".automation-script-modal")
 

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -552,7 +552,7 @@ class TestKdumpNFS(KdumpHelpers):
 class TestKdumpNFSAnsible(KdumpHelpers):
     provision = {
         "cockpit": {"memory_mb": 512},
-        "kdump_ansible_machine": {"address": "10.111.113.1/24", "memory_mb": 1024, "capture_console": True},
+        "kdump_ansible_machine": {"address": "10.111.113.1/24", "memory_mb": 1500, "capture_console": True},
         "nfs": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/24", "memory_mb": 512},
     }
 


### PR DESCRIPTION
See https://github.com/cockpit-project/bots/pull/6706 and the discussions with the kdump maintainer. This fixes [this failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-6706-f3e62d04-20240808-042120-fedora-40-firefox-expensive-cockpit-project-cockpit/log.html).

 - commit 5b3ec7b3ecc01a2a3b : merely waiting longer for the initrd to build [fails](https://cockpit-logs.us-east-1.linodeobjects.com/pull-20850-5b3ec7b3-20240808-120154-fedora-40-expensive-bots%236706/log.html)
 - commit 3409fca02e59995f1f0 : rebuilding initrd with verbosity [still fails](https://cockpit-logs.us-east-1.linodeobjects.com/pull-20850-3409fca0-20240808-125857-fedora-40-expensive-bots%236706/log.html)
 - commit dad395a43e88c4: Increase RAM for kdump machine from 1024 to 1280 MiB: [better, but still buggy](https://cockpit-logs.us-east-1.linodeobjects.com/pull-20850-dad395a4-20240808-174742-fedora-40-expensive-bots%236706/log.html#6-2)
 - commit d0f79b82c99a6: Increase RAM for kdump machine from 1024 to 1500 MiB: [works](https://cockpit-logs.us-east-1.linodeobjects.com/pull-20850-d0f79b82-20240808-181436-fedora-40-expensive-bots%236706/log.html)