### PR TITLE
selinux: remove deprecated labelOff property of a Switch

### DIFF
--- a/pkg/selinux/setroubleshoot-view.jsx
+++ b/pkg/selinux/setroubleshoot-view.jsx
@@ -260,7 +260,6 @@ class SELinuxStatus extends React.Component {
                     <h2>{_("SELinux policy")}</h2>
                     <Switch isChecked={this.props.selinuxStatus.enforcing}
                             label={_("Enforcing")}
-                            labelOff={_("Permissive")}
                             onChange={this.props.changeSelinuxMode} />
                 </Flex>
                 { note !== null &&


### PR DESCRIPTION
This property has been removed from PatternFly 6 with as reasoning that a label should always convey the value when the checked state is true and should not change based on the selection state.

https://github.com/patternfly/patternfly/issues/6347

Relates: #20973