### PR TITLE
test: Rewrite TestGrafanaClient without relying on Promise

### DIFF
--- a/pkg/lib/service.js
+++ b/pkg/lib/service.js
@@ -223,7 +223,7 @@ export function proxy(name, kind) {
             refresh();
     }
 
-    /* HACK - https://bugs.freedesktop.org/show_bug.cgi?id=69575
+    /* HACK - https://github.com/systemd/systemd/issues/570#issuecomment-125334529
      *
      * We need to explicitly get new property values when getting
      * a UnitNew signal since UnitNew doesn't carry them.

--- a/test/common/webdriver_bidi.py
+++ b/test/common/webdriver_bidi.py
@@ -150,7 +150,7 @@ def unpack_value(raw: Any) -> Any:
     if type_ == "object":
         obj = {}
         for k, v in raw["value"]:
-            obj[k] = unpack_value(v["value"])
+            obj[k] = unpack_value(v)
         return obj
     raise ValueError(f"Unknown type in {raw!r}")
 

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1495,7 +1495,6 @@ class TestGrafanaClient(testlib.MachineCase):
             # Select PCP redis, HTTP URL http://10.111.112.1:44322
             redis_url = 'http://10.111.112.1:44322'
             bg.open("/datasources/new")
-            bg.wait_visible("[aria-label='Add new data source PCP Redis']")
             bg.click("[aria-label='Add new data source PCP Redis']")
             bg.set_input_text("input[placeholder='http://localhost:44322']", redis_url)
             bg.click("button:contains('Save &')")  # Save & [tT]est

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1482,23 +1482,41 @@ class TestGrafanaClient(testlib.MachineCase):
 
         # Log into Grafana (usually http://127.0.0.2:3002 if you do it interactively)
         bg = testlib.Browser(mg.forward['3000'], label=self.label() + "-" + mg.label, machine=self)
+
+        # HACK: Grafana uses zone.js which patches the global Promise object
+        # this breaks webdriver's `awaitPromise` logic, so none of our Browser.wait_*() work
+        def bgwait_present(sel):
+            for _ in range(15):
+                if bg.is_present(sel):
+                    break
+                time.sleep(1)
+            else:
+                raise testlib.Error("timed out waiting for " + sel)
+
+        # we don't get the Promise result of ph_find_scroll_into_view, use JS events
+        def bgclick(sel):
+            bgwait_present(sel)
+            bg.mouse(sel, "click", x=1)
+
         try:
             bg.open("/")
-            bg.wait_in_text("body", "Welcome to Grafana")
+            bgwait_present("input[name='password']")
+            testlib.wait(lambda: "Welcome to Grafana" in bg.text("body"))
             bg.set_input_text("input[name='user']", "admin")
             bg.set_input_text("input[name='password']", "foobar")
-            bg.click("button:contains('Log in')")
-            bg.wait_in_text("body", "Add your first data source")
+            bgclick("button:contains('Log in')")
+            testlib.wait(lambda: "Add your first data source" in bg.text("body"))
 
             # Add the PCP redis data source for our client machine
             # Cog (Configuration) menu → Data Sources → Add
             # Select PCP redis, HTTP URL http://10.111.112.1:44322
             redis_url = 'http://10.111.112.1:44322'
             bg.open("/datasources/new")
-            bg.click("[aria-label='Add new data source PCP Redis']")
+            bgclick("[aria-label='Add new data source PCP Redis']")
+            bgwait_present("input[placeholder='http://localhost:44322']")
             bg.set_input_text("input[placeholder='http://localhost:44322']", redis_url)
-            bg.click("button:contains('Save &')")  # Save & [tT]est
-            bg.wait_in_text("body", "Data source is working")
+            bgclick("button:contains('Save &')")  # Save & [tT]est
+            testlib.wait(lambda: "Data source is working" in bg.text("body"))
 
             # Grafana auto-discovers "host" variable for incoming metrics; it takes a while to receive the first
             # measurement; that event is not observable directly in Grafana, and the dashboard does not auto-update to
@@ -1508,20 +1526,20 @@ class TestGrafanaClient(testlib.MachineCase):
             testlib.wait(lambda: mg.execute(f"curl --max-time 10 --silent --show-error '{redis_url}/series/query?expr=kernel.all.load'").strip() != '[]', delay=10, tries=30)
 
             # Switch to "Dashboards" tab, import "Host Overview"
-            bg.click("a[href$='/dashboards'][role=tab]")
-            with bg.wait_timeout(60):
-                bg.wait_not_in_text("body", "Loading")
-            bg.click("tr:contains('PCP Redis: Host Overview') button:contains('Import')")
-            bg.wait_visible("tr:contains('PCP Redis: Host Overview') button:contains('Re-import')")
+            bgclick("a[href$='/dashboards'][role=tab]")
+            testlib.wait(lambda: "Loading" not in bg.text("body"))
+            bgclick("tr:contains('PCP Redis: Host Overview') button:contains('Import')")
+            bgwait_present("tr:contains('PCP Redis: Host Overview') button:contains('Re-import')")
 
             # .. and the dashboard name becomes clickable
-            bg.click("a:contains('PCP Redis: Host Overview')")
+            bgclick("a:contains('PCP Redis: Host Overview')")
 
-            bg.wait_in_text("#var-host", "grafana-client")
+            testlib.wait(lambda: "grafana-client" in bg.text("#var-host"))
 
             # expect a "Load average" panel with sensible numbers
-            bg.wait_in_text("section[data-testid*='Load average'],div[data-testid*='Load average']", "minute")
-            self.assertRegex(bg.text("section[data-testid*='Load average'],div[data-testid*='Load average']"), r"[0-9]\.[0-9]")
+            load_avg_sel = "section[data-testid*='Load average'],div[data-testid*='Load average']"
+            testlib.wait(lambda: "minute" in bg.text(load_avg_sel))
+            self.assertRegex(bg.text(load_avg_sel), r"[0-9]\.[0-9]")
         except Exception:
             bg.snapshot("FAIL-grafana")
             raise


### PR DESCRIPTION
Latest Grafana started to use zone.js [1], which completely replaces the
global `Promise` class with a custom implementation. This doesn't
serialize well through WebDriver, and completely breaks the
`awaitPromise` mode of script evaluation. In other words, this breaks
all our `Browser.wait*()` methods.

So rewrite the Grafana part of `TestGrafanaClient` to use Python-level
polling, and use the old JS-layer mouse click emulation (as the HTML
Element result from `ph_find_scroll_into_view()` also isn't accessible).

See https://github.com/cockpit-project/bots/pull/6838

[1] https://github.com/angular/zone.js

---

Plus a few small fixes.