### PR TITLE
containers/ws: Install our other Cockpit pages

### DIFF
--- a/containers/ws/install.sh
+++ b/containers/ws/install.sh
@@ -6,6 +6,17 @@ OSVER=$(. /etc/os-release && echo "$VERSION_ID")
 INSTALLROOT=/build
 INSTALL="dnf install -y --installroot=$INSTALLROOT --releasever=$OSVER --setopt=install_weak_deps=False"
 
+# keep in sync with test/ostree.install
+PACKAGES="
+kdump
+networkmanager
+packagekit
+selinux
+sosreport
+storaged
+system
+"
+
 dnf install -y 'dnf-command(download)' cpio
 $INSTALL coreutils-single util-linux-core sed sscg python3 openssh-clients
 
@@ -20,15 +31,14 @@ unpack() {
 # -system and -networkmanager are only for beibooting; don't install their dependencies
 if [ -n "$rpm" ]; then
     $INSTALL /container/rpms/cockpit-ws-*$OSVER.*$arch.rpm /container/rpms/cockpit-bridge-*$OSVER.*$arch.rpm
-    for rpm in /container/rpms/cockpit-system-*$OSVER.*$arch.rpm \
-             /container/rpms/cockpit-networkmanager-*$OSVER.*$arch.rpm; do
-        unpack $rpm
+    for rpm in $PACKAGES; do
+        unpack /container/rpms/cockpit-$rpm-*$OSVER.*$arch.rpm
     done
 else
     $INSTALL cockpit-ws cockpit-bridge
-    dnf download cockpit-networkmanager cockpit-system
-    for rpm in cockpit-networkmanager*.rpm cockpit-system*.rpm; do
-        unpack $rpm
+    for rpm in $PACKAGES; do
+        dnf download cockpit-$rpm
+        unpack cockpit-$rpm-*.rpm
     done
 fi
 

--- a/pkg/apps/manifest.json
+++ b/pkg/apps/manifest.json
@@ -1,4 +1,8 @@
 {
+    "conditions": [
+        {"path-exists": "/lib/systemd/system/packagekit.service"},
+        {"path-not-exists": "/sysroot/ostree"}
+    ],
     "tools": {
         "index": {
             "label": "Applications",

--- a/pkg/apps/manifest.json
+++ b/pkg/apps/manifest.json
@@ -1,5 +1,6 @@
 {
     "conditions": [
+        {"path-exists": "/usr/bin/cockpit-bridge"},
         {"path-exists": "/lib/systemd/system/packagekit.service"},
         {"path-not-exists": "/sysroot/ostree"}
     ],

--- a/test/ostree.install
+++ b/test/ostree.install
@@ -1,6 +1,17 @@
 #!/bin/sh
 set -eu
 
+# keep in sync with containers/ws/install.sh
+PACKAGES="
+kdump
+networkmanager
+packagekit
+selinux
+sosreport
+storaged
+system
+"
+
 cd /var/tmp/
 
 # install/upgrade RPMs that apply to OSTree
@@ -9,12 +20,8 @@ rpm-ostree install --cache-only cockpit-bridge-*.rpm \
     cockpit-networkmanager-*.rpm cockpit-system-*.rpm cockpit-tests-*.rpm
 
 # update cockpit packages and install scripts in the container
-for rpm in /var/tmp/cockpit-ws-*.rpm \
-           /var/tmp/cockpit-bridge-*.rpm \
-           /var/tmp/cockpit-networkmanager-*.rpm \
-           /var/tmp/cockpit-system-*.rpm \
-           /var/tmp/cockpit-tests-*.rpm; do
-    rpm2cpio "$rpm" | cpio -i --make-directories --directory=/var/tmp/install
+for rpm in ws bridge tests $PACKAGES; do
+    rpm2cpio /var/tmp/cockpit-$rpm-*.rpm | cpio -i --make-directories --directory=/var/tmp/install
 done
 podman run --name build-cockpit -i \
     -v /var/tmp/:/run/build:Z \

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -391,6 +391,20 @@ This <is <not XML.
         b.wait_not_present(".pf-v5-c-empty-state")
         b.wait_visible(".app-list .pf-v5-c-data-list__item-row:contains('Summary 2')")
 
+    def testNoPackageKit(self):
+        b = self.browser
+        m = self.machine
+
+        m.execute("systemctl stop packagekit")
+        system_service = m.execute("systemctl show -p FragmentPath packagekit.service | cut -f2 -d=").strip()
+        m.execute(f"mv {system_service} {system_service}.disabled")
+        self.addCleanup(m.execute, f"mv {system_service}.disabled {system_service}")
+
+        self.assertNotIn("\napps", m.execute("cockpit-bridge --packages"))
+        self.login_and_go(None)
+        b.wait_in_text("#host-apps", "Terminal")
+        self.assertNotIn("Applications", b.text("#host-apps"))
+
 
 if __name__ == '__main__':
     testlib.test_main()

--- a/test/verify/check-ws-bastion
+++ b/test/verify/check-ws-bastion
@@ -70,6 +70,10 @@ class TestWsBastionContainer(testlib.MachineCase):
 
         b.wait_visible('#content')
         b.wait_text('#current-username', 'admin')
+        # Our test VM only pre-installs -system and -networkmanager
+        b.wait_in_text("#host-apps", "Overview")
+        b.wait_in_text("#host-apps", "Networking")
+        self.assertNotIn("Kernel dump", b.text("#host-apps"))
         # runs the ssh target's bridge (no beiboot)
         m.execute("pgrep -f /usr/bin/[c]ockpit-bridge")
         b.logout()
@@ -89,6 +93,14 @@ class TestWsBastionContainer(testlib.MachineCase):
         b.try_login()
         b.wait_visible('#content')
         m.execute("pgrep -f '[p]ython3 -ic # cockpit-bridge'")
+        # beiboot mode has extra included pages
+        b.wait_in_text("#host-apps", "Overview")
+        b.wait_in_text("#host-apps", "Networking")
+        b.wait_in_text("#host-apps", "Kernel dump")
+        b.wait_in_text("#host-apps", "SELinux")
+        # but Storage and Applications are hidden due to failing manifest conditions
+        self.assertNotIn("Storage", b.text("#host-apps"))
+        self.assertNotIn("Applications", b.text("#host-apps"))
         b.logout()
 
     def testKnownHosts(self):


### PR DESCRIPTION
Kdump, Networking, SELinux, Storaged, and Software Updates are all fine
and useful for beiboot mode. Apps doesn't, but that's hidden by the
manifest condition.

---

Plus two fixes for the Applications page.

Aside from boosting the ws container, this is also a prerequisite for https://issues.redhat.com/browse/COCKPIT-1178.