### PR TITLE
lib: cockpit: log channel instead of control

### DIFF
--- a/pkg/lib/cockpit/_internal/transport.ts
+++ b/pkg/lib/cockpit/_internal/transport.ts
@@ -198,7 +198,7 @@ class Transport extends EventEmitter<{ ready(): void }> {
                 transport_debug("recv control:", control);
             } else {
                 payload = message.substring(nl + 1);
-                transport_debug("recv text message:", control, payload);
+                transport_debug("recv text message:", channel, payload);
             }
         }
 


### PR DESCRIPTION
Control messages are logged in the other if conditional and with this patch we log:

transport.ts:29 recv text message: 2:2!3 [[675520512.0]]

Instead of:

transport.ts:29 recv text message: null [[675520512.0]]