### PR TITLE
login: Prevent multiple logins in a single browser session

### DIFF
--- a/pkg/static/login.js
+++ b/pkg/static/login.js
@@ -338,6 +338,27 @@ import "./login.scss";
         event.stopPropagation();
     }
 
+    function deal_with_multihost() {
+        // If we are currently logged in to some machine, but still
+        // end up on the login page, we are about to load resources
+        // from two machines into the same browser origin. This needs
+        // to be allowed explicitly via a configuration setting.
+
+        const logged_into = environment.logged_into || [];
+        const cur_machine = logged_into.length > 0 ? logged_into[0] : null;
+
+        function redirect_to_current_machine() {
+            if (cur_machine === ".") {
+                login_reload("/");
+            } else {
+                login_reload("/=" + cur_machine);
+            }
+        }
+
+        if (cur_machine && !environment.page.allow_multihost)
+            redirect_to_current_machine();
+    }
+
     function boot() {
         window.onload = null;
 
@@ -347,6 +368,8 @@ import "./login.scss";
             if (window.cockpit_po[""]["language-direction"])
                 document.documentElement.dir = window.cockpit_po[""]["language-direction"];
         }
+
+        deal_with_multihost();
 
         setup_path_globals(window.location.pathname);
 

--- a/src/ws/cockpitauth.h
+++ b/src/ws/cockpitauth.h
@@ -102,7 +102,10 @@ gboolean        cockpit_auth_local_finish    (CockpitAuth *self,
 CockpitWebService *  cockpit_auth_check_cookie    (CockpitAuth *self,
                                                    CockpitWebRequest *request);
 
-gchar *         cockpit_auth_parse_application    (const gchar *path,
+gboolean        cockpit_auth_is_valid_cookie_value (CockpitAuth *self,
+                                                    const gchar *cookie_value);
+
+  gchar *         cockpit_auth_parse_application    (const gchar *path,
                                                    gboolean *is_host);
 
 gchar *         cockpit_auth_empty_cookie_value       (const gchar *path,

--- a/src/ws/cockpithandlers.c
+++ b/src/ws/cockpithandlers.c
@@ -277,8 +277,47 @@ add_page_to_environment (JsonObject *object,
   json_object_set_object_member (object, "page", page);
 }
 
+static void
+add_logged_into_to_environment (JsonObject *object,
+                                CockpitAuth *auth,
+                                GHashTable *request_headers)
+{
+  JsonArray *logged_into = json_array_new ();
+
+  gchar *h = g_hash_table_lookup (request_headers, "Cookie");
+  while (h && *h) {
+    const gchar *start = h;
+    while (*h && *h != '=')
+      h++;
+    const gchar *equal = h;
+    while (*h && *h != ';')
+      h++;
+    const gchar *end = h;
+    if (*h)
+      h++;
+    while (*h && *h == ' ')
+      h++;
+
+    if (*equal != '=')
+      continue;
+
+    g_autofree gchar *value = g_strndup (equal + 1, end - equal - 1);
+
+    if (!cockpit_auth_is_valid_cookie_value (auth, value))
+      continue;
+
+    g_autofree gchar *name = g_strndup (start, equal - start);
+    if (g_str_equal (name, "cockpit"))
+      json_array_add_string_element(logged_into, ".");
+    else if (g_str_has_prefix (name, "machine-cockpit+"))
+      json_array_add_string_element(logged_into, name + strlen("machine-cockpit+"));
+  }
+
+  json_object_set_array_member (object, "logged_into", logged_into);
+}
+
 static GBytes *
-build_environment (GHashTable *os_release)
+build_environment (GHashTable *os_release, CockpitAuth *auth, GHashTable *request_headers)
 {
   /*
    * We don't include entirety of os-release into the
@@ -310,6 +349,7 @@ build_environment (GHashTable *os_release)
   json_object_set_boolean_member (object, "is_cockpit_client", is_cockpit_client);
 
   add_page_to_environment (object, is_cockpit_client);
+  add_logged_into_to_environment (object, auth, request_headers);
 
   hostname = g_malloc0 (HOST_NAME_MAX + 1);
   gethostname (hostname, HOST_NAME_MAX);
@@ -386,7 +426,7 @@ send_login_html (CockpitWebResponse *response,
   GBytes *po_bytes;
   CockpitWebFilter *filter3 = NULL;
 
-  environment = build_environment (ws->os_release);
+  environment = build_environment (ws->os_release, ws->auth, headers);
   filter = cockpit_web_inject_new (marker, environment, 1);
   g_bytes_unref (environment);
   cockpit_web_response_add_filter (response, filter);
@@ -455,6 +495,7 @@ send_login_html (CockpitWebResponse *response,
                                     "Content-Security-Policy", content_security_policy,
                                     "Set-Cookie", cookie_line,
                                     NULL);
+      cockpit_web_response_set_cache_type (response, COCKPIT_WEB_RESPONSE_NO_CACHE);
       if (cockpit_web_response_queue (response, bytes))
         cockpit_web_response_complete (response);
 

--- a/test/verify/check-embed
+++ b/test/verify/check-embed
@@ -48,10 +48,6 @@ Shell=/embed-cockpit/index.html
 
         b.wait_visible("#embed-loaded")
         b.wait_visible("#embed-address")
-        m.write("/etc/cockpit/cockpit.conf", """
-[WebService]
-Shell=/shell/index.html
-""")
         b.set_val("#embed-address", f"http://{m.web_address}:{m.web_port}")
         b.click("#embed-full")
         b.wait_visible("iframe[name='embed-full'][loaded]")

--- a/test/verify/check-embed
+++ b/test/verify/check-embed
@@ -25,7 +25,7 @@ import testlib
 @testlib.nondestructive
 class TestEmbed(testlib.MachineCase):
 
-    def testBasic(self):
+    def testBasic(self, allow_multi_host=True):
         b = self.browser
         m = self.machine
 
@@ -39,9 +39,10 @@ class TestEmbed(testlib.MachineCase):
 
         # replace the shell with our embedded page, this way we can avoid
         # cross-origin errors when executing js in the iframe
-        m.write("/etc/cockpit/cockpit.conf", """
+        m.write("/etc/cockpit/cockpit.conf", f"""
 [WebService]
 Shell=/embed-cockpit/index.html
+AllowMultiHost={"yes" if allow_multi_host else "no"}
 """)
         m.start_cockpit()
         self.login_and_go()
@@ -61,12 +62,25 @@ Shell=/embed-cockpit/index.html
         b.switch_to_frame("embed-terminal")
         b.wait_visible("#terminal")
 
-        # Clicking on the link with separate auth, shouldn't log in automatically
+        # Clicking on the link with separate auth, what happens
+        # depends on allow_multi_host
         b.switch_to_top()
         b.click("#embed-auth")
         b.wait_visible("iframe[name='embed-auth'][loaded]")
         b.switch_to_frame("embed-auth")
-        b.wait_visible("#login-user-input")
+        if allow_multi_host:
+            # When multiple connections are allowed, we get a fresh
+            # login page
+            b.wait_visible("#login-user-input")
+        else:
+            # When multiple connections are not allowed, we get
+            # redirected to "/" of the already open session. This
+            # loads the shell, which is /embed-cockpit/index.html in
+            # this test...
+            b.wait_visible("#embed-links")
+
+    def testNoMultiHost(self):
+        self.testBasic(allow_multi_host=False)
 
     @testlib.skipBrowser("Chromium cannot inspect cross-origin frames", "chromium")
     def testCrossOrigin(self):


### PR DESCRIPTION
unless allowed by cockpit.conf.

If the login page is loaded and a valid session cookie is already available, then we are about to log into a second host from the same browser session, and both logins will have access to each others cookies. This should only be allowed when AllowMultiHost is true. If it is not true, the login page immediately redirects to the session for the existing cookie.

Information about session cookies is not available to login.js, so cockpit-ws helps out by exposing which ones are present, without exposing the cookies themselves.

- [x] tests
- [x] coverage