### PR TITLE
test: Add test for Machine.clone_container() API

### DIFF
--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -7,7 +7,7 @@ PLAN="$1"
 cd "${SOURCE}"
 
 # tests need cockpit's bots/ libraries
-git clone --depth=1 https://github.com/cockpit-project/bots
+git clone -b nspawn-machine --depth=1 https://github.com/cockpit-project/bots
 
 # release tarballs include the necessary npm modules for testing
 if [ -d .git ]; then

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -47,6 +47,7 @@ if [ "$PLAN" = "main" ]; then
            TestAccounts
            TestBonding
            TestBridge
+           TestConnection.testCloneContainer
            TestFirewall
            TestJournal
            TestKdump

--- a/test/run
+++ b/test/run
@@ -18,6 +18,8 @@
 
 set -eu
 
+export COCKPIT_BOTS_REF=nspawn-machine
+
 test/common/make-bots
 test/common/pixel-tests pull
 

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -1222,6 +1222,25 @@ UnixPath=/run/cockpit/session
         self.assertGreater(len(bridges), 0)
         self.assertIn('sudo', bridge_names)
 
+    @testlib.skipOstree("OSTree doesn't have networkd")
+    @testlib.nondestructive
+    def testCloneContainer(self):
+        m = self.machine
+        m2 = m.clone_container()
+
+        # the two now have independent file systems
+        m.write("/tmp/stamp-host", "host")
+        m.write("/run/stamp-host", "host")
+        m2.write("/tmp/stamp-container", "container")
+        m2.write("/run/stamp-container", "container")
+        m.execute("! ls /tmp/stamp-container; ! ls /run/stamp-container")
+        m2.execute("! ls /tmp/stamp-host; ! ls /run/stamp-host")
+
+        # and independent systemd
+        m.execute("systemctl stop systemd-hostnamed.service")
+        m2.execute("systemctl start systemd-hostnamed.service")
+        m.execute("! systemctl status systemd-hostnamed.service")
+
 
 class TestReverseProxy(testlib.MachineCase):
 


### PR DESCRIPTION
Check that we can clone a container and that it is isolated from the host.

---

This depends on, and temporarily tests against https://github.com/cockpit-project/bots/pull/6974

The first version is just a simple test, I want to see how it works across our OSes. Once I settled that, I'll convert a destructive `provision` test.