### PR TITLE
systemd: Relax cockpit-ws-user.service dependencies

### DIFF
--- a/src/systemd/cockpit-ws-user.service
+++ b/src/systemd/cockpit-ws-user.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Dynamic user for cockpit-ws
 Documentation=man:cockpit-ws(8)
+# avoid dependency loop with basic.target/sockets.target shutdown
+DefaultDependencies=no
 BindsTo=cockpit.service
 
 [Service]


### PR DESCRIPTION
cockpit-ws-user.service does nothing except calling `true`, so it does not have any actual dependencies. Drop the implicit `basic.target` dependency so that the running unit can be shut down cleanly.

Previously, this caused a dependency loop, which systemd resolved in an unhappy way:

> basic.target: Job cockpit-ws-user.service/stop deleted to break ordering cycle starting with basic.target/stop
> basic.target: Found dependency on basic.target/stop
> basic.target: Found dependency on sockets.target/stop
> basic.target: Found dependency on cockpit-wsinstance-https-factory.socket/stop
> basic.target: Found ordering cycle on cockpit-ws-user.service/stop

Fixes #20914