### PR TITLE
Revert "test: Increase RAM for TestKdumpNFS machine"

### DIFF
--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -554,7 +554,7 @@ class TestKdumpNFS(KdumpHelpers):
 class TestKdumpNFSAnsible(KdumpHelpers):
     provision = {
         "cockpit": {"memory_mb": 512},
-        "kdump_ansible_machine": {"address": "10.111.113.1/24", "memory_mb": 1500, "capture_console": True},
+        "kdump_ansible_machine": {"address": "10.111.113.1/24", "memory_mb": 1024, "capture_console": True},
         "nfs": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/24", "memory_mb": 512},
     }
 


### PR DESCRIPTION
We have a better theory now of how kdump works and especially what crashkernel means, and increasing the physical RAM of a machine is not expected to help with growing initramfs sizes.

It _did_ help, for mysterious reasons, but not totally reliably. So let's revert this, save some RAM, and wait for a real fix.

See https://bugzilla.redhat.com/show_bug.cgi?id=2305968

This reverts commit 3fb39bbb91a64a92dbd8073a168bbfab737dc856.