### PR TITLE
Revert "lib: Port cockpit-components-file-autocomplete.jsx to fsinfo"

### DIFF
--- a/test/verify/check-shell-keys
+++ b/test/verify/check-shell-keys
@@ -313,7 +313,7 @@ session    optional     pam_ssh_add.so
         b.wait_in_text("#credentials-modal .pf-v5-c-select__menu-item.pf-m-disabled", "No such file or directory")
         b.focus("#credentials-modal .pf-v5-c-select__toggle-typeahead input")
         b.key("Backspace", 5)
-        b.wait_visible("#credentials-modal .pf-v5-c-select__menu-item.dir:contains('/var/lib/')")
+        b.wait_visible("#credentials-modal .pf-v5-c-select__menu-item.directory:contains('/var/lib/')")
         b.click("#credentials-modal .pf-v5-c-select__toggle-clear")
         b.wait_val("#credentials-modal .pf-v5-c-select__toggle-typeahead input", "")
 


### PR DESCRIPTION
This reverts commit 03fcd561ac30f716cca945d844bd93ad6b33363a.

The "fsinfo" channel does not work on rhel-8-10.