### PR TITLE
test: Drop tracer support from CentOS/RHEL 10

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -172,7 +172,6 @@ You can set these environment variables to configure the test suite:
                   "fedora-40"
                   "fedora-coreos"
                   "rhel-9-4"
-                  "rhel4edge",
                   "ubuntu-2204"
                   "ubuntu-stable"
                "fedora-40" is the default (TEST_OS_DEFAULT in bots/lib/constants.py)

--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -45,7 +45,6 @@
     - firewalld
     - lvm2
     - nfs-utils
-    - python3-tracer
     - stratis-cli
     - stratisd
     - subscription-manager
@@ -72,7 +71,6 @@
     - firewalld
     - lvm2
     - nfs-utils
-    - python3-tracer
     - rpm-build
     - stratis-cli
     - stratisd

--- a/test/common/storagelib.py
+++ b/test/common/storagelib.py
@@ -648,7 +648,7 @@ class StorageCase(MachineCase, StorageHelpers):
 
     def setUp(self):
 
-        if self.image in ["fedora-coreos", "rhel4edge"]:
+        if self.image == "fedora-coreos":
             self.skipTest("No udisks/cockpit-storaged on OSTree images")
 
         super().setUp()

--- a/test/image-prepare
+++ b/test/image-prepare
@@ -178,7 +178,7 @@ def main():
 
     dist_tar = subprocess.check_output([f'{BASE_DIR}/tools/make-dist'], text=True).strip()
 
-    if args.image in ["fedora-coreos", "rhel4edge"]:
+    if args.image == "fedora-coreos":
         customize += build_install_ostree(dist_tar, args.image, args.verbose, args.quick)
     else:
         customize += build_install_package(dist_tar, args.image)

--- a/test/ostree.install
+++ b/test/ostree.install
@@ -5,21 +5,8 @@ set -eu
 # Note: cockpit-selinux would be desirable, but needs setroubleshoot-server which isn't installed
 cd /var/tmp/
 
-# rhel4edge includes cockpit packages in the image itself, fedora-coreos overlays them
-. /usr/lib/os-release
-if [ "${ID:-}" = "rhel" ]; then
-    rpm-ostree override replace --cache-only cockpit-bridge-*.rpm \
-        cockpit-system-*.rpm
-    rpm-ostree install --cache-only cockpit-tests-*.rpm
-else
-    rpm-ostree install --cache-only cockpit-bridge-*.rpm \
-        cockpit-networkmanager-*.rpm cockpit-system-*.rpm cockpit-tests-*.rpm
-fi
-
-# rhel4edge has passwordless sudo but a loads of tests don't expect that
-if [ "${ID:-}" = "rhel" ]; then
-    sed -i '$ d' /etc/sudoers
-fi
+rpm-ostree install --cache-only cockpit-bridge-*.rpm \
+    cockpit-networkmanager-*.rpm cockpit-system-*.rpm cockpit-tests-*.rpm
 
 # update cockpit-ws and install scripts in the container
 for rpm in /var/tmp/cockpit-ws-*.rpm /var/tmp/cockpit-bridge-*.rpm; do

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -437,7 +437,7 @@ class TestConnection(testlib.MachineCase):
 
         # certmonger generated certificate; asciibetically later than the above
         # not all images have certmonger
-        if m.image not in ["debian-stable", "debian-testing", "fedora-coreos", "rhel4edge", "arch"]:
+        if m.image not in ["debian-stable", "debian-testing", "fedora-coreos", "arch"]:
             hostname = m.execute("hostname --fqdn").strip()
             m.execute(f"getcert request -f /etc/cockpit/ws-certs.d/monger.cert -k /etc/cockpit/ws-certs.d/monger.key -D {hostname} --ca=local --wait")
             self.addCleanup(m.execute, "getcert stop-tracking -f /etc/cockpit/ws-certs.d/monger.cert")

--- a/test/verify/check-networkmanager-settings
+++ b/test/verify/check-networkmanager-settings
@@ -128,7 +128,7 @@ class TestNetworkingSettings(netlib.NetworkCase):
 
         # Check that IPv4/IPv6 settings dialogs only show the supported IP methods for wireguard
         # Skip images without the wireguard-tools package
-        if m.image not in ["rhel4edge", "centos-10"] and not m.image.startswith("rhel-8"):
+        if m.image not in ["centos-10"] and not m.image.startswith("rhel-8"):
             b.go("/network")
             b.click("#networking-add-wg")
             b.set_input_text("#network-wireguard-settings-addresses-input", "1.2.3.4/24")

--- a/test/verify/check-networkmanager-wireguard
+++ b/test/verify/check-networkmanager-wireguard
@@ -30,7 +30,7 @@ class TestWireGuard(packagelib.PackageCase, netlib.NetworkCase):
         b.wait_visible("#network-wireguard-settings-dialog")
         iface_name = b.val("#network-wireguard-settings-interface-name-input")
         b.wait_visible("#network-wireguard-settings-save:disabled")
-        if m1.image in ["rhel4edge"] or m1.image.startswith("rhel-8"):
+        if m1.image.startswith("rhel-8"):
             b.wait_visible(".pf-v5-c-alert:contains('wireguard-tools package is not installed')")
             b.click("button:contains('Cancel')")
             b.wait_not_present("#network-ip-settings-dialog")

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -24,7 +24,7 @@ from collections.abc import Collection
 import packagelib
 import testlib
 
-OSesWithoutTracer = ["debian-stable", "debian-testing", "ubuntu-2204", "ubuntu-stable", "fedora-coreos"]
+OSesWithoutTracer = ["debian-stable", "debian-testing", "ubuntu-2204", "ubuntu-stable", "fedora-coreos", "centos-10", "rhel-10-0"]
 OSesWithoutKpatch = ["debian-*", "ubuntu-*", "arch", "fedora-*", "centos-*"]
 
 

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -24,8 +24,8 @@ from collections.abc import Collection
 import packagelib
 import testlib
 
-OSesWithoutTracer = ["debian-stable", "debian-testing", "ubuntu-2204", "ubuntu-stable", "fedora-coreos", "rhel4edge"]
-OSesWithoutKpatch = ["debian-*", "ubuntu-*", "arch", "fedora-*", "rhel4edge", "centos-*"]
+OSesWithoutTracer = ["debian-stable", "debian-testing", "ubuntu-2204", "ubuntu-stable", "fedora-coreos"]
+OSesWithoutKpatch = ["debian-*", "ubuntu-*", "arch", "fedora-*", "centos-*"]
 
 
 class NoSubManCase(packagelib.PackageCase):
@@ -1638,7 +1638,7 @@ class TestAutoUpdates(NoSubManCase):
         b.wait_visible("#autoupdates-settings button:disabled")
 
 
-@testlib.skipImage("Image uses OSTree", "fedora-coreos", "rhel4edge")
+@testlib.skipImage("Image uses OSTree", "fedora-coreos")
 class TestAutoUpdatesInstall(NoSubManCase):
     def testUnsupported(self):
         b = self.browser

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -822,7 +822,7 @@ class TestMultiMachine(testlib.MachineCase):
         b.wait_not_present('#hosts_setup_server_dialog')
         b.enter_page("/system", host="fred@10.111.113.2")
 
-        # Relogin.  This should now work seamlessly (except on fedora-coreos and rhel4edge
+        # Relogin.  This should now work seamlessly (except on OSTree images
         # which don't have pam-ssh-add in its PAM stack.)
         if not m1.ostree_image:
             b.relogin(None, wait_remote_session_machine=m1)

--- a/test/verify/check-ws-bastion
+++ b/test/verify/check-ws-bastion
@@ -22,7 +22,7 @@ import testlib
 HOST = "host.containers.internal"
 
 
-@testlib.onlyImage("no cockpit/ws container on this image", "fedora-coreos", "rhel4edge")
+@testlib.onlyImage("no cockpit/ws container on this image", "fedora-coreos")
 @testlib.nondestructive
 class TestWsBastionContainer(testlib.MachineCase):
     def setUp(self):
@@ -218,7 +218,7 @@ class TestWsBastionContainer(testlib.MachineCase):
         b.wait_visible('#content')
 
 
-@testlib.onlyImage("no cockpit/ws container on this image", "fedora-coreos", "rhel4edge")
+@testlib.onlyImage("no cockpit/ws container on this image", "fedora-coreos")
 @testlib.nondestructive
 class TestWsPrivileged(testlib.MachineCase):
     def testService(self):


### PR DESCRIPTION
The package was just dropped from RHEL 10 [1], see https://issues.redhat.com/browse/RHELBLD-15667
    
[1] https://gitlab.com/redhat/centos-stream/rpms/tracer/-/commit/513b244618e63630

Also drop obsolete rhel4edge special cases.

----

This needs to land in lockstep with https://github.com/cockpit-project/bots/pull/6739