### PR TITLE
tmt: drop special-casing for RHEL 8

### DIFF
--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -63,16 +63,6 @@ if [ "$PLAN" = "main" ]; then
     # PCI devices list is not predictable
     EXCLUDES="$EXCLUDES TestSystemInfo.testHardwareInfo"
 
-    if [ "${TEST_OS#rhel-8}" != "$TEST_OS" ]; then
-        # no cockpit-tests package in RHEL 8
-        EXCLUDES="$EXCLUDES TestLogin.testSELinuxRestrictedUser"
-
-        # fails to start second browser, timing out on http://127.0.0.1:{cdp_port}/json/list
-        # impossible to debug without access to the infra
-        EXCLUDES="$EXCLUDES TestAccounts.testUserPasswords"
-
-    fi
-
     # TODO: investigate failure
     if [ "$TEST_OS" = "centos-10" ]; then
         EXCLUDES="$EXCLUDES TestLogin.testClientCertAuthentication"


### PR DESCRIPTION
Although we've generally tried to keep our "not on rhel8" decorators around for when we get tests working there again in our CI (via beiboot), running on testing farm will probably never come back, since we can't install RPMs there anymore.

Drop the special-casing for it — it's dead code and likely to forever remain that way.