### PR TITLE
Fix LICENSE.txt installation and most Debian lintian messages

### DIFF
--- a/pkg/Makefile.am
+++ b/pkg/Makefile.am
@@ -34,9 +34,11 @@ $(DIST_STAMP): $(srcdir)/package-lock.json $(PKG_INPUTS)
 
 EXTRA_DIST += build.js files.js package.json package-lock.json
 
+# don't install empty LEGAL.txt files, see https://github.com/evanw/esbuild/issues/3670
 INSTALL_DATA_LOCAL_TARGETS += install-bundles
 install-bundles:
-	cd $(srcdir)/dist; find */* -type f -exec install -D -m 644 '{}' '$(abspath $(DESTDIR)$(datadir))/cockpit/{}' \;
+	cd $(srcdir)/dist; find */* -type f ! -name '*.LEGAL.txt' -exec install -D -m 644 '{}' '$(abspath $(DESTDIR)$(datadir))/cockpit/{}' \;
+	find $(srcdir)/dist -name '*.LEGAL.txt' ! -empty -exec install --target-directory '$(abspath $(DESTDIR)$(docdir))/legal' '{}' -D -m 644 '{}'  \;
 
 UNINSTALL_LOCAL_TARGETS += uninstall-bundles
 uninstall-bundles:

--- a/tools/debian/cockpit-bridge.lintian-overrides
+++ b/tools/debian/cockpit-bridge.lintian-overrides
@@ -1,0 +1,2 @@
+# not documentation, but bridge fallback for errors
+cockpit-bridge: package-contains-documentation-outside-usr-share-doc *data/fail.html*

--- a/tools/debian/cockpit-networkmanager.lintian-overrides
+++ b/tools/debian/cockpit-networkmanager.lintian-overrides
@@ -1,0 +1,1 @@
+cockpit-networkmanager: package-contains-documentation-outside-usr-share-doc *usr/share/cockpit/*html*

--- a/tools/debian/cockpit-packagekit.lintian-overrides
+++ b/tools/debian/cockpit-packagekit.lintian-overrides
@@ -1,0 +1,1 @@
+cockpit-packagekit: package-contains-documentation-outside-usr-share-doc *usr/share/cockpit/*html*

--- a/tools/debian/cockpit-sosreport.lintian-overrides
+++ b/tools/debian/cockpit-sosreport.lintian-overrides
@@ -1,0 +1,1 @@
+cockpit-sosreport: package-contains-documentation-outside-usr-share-doc *usr/share/cockpit/*html*

--- a/tools/debian/cockpit-storaged.lintian-overrides
+++ b/tools/debian/cockpit-storaged.lintian-overrides
@@ -1,0 +1,1 @@
+cockpit-storaged: package-contains-documentation-outside-usr-share-doc *usr/share/cockpit/*html*

--- a/tools/debian/cockpit-system.lintian-overrides
+++ b/tools/debian/cockpit-system.lintian-overrides
@@ -1,0 +1,1 @@
+cockpit-system: package-contains-documentation-outside-usr-share-doc *usr/share/cockpit/*html*

--- a/tools/debian/cockpit-tests.lintian-overrides
+++ b/tools/debian/cockpit-tests.lintian-overrides
@@ -1,0 +1,1 @@
+cockpit-tests: package-contains-documentation-outside-usr-share-doc *usr/share/cockpit/*html*

--- a/tools/debian/cockpit-tests.lintian-overrides
+++ b/tools/debian/cockpit-tests.lintian-overrides
@@ -1,1 +1,3 @@
 cockpit-tests: package-contains-documentation-outside-usr-share-doc *usr/share/cockpit/*html*
+# triggered on demand by cockpit.service
+cockpit-tests: systemd-service-file-missing-documentation-key *cockpit-session@.service*

--- a/tools/debian/cockpit-ws.lintian-overrides
+++ b/tools/debian/cockpit-ws.lintian-overrides
@@ -4,6 +4,11 @@ cockpit-ws: font-outside-font-dir *usr/share/cockpit/static/fonts/*
 cockpit-ws: font-in-non-font-package *usr/share/cockpit/static/fonts/*
 cockpit-ws: groff-message *macro *an-trap*usr/share/man/man8/cockpit-ws.8.gz*
 cockpit-ws: package-contains-documentation-outside-usr-share-doc *usr/share/cockpit/*html*
+# the binaries are in /usr/lib/cockpit, but we still want to document them
+cockpit-ws: spare-manual-page *cockpit-desktop.*
+cockpit-ws: spare-manual-page *cockpit-tls.*
+cockpit-ws: spare-manual-page *cockpit-ws.*
+cockpit-ws: spare-manual-page *pam_ssh_add*
 # triggered on demand by cockpit.service
 cockpit-ws: systemd-service-file-missing-install-key *cockpit-wsinstance*
 # triggered by cockpit.socket

--- a/tools/debian/cockpit-ws.lintian-overrides
+++ b/tools/debian/cockpit-ws.lintian-overrides
@@ -3,3 +3,4 @@ cockpit-ws: shared-library-lacks-prerequisites *security/pam_cockpit_cert.so*
 cockpit-ws: font-outside-font-dir *usr/share/cockpit/static/fonts/*
 cockpit-ws: font-in-non-font-package *usr/share/cockpit/static/fonts/*
 cockpit-ws: groff-message *macro *an-trap*usr/share/man/man8/cockpit-ws.8.gz*
+cockpit-ws: package-contains-documentation-outside-usr-share-doc *usr/share/cockpit/*html*

--- a/tools/debian/cockpit-ws.lintian-overrides
+++ b/tools/debian/cockpit-ws.lintian-overrides
@@ -4,3 +4,7 @@ cockpit-ws: font-outside-font-dir *usr/share/cockpit/static/fonts/*
 cockpit-ws: font-in-non-font-package *usr/share/cockpit/static/fonts/*
 cockpit-ws: groff-message *macro *an-trap*usr/share/man/man8/cockpit-ws.8.gz*
 cockpit-ws: package-contains-documentation-outside-usr-share-doc *usr/share/cockpit/*html*
+# triggered on demand by cockpit.service
+cockpit-ws: systemd-service-file-missing-install-key *cockpit-wsinstance*
+# triggered by cockpit.socket
+cockpit-ws: systemd-service-file-missing-install-key *cockpit.service*

--- a/tools/debian/cockpit.lintian-overrides
+++ b/tools/debian/cockpit.lintian-overrides
@@ -1,0 +1,1 @@
+cockpit: spare-manual-page *cockpit.*

--- a/tools/debian/copyright.template
+++ b/tools/debian/copyright.template
@@ -53,49 +53,6 @@ License: LGPL-2.1-or-later
  On Debian systems, the complete text of the GNU Lesser General
  Public License can be found in "/usr/share/common-licenses/LGPL-2.1".
 
-License: GPL-2+
- This program is free software; you can redistribute it and/or modify it
- under the terms of the GNU General Public License as published by the
- Free Software Foundation; either version 2 of the License, or (at your
- option) any later version.
- .
- This program is distributed in the hope that it will be useful, but
- WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- for more details.
- .
- On Debian systems, the complete text of the GNU General
- Public License can be found in "/usr/share/common-licenses/GPL-2".
-
-License: BSD-4-clause
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions
- are met:
- 1. Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
- 2. Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
- 3. All advertising materials mentioning features or use of this software
- must display the following acknowledgment:
- This product includes software developed by the University of
- California, Berkeley and its contributors.
- 4. Neither the name of the University nor the names of its contributors
- may be used to endorse or promote products derived from this software
- without specific prior written permission.
- .
- THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
- FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
- OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
- SUCH DAMAGE.
-
 License: MIT
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to
@@ -158,16 +115,3 @@ License: MIT-IBM-immunity
  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER ARISING
  OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE, EVEN
  IF IBM IS APPRISED OF THE POSSIBILITY OF SUCH DAMAGES.
-
-License: Apache-2.0
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
- .
- https://www.apache.org/licenses/LICENSE-2.0.html
- .
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.

--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -51,6 +51,9 @@ override_dh_install:
 	# handled by package maintainer scripts
 	rm debian/tmp/etc/motd.d/cockpit debian/tmp/etc/issue.d/cockpit.issue
 
+	# already processed into debian/copyright
+	rm -r debian/tmp/usr/share/doc/cockpit/legal
+
 	# unpackaged modules
 	rm -r debian/tmp/usr/share/cockpit/kdump
 	rm debian/tmp/usr/share/metainfo/org.cockpit_project.cockpit_kdump.metainfo.xml

--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -1,5 +1,7 @@
 #!/usr/bin/make -f
 
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
 # we need an apparmor profile for >= 4.0; this exists in Ubuntu >= 24.04, but not in Debian yet


### PR DESCRIPTION
[Current Debian builds](https://cockpit-logs.us-east-1.linodeobjects.com/pull-21103-0f79b0ea-20241010-101123-debian-testing-other/log) (search for "lintian --fail") have two screenfuls of lintian messages. This fixes most of them.

The remaining ones are

> I: cockpit-tests: arch-dep-package-has-big-usr-share 18085kB 100%
> I: cockpit-system: ored-depends-on-obsolete-package Recommends: policykit-1 => polkitd and optionally pkexec
> I: cockpit-doc: possible-documentation-but-no-doc-base-registration

which are harmless. The second one is intended, as that's just an alternate dependency for backports. But it's a good reminder to clean it up some day.