### PR TITLE
shell: Use the "load" event instead of polling to catch ready frames

### DIFF
--- a/pkg/shell/state.jsx
+++ b/pkg/shell/state.jsx
@@ -123,11 +123,9 @@ export function ShellState() {
      * for its "ready", "loaded", and "hash" properties.
      *
      * The "ready" property starts out false and goes to true once the
-     * corresponding iframe has created the document and window
-     * objects for the actual frame content and you can attach event
-     * handlers to it. The "loaded" property starts out false and goes
-     * true once the code loaded into the frame has sent its "init"
-     * message.
+     * corresponding iframe has loaded its URL. The "loaded" property
+     * starts out false and goes true once the code loaded into the
+     * frame has sent its "init" message.
      *
      * Removing things (frames) is complicated, as usual.  We need to
      * be able to represent the state "The current frame has been

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -191,6 +191,10 @@ OnCalendar=daily
         b.click("#display-language-modal footer button.pf-m-primary")
         b.wait_language("de-de")
 
+        # Wait for the shell to be fully loaded again so that b.go()
+        # starts working.
+        b.enter_page("/metrics")
+
         # Check that the system page is translated
         b.go("/system")
         b.enter_page("/system")
@@ -549,6 +553,11 @@ OnCalendar=daily
         b.click('#display-language-modal li[data-value=de-de] button')
         b.click("#display-language-modal footer button.pf-m-primary")
         b.wait_language("de-de")
+
+        # Wait for the shell to be fully loaded again so that b.go()
+        # starts working.
+        b.enter_page("/network/firewall")
+
         b.go("/system")
         b.enter_page("/system")
         b.wait_in_text(".ct-overview-header", "Neustart")

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -446,9 +446,6 @@ OnCalendar=daily
         # On Ubuntu and Debian we would need to generate locales - just ignore it
         self.allow_journal_messages("invalid or unusable locale: de_DE.UTF-8")
 
-        # Clean up failed services for screenshots
-        m.execute("systemctl reset-failed")
-
         self.login_and_go()
 
         filter_sel = ".pf-v5-c-text-input-group__text-input"
@@ -480,7 +477,10 @@ OnCalendar=daily
         b.wait_text("#host-apps li a:contains('Services')", "ServicesContains: systemd")
         b.wait_text("#host-apps li a:contains('Services') mark", "systemd")
 
+        # Clean up failed services for screenshots
+        m.execute("systemctl reset-failed")
         b.wait_not_present("#services-error")
+
         b.assert_pixels("#nav-system", "menu-search", skip_layouts=["mobile"])
         b.set_layout("mobile")
         b.click("#nav-system-item")

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -395,23 +395,30 @@ OnCalendar=daily
 
     def testFrameReload(self):
         b = self.browser
+        m = self.machine
+
         frame = "cockpit1:localhost/playground/test"
         self.addCleanup(self.machine.execute, "rm -f /tmp/counter")
 
         self.login_and_go("/playground/test")
 
-        b.wait_text('#file-content', "0")
-        b.click("#modify-file")
-        b.wait_text('#file-content', "1")
+        # Check that channels are closed when a frame is reloaded.
 
+        # Lock a file, that keeps a channel open.
+        m.execute("touch /tmp/playground-test-lock")
+        b.click(".lock-channel button")
+        b.wait_in_text(".lock-channel span", 'locked')
+        m.execute("! flock --nonblock /tmp/playground-test-lock true")
+
+        # Now reload the frame by kicking its "src" attribute.
         b.switch_to_top()
-        b.eval_js('ph_set_attr("iframe[name=\'%s\']", "data-ready", null)' % frame)
         b.eval_js('ph_set_attr("iframe[name=\'%s\']", "src", "../playground/test.html?i=1#/")' % frame)
-        b.wait_visible(f"iframe.container-frame[name='{frame}'][data-ready]")
+
+        # The channel and the lock should have gone away
+        m.execute("flock --timeout 10 /tmp/playground-test-lock true")
 
         b.enter_page("/playground/test")
-
-        b.wait_text('#file-content', "1")
+        b.wait_not_in_text(".lock-channel span", 'locked')
 
         self.allow_restart_journal_messages()
 

--- a/test/verify/check-shell-menu
+++ b/test/verify/check-shell-menu
@@ -175,6 +175,7 @@ class TestMenu(testlib.MachineCase):
         # reset
         b.reload()
         b.wait_visible("#hosts-sel")
+        b.wait_text("#super-user-indicator", "Administrative access")
 
         # press Tab twice → "Skip main navigation" skiplink
         b.key("Tab")
@@ -186,20 +187,12 @@ class TestMenu(testlib.MachineCase):
         self.assertEqual(b.eval_js("document.activeElement.getAttribute('id')"), "hosts-sel")
 
         # actually skips the page menu and goes on to top nav bar; where exactly depends on whether
-        # the host switcher is enabled, and whether the privilege button is visible (not with ws container)
+        # the host switcher is enabled.
         b.key("Tab")
         if self.multihost_enabled:
             b.wait_js_cond("document.activeElement.getAttribute('id') === 'host-toggle'")
             b.key("Tab")
-            if self.machine.ostree_image:
-                b.wait_js_cond("document.activeElement.textContent === 'Help'")
-            else:
-                b.wait_js_cond("document.activeElement.textContent === 'Administrative access'")
-        else:
-            if self.machine.ostree_image:
-                b.wait_js_cond("document.activeElement.textContent === 'Help'")
-            else:
-                b.wait_js_cond("document.activeElement.textContent === 'Administrative access'")
+        b.wait_js_cond("document.activeElement.textContent === 'Administrative access'")
 
         # reset
         b.reload()

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -589,6 +589,7 @@ class TestMultiMachine(testlib.MachineCase):
     @testlib.todoPybridgeRHEL8()
     def testFrameReload(self):
         b = self.browser
+        m2 = self.machines["machine2"]
 
         frame = "cockpit1:10.111.113.2/playground/test"
         m2_path = "/@10.111.113.2/playground/test"
@@ -601,9 +602,13 @@ class TestMultiMachine(testlib.MachineCase):
         b.go(m2_path)
         b.enter_page("/playground/test", "10.111.113.2")
 
-        b.wait_text('#file-content', "0")
-        b.click("#modify-file")
-        b.wait_text('#file-content', "1")
+        # Check that channels are closed when a frame is reloaded.
+
+        # Lock a file on m2, that keeps a channel open.
+        m2.execute("touch /tmp/playground-test-lock")
+        b.click(".lock-channel button")
+        b.wait_in_text(".lock-channel span", 'locked')
+        m2.execute("! flock --nonblock /tmp/playground-test-lock true")
 
         # load the same page on m1
         b.switch_to_top()
@@ -611,20 +616,18 @@ class TestMultiMachine(testlib.MachineCase):
         b.enter_page("/playground/test")
         b.wait_text('#file-content', "0")
 
-        # go back to m2 and reload frame.
-        b.switch_to_top()
+        # Now reload the m2 frame by kicking its "src" attribute.
         b.go(m2_path)
         b.enter_page("/playground/test", "10.111.113.2")
-        b.wait_text('#file-content', "1")
+        b.wait_in_text(".lock-channel span", 'locked')
         b.switch_to_top()
-
-        b.eval_js('ph_set_attr("iframe[name=\'%s\']", "data-ready", null)' % frame)
         b.eval_js('ph_set_attr("iframe[name=\'%s\']", "src", "../playground/test.html?i=1#/")' % frame)
-        b.wait_visible(f"iframe.container-frame[name='{frame}'][data-ready]")
+
+        # The channel and the lock should have gone away
+        m2.execute("flock --timeout 10 /tmp/playground-test-lock true")
 
         b.enter_page("/playground/test", "10.111.113.2")
-
-        b.wait_text('#file-content', "1")
+        b.wait_not_in_text(".lock-channel span", 'locked')
 
         self.allow_hostkey_messages()
 


### PR DESCRIPTION
- [x] TestPages flakes with Firefox

