### PR TITLE
bridge: call connection_lost "soon"

### DIFF
--- a/src/cockpit/channel.py
+++ b/src/cockpit/channel.py
@@ -366,7 +366,7 @@ class ProtocolChannel(Channel, asyncio.Protocol):
     Otherwise, if the subclass implements .do_open() itself, it is responsible
     for setting up the connection and ensuring that .connection_made() is called.
     """
-    _transport: 'asyncio.Transport | None'
+    _transport: 'asyncio.Transport | None' = None
     _send_pongs: bool = True
     _last_ping: 'JsonObject | None' = None
     _create_transport_task: 'asyncio.Task[asyncio.Transport] | None' = None

--- a/src/cockpit/transports.py
+++ b/src/cockpit/transports.py
@@ -142,7 +142,7 @@ class _Transport(asyncio.Transport):
         self._closing = True
         self._close_reader()
         self._remove_write_queue()
-        self._protocol.connection_lost(exc)
+        self._loop.call_soon(self._protocol.connection_lost, exc)
         self._close()
 
     def can_write_eof(self) -> bool:


### PR DESCRIPTION
The standard Python asyncio Transport classes protect their caller from having to deal with exceptions when calling .write().  In case an exception does occur, they capture it and close the transport, passing the exception on to the connection_lost() handler.  This makes it a lot easier to interact with the transport: because OS-level errors are handled out of band, protocols don't have to consider that any write might fail.

Our Transport classes do the same thing, but there's an important difference: the standard library defers the call to .connection_lost(), but our transports invoke it immediately.

This creates a weird scenario whereby your connection_lost() handler can get called in the middle of your connection_made() handler, if you should happen to do a .write() there which fails.  Since connection_lost() reasonably assumes that connection_made() has run, you can get into all kinds of trouble.  Worst of all, once .connection_lost() is done running, control flow returns back to your .connection_made() handler, which continues running as if nothing has happened in the meantime.

Let's adopt the standard Python behaviour here and defer the .connection_lost() call.  We need to adjust some unit tests which assumed the old behaviour: adjust them to ensure that we specifically *don't* have that behaviour anymore.