### PR TITLE
packit: Re-enable Fedora 41

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -28,8 +28,7 @@ jobs:
     trigger: pull_request
     targets:
       - fedora-40
-      # not supported by TF yet
-      # - fedora-41
+      - fedora-41
       - fedora-latest-stable-aarch64
       - fedora-rawhide
       - centos-stream-9-x86_64


### PR DESCRIPTION
Testing Farm has a working image now.

Partially reverts commit e0012e909