### PR TITLE
metrics: remove re-login requirement for loading PCP metrics

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1327,13 +1327,6 @@ class TestMetricsPackages(packagelib.PackageCase):
         b.click(".pf-v5-c-empty-state button.pf-m-primary")
         b.click("#dialog button:contains('Install')")
         b.wait_not_present("#dialog")
-        b.click("button:contains('Log out')")
-        b.leave_page()
-        b.click("button:contains('Reconnect')")
-        b.set_val("#login-user-input", "admin")
-        b.set_val("#login-password-input", "foobar")
-        b.click('#login-button')
-        b.enter_page("/metrics")
         b.wait_in_text(".pf-v5-c-empty-state", "Metrics history could not be loaded")
         b.logout()
 
@@ -1353,17 +1346,11 @@ class TestMetricsPackages(packagelib.PackageCase):
         m.execute('until [ $(systemctl is-enabled pmlogger) = enabled ]; do sleep 1; done')
         # also needs to wait for activating → active
         m.execute('until [ $(systemctl is-active pmlogger) = active ]; do sleep 1; done')
-        # triggers "needs logout"
-        b.click("button:contains('Log out')")
-        b.leave_page()
-        b.click("button:contains('Reconnect')")
-        b.set_val("#login-user-input", "admin")
-        b.set_val("#login-password-input", "foobar")
-        b.click('#login-button')
-        b.enter_page("/metrics")
-        # this is just a fake python3-pcp package
         b.wait_in_text(".pf-v5-c-empty-state", "Metrics history could not be loaded")
         b.wait_in_text(".pf-v5-c-empty-state", "pmlogger.service is failing to collect data")
+        # wait till systemd actions are finished before opening a new dialog,
+        # not doing so creates a race where Dialogs.close() can be called when opening a new dialog.
+        b.wait_visible("#metrics-header-section button.pf-m-secondary[data-test-install-finished='done']")
 
         # install redis
         b.click("#metrics-header-section button.pf-m-secondary")

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1352,6 +1352,13 @@ class TestMetricsPackages(packagelib.PackageCase):
         # not doing so creates a race where Dialogs.close() can be called when opening a new dialog.
         b.wait_visible("#metrics-header-section button.pf-m-secondary[data-test-install-finished='done']")
 
+        # HACK: There's a PF bug that makes the memory tooltip stay around forever
+        # once opening the PCP config dialog; make sure it goes away, to avoid
+        # obscuring the pmproxy switch
+        if b.is_present(".pf-v5-c-tooltip"):
+            b.mouse("#current-memory-usage-description", "mouseleave")
+            b.wait_not_present(".pf-v5-c-tooltip")
+
         # install redis
         b.click("#metrics-header-section button.pf-m-secondary")
         b.wait_visible(self.pcp_dialog_selector)


### PR DESCRIPTION
With the switch to the python PCP implementation the metrics page no longer needs to re-login to load the new pcp manifest. The Python bridge will re-attempt import the PCP module and then load metrics as expected with one minor issue that uninstalling python3-pcp keeps the PCP module in memory.