### PR TITLE
test: Re-teach Browser.input_text() about \n

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -596,6 +596,9 @@ class Browser:
     def input_text(self, text: str) -> None:
         actions = []
         for c in text:
+            # quality-of-life special case
+            if c == '\n':
+                c = WEBDRIVER_KEYS["Enter"]
             actions.append({"type": "keyDown", "value": c})
             actions.append({"type": "keyUp", "value": c})
         self.bidi("input.performActions", context=self.driver.context, actions=[


### PR DESCRIPTION
`Browser.input_text()` is not generally meant for non-ASCII characters (that's `Browser.key()`). But a newline is such a common case that it's worth handling it speciallly.

This was originally introduced in commit d3632786a1602b5 but I missed that in the BiDi conversion in commit 0ec830da3dbda7.

---

This will fix https://github.com/cockpit-project/cockpit-files/pull/509