### PR TITLE
Standardize healthcard CSS

### DIFF
--- a/pkg/systemd/overview-cards/healthCard.scss
+++ b/pkg/systemd/overview-cards/healthCard.scss
@@ -24,6 +24,11 @@
       > :not(a):last-child {
         flex: auto;
       }
+
+      .pf-v5-l-flex {
+        column-gap: var(--pf-v5-global--spacer--sm);
+        row-gap: var(--pf-v5-global--spacer--xs);
+      }
     }
   }
 }


### PR DESCRIPTION
Standardize column-gap to 8px, and row-gap to 4px.

![Screenshot from 2024-09-27 01-22-23](https://github.com/user-attachments/assets/b2916978-85cf-48b3-8608-0c90bcaf8bce)


Fixes: https://github.com/cockpit-project/cockpit/issues/20822