### PR TITLE
test: drop privileges and then try to upload to /root

### DIFF
--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -944,8 +944,8 @@ OnCalendar=daily
             self.assertEqual(m.execute('ls -A /mnt/upload'), '')
 
         # Upload permission error
-        b.set_file_autocomplete_val("#demo-upload", "/root/")
         b.drop_superuser()
+        b.set_file_autocomplete_val("#demo-upload", "/root/")
         b.upload_files("#demo-upload input[type='file']", [test_upload_file])
         b.wait_in_text(".pf-v5-c-alert", "Not permitted to perform this action")
 


### PR DESCRIPTION
The file component apparently has some state issues when we first set it and then drop privileges. This can be easily reproduced on fedora-coreos by inserting a sleep()

```
b.set_file_autocomplete_val()
import time
time.sleep(5)
b.drop_superuser()
```

Workaround the flake by first dropping privileges and then selecting the directory.

---

This occurs ~ 30% on coreos.

https://cockpit-logs.us-east-1.linodeobjects.com/pull-20950-60f3a41a-20240829-111721-fedora-coreos-expensive/log.html
https://cockpit-logs.us-east-1.linodeobjects.com/pull-6805-b81a66de-20240828-124745-fedora-coreos-expensive-cockpit-project-cockpit/log.html#39