### PR TITLE
containers/ws: Support host-specific ssh keys

### DIFF
--- a/containers/ws/README.md
+++ b/containers/ws/README.md
@@ -97,11 +97,15 @@ can mount your known host keys into the container at
 
     -v /path/to/known_hosts:/etc/ssh/ssh_known_hosts:ro,Z
 
-You can also mount an encrypted private key inside the container and set the environment variable `COCKPIT_SSH_KEY_PATH` to point to it:
+You can also mount encrypted private keys inside the container. You can set an environment variable, `COCKPIT_SSH_KEY_PATH_MYHOST`, where `MYHOST` is the uppercased hostname used in the `Connect to` field, and cockpit will use that private key to login for the specified host. Private keys can be set for multiple hosts this way by changing the value of `MYHOST`. You can also set an environment variable, `COCKPIT_SSH_KEY_PATH`, which will be used as a fallback key if no host-specific key is set:
 
-    -e COCKPIT_SSH_KEY_PATH=/id_rsa -v ~/.ssh/id_rsa:/id_rsa:ro,Z
+    -e COCKPIT_SSH_KEY_PATH_MYHOST=/.ssh/myhost_id_rsa \
+    -e COCKPIT_SSH_KEY_PATH_MYSERVER=/.ssh/myserver_id_rsa \
+    -e COCKPIT_SSH_KEY_PATH_192.168.1.1=/.ssh/another_id_rsa \
+    -e COCKPIT_SSH_KEY_PATH=/.ssh/id_rsa \
+    -v ~/.ssh/:/.ssh:ro,Z
 
-Then cockpit will use the provided password to decrypt the key and establish an SSH connection to the given host using that private key.
+Private keys can be encrypted; then cockpit uses the provided password to decrypt the key.
 
 ## More Info
 

--- a/containers/ws/cockpit-auth-ssh-key
+++ b/containers/ws/cockpit-auth-ssh-key
@@ -15,15 +15,15 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <https://www.gnu.org/licenses/>.
-#
-# This command is meant to be used as an authentication command launched
-# by cockpit-ws. It asks for authentication from cockpit-ws and expects
-# to receive a basic auth header in response. If COCKPIT_SSH_KEY_PATH is set
-# we will try to decrypt the key with the given password. If successful
-# we send the decrypted key to cockpit-ws for use with cockpit-ssh.
-# Once finished we exec cockpit-ssh to actually establish the ssh connection.
-# All communication with cockpit-ws happens on stdin and stdout using the
-# cockpit protocol
+
+# This command is meant to be used as an authentication command launched by
+# cockpit-ws. It asks for authentication from cockpit-ws and expects to
+# receive a basic auth header in response. If COCKPIT_SSH_KEY_PATH or
+# COCKPIT_SSH_KEY_PATH_{HOSTNAME} is set, we will try to decrypt the key with
+# the given password. If successful we send the decrypted key to cockpit-ws
+# for use with cockpit-ssh. Once finished we exec cockpit-ssh to actually
+# establish the ssh connection. All communication with cockpit-ws happens on
+# stdin and stdout using the cockpit protocol
 # (https://github.com/cockpit-project/cockpit/blob/main/doc/protocol.md)
 
 import base64
@@ -172,7 +172,8 @@ def main(args):
         usage()
 
     host = args[1]
-    key_name = os.environ.get("COCKPIT_SSH_KEY_PATH")
+    key_env = f"COCKPIT_SSH_KEY_PATH_{host.upper()}"
+    key_name = os.environ.get(key_env) or os.environ.get("COCKPIT_SSH_KEY_PATH")
     if key_name:
         send_auth_command("*", None)
         try:

--- a/test/verify/check-ws-bastion
+++ b/test/verify/check-ws-bastion
@@ -164,58 +164,69 @@ class TestWsBastionContainer(testlib.MachineCase):
         b = self.browser
 
         KEY_PASSWORD = "sshfoobar"
+
         # old RSA/PEM format
         m.execute(f"ssh-keygen -q -f /root/id_bastion -t rsa -m PEM -N {KEY_PASSWORD}")
         m.execute(f"ssh-keyscan localhost | sed 's/^localhost/{HOST}/' > /root/known_hosts")
         self.addCleanup(m.execute, "rm /root/known_hosts /root/id_bastion /root/id_bastion.pub")
 
-        m.execute("podman run -d --name cockpit-bastion -p 9090:9090 "
-                  "-v /root/known_hosts:/etc/ssh/ssh_known_hosts:ro,Z "
-                  "-v /root/id_bastion:/id_bastion:ro,Z "
-                  "-e COCKPIT_SSH_KEY_PATH=/id_bastion "
-                  "-e G_MESSAGES_DEBUG=cockpit-ssh "
-                  "localhost/cockpit/ws")
-        m.execute("until curl --fail --head -k https://localhost:9090/; do sleep 1; done")
+        def do_test_key_login(ssh_key_env: str):
+            m.execute(
+                "podman run -d --name cockpit-bastion -p 9090:9090 "
+                "-v /root/known_hosts:/etc/ssh/ssh_known_hosts:ro,Z "
+                "-v /root/id_bastion:/id_bastion:ro,Z "
+                f"-e {ssh_key_env}=/id_bastion "
+                "-e G_MESSAGES_DEBUG=cockpit-ssh "
+                "localhost/cockpit/ws"
+            )
+            m.execute("until curl --fail --head -k https://localhost:9090/; do sleep 1; done")
 
-        b.open("/", tls=True)
-        b.set_val("#login-user-input", "admin")
-        b.set_val("#server-field", HOST)
+            b.open("/", tls=True)
+            b.set_val("#login-user-input", "admin")
+            b.set_val("#server-field", HOST)
 
-        # the account password does not work
-        b.set_val("#login-password-input", "foobar")
-        b.click("#login-button")
-        b.wait_text_not("#login-error-message", "")
+            # the account password does not work
+            b.set_val("#login-password-input", "foobar")
+            b.click("#login-button")
+            b.wait_text_not("#login-error-message", "")
 
-        # SSH key password, but key is not authorized
-        b.set_val("#login-password-input", KEY_PASSWORD)
-        b.click("#login-button")
-        b.wait_text_not("#login-error-message", "")
+            # SSH key password, but key is not authorized
+            b.set_val("#login-password-input", KEY_PASSWORD)
+            b.click("#login-button")
+            b.wait_text_not("#login-error-message", "")
 
-        # authorize key
-        self.restore_file("/home/admin/.ssh/authorized_keys")
-        # Do not use authorized_keys.d as that does not work on rhel4edge
-        # Do not append but overwrite so we are sure the right key is used
-        m.execute("cat /root/id_bastion.pub > /home/admin/.ssh/authorized_keys")
+            # authorize key
+            self.restore_file("/home/admin/.ssh/authorized_keys")
+            # Do not use authorized_keys.d as that does not work on rhel4edge
+            # Do not append but overwrite so we are sure the right key is used
+            m.execute("cat /root/id_bastion.pub > /home/admin/.ssh/authorized_keys")
 
-        # fails with wrong key password
-        b.set_val("#login-password-input", "notthispassword")
-        b.click("#login-button")
-        b.wait_text_not("#login-error-message", "")
+            # fails with wrong key password
+            b.set_val("#login-password-input", "notthispassword")
+            b.click("#login-button")
+            b.wait_text_not("#login-error-message", "")
 
-        # works with correct key password
-        b.set_val("#login-password-input", KEY_PASSWORD)
-        b.click("#login-button")
-        b.wait_visible('#content')
-        b.logout()
+            # works with correct key password
+            b.set_val("#login-password-input", KEY_PASSWORD)
+            b.click("#login-button")
+            b.wait_visible('#content')
+            b.logout()
 
-        # now test with current OpenSSH format
-        m.execute(f"yes | ssh-keygen -q -f /root/id_bastion -t rsa -N {KEY_PASSWORD}")
-        m.execute("cat /root/id_bastion.pub > /home/admin/.ssh/authorized_keys")
-        b.set_val("#login-user-input", "admin")
-        b.set_val("#server-field", HOST)
-        b.set_val("#login-password-input", KEY_PASSWORD)
-        b.click("#login-button")
-        b.wait_visible('#content')
+            # now test with current OpenSSH format
+            m.execute(f"yes | ssh-keygen -q -f /root/id_bastion -t rsa -N {KEY_PASSWORD}")
+            m.execute("cat /root/id_bastion.pub > /home/admin/.ssh/authorized_keys")
+            b.set_val("#login-user-input", "admin")
+            b.set_val("#server-field", HOST)
+            b.set_val("#login-password-input", KEY_PASSWORD)
+            b.click("#login-button")
+            b.wait_visible('#content')
+
+            b.logout()
+            m.execute("podman rm -f -t0 cockpit-bastion")
+            m.execute("rm /home/admin/.ssh/authorized_keys")
+
+        for ssh_key_env in ["COCKPIT_SSH_KEY_PATH", f"COCKPIT_SSH_KEY_PATH_{HOST.upper()}"]:
+            do_test_key_login(ssh_key_env=ssh_key_env)
 
 
 @testlib.onlyImage("no cockpit/ws container on this image", "fedora-coreos")


### PR DESCRIPTION
This PR adds the ability to set host-specific ssh keys via env-var in the cockpit-ws container.

Users can pass environment variables in the format of `COCKPIT_SSH_KEY_PATH_{HOSTNAME}`, where `HOSTNAME` is the hostname used in the `Connect to` field of the cockpit login page, and cockpit will use the configured key to login to the host. If no host-specific key is set, it falls back to using the `COCKPIT_SSH_KEY_PATH` environment variable.

I still need to make a unit test, but I wanted to ask for suggestions as to the best route. The [cockpit bastion test](https://github.com/cockpit-project/cockpit/blob/f071d8cd2a20b309dae72392a7a49223d2aaa3c1/test/verify/check-ws-bastion#L162-L219) could be replicated, or it could be refactored to test host-specific keys. I wasn't sure what the best approach would be, and would appreciate any advice before proceeding!

This functionality will enable users to login to multiple hosts via ssh keys once the host-switcher is deprecated, providing a solution to user concerns such as  #20901

## cockpit/ws container: Support host specific SSH keys

The [cockpit/ws](https://quay.io/repository/cockpit/ws) container now supports adding a multiple SSH private keys. In addition to the existing `$COCKPIT_SSH_KEY_PATH` environment variable you can now set host specific `$COCKPIT_SSH_KEY_PATH_`*HOSTNAME* variables, where `HOSTNAME` is the host name (in capital letters) used in the `Connect to:` field of the login page.

_Thanks to [benniekiss](https://github.com/benniekiss) for contributing this feature!_