### PR TITLE
lib: Fix race condition in Terminal size calculation

### DIFF
--- a/pkg/lib/cockpit-components-terminal.jsx
+++ b/pkg/lib/cockpit-components-terminal.jsx
@@ -316,10 +316,13 @@ export class Terminal extends React.Component {
         const padding = 10; // Leave a bit of space around terminal
         const realHeight = this.terminal._core._renderService.dimensions.css.cell.height;
         const realWidth = this.terminal._core._renderService.dimensions.css.cell.width;
+        const parentHeight = this.terminalRef.current.parentElement.clientHeight;
+        const parentWidth = this.terminalRef.current.parentElement.clientWidth;
         if (realHeight && realWidth && realWidth !== 0 && realHeight !== 0)
             return {
-                rows: Math.floor((this.terminalRef.current.parentElement.clientHeight - padding) / realHeight),
-                cols: Math.floor((this.terminalRef.current.parentElement.clientWidth - padding - 12) / realWidth) // Remove 12px for scrollbar
+                // it can happen that parent{Width,Height} are not yet initialized (0), avoid negative values
+                rows: Math.max(Math.floor((parentHeight - padding) / realHeight), 1),
+                cols: Math.max(Math.floor((parentWidth - padding - 12) / realWidth), 1) // Remove 12px for scrollbar
             };
 
         return { rows: this.state.rows, cols: this.state.cols };


### PR DESCRIPTION
On initializing the page there can be a short time window when the
terminal's CSS cell size is already set, but the parent element's
`client{Width,Height}` are still zero. In that case,
`calculateDimensions()` returned a negative rows/cols, which caused a
bridge crash:

```
fcntl.ioctl(self._pty_fd, termios.TIOCSWINSZ, struct.pack('2H4x', size.rows, size.cols))
struct.error: 'H' format requires 0 <= number <= 65535
```

Avoid that by checking the parent sizes and falling back to the explicit
state while any of the values is still uninitialized.

----

[This test fails all the time now](https://cockpit-logs.us-east-1.linodeobjects.com/pull-0-b5a98be3-20240812-013044-fedora-40-daily/log.html#153),  since end of last week. Probably triggered by #20841 , but that was just accidental. let's find out what happens.

Amplified test with the fix, on [f-40](https://cockpit-logs.us-east-1.linodeobjects.com/pull-20877-d4d13bd4-20240812-123810-fedora-40-expensive/log.html) and [rhel-9-5](https://cockpit-logs.us-east-1.linodeobjects.com/pull-20877-d4d13bd4-20240812-123807-rhel-9-5-expensive/log.html)