### PR TITLE
pkg: add qunit tests for modify() "" vs null

### DIFF
--- a/pkg/base1/test-file.js
+++ b/pkg/base1/test-file.js
@@ -199,6 +199,28 @@ QUnit.test("modify", async assert => {
     assert.equal(n, 1, "callback called once");
 
     assert.equal(await cockpit.spawn(["cat", dir + "/quux"]), "dcba\n", "correct content");
+
+    // make sure that writing "" results in an empty file, not a deleted one
+    n = 0;
+    await file.modify(old => {
+        n += 1;
+        assert.equal(old, "dcba\n", "correct old content");
+        return "";
+    });
+    assert.equal(n, 1, "callback called once");
+
+    assert.equal(await cockpit.spawn(["cat", dir + "/quux"]), "", "correct content");
+
+    // make sure that writing null deletes the file
+    n = 0;
+    await file.modify(old => {
+        n += 1;
+        assert.equal(old, "", "correct old content");
+        return null;
+    });
+    assert.equal(n, 1, "callback called once");
+
+    assert.rejects(cockpit.spawn(["cat", dir + "/quux"]), /No such file or directory/, "file deleted");
 });
 
 QUnit.test("modify with conflict", async assert => {


### PR DESCRIPTION
Add some extra tests to make sure that `null` returned from a modify() callback will result in a deleted file whereas "" will result in an empty file.