### PR TITLE
sosreport: Explicitly specify "host" in download channel options

### DIFF
--- a/pkg/sosreport/sosreport.jsx
+++ b/pkg/sosreport/sosreport.jsx
@@ -200,6 +200,7 @@ function sosCreate(args, setProgress, setError, setErrorDetail) {
 function sosDownload(path) {
     const basename = path_basename(path);
     const query = window.btoa(JSON.stringify({
+        host: cockpit.transport.host,
         payload: "fsread1",
         binary: "raw",
         path,


### PR DESCRIPTION
This makes it work when downloading from a remote machine.

No default will be provided by Cockpit itself, unlike with cockpit.channel() etc.
