### PR TITLE
Drop remaining libssh references

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends gettext libssh-dev zlib1g-dev libkrb5-dev libxslt1-dev libglib2.0-dev libgnutls28-dev libsystemd-dev libpolkit-agent-1-dev libpcp3-dev libjson-glib-dev libpam0g-dev libpcp-import1-dev libpcp-pmda3-dev systemd xsltproc xmlto docbook-xsl
+          sudo apt-get install -y --no-install-recommends gettext zlib1g-dev libkrb5-dev libxslt1-dev libglib2.0-dev libgnutls28-dev libsystemd-dev libpolkit-agent-1-dev libpcp3-dev libjson-glib-dev libpam0g-dev libpcp-import1-dev libpcp-pmda3-dev systemd xsltproc xmlto docbook-xsl
         if: ${{ matrix.language == 'cpp' }}
 
       - name: Build

--- a/doc/guide/feature-machines.xml
+++ b/doc/guide/feature-machines.xml
@@ -12,9 +12,6 @@
     <link linkend="authentication">authenticated</link> with the logged in
     user's password and/or SSH keys.</para>
 
-  <para>Using SSH keys is only supported when the system has the
-    necessary APIs in libssh.</para>
-
   <para>SSH host keys are stored in
     <filename>/etc/ssh/ssh_known_hosts</filename>.</para>
 

--- a/selinux/cockpit.te
+++ b/selinux/cockpit.te
@@ -60,7 +60,7 @@ can_exec(cockpit_ws_t,ssh_exec_t)
 
 # cockpit-ws can read from /dev/urandom
 dev_read_urand(cockpit_ws_t) # for authkey
-dev_read_rand(cockpit_ws_t)  # for libssh
+dev_read_rand(cockpit_ws_t)  # for ssh
 
 # cockpit-ws allows connections on websm port
 corenet_tcp_bind_websm_port(cockpit_ws_t)

--- a/src/common/preload-temp-home.c
+++ b/src/common/preload-temp-home.c
@@ -42,7 +42,7 @@ get_libc_func(const char *f)
 
 /**
  * Change pw_dir to the value of $HOME for the current uid.
- * This is useful for libssh's expansion of ~ to point to our temporary test
+ * This is useful for ssh's expansion of ~ to point to our temporary test
  * $HOME instead of the real one from /etc/passwd.
  *
  */
@@ -55,7 +55,7 @@ int getpwuid_r(uid_t uid, struct passwd *pwd, char *buf, size_t buflen, struct p
         /* fprintf(stderr, "temp-home wrapped getpwuid_r(uid %i): changing original home %s to $HOME %s\n", (int) uid, pwd->pw_dir, getenv("HOME")); */
         /* note: in theory the caller might change this and thus change the
          * environment, but this is only for the unit tests where we know that
-         * libssh doesn't do that, so avoid any unnecessary copying here */
+         * nothing does that, so avoid any unnecessary copying here */
         pwd->pw_dir = getenv("HOME");
     }
     return res;

--- a/tools/arch/PKGBUILD
+++ b/tools/arch/PKGBUILD
@@ -11,7 +11,7 @@ pkgdesc='A systemd web based user interface for Linux servers'
 arch=('x86_64')
 url='https://cockpit-project.org/'
 license=(LGPL)
-makedepends=(krb5 libssh accountsservice json-glib glib-networking glib2-devel
+makedepends=(krb5 accountsservice json-glib glib-networking glib2-devel
              git intltool gtk-doc gobject-introspection networkmanager xmlto npm pcp
              python-build python-installer python-wheel)
 source=("cockpit-${pkgver}.tar.xz"
@@ -40,7 +40,7 @@ build() {
 }
 
 package_cockpit() {
-  depends=(krb5 libssh json-glib glib-networking python)
+  depends=(krb5 json-glib glib-networking python)
   backup=('etc/pam.d/cockpit' 'etc/cockpit/disallowed-users')
   optdepends=("cockpit-pcp: reading performance metrics"
               "cockpit-storaged: manage storage"


### PR DESCRIPTION
Cleanup after #19441. In particular, drop the dependency in the Arch packaging.