### PR TITLE
cockpit.js: fix cockpit.file().replace('')

### DIFF
--- a/pkg/base1/test-file.js
+++ b/pkg/base1/test-file.js
@@ -67,6 +67,12 @@ QUnit.test("simple replace", async assert => {
     assert.equal(res, "4321\n", "correct content");
 });
 
+QUnit.test("empty replace", async assert => {
+    await cockpit.file(`${dir}/bar`).replace("");
+    const res = await cockpit.spawn(["cat", `${dir}/bar`]);
+    assert.equal(res, "", "correct content");
+});
+
 QUnit.test("stringify replace", async assert => {
     await cockpit.file(dir + "/bar", { syntax: JSON }).replace({ foo: 4321 });
     const res = await cockpit.spawn(["cat", dir + "/bar"]);

--- a/pkg/lib/cockpit.d.ts
+++ b/pkg/lib/cockpit.d.ts
@@ -248,7 +248,7 @@ declare module 'cockpit' {
 
     interface FileHandle<T> {
         read(): Promise<T>;
-        replace(new_content: T, expected_tag?: FileTag): Promise<FileTag>;
+        replace(new_content: T | null, expected_tag?: FileTag): Promise<FileTag>;
         watch(callback: FileWatchCallback<T>, options?: { read?: boolean }): FileWatchHandle;
         modify(callback: (data: T) => T, initial_content?: string, initial_tag?: FileTag): Promise<[T, FileTag]>;
         close(): void;

--- a/pkg/lib/cockpit.js
+++ b/pkg/lib/cockpit.js
@@ -2277,9 +2277,20 @@ function factory() {
                 }
             });
 
-            iterate_data(file_content, function(data) {
-                replace_channel.send(data);
-            });
+            // null means 'erase this file', which is what will happen if
+            // we send no data. the empty string means "write an empty
+            // file", and in order to do that, we need to explicitly send
+            // an empty frame (or we'll delete the file). iterate_data()
+            // doesn't call us if the string is empty, so we handle it.
+            if (file_content !== null) {
+                if (file_content.length === 0 || file_content.byteLength === 0) {
+                    replace_channel.send(file_content);
+                } else {
+                    iterate_data(file_content, data => {
+                        replace_channel.send(data);
+                    });
+                }
+            }
 
             replace_channel.control({ command: "done" });
             return dfd.promise;

--- a/pkg/users/authorized-keys.js
+++ b/pkg/users/authorized-keys.js
@@ -120,7 +120,7 @@ function AuthorizedKeys (user_name, home_dir) {
             const new_lines = [];
 
             if (!content)
-                return "";
+                return null;
 
             lines = content.trim().split('\n');
             for (let i = 0; i < lines.length; i++) {
@@ -129,7 +129,7 @@ function AuthorizedKeys (user_name, home_dir) {
                 else
                     new_lines.push(lines[i]);
             }
-            return new_lines.join("\n");
+            return new_lines.join("\n") || null;
         });
     };
 


### PR DESCRIPTION
We call iterate_data() on whatever the user passed to us, but this function will make zero callbacks if the string is empty.  That's a problem, because the fsreplace1 channel interprets this as a request to delete the file.

If we have an empty string, then send the empty string to make sure we end up with an empty file.  Also treat the `null` case more explicitly (and add a type annotation for it: we missed that before).

Add a test case too.