### PR TITLE
flatpak: bump GNOME depend to 47

### DIFF
--- a/.github/workflows/flatpak-test.yml
+++ b/.github/workflows/flatpak-test.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
 
       - name: Build and install flatpak
-        run: ELEMENT_TREE_NO_INDENT=1 dbus-run-session sh -x containers/flatpak/install --user --install-deps-from=flathub
+        run: dbus-run-session sh -x containers/flatpak/install --user --install-deps-from=flathub
 
       - name: Smoke-test the installed flatpak
         run: |

--- a/.github/workflows/flatpak-test.yml
+++ b/.github/workflows/flatpak-test.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Install required build and test dependencies
         run: |
           sudo apt update
-          sudo apt install -y --no-install-recommends autoconf automake elfutils libglib2.0-dev libsystemd-dev xsltproc xmlto gettext flatpak xvfb cockpit-system appstream appstream-util
+          sudo apt install -y --no-install-recommends autoconf automake elfutils libglib2.0-dev libsystemd-dev xsltproc xmlto gettext flatpak xvfb cockpit-system appstream
 
       - name: Configure flathub remote
         run: flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo

--- a/containers/flatpak/Makefile.am
+++ b/containers/flatpak/Makefile.am
@@ -16,12 +16,12 @@ INSTALL_FLATPAK_TARGETS = \
 	$(NULL)
 
 install-for-flatpak: $(INSTALL_FLATPAK_TARGETS)
-	appstream-util validate --nonet src/client/org.cockpit_project.CockpitClient.metainfo.xml
+	appstreamcli validate --no-net src/client/org.cockpit_project.CockpitClient.metainfo.xml
 	if test -s "${DOWNSTREAM_RELEASES_XML}"; then \
 	    $(top_srcdir)/tools/patch-metainfo \
 	        '$(DESTDIR)$(datadir)/metainfo/org.cockpit_project.CockpitClient.metainfo.xml' \
 	        "${DOWNSTREAM_RELEASES_XML}"; \
 	fi
-	appstream-util validate --nonet $(DESTDIR)$(datadir)/metainfo/org.cockpit_project.CockpitClient.metainfo.xml
+	appstreamcli validate --no-net $(DESTDIR)$(datadir)/metainfo/org.cockpit_project.CockpitClient.metainfo.xml
 	cp -rT dist/static $(DESTDIR)$(pkgdatadir)/static
 	rm -rf $(DESTDIR)$(pkgdatadir)/apps $(DESTDIR)$(pkgdatadir)/playground

--- a/containers/flatpak/prepare
+++ b/containers/flatpak/prepare
@@ -86,7 +86,7 @@ def create_manifest(
     return {
         'app-id': FLATPAK_ID,
         'runtime': 'org.gnome.Platform',
-        'runtime-version': '45',
+        'runtime-version': '47',
         'sdk': 'org.gnome.Sdk',
         'command': 'cockpit-client',
         'rename-icon': 'cockpit-client',


### PR DESCRIPTION
The new Sdk drops the old appstream-util command for favour of appstreamcli, so move to using it to validate our files.


Fixes https://github.com/flathub/org.cockpit_project.CockpitClient/issues/46