### PR TITLE
test: Determine TestStorageNBDE tang iface dynamically

### DIFF
--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <https://www.gnu.org/licenses/>.
 
+import json
 import subprocess
 
 import packagelib
@@ -774,8 +775,8 @@ class TestStorageNBDE(storagelib.StorageCase, packagelib.PackageCase):
 
         # Tell the initrd to configure our special inter-machine
         # network that has the "tang" machine.
-        #
-        iface = "ens15" if m.image in ["centos-10", "fedora-41"] else "eth1"
+        routes = json.loads(m.execute("ip --json route show 10.111.112.0/20"))
+        iface = routes[0]["dev"]
         m.execute(f"grubby --update-kernel=ALL --args='ip=10.111.112.1::10.111.112.1:255.255.255.0::{iface}:off'")
 
         try:


### PR DESCRIPTION
Stop hardcoding the interface name and detect it dynamically. More OSes (rhel-10-0 right now) are switching to systemd interface naming.

----

This will fix the cockpit failure in https://github.com/cockpit-project/bots/pull/6796