### PR TITLE
ws: use the failing "init" message as /login result

### DIFF
--- a/src/common/cockpitwebresponse.c
+++ b/src/common/cockpitwebresponse.c
@@ -1218,6 +1218,7 @@ cockpit_web_response_error_with_body (CockpitWebResponse *self,
 void
 cockpit_web_response_gerror (CockpitWebResponse *self,
                              GHashTable *headers,
+                             GBytes *body,
                              GError *error)
 {
   int code;
@@ -1239,7 +1240,7 @@ cockpit_web_response_gerror (CockpitWebResponse *self,
   else
     code = 500;
 
-  cockpit_web_response_error (self, code, headers, "%s", error->message);
+  cockpit_web_response_error_with_body (self, code, error->message, headers, body);
 }
 
 static gboolean

--- a/src/common/cockpitwebresponse.h
+++ b/src/common/cockpitwebresponse.h
@@ -108,6 +108,7 @@ void                  cockpit_web_response_error         (CockpitWebResponse *se
 
 void                  cockpit_web_response_gerror        (CockpitWebResponse *self,
                                                           GHashTable *headers,
+                                                          GBytes *body,
                                                           GError *error);
 
 gchar **              cockpit_web_response_resolve_roots (const gchar **roots);

--- a/src/common/cockpitwebresponse.h
+++ b/src/common/cockpitwebresponse.h
@@ -95,6 +95,11 @@ void                  cockpit_web_response_content       (CockpitWebResponse *se
                                                           GBytes *block,
                                                           ...) G_GNUC_NULL_TERMINATED;
 
+void                  cockpit_web_response_error_with_body (CockpitWebResponse *self,
+                                                            guint code,
+                                                            const gchar *reason,
+                                                            GHashTable *headers,
+                                                            GBytes *body);
 void                  cockpit_web_response_error         (CockpitWebResponse *self,
                                                           guint status,
                                                           GHashTable *headers,

--- a/src/common/test-webresponse.c
+++ b/src/common/test-webresponse.c
@@ -217,7 +217,7 @@ test_return_gerror_headers (TestCase *tc,
   g_hash_table_insert (headers, g_strdup ("Header1"), g_strdup ("value1"));
 
   error = g_error_new (G_IO_ERROR, G_IO_ERROR_FAILED, "Reason here: %s", "booyah");
-  cockpit_web_response_gerror (tc->response, headers, error);
+  cockpit_web_response_gerror (tc->response, headers, NULL, error);
 
   g_error_free (error);
   g_hash_table_destroy (headers);

--- a/src/ws/cockpithandlers.c
+++ b/src/ws/cockpithandlers.c
@@ -540,18 +540,15 @@ on_login_complete (GObject *object,
 
   if (error)
     {
+      g_autoptr(GBytes) body = NULL;
+
       if (response_data)
         {
           g_hash_table_insert (headers, g_strdup ("Content-Type"), g_strdup ("application/json"));
-          g_autoptr(GBytes) content = cockpit_json_write_bytes (response_data);
-          cockpit_web_response_headers_full (response, 401, "Authentication required", -1, headers);
-          cockpit_web_response_queue (response, content);
-          cockpit_web_response_complete (response);
+          body = cockpit_json_write_bytes (response_data);
         }
-      else
-        {
-          cockpit_web_response_gerror (response, headers, NULL, error);
-        }
+
+      cockpit_web_response_gerror (response, headers, body, error);
     }
   else
     {

--- a/src/ws/cockpithandlers.c
+++ b/src/ws/cockpithandlers.c
@@ -550,7 +550,7 @@ on_login_complete (GObject *object,
         }
       else
         {
-          cockpit_web_response_gerror (response, headers, error);
+          cockpit_web_response_gerror (response, headers, NULL, error);
         }
     }
   else

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -875,7 +875,7 @@ matchrule = <SUBJECT>^DC=LAN,DC=COCKPIT,CN=alice$
         # another certificate gets rejected
         self.allow_journal_messages("cockpit-session: No matching user for certificate")
         do_test(["--cert", self.vm_tmpdir + "/bob.pem", "--key", self.vm_tmpdir + "/bob.key"],
-                ["HTTP/1.1 401 Authentication failed", '<h1>Authentication failed</h1>'],
+                ["HTTP/1.1 401 Authentication failed"],
                 not_expected=["crsf-token"])
 
         # check expired certificate
@@ -893,7 +893,7 @@ matchrule = <SUBJECT>^DC=LAN,DC=COCKPIT,CN=alice$
         m.write("/etc/cockpit/cockpit.conf", "[Basic]\naction = none\n", append=True)
         do_test(alice_cert_key, ['HTTP/1.1 200 OK', '"csrf-token"'])
         do_test(['-u', 'alice:foobar123'],
-                ['HTTP/1.1 401 Authentication disabled', '<h1>Authentication disabled</h1>'],
+                ['HTTP/1.1 401 Authentication disabled'],
                 not_expected=["crsf-token"])
 
         # wwithout a CA, alice's cert fails
@@ -906,7 +906,7 @@ matchrule = <SUBJECT>^DC=LAN,DC=COCKPIT,CN=alice$
         self.allow_journal_messages("cockpit-session: Failed to map .* Could not activate remote peer.*")
         self.allow_journal_messages("cockpit-session: Failed to map .* Unit sssd-ifp.service is masked.")
         m.execute("systemctl mask sssd-ifp; systemctl stop sssd-ifp")
-        do_test(alice_cert_key, ["HTTP/1.1 401 Authentication failed", '<h1>Authentication failed</h1>'],
+        do_test(alice_cert_key, ["HTTP/1.1 401 Authentication failed"],
                 not_expected=["crsf-token"])
         m.execute("systemctl unmask sssd-ifp")
 

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -432,7 +432,7 @@ class CommonTests:
         self.allow_journal_messages("cockpit-session: user account access failed: 4 alice: System error")
 
         # cert auth should not be enabled by default
-        do_test(alice_cert_key, ["HTTP/1.1 401 Authentication required", '"authorize"'])
+        do_test(alice_cert_key, ["HTTP/1.1 401 Authentication failed", '"authorize"'])
         # password auth should work (but might need to be retried)
         do_test(alice_user_pass, ['HTTP/1.1 200 OK', '"csrf-token"'], session_leader='cockpit-session', retry=True)
 
@@ -458,14 +458,14 @@ class CommonTests:
         self.allow_journal_messages("cockpit-session: No matching user for certificate")
         m.upload(["bob.pem", "bob.key"], "/var/tmp", relative_dir="src/tls/ca/")
         do_test(['--cert', "/var/tmp/bob.pem", '--key', "/var/tmp/bob.key"],
-                ["HTTP/1.1 401 Authentication failed", '<h1>Authentication failed</h1>'],
+                ["HTTP/1.1 401 Authentication failed"],
                 not_expected=["crsf-token"])
         self.allow_journal_messages("cockpit-session: Failed to map certificate to user: .* Invalid certificate provided")
 
         # disallow password auth
         m.write("/etc/cockpit/cockpit.conf", "[Basic]\naction = none\n", append=True)
         do_test(alice_cert_key, ['HTTP/1.1 200 OK', '"csrf-token"'])
-        do_test(alice_user_pass, ['HTTP/1.1 401 Authentication disabled', '<h1>Authentication disabled</h1>'],
+        do_test(alice_user_pass, ['HTTP/1.1 401 Authentication disabled'],
                 not_expected=["crsf-token"])
 
         # valid user certificate which fails CA validation


### PR DESCRIPTION
If we fail a login attempt in response to receiving a

```json
{ "command": "init", "problem", "..." }
```

control message from the session program, then return the message in full as the result text for the /login page.

This makes use of an until-now dead code path in cockpithandlers that pretty-prints and sets JSON data as the body of the GET /cockpit/login result if it's returned from cockpit_auth_login_finish().  Previously we were returning a fancy fail.html-formatted page which the XHR request in login.js was simply ignoring.

Going forward, this will allow us to forward more interesting errors to the login page.

Adjust the auth tests to expect the response blob in the cases where it's relevant instead of always expecting NULL on the error path.