### PR TITLE
flatpak: Drop default-branch property from manifest

### DIFF
--- a/containers/flatpak/prepare
+++ b/containers/flatpak/prepare
@@ -88,7 +88,6 @@ def create_manifest(
         'runtime': 'org.gnome.Platform',
         'runtime-version': '45',
         'sdk': 'org.gnome.Sdk',
-        'default-branch': branch,
         'command': 'cockpit-client',
         'rename-icon': 'cockpit-client',
         'finish-args': [


### PR DESCRIPTION
The machine told me so! See
https://github.com/flathub/org.cockpit_project.CockpitClient/pull/45