### PR TITLE
Fix bridge crashes on early channel opening failure

### DIFF
--- a/src/cockpit/channel.py
+++ b/src/cockpit/channel.py
@@ -386,6 +386,7 @@ class ProtocolChannel(Channel, asyncio.Protocol):
         raise NotImplementedError
 
     def do_open(self, options: JsonObject) -> None:
+        self._transport = None
         loop = asyncio.get_running_loop()
         self._create_transport_task = asyncio.create_task(self.create_transport(loop, options))
         self._create_transport_task.add_done_callback(self.create_transport_done)

--- a/src/cockpit/channels/filesystem.py
+++ b/src/cockpit/channels/filesystem.py
@@ -530,8 +530,8 @@ class FsInfoChannel(Channel, PathWatchListener):
 
     def do_close(self) -> None:
         # non-watch channels close immediately — if we get this, we're watching
-        assert self.path_watch is not None
-        self.path_watch.close()
+        if self.path_watch is not None:
+            self.path_watch.close()
         self.close()
 
     def do_open(self, options: JsonObject) -> None:


### PR DESCRIPTION
These have plagued c-files for a while, see e.g. [this crash](https://cockpit-logs.us-east-1.linodeobjects.com/pull-6730-54fd8f07-20240812-225338-debian-testing-cockpit-project-cockpit-files/log.html#16) (top of the [weather report](https://ci-weather-cockpit.apps.ocp.cloud.ci.centos.org/tests.html?repo=cockpit-project%2Fcockpit-files&days=7)).

The second patch is fixing the crash that I got when I was smoke-testing the first one. See https://github.com/cockpit-project/bots/pull/6730#issuecomment-2285281137 . It's also on the weather report, [example](https://cockpit-logs.us-east-1.linodeobjects.com/pull-701-64610cc9-20240812-041706-debian-testing/log.html#17-2)

I've tried for 90 mins to write an unit test for the first one, but I just don't grasp that. I monkeyed around with

```diff
diff --git src/cockpit/transports.py src/cockpit/transports.py
index 8aabc7d83..491638587 100644
--- src/cockpit/transports.py
+++ src/cockpit/transports.py
@@ -241,9 +241,11 @@ class _Transport(asyncio.Transport):
 
         try:
             n_bytes = os.write(self._out_fd, data)
+            logger.warning('Transport.write %r succeeded %i', data, n_bytes)
         except BlockingIOError:
             n_bytes = 0
         except OSError as exc:
+            logger.warning('Transport.write %r failed %r', data, exc)
             self.abort(exc)
             return
 
diff --git test/pytest/mocktransport.py test/pytest/mocktransport.py
index ed2c6f721..b06e6b4b9 100644
--- test/pytest/mocktransport.py
+++ test/pytest/mocktransport.py
@@ -25,7 +25,9 @@ class MockTransport(asyncio.Transport):
     def send_data(self, channel: str, data: bytes) -> None:
         msg = channel.encode('ascii') + b'\n' + data
         msg = str(len(msg)).encode('ascii') + b'\n' + msg
+        print("XXXXX MockTransport send_data %r" % data)
         self.protocol.data_received(msg)
+        print("XXXXX MockTransport send_data done")
 
     def send_init(self, version=1, host=MOCK_HOSTNAME, **kwargs):
         self.send_json('', command='init', version=version, host=host, **kwargs)
@@ -124,7 +126,9 @@ class MockTransport(asyncio.Transport):
 
     async def assert_msg(self, expected_channel: str, absent_keys: 'Iterable[str]' = (),
                          **kwargs: JsonValue) -> JsonObject:
+        print("XXX assert_msg waiting next_msg on", expected_channel)
         msg = await self.next_msg(expected_channel)
+        print("XXX assert_msg got next_msg", msg)
         assert msg == dict(msg, **{k.replace('_', '-'): v for k, v in kwargs.items()}), msg
         for absent_key in absent_keys:
             assert absent_key not in msg
diff --git test/pytest/test_bridge.py test/pytest/test_bridge.py
index b4b02d78c..a4ae51bd2 100644
--- test/pytest/test_bridge.py
+++ test/pytest/test_bridge.py
@@ -1379,3 +1379,16 @@ async def test_fsinfo_targets(transport: MockTransport, tmp_path: Path) -> None:
     # double-check with the non-watch variant
     client = await FsInfoClient.open(transport, tmp_path, ['type', 'target', 'targets'], fnmatch='l*')
     assert await client.wait() == state
+
+
+@pytest.mark.asyncio
+async def test_early_write_error(transport: MockTransport, monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_write(_data):
+        # transport.close_future.set_result(OSError("moo"))
+        transport.protocol.connection_lost(OSError("meh"))
+        transport.send_close("1.1", problem="kaputt")
+
+    # MockTransport.write = fail_write
+    # monkeypatch.setattr(transport, 'write', unittest.mock.Mock(side_effect=OSError))
+    monkeypatch.setattr(transport, 'write', fail_write)
+    await transport.check_open('echo', channel="1.1", problem="mieps")
diff --git test/pytest/test_transport.py test/pytest/test_transport.py
index 7c819c009..cedaf62a0 100644
--- test/pytest/test_transport.py
+++ test/pytest/test_transport.py
@@ -469,3 +469,13 @@ class TestSubprocessTransport:
         while protocol.transport is not None:
             await asyncio.sleep(0.1)
         assert protocol.transport is None
+
+    @pytest.mark.asyncio
+    async def test_early_write_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        loop = asyncio.get_running_loop()
+        protocol = Protocol()
+        monkeypatch.setattr(os, 'write', unittest.mock.Mock(side_effect=OSError))
+        transport = cockpit.transports.SubprocessTransport(loop, protocol, ['true'])
+        protocol.close_on_eof = False
+        while not protocol.exited:
+            await asyncio.sleep(0.1)

```

But nothing here really fits -- `test_transport` all uses `MockTransport` which is so different in behaviour from the real `_Transport` class that I find it (too) hard to reproduce the behaviour. The test_bridge  level felt more promising, but I couldn't make that work either.