### PR TITLE
test: Adjust TestLogin.testBasic for current coreutils

### DIFF
--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -119,14 +119,15 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         self.check_shell()
 
         if not m.ostree_image:  # logs in via ssh, not cockpit-session
-            self.assertRegex(m.execute("who"), r"(^|\n)admin *web.*(\d+\.\d+|::)")
+            # older coreutils shows the session type (web), newer ones the service name
+            self.assertRegex(m.execute("who"), r"(^|\n)admin *(web|cockpit).*(\d+\.\d+|::)")
 
         # reload, which should log us in with the cookie
         b.reload()
         self.check_shell()
 
         if not m.ostree_image:  # logs in via ssh, not cockpit-session
-            self.assertRegex(m.execute("who"), r"(^|\n)admin *web.*(\d+\.\d+|::)")
+            self.assertRegex(m.execute("who"), r"(^|\n)admin *(web|cockpit).*(\d+\.\d+|::)")
 
         b.go("/users#/admin")
         b.enter_page("/users")


### PR DESCRIPTION
coreutils with systemd session support and the latest fix [1] show the service name instead of the session type in `who`. Adjust the test to accept either.

Also see https://bugzilla.redhat.com/show_bug.cgi?id=2307847

[1] https://git.savannah.gnu.org/cgit/gnulib.git/commit/?id=43f7f428a1665950233557bd97611bd5e996b5cb

----

I locally tested https://bodhi.fedoraproject.org/updates/FEDORA-2024-17516d6499 in a rawhide image, and it passes now. It's not yet visible in a compose, but Testing Farm is using the tag repo, so there's actually a chance that this passes now (I don't know how aggressively it `dnf update`'s)