### PR TITLE
storaged: btrfs: show btrfs filesystem "root" subvolume as "top-level"

### DIFF
--- a/pkg/storaged/btrfs/subvolume.jsx
+++ b/pkg/storaged/btrfs/subvolume.jsx
@@ -404,6 +404,16 @@ function make_btrfs_subvolume_page(parent, volume, subvol, path_prefix, subvols)
             return str;
     }
 
+    // Show the hidden "root" of a btrfs filesystem as "top-level" as "/" can
+    // be confused with the root filesystem.
+    // https://btrfs.readthedocs.io/en/latest/Subvolumes.html
+    function subvol_name(subvol, path_prefix) {
+        if (subvol.id === 5) {
+            return "top-level";
+        }
+        return strip_prefix(subvol.pathname, path_prefix);
+    }
+
     let snapshot_origin = null;
     if (subvol.id !== 5 && subvol.parent_uuid !== null) {
         for (const sv of subvols) {
@@ -418,7 +428,7 @@ function make_btrfs_subvolume_page(parent, volume, subvol, path_prefix, subvols)
         title: _("btrfs subvolume"),
         next: null,
         page_location: ["btrfs", volume.data.uuid, subvol.pathname],
-        page_name: strip_prefix(subvol.pathname, path_prefix),
+        page_name: subvol_name(subvol, path_prefix),
         page_size: mounted && <StorageUsageBar stats={use} short />,
         location: mp_text,
         component: BtrfsSubvolumeCard,
@@ -452,7 +462,7 @@ const BtrfsSubvolumeCard = ({ card, volume, subvol, snapshot_origin, mismount_wa
                                     backing_block={block} content_block={block} subvol={subvol} />}>
             <CardBody>
                 <DescriptionList className="pf-m-horizontal-on-sm">
-                    <StorageDescription title={_("Name")} value={subvol.pathname} />
+                    <StorageDescription title={_("Name")} value={subvol.id === 5 ? "top-level" : subvol.pathname} />
                     <StorageDescription title={_("ID")} value={subvol.id} />
                     {snapshot_origin !== null &&
                     <StorageDescription title={_("Snapshot origin")}>

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1816,13 +1816,14 @@ class MachineCase(unittest.TestCase):
         # cockpit configuration
         self.restore_dir("/etc/cockpit")
 
-        if not m.ws_container:
+        if not m.ostree_image:
             # for storage tests
             self.restore_file("/etc/fstab")
             self.restore_file("/etc/crypttab")
 
-            # tests expect cockpit.service to not run at start; also, avoid log leakage into the next test
-            self.addCleanup(m.execute, "systemctl stop --quiet cockpit")
+            if not m.ws_container:
+                # tests expect cockpit.service to not run at start; also, avoid log leakage into the next test
+                self.addCleanup(m.execute, "systemctl stop --quiet cockpit")
 
         # The sssd daemon seems to get confused when we restore
         # backups of /etc/group etc and stops following updates to it.

--- a/test/verify/check-storage-btrfs
+++ b/test/verify/check-storage-btrfs
@@ -63,7 +63,7 @@ class TestStorageBtrfs(storagelib.StorageCase):
         b.wait_visible(self.card_desc_action("btrfs filesystem", "Label") + ":disabled")
 
         # Unmount to change label
-        self.click_dropdown(self.card_row("btrfs filesystem", name="/"), "Unmount")
+        self.click_dropdown(self.card_row("btrfs filesystem", name="top-level"), "Unmount")
         self.confirm()
         b.wait_visible(self.card_row("btrfs filesystem", location=f"{mount_point} (not mounted)"))
 
@@ -73,7 +73,7 @@ class TestStorageBtrfs(storagelib.StorageCase):
         b.wait_text(self.card_desc("btrfs filesystem", "Label"), label)
 
         # Mount writable for the rest of the test
-        self.click_dropdown(self.card_row("btrfs filesystem", name="/"), "Mount")
+        self.click_dropdown(self.card_row("btrfs filesystem", name="top-level"), "Mount")
         self.dialog({"mount_options.ro": False})
         b.wait_visible(self.card_row("btrfs filesystem", location=f"{mount_point}"))
 
@@ -92,7 +92,7 @@ class TestStorageBtrfs(storagelib.StorageCase):
         self.confirm()
 
         b.wait_visible(self.card_row("btrfs filesystem", location=f"{mount_point} (not mounted)"))
-        self.click_dropdown(self.card_row("btrfs filesystem", name="/"), "Mount")
+        self.click_dropdown(self.card_row("btrfs filesystem", name="top-level"), "Mount")
         self.confirm()
 
         b.wait_visible(self.card_row("btrfs filesystem", location=mount_point))
@@ -591,7 +591,7 @@ class TestStorageBtrfs(storagelib.StorageCase):
         self.login_and_go("/storage")
 
         self.click_card_row("Storage", name="sda")
-        b.wait_visible(self.card_row("btrfs filesystem", name="/"))
+        b.wait_visible(self.card_row("btrfs filesystem", name="top-level"))
 
     def testNothingMounted(self):
         m = self.machine

--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -28,7 +28,7 @@ class TestStorageMounting(storagelib.StorageCase):
         b = self.browser
 
         b.wait_visible(self.card("btrfs filesystem"))
-        self.click_card_row("btrfs filesystem", name="/")
+        self.click_card_row("btrfs filesystem", name="top-level")
         b.wait_visible(self.card("btrfs subvolume"))
 
     def testMounting(self):


### PR DESCRIPTION
Showing this as "/" confuses users as they might think it is the root partition and official btrfs terminology names it "top-level".

https://btrfs.readthedocs.io/en/latest/Subvolumes.html

Relates: #19920

---

![image](https://github.com/user-attachments/assets/a13a05db-e2c3-4c3f-943c-cbe1ad227e00)
