### PR TITLE
src: Sort files in built beipack

### DIFF
--- a/src/build_backend.py
+++ b/src/build_backend.py
@@ -86,7 +86,7 @@ def build_wheel(wheel_directory: str,
 
         def beipack_self(main: str, args: str = '') -> bytes:
             from cockpit._vendor.bei import beipack
-            contents = {name: wheel.read(name) for name in wheel.namelist()}
+            contents = {name: wheel.read(name) for name in sorted(wheel.namelist())}
             pack = beipack.pack(contents, main, args=args).encode()
             return lzma.compress(pack, preset=lzma.PRESET_EXTREME)
 


### PR DESCRIPTION
`cockpit-bridge.beipack.xz` is currently not reproducible [1] as the order of files in it differs. Dictionaries are
insertion-stable/reproducible since Python 3.7, so apparently the order of files in (`cockpit-0-py3-none-any.whl`) depends on the environment (we don't ship that wheel itself in distro packages).

Sort the file names to make the content reproducible.

[1] https://tests.reproducible-builds.org/debian/rb-pkg/unstable/amd64/diffoscope-results/cockpit.html

----

It's not obvious to me how to reproduce the different file layout -- I tried different build paths and different `LANG`/`LC_ALL`/`LANGUAGE` values, which are the most obvious candidates from the [build environment diff](https://tests.reproducible-builds.org/debian/logdiffs/unstable/amd64/cockpit_323-1.diff.gz). In all cases I got the same beipack. However, the order (of course) does change with this `sorted()` patch.