### PR TITLE
beiboot: Enable beiboot feature for distro packages for same OS

### DIFF
--- a/pkg/static/login.js
+++ b/pkg/static/login.js
@@ -1037,7 +1037,13 @@ function debug(...args) {
             } else if (xhr.status == 403) {
                 login_failure(_(decodeURIComponent(xhr.statusText)) || _("Permission denied"));
             } else if (xhr.status == 500 && xhr.statusText.indexOf("no-cockpit") > -1) {
-                login_failure(format(_("A compatible version of Cockpit is not installed on $0."), login_machine || "localhost"));
+                // always show what's going on
+                let message = format(_("A compatible version of Cockpit is not installed on $0."), login_machine || "localhost");
+                // in beiboot mode we get some more info
+                const error = JSON.parse(xhr.responseText);
+                if (error.supported)
+                    message += " " + format(_("This is only supported for $0 on the target machine."), error.supported);
+                login_failure(message);
             } else if (xhr.statusText) {
                 fatal(decodeURIComponent(xhr.statusText));
             } else {

--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -49,9 +49,9 @@
 #define ACTION_NONE "none"
 #define LOCAL_SESSION "local-session"
 
-/* for the time being, we only support running an installed cockpit-bridge on the remote,
- * and leave beibooting to the flatpak */
-const gchar *cockpit_ws_ssh_program = "/usr/bin/env python3 -m cockpit.beiboot --remote-bridge=always";
+/* we only support beibooting machines with a known/vetted OS, as it's impossible to guarantee
+ * forward compatibility for all pages */
+const gchar *cockpit_ws_ssh_program = "/usr/bin/env python3 -m cockpit.beiboot --remote-bridge=supported";
 
 /* Some tunables that can be set from tests */
 const gchar *cockpit_ws_session_program = LIBEXECDIR "/cockpit-session";

--- a/test/verify/check-loopback
+++ b/test/verify/check-loopback
@@ -38,14 +38,6 @@ class TestLoopback(testlib.MachineCase):
         b.logout()
         b.wait_visible("#login")
 
-        self.restore_file("/usr/bin/cockpit-bridge")
-        m.execute("rm /usr/bin/cockpit-bridge")
-
-        b.set_val('#login-user-input', "admin")
-        b.set_val('#login-password-input', "foobar")
-        b.click('#login-button')
-        b.wait_text("#login-error-message", "A compatible version of Cockpit is not installed on localhost.")
-
         m.disconnect()
         self.restore_dir("/etc/ssh", restart_unit=self.sshd_service)
         m.execute("sed -i 's/.*PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config $(ls /etc/ssh/sshd_config.d/* 2>/dev/null || true)")

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -355,6 +355,23 @@ class TestMultiMachine(testlib.MachineCase):
         b.wait_in_text(hostname_selector, "machine2")
         b.logout()
 
+        # beiboot mode: same OS → compatible, supported
+        break_bridge(m2)
+        b.try_login(password="alt-password")
+        b.wait_visible('#content')
+        b.logout()
+
+        # beiboot mode: future OS version → incompatible, not supported
+        # rolling OSes don't have a VERSION_ID
+        if m.image not in ["arch", "debian-testing"]:
+            m2.execute("sed -i '/^VERSION_ID/ s/$/1/' /etc/os-release")
+            b.try_login(password="alt-password")
+            b.wait_in_text('#login-error-message', "A compatible version of Cockpit is not installed on 10.111.113.2")
+            source_os = m.execute('. /etc/os-release; echo "$ID $VERSION_ID"').strip()
+            b.wait_in_text('#login-error-message', f"This is only supported for {source_os} on the target machine")
+
+        fix_bridge(m2)
+
         login_options = '#show-other-login-options'
 
         # Connect to bad machine


### PR DESCRIPTION
We recently eliminated all on-demand installations of cockpit-* packages in beiboot mode, which prevents accidentally moving from a beiboot to a distro package scenario.

This means we can now carefully open up the beiboot feature for distro packages. However, we need to be careful here: While we can reasonably assume an ever-green flatpak and cockpit/ws container, distro packages may be arbitrarily old, and hence incompatible with APIs from newer OSes. So start small and only allow connecting to the same target OS as the host. This should already cover a lot of use cases in homogenous environments.

Note that this only applies to direct logins (bastion host). The code path for the (deprecated) host switcher is completely different and doesn't support beiboot at all.

Drop the `no-cockpit` part of TestLoopback.testBasic. Removing /usr/bin/cockpit-bridge now just enables beiboot mode, the OS is always compatible (as it's localhost), and we already check this in TestMultiMachine.

Part of https://issues.redhat.com/browse/COCKPIT-1178

Note that this is an initial step -- we can extend this by translating our bots testmap into a list of allowed OSes, if/when we want to.

---

Depends on:
 - [x] #21124

Follow-ups:
 - [ ] #21130

---

## Connect to similar servers without Cockpit installed

The [Cockpit Client flatpak](https://flathub.org/apps/org.cockpit_project.CockpitClient) has been capable of connecting to remote machines without Cockpit installed since its beginning in [release 295](https://cockpit-project.org/blog/cockpit-295.html). Recently in version [326](https://cockpit-project.org/blog/cockpit-326.html), the [cockpit/ws container](https://quay.io/repository/cockpit/ws) got the same feature.

With this release Cockpit gradually introduces this feature to the standard Linux distribution packages (rpm/deb/Arch). Initially you can connect to a remote machine without installed Cockpit if it runs the same operating system version as the host from which you make the connection. This ensures compatibility and safety: Unlike with the flatpak and container, which can be assumed to be always up to date in production, distribution packages can be quite old, and thus not be compatible when connecting to newer OS versions.