### PR TITLE
storage: Never enable iSCSI in Anaconda mode

### DIFF
--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -895,13 +895,15 @@ function init_model(callback) {
             console.warn("Can't enable storaged btrfs module", error.toString());
         }
 
-        try {
-            await client.manager.EnableModule("iscsi", true);
-            client.manager_iscsi = proxy("Manager.ISCSI.Initiator", "Manager");
-            await client.manager_iscsi.wait();
-            client.features.iscsi = (client.manager_iscsi.valid && client.manager_iscsi.SessionsSupported !== false);
-        } catch (error) {
-            console.warn("Can't enable storaged iscsi module", error.toString());
+        if (!client.in_anaconda_mode()) {
+            try {
+                await client.manager.EnableModule("iscsi", true);
+                client.manager_iscsi = proxy("Manager.ISCSI.Initiator", "Manager");
+                await client.manager_iscsi.wait();
+                client.features.iscsi = (client.manager_iscsi.valid && client.manager_iscsi.SessionsSupported !== false);
+            } catch (error) {
+                console.warn("Can't enable storaged iscsi module", error.toString());
+            }
         }
 
         try {


### PR DESCRIPTION
See #20844.

I am not sure if this is needed or wanted or even sufficient...

Not having any iscsi packages installed should have the same effect, but maybe that is too brittle. Also, we might need to make this conditional on whether we are online, or not.
