### PR TITLE
test: Implement "contextmenu" mouse event for BiDi

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -515,6 +515,12 @@ class Browser:
         # sidestep the browser
         element = self.call_js_func('ph_find_scroll_into_view', selector)
 
+        # btn=2 for context menus doesn't work with ph_mouse(); so translate the old ph_mouse() API
+        if event == "contextmenu":
+            assert btn == 0, "contextmenu event can only be done with default 'btn' value"
+            btn = 2
+            event = "click"
+
         actions = [{"type": "pointerMove", "x": 0, "y": 0, "origin": {"type": "element", "element": element}}]
         down = {"type": "pointerDown", "button": btn}
         up = {"type": "pointerUp", "button": btn}


### PR DESCRIPTION
cockpit-podman uses this. Conceptually this is strange, as mouses don't have a "context menu" button -- they have a right button (aka `btn=2`). But this does not work with `ph_mouse()`, so translate it to a right click.

---

no-test, as we don't use "contextmenu" anywhere in the cockpit tests. But we do in c-files, and this will unblock https://github.com/cockpit-project/cockpit-files/pull/714 . I tested this change locally, and it fixes the tests.

I also updated https://github.com/cockpit-project/cockpit-files/pull/714 to pull in this PR, to get a test run.