### PR TITLE
test: support Arch Linux's chromium binary name in BiDi, Don't change context in WebdriverBidi.restore_context()

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1009,6 +1009,7 @@ class Browser:
         passwordless: bool | None = False
     ) -> None:
         with self.driver.restore_context():
+            self.switch_to_top()
             self.open_superuser_dialog()
 
             # In (open)SUSE images, superuser access always requires the root password
@@ -1032,6 +1033,7 @@ class Browser:
 
     def drop_superuser(self) -> None:
         with self.driver.restore_context():
+            self.switch_to_top()
             self.open_superuser_dialog()
             self.wait_in_text("div[role=dialog]", "Switch to limited access")
             self.click("div[role=dialog] button.pf-m-primary")
@@ -1139,7 +1141,7 @@ class Browser:
             self.cdp_command("Emulation.setEmulatedMedia", features=[{'name': 'prefers-color-scheme', 'value': name}])
 
     def _set_direction(self, direction: str) -> None:
-        with self.driver.restore_context(switch_to_top=False):
+        with self.driver.restore_context():
             if self.is_present("#shell-page"):
                 self.switch_to_top()
                 self.set_attr("#shell-page", "dir", direction)

--- a/test/common/webdriver_bidi.py
+++ b/test/common/webdriver_bidi.py
@@ -345,7 +345,7 @@ class ChromiumBidi(WebdriverBidi):
     async def start_bidi_session(self) -> None:
         assert self.bidi_session is None
 
-        candidate_binaries = ["/usr/bin/chromium-browser"]
+        candidate_binaries = ["/usr/bin/chromium-browser", "/usr/bin/chromium"]
         if self.headless:
             candidate_binaries.insert(0, "/usr/lib64/chromium-browser/headless_shell")
         binaries = [path for path in candidate_binaries if os.path.exists(path)]

--- a/test/common/webdriver_bidi.py
+++ b/test/common/webdriver_bidi.py
@@ -327,10 +327,8 @@ class WebdriverBidi:
         log_command.info("← switch_to_top")
 
     @contextlib.contextmanager
-    def restore_context(self, *, switch_to_top: bool = True) -> Iterator[None]:
+    def restore_context(self) -> Iterator[None]:
         saved = self.context
-        if switch_to_top:
-            self.switch_to_top()
         try:
             yield
         finally:


### PR DESCRIPTION
Addresses a late comment from @mvollmer in https://github.com/cockpit-project/cockpit/pull/20832#pullrequestreview-2234962385