### PR TITLE
storaged: Adjust stratis fs limits layout in creation dialog

### DIFF
--- a/pkg/storaged/stratis/pool.jsx
+++ b/pkg/storaged/stratis/pool.jsx
@@ -43,7 +43,7 @@ import {
 } from "../utils.js";
 
 import {
-    dialog_open, SelectSpaces, TextInput, PassInput, SelectOne, SizeSlider, CheckBoxes,
+    dialog_open, SelectSpaces, TextInput, PassInput, SelectOne, SizeSlider, CheckBoxes, Group,
     BlockingMessage, TeardownMessage,
     init_teardown_usage
 } from "../dialog.jsx";
@@ -92,40 +92,42 @@ function create_fs(pool) {
                       {
                           validate: name => validate_fs_name(null, name, filesystems)
                       }),
-            CheckBoxes("set_custom_size", _("Stratis filesystem"),
-                       {
-                           value: {
-                               enabled: !pool.Overprovisioning,
-                           },
-                           fields: [
-                               { tag: "enabled", title: _("Set initial size") },
-                           ]
-                       }),
-            SizeSlider("size", "",
-                       {
-                           visible: vals => vals.set_custom_size.enabled,
-                           min: fsys_min_size,
-                           max: pool.Overprovisioning ? stats.pool_total : stats.pool_free,
-                           allow_infinite: pool.Overprovisioning,
-                           round: 512
-                       }),
-            CheckBoxes("set_custom_limit", "",
-                       {
-                           value: {
-                               enabled: false,
-                           },
-                           fields: [
-                               { tag: "enabled", title: _("Limit size") },
-                           ]
-                       }),
-            SizeSlider("limit", "",
-                       {
-                           visible: vals => vals.set_custom_limit.enabled,
-                           min: fsys_min_size,
-                           max: pool.Overprovisioning ? stats.pool_total : stats.pool_free,
-                           allow_infinite: true,
-                           round: 512
-                       }),
+            Group(_("Stratis filesystem"), [
+                CheckBoxes("set_custom_size", null,
+                           {
+                               value: {
+                                   enabled: !pool.Overprovisioning,
+                               },
+                               fields: [
+                                   { tag: "enabled", title: _("Set initial size") },
+                               ]
+                           }),
+                SizeSlider("size", null,
+                           {
+                               visible: vals => vals.set_custom_size.enabled,
+                               min: fsys_min_size,
+                               max: pool.Overprovisioning ? stats.pool_total : stats.pool_free,
+                               allow_infinite: pool.Overprovisioning,
+                               round: 512
+                           }),
+                CheckBoxes("set_custom_limit", null,
+                           {
+                               value: {
+                                   enabled: false,
+                               },
+                               fields: [
+                                   { tag: "enabled", title: _("Limit size") },
+                               ]
+                           }),
+                SizeSlider("limit", null,
+                           {
+                               visible: vals => vals.set_custom_limit.enabled,
+                               min: fsys_min_size,
+                               max: pool.Overprovisioning ? stats.pool_total : stats.pool_free,
+                               allow_infinite: true,
+                               round: 512
+                           }),
+            ]),
             TextInput("mount_point", _("Mount point"),
                       {
                           validate: (val, values, variant) => {

--- a/pkg/storaged/stratis/pool.jsx
+++ b/pkg/storaged/stratis/pool.jsx
@@ -92,28 +92,35 @@ function create_fs(pool) {
                       {
                           validate: name => validate_fs_name(null, name, filesystems)
                       }),
-            CheckBoxes("size_options", _("Manage virtual size"),
+            CheckBoxes("set_custom_size", _("Stratis filesystem"),
                        {
                            value: {
-                               custom_size: !pool.Overprovisioning,
-                               custom_limit: false,
+                               enabled: !pool.Overprovisioning,
                            },
                            fields: [
-                               { tag: "custom_size", title: _("Specify initial virtual filesystem size") },
-                               { tag: "custom_limit", title: _("Limit virtual filesystem size") },
+                               { tag: "enabled", title: _("Set initial size") },
                            ]
                        }),
-            SizeSlider("size", _("Initial virtual size"),
+            SizeSlider("size", "",
                        {
-                           visible: vals => vals.size_options.custom_size,
+                           visible: vals => vals.set_custom_size.enabled,
                            min: fsys_min_size,
                            max: pool.Overprovisioning ? stats.pool_total : stats.pool_free,
                            allow_infinite: pool.Overprovisioning,
                            round: 512
                        }),
-            SizeSlider("limit", _("Virtual size limit"),
+            CheckBoxes("set_custom_limit", "",
                        {
-                           visible: vals => vals.size_options.custom_limit,
+                           value: {
+                               enabled: false,
+                           },
+                           fields: [
+                               { tag: "enabled", title: _("Limit size") },
+                           ]
+                       }),
+            SizeSlider("limit", "",
+                       {
+                           visible: vals => vals.set_custom_limit.enabled,
                            min: fsys_min_size,
                            max: pool.Overprovisioning ? stats.pool_total : stats.pool_free,
                            allow_infinite: true,
@@ -136,9 +143,9 @@ function create_fs(pool) {
             Variants: action_variants,
             action: async function (vals) {
                 let size_spec = [false, ""]; let limit_spec = [false, ""];
-                if (vals.size_options.custom_size)
+                if (vals.set_custom_size.enabled)
                     size_spec = [true, vals.size.toString()];
-                if (vals.size_options.custom_limit)
+                if (vals.set_custom_limit.enabled)
                     limit_spec = [true, vals.limit.toString()];
                 const result = await pool.CreateFilesystems([[vals.name, size_spec, limit_spec]]).then(std_reply);
                 if (result[0])

--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -432,7 +432,7 @@ systemctl restart stratisd
 
         b.click(self.card_button("Stratis filesystems", "Create new filesystem"))
         self.dialog_wait_open()
-        self.dialog_wait_val('size_options.custom_size', val=True)
+        self.dialog_wait_val('set_custom_size.enabled', val=True)
         self.dialog_set_val('name', 'fsys1')
         self.dialog_apply_secondary()
         self.dialog_wait_close()
@@ -463,7 +463,7 @@ systemctl restart stratisd
 
         b.click(self.card_button("Stratis filesystems", "Create new filesystem"))
         self.dialog_wait_open()
-        self.dialog_wait_val('size_options.custom_size', val=False)
+        self.dialog_wait_val('set_custom_size.enabled', val=False)
         self.dialog_cancel()
         self.dialog_wait_close()
 
@@ -501,9 +501,9 @@ systemctl restart stratisd
         b.click(self.card_button("Stratis filesystems", "Create new filesystem"))
         self.dialog_wait_open()
         self.dialog_set_val('name', 'fsys1')
-        self.dialog_set_val('size_options.custom_size', val=True)
+        self.dialog_set_val('set_custom_size.enabled', val=True)
         self.dialog_set_val('size', 800)
-        self.dialog_set_val('size_options.custom_limit', val=True)
+        self.dialog_set_val('set_custom_limit.enabled', val=True)
         self.dialog_set_val('limit', 1600)
         self.dialog_apply_secondary()
         self.dialog_wait_close()


### PR DESCRIPTION
Clean up the dialog changes from commit 236ffd3fb612 as per [1]:

 - Visually merge both options into "Stratis filesystem" and avoid extra top-level labels.
 - Point out that the sizes are Stratis specific, as it doesn't say anywhere else in the dialog.
 - Remove redundant "virtual filesystem" words in the options
 - Avoid "Manage", pretty much all of Cockpit is "managing" something.

[1] https://github.com/cockpit-project/cockpit/pull/21039#issuecomment-2373963643

----

The default dialog now looks like this:

![image](https://github.com/user-attachments/assets/46829ad8-d6a9-4b03-b746-4d6df01300d6)

The checkbox separation is a bit awkward -- that's a result from them now being two separate components, instead of a single  group. I tried for about half an hour to mess around with the CSS, but I can't even find the knob which does the flex component spacing. The more obvious ones are `--pf-v5-l-stack--m-gutter--Gap` and `.pf-v5-l-stack.pf-m-gutter gap`, but disabling or changing them to "200px" does not change anything visually. I also looked through all *gap*, *height*, *size*, *padding* etc. properties, and absolutely none of them influence the gap. But then again this is now by design..

With the limits enabled, it now looks like this:

![image](https://github.com/user-attachments/assets/5fc91040-e6a0-4470-a73a-d5d211756535)

I did not do anything about the default value (current default is "max"). I can't judge whether this is right, and presumably we also shouldn't -- it's the admin's job to lower them to a suitable size.

One thing which we should fix though is to not allow setting the limit size below the initial size?