### PR TITLE
test: navigate to the admin page directly

### DIFF
--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -1089,8 +1089,7 @@ class TestAccounts(testlib.MachineCase):
         self.login_and_go("/users")
         b.logout()
 
-        self.login_and_go("/users")
-        b.go("#/admin")
+        self.login_and_go("/users#/admin")
         b.wait_visible("#account-logs")
         # Header + one line of logins
         b.wait_js_func("ph_count_check", "#account-logs tr", 2)


### PR DESCRIPTION
Mysteriously on Fedora-41 this test flakes and fails showing an image of the users page wich makes it seem `b.go()` failed. Work around this flake by directly opening the users page.

---

https://cockpit-logs.us-east-1.linodeobjects.com/pull-20947-89446677-20240827-131830-fedora-41-other/log.html#142
https://cockpit-logs.us-east-1.linodeobjects.com/pull-6790-ab78a2e9-20240826-100045-fedora-41-other-cockpit-project-cockpit/log.html#142