### PR TITLE
bridge: stop installing our custom PCP log configuration

### DIFF
--- a/src/bridge/Makefile.am
+++ b/src/bridge/Makefile.am
@@ -255,9 +255,6 @@ endif
 
 if ENABLE_PCP
 
-pmlogconfdir = $(localstatedir)/lib/pcp/config/pmlogconf/tools
-dist_pmlogconf_DATA = src/bridge/pmlogconf/cockpit
-
 libexec_PROGRAMS += cockpit-pcp
 
 noinst_LIBRARIES += libcockpit-pcp.a

--- a/src/bridge/pmlogconf/cockpit
+++ b/src/bridge/pmlogconf/cockpit
@@ -1,9 +1,0 @@
-#pmlogconf-setup 2.0
-ident   Metrics used by Cockpit
-force   include
-        kernel.all.cpu.nice
-        kernel.all.cpu.user
-        kernel.all.cpu.sys
-        mem.util.used
-        network.interface.total.bytes
-        disk.dev.total_bytes

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -603,7 +603,6 @@ Cockpit support for reading PCP metrics and loading PCP archives.
 
 %files -n cockpit-pcp -f pcp.list
 %{_libexecdir}/cockpit-pcp
-%{_localstatedir}/lib/pcp/config/pmlogconf/tools/cockpit
 
 %post -n cockpit-pcp
 systemctl reload-or-try-restart pmlogger

--- a/tools/debian/cockpit-pcp.install
+++ b/tools/debian/cockpit-pcp.install
@@ -1,3 +1,2 @@
-var/lib/pcp/config/pmlogconf/tools/cockpit
 usr/lib/cockpit/cockpit-pcp
 usr/share/cockpit/pcp/


### PR DESCRIPTION
The pmlogconf file for Cockpit contained all the metrics we required on the metrics page but got out of sync for a while now.

The default metrics PCP seems to collect are in
/var/lib/pcp/config/pmlogger/config.default which contains all the metrics we request.

---

Important to note that this seems to come from the `pcp` package so we need to check for this and `python3-pcp` on the metrics page. (pcp is also needed for pmlogger ofcourse)