### PR TITLE
test: Don't explicitly go to x0.cockpit.lan in TestIPA

### DIFF
--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -592,7 +592,7 @@ class TestIPA(TestRealms, CommonTests):
 
         # check respecting FreeIPA's/sssd's ssh known host keys; login_and_go() does not expect/answer
         # unknown host prompts
-        b.login_and_go(user=f'{self.admin_user}@cockpit.lan', password=self.admin_password, host="x0.cockpit.lan")
+        b.login_and_go(user=f'{self.admin_user}@cockpit.lan', password=self.admin_password)
         # starts proper session
         m.execute("until loginctl --no-legend list-sessions | grep -qi 'admin@COCKPIT.LAN.*web console'; do sleep 1; done", timeout=10)
         b.logout()


### PR DESCRIPTION
x0.cockpit.lan is the name of the local machine, but specifying it with login_and_go will navigate to it as a remote host, using a URL like

    https://127.0.0.2:9091/@x0.cockpit.lan

This is not needed since the test only wants the session on localhost, and doesn't care what happens inside the session. It would be harmless except that Cockpit might spontaneously open the "Add host" dialog for "x0.cockpit.lan", which will make the session menu inaccessible for the subsequent logout. (Only on Firefox, Chrome manages to open it anyway.)