### PR TITLE
packit: Temporarily disable Fedora 41 tests

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -28,9 +28,10 @@ jobs:
     trigger: pull_request
     targets:
       - fedora-40
-      - fedora-41
-      - fedora-latest-aarch64
-      - fedora-development
+      # not supported by TF yet
+      # - fedora-41
+      - fedora-latest-stable-aarch64
+      - fedora-rawhide
       - centos-stream-9-x86_64
       - centos-stream-9-aarch64
       - centos-stream-10


### PR DESCRIPTION
Testing Farm does not yet have a Fedora 41 image.

Also move the Fedora aarch64 run to the latest stable. Right now this will go back to Fedora 40 instead of 41, so that we don't lose ARM testing.

----

We have F41 enabled in other projects, we'll notice when it starts working.