### PR TITLE
Two CDP fixes

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -414,7 +414,7 @@ class Browser:
         """Allow browser downloads"""
         # this is only necessary for headless chromium
         if self.browser == "chromium":
-            self.cdp_command("Page.setDownloadBehavior", behavior="allow", downloadPath=str(self.driver.download_dir))
+            self.cdp_command("Browser.setDownloadBehavior", behavior="allow", downloadPath=str(self.driver.download_dir))
 
     def upload_files(self, selector: str, files: Sequence[str]) -> None:
         """Upload a local file to the browser

--- a/test/common/webdriver_bidi.py
+++ b/test/common/webdriver_bidi.py
@@ -395,7 +395,7 @@ class ChromiumBidi(WebdriverBidi):
 
         reply = None
         payload = json.dumps({"id": self.last_cdp_id, "method": method, "params": params})
-        log_proto.debug("CDP ← %r", payload)
+        log_command.info("CDP ← %r", payload)
         await self.cdp_ws.send_str(payload)
         async for msg in self.cdp_ws:
             if msg.type == aiohttp.WSMsgType.TEXT:
@@ -406,7 +406,7 @@ class ChromiumBidi(WebdriverBidi):
                     log_proto.warning("CDP message: %r", reply)
             else:
                 log_proto.debug("CDP non-text message: %r", msg)
-        log_proto.debug("CDP → %r", reply)
+        log_command.info("CDP → %r", reply)
         assert reply
         self.last_cdp_id += 1
         return reply


### PR DESCRIPTION
This PR is a bit lame, but I don't want to forget about it. I was originally trying something else -- Chromium [supports sending CDP commands directly through the BiDi protocol](https://github.com/GoogleChromeLabs/chromium-bidi?tab=readme-ov-file#bidi), which is cool -- until you try to use it. Some commands work fine, but some like `Emulation.setUserAgentOverride` just fail with "wasn't found" :cry: 

For posterity:

```diff
diff --git test/common/testlib.py test/common/testlib.py
index 1390fdb53..e8ae98c46 100644
--- test/common/testlib.py
+++ test/common/testlib.py
@@ -313,22 +313,19 @@ class Browser:
         self.bidi_thread.join()
         self.valid = False
 
-    def bidi(self, method: str, **params: Any) -> webdriver_bidi.JsonObject:
+    def bidi(self, method_name: str, **params: Any) -> webdriver_bidi.JsonObject:
         """Send a Webdriver BiDi command and return the JSON response"""
 
         try:
-            return self.run_async(self.driver.bidi(method, **params))
+            return self.run_async(self.driver.bidi(method_name, **params))
         except webdriver_bidi.WebdriverError as e:
             raise Error(str(e)) from None
 
-    def cdp_command(self, method: str, **params: Any) -> webdriver_bidi.JsonObject:
+    def cdp_command(self, method_name: str, **params: Any) -> webdriver_bidi.JsonObject:
         """Send a Chrome DevTools Protocol command and return the JSON response"""
 
-        if self.browser == "chromium":
-            assert isinstance(self.driver, webdriver_bidi.ChromiumBidi)
-            return self.run_async(self.driver.cdp(method, **params))
-        else:
-            raise webdriver_bidi.WebdriverError("CDP is only supported in Chromium")
+        # this is a Chromium specific BiDi extension, see https://github.com/GoogleChromeLabs/chromium-bidi
+        return self.bidi("cdp.sendCommand", method=method_name, params=params)
 
     def open(self, href: str, cookie: Mapping[str, str] | None = None, tls: bool = False) -> None:
         """Load a page into the browser.
diff --git test/common/webdriver_bidi.py test/common/webdriver_bidi.py
index a8f44a150..0cc2c5104 100644
--- test/common/webdriver_bidi.py
+++ test/common/webdriver_bidi.py
@@ -245,20 +245,21 @@ class WebdriverBidi(contextlib.AbstractAsyncContextManager):  # type: ignore[typ
                 log_proto.error("BiDi failure: %s", msg)
                 break
 
-    async def bidi(self, method: str, *, quiet: bool = False, timeout: int = 10, **params: Any) -> JsonObject:
+    async def bidi(self, method_name: str, *, quiet: bool = False, timeout: int = 10, **params: Any) -> JsonObject:
         """Send a Webdriver BiDi command and return the JSON response
 
         Most commands ought to be quick, so the default timeout is 10 seconds.
         Set a custom one if you call a function which waits/polls for something
         for a non-trivial duration.
         """
-        payload = json.dumps({"id": self.last_id, "method": method, "params": params})
-        log_command.info("← %s(%r) [id %i]", method, 'quiet' if quiet else params, self.last_id)
+        payload = json.dumps({"id": self.last_id, "method": method_name, "params": params})
+        log_command.info("← %s(%r) [id %i]", method_name, 'quiet' if quiet else params, self.last_id)
         await self.ws.send_str(payload)
         future = asyncio.get_event_loop().create_future()
         self.pending_commands[self.last_id] = future
         res = await asyncio.wait_for(future, timeout=timeout)
-        if "result" in res:
+        # don't unpack return values of the CDP BiDi bridge, they are structured differently
+        if not method_name.startswith("cdp") and "result" in res:
             value = unpack_value(res["result"])
             log_proto.debug("[id %i] unpacking raw result %r", self.last_id, res["result"])
             res["result"] = value

```

(and then we could have dropped the whole CDP socket connection and machinery). But alas, we can't have nice things.