### PR TITLE
test: drop Fedora-39 from tests

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -45,7 +45,7 @@ if grep -q 'ID=.*fedora' /etc/os-release && [ "$PLAN" = "main" ]; then
     dnf install -y NetworkManager-team
 fi
 
-if grep -Eq 'platform:(f39|f40)' /etc/os-release; then
+if grep -q 'platform:f40' /etc/os-release; then
     # required by TestJournal.testAbrt*
     dnf install -y abrt abrt-addon-ccpp reportd libreport-plugin-bugzilla libreport-fedora
 fi

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -714,7 +714,7 @@ class TestHistoryMetrics(testlib.MachineCase):
         checkEnabled(expected=True)
 
     @testlib.nondestructive
-    @testlib.onlyImage("only Fedora 40 and Fedora 39 have both valkey and redis", "fedora-40", "fedora-39")
+    @testlib.onlyImage("only Fedora 40 has both valkey and redis", "fedora-40")
     def testPmProxySettingsRedis(self):
         self.machine.execute("systemctl mask valkey")
         self.addCleanup(self.machine.execute, "systemctl unmask valkey")
@@ -1260,7 +1260,7 @@ class TestMetricsPackages(packagelib.PackageCase):
         redis_package = "valkey" if redis_service == "valkey" else "redis"
         extra_packages = ""
         if redis_package == "valkey":
-            if m.image in ["fedora-39", "fedora-40"]:
+            if m.image == "fedora-40":
                 # Older Fedoras have the actual redis installed as
                 # well, and we want to remove that too to trigger the
                 # install dialog.

--- a/test/verify/check-system-journal
+++ b/test/verify/check-system-journal
@@ -23,7 +23,7 @@ import testlib
 
 sleep_crash_list_sel = "#journal-box .cockpit-logline .cockpit-log-message:contains('(sleep) crashed in')"
 
-ABRT_OS = ["fedora-39", "fedora-40"]
+ABRT_OS = ["fedora-40"]
 
 
 class TestJournal(testlib.MachineCase):


### PR DESCRIPTION
We longer test on Fedora-39, as we test on 40 and 41.