### PR TITLE
static: Handle no-cockpit error

### DIFF
--- a/pkg/static/login.js
+++ b/pkg/static/login.js
@@ -1036,6 +1036,8 @@ function debug(...args) {
                 }
             } else if (xhr.status == 403) {
                 login_failure(_(decodeURIComponent(xhr.statusText)) || _("Permission denied"));
+            } else if (xhr.status == 500 && xhr.statusText.indexOf("no-cockpit") > -1) {
+                login_failure(format(_("A compatible version of Cockpit is not installed on $0."), login_machine || "localhost"));
             } else if (xhr.statusText) {
                 fatal(decodeURIComponent(xhr.statusText));
             } else {

--- a/test/verify/check-loopback
+++ b/test/verify/check-loopback
@@ -44,8 +44,7 @@ class TestLoopback(testlib.MachineCase):
         b.set_val('#login-user-input', "admin")
         b.set_val('#login-password-input', "foobar")
         b.click('#login-button')
-        b.wait_visible('#login-fatal')
-        self.assertIn("no-cockpit", b.text('#login-fatal'))
+        b.wait_text("#login-error-message", "A compatible version of Cockpit is not installed on localhost.")
 
         m.disconnect()
         self.restore_dir("/etc/ssh", restart_unit=self.sshd_service)
@@ -53,8 +52,6 @@ class TestLoopback(testlib.MachineCase):
         m.execute(self.restart_sshd)
         m.wait_execute()
 
-        b.reload()
-        b.wait_visible("#login")
         b.set_val('#login-user-input', "admin")
         b.set_val('#login-password-input', "foobar")
         b.click('#login-button')


### PR DESCRIPTION
When directly logging into a remote host without cockpit installed, the login page showed an unhelpful and untranslatable fatal error message:

> Authentication failed: no-cockpit: [Errno 2] No such file or directory

This also left the user with nothing actionable other than reloading the page.

Handle the "no-cockpit" problem code and show a proper error message. Use the exact same one as in the shell's host switcher, to avoid introducing another similar translatable string. This also goes back to the login form, to either choose another host, or reattempt the login after installing cockpit on the target.

---

Spotted in #21121. In that PR we'll most probably refine that error message.

Screenshot on main:

![login-no-cockpit-main](https://github.com/user-attachments/assets/c47a4c77-6ed3-416c-a7e5-7019f5870e99)

Screenshot with this PR -- I deliberately left it at German to see that it gets translated:

![login-no-cockpit-pr](https://github.com/user-attachments/assets/810cfe02-b65e-40d2-9801-60c6dc63f740)

Note the "localhost" is a bit synthetic here due to how the test is set up -- ordinarily you'd choose a remote machine in the login form.