### PR TITLE
cockpit: metrics: remove unneeded last_timestamp check

### DIFF
--- a/src/cockpit/channels/metrics.py
+++ b/src/cockpit/channels/metrics.py
@@ -117,7 +117,7 @@ class InternalMetricsChannel(AsyncChannel):
         return samples
 
     def calculate_sample_rate(self, value: float, old_value: Optional[float]) -> Union[float, bool]:
-        if old_value is not None and self.last_timestamp:
+        if old_value is not None:
             return (value - old_value) / (self.next_timestamp - self.last_timestamp)
         else:
             return False


### PR DESCRIPTION
The work in progress PCP implementation uses similar copy of this function and uncovered an issue when `{ "derive": "rate" }` is passed. Compared to the C implementation it would return [False, False, 1.0] instead of [False, 1.0, 1.0]. As last_timestamp had to change from 0 to something truthy.

This check was in essence unneeded as `x - 0` is always safe. As the PCP Python port drops this condition, drop it here as well.