### PR TITLE
systemd: Don't open and close tuned DBus connections asynchronously

### DIFF
--- a/pkg/lib/service.js
+++ b/pkg/lib/service.js
@@ -290,9 +290,9 @@ export function proxy(name, kind) {
 
             call_manager(dbus, method, args)
                     .then(([path]) => { pending_job_path = path })
-                    .catch(() => {
+                    .catch(ex => {
                         dbus.close();
-                        reject();
+                        reject(ex);
                     });
         });
     }


### PR DESCRIPTION
The TunedPerformanceProfile component was keeping a DBus connection open to tuned, and was closing and reopening it whenever something might have changed that requires it.

This happened asynchronously with the rest of the code that was using this DBus connection, and would frequently cause that code to fail with "disconnected" errors.

Also, the TunedDialog was itself causing changes that require a new DBus connection (namely starting the tuned.service), but was always working with the one that was originally passed into it via its properties.

Let's straighten this all out:

 - Polling for the button state will open its own dedicated DBUs connection and close it when polling is done.  There is no need to keep a DBus connection open for the whole Cockpit session.

 - The tuned.service is started when the dialog is opened and a DBus
   connection is opened explicitly for the dialog after that and
   closed when the dialog is closed.