### PR TITLE
test: Wait longer for health check to fail

### DIFF
--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -140,7 +140,7 @@ class TestConnection(testlib.MachineCase):
 
         try:
             b.switch_to_top()
-            with b.wait_timeout(60):
+            with b.wait_timeout(90):
                 b.wait_visible(".curtains-ct")
 
             b.wait_in_text(".curtains-ct h1", "Disconnected")


### PR DESCRIPTION
I see this on every test run:

  WARNING: Waiting for ph_is_visible(".curtains-ct") took 59.0 seconds, which is 98% of the timeout.

The time it takes for the health check to fail seems to be pretty consistent, so this isn't really a flake. But still, we shouldn't cut it this close, I'd say.