### PR TITLE
cockpit.js: translate a couple more error codes

### DIFF
--- a/pkg/lib/cockpit.js
+++ b/pkg/lib/cockpit.js
@@ -2618,6 +2618,10 @@ function factory() {
             return _("Cockpit could not contact the given host.");
         else if (problem == "too-large")
             return _("Too much data");
+        else if (problem == "not-found")
+            return _("No such file or directory");
+        else if (problem == "change-conflict")
+            return _("The existing file changed unexpectedly");
         else
             return problem;
     };


### PR DESCRIPTION
cockpit.message() is missing the most obvious error (ENOENT) and another common one that we see leaking through the UI in the new editor component in Cockpit Files.

Add these.