### PR TITLE
cockpit: support setting owner/group in fsreplace1

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -1075,6 +1075,8 @@ The following options can be specified in the "open" control message:
     If set `group` also has to be set.
   - `group`: a string, or an integer, the gid of the file group (`st_gid`)
     If set `user` also has to be set.
+  - `mode`:  an integer, usually expressed in octal, but in json it is the
+    equivalent value in decimal.
 
 You should write the new content to the channel as one or more
 messages.  To indicate the end of the content, send a "done" message.

--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -1091,9 +1091,8 @@ content will be replaced with a "rename" syscall when the channel is
 closed without problem code.  If the channel is closed with a problem
 code (by either client or server), the file will be left untouched.
 
-If `tag` is given, file owner and mode are preserved (copied from the
-original file). Other attributes (like ACLs or locally modified SELinux
-context) are never copied.
+If `tag` is given, file owner, mode and SELinux context are preserved (copied
+from the original file). Other attributes (like ACLs) are never copied.
 
 In addition to the usual "problem" field, the "close" control message
 sent by the server might have the following additional fields:

--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -1070,6 +1070,12 @@ The following options can be specified in the "open" control message:
    you don't set this field, the actual tag will not be checked.  To
    express that you expect the file to not exist, use "-" as the tag.
 
+* "attrs": a JSON object containing optional file attributes to set:
+  - `user`: a string, or an integer, the uid of the file owner (`st_uid`).
+    If set `group` also has to be set.
+  - `group`: a string, or an integer, the gid of the file group (`st_gid`)
+    If set `user` also has to be set.
+
 You should write the new content to the channel as one or more
 messages.  To indicate the end of the content, send a "done" message.
 
@@ -1091,8 +1097,9 @@ content will be replaced with a "rename" syscall when the channel is
 closed without problem code.  If the channel is closed with a problem
 code (by either client or server), the file will be left untouched.
 
-If `tag` is given, file owner, mode and SELinux context are preserved (copied
-from the original file). Other attributes (like ACLs) are never copied.
+If `tag` is given and no equivalent `attrs`, file owner, mode and SELinux
+context are preserved (copied from the original file). Other attributes (like
+ACLs) are never copied.
 
 In addition to the usual "problem" field, the "close" control message
 sent by the server might have the following additional fields:

--- a/pkg/base1/test-file.ts
+++ b/pkg/base1/test-file.ts
@@ -138,7 +138,7 @@ QUnit.test("fsreplace1 attrs", async assert => {
     valid.close(); // no-op
 
     const invalid = cockpit.channel({ payload: "fsreplace1", path: `${dir}/tmp`, attrs: { foo: 1 } });
-    await assert.rejects(invalid.wait(), /attrs must be empty/, "rejects non-empty attrs");
+    await assert.rejects(invalid.wait(), /"attrs" contains unsupported key\(s\): foo/, "rejects non-empty attrs");
 });
 
 QUnit.test("remove", async assert => {

--- a/pkg/playground/test.html
+++ b/pkg/playground/test.html
@@ -54,6 +54,11 @@
                     <input id="fsreplace1-content" />
                     <input id="fsreplace1-use-tag" type="checkbox" />
 		    <label for="fsreplace1-use-tag">Use existing tag</label>
+                    <p>user/group</p>
+                    <input id="fsreplace1-user" placeholder="For example, admin" />
+                    <input id="fsreplace1-group" placeholder="For example, admin" />
+                    <p>file mode</p>
+                    <input id="fsreplace1-mode" type='number' placeholder="For example, 644" />
                     <button id="fsreplace1-create" class="pf-v6-c-button pf-m-secondary">Create file</button>
                     <div id="fsreplace1-error"></div>
                 </div>

--- a/src/cockpit/jsonutil.py
+++ b/src/cockpit/jsonutil.py
@@ -87,6 +87,15 @@ def get_str_or_none(obj: JsonObject, key: str, default: Optional[str]) -> Option
     return _get(obj, lambda v: None if v is None else typechecked(v, str), key, default)
 
 
+def get_str_or_int(obj: JsonObject, key: str, default: Optional[Union[str, int]]) -> Optional[Union[str, int]]:
+    def as_str_or_int(value: JsonValue) -> Union[str, int]:
+        if not isinstance(value, (str, int)):
+            raise JsonError(value, 'must be a string or integer')
+        return value
+
+    return _get(obj, as_str_or_int, key, default)
+
+
 def get_dict(obj: JsonObject, key: str, default: Union[DT, _Empty] = _empty) -> Union[DT, JsonObject]:
     return _get(obj, lambda v: typechecked(v, dict), key, default)
 

--- a/test/pytest/test_bridge.py
+++ b/test/pytest/test_bridge.py
@@ -528,6 +528,10 @@ async def test_fsreplace1(transport: MockTransport, tmp_path: Path) -> None:
     assert myfile.read_bytes() == b'some stuff'
     # no leftover files
     assert os.listdir(tmp_path) == ['newfile']
+    # default umask is applied
+    prev_umask = os.umask(0)
+    os.umask(prev_umask)
+    assert stat.S_IMODE(myfile.stat().st_mode) == 0o666 & ~prev_umask
 
     # now update its contents
     ch = await transport.check_open('fsreplace1', path=str(myfile))

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -1064,6 +1064,72 @@ OnCalendar=daily
         self.check_system_menu("Overview", present=True)
         self.check_system_menu("Networking", present=False)
 
+    def testFsreplaceOwnership(self) -> None:
+        b = self.browser
+
+        self.login_and_go("/playground/test")
+
+        def stat(fmt: str, path: str) -> str:
+            return self.machine.execute(['stat', f'--format={fmt}', path]).strip()
+
+        def assert_stat(fmt: str, path: str, expected: str) -> None:
+            self.assertEqual(stat(fmt, path), expected)
+
+        def assert_mode(path: str, mode: str) -> None:
+            assert_stat('%a', path, mode)
+
+        def assert_owner(path: str, owner: str) -> None:
+            assert_stat('%U:%G', path, owner)
+
+        def assert_content(path: str, expected: str) -> None:
+            self.assertEqual(self.machine.execute(f"cat {path}").strip(), expected)
+
+        def set_file_bits(filename: str, content: str,
+                          owner: str = "", group: str = "",
+                          mode: str | None = None) -> None:
+            b.set_input_text("#fsreplace1-filename", filename)
+            b.set_input_text("#fsreplace1-content", content)
+            b.set_input_text("#fsreplace1-user", owner)
+            b.set_input_text("#fsreplace1-group", group)
+            if mode is not None:
+                b.set_input_text("#fsreplace1-mode", mode)
+
+            b.click("#fsreplace1-create")
+            b.wait_visible("#fsreplace1-create:not(:disabled)")
+
+        # Set file permissions on new files
+        filename = "/home/admin/admin.txt"
+        content = "adminfile"
+        set_file_bits(filename, content, "admin", "root")
+        assert_owner(filename, "admin:root")
+        assert_content(filename, content)
+
+        filename = "/home/admin/root.txt"
+        content = "rootfile"
+        set_file_bits(filename, content, "root", "root")
+        assert_owner(filename, "root:root")
+        assert_content(filename, content)
+
+        filename = "/home/admin/root.txt"
+        content = "rootfile"
+        set_file_bits(filename, content, "root", "root")
+        assert_owner(filename, "root:root")
+        assert_content(filename, content)
+
+        filename = f"{self.vm_tmpdir}/root-mode.txt"
+        set_file_bits(filename, content, "root", "root", str(0o600))
+        assert_owner(filename, "root:root")
+        assert_mode(filename, "600")
+        assert_content(filename, content)
+
+        # Mode on existing files
+        filename = f"{self.vm_tmpdir}/existing.txt"
+        self.machine.execute(f"install -m 644 -g admin -o admin /dev/null {filename}")
+        set_file_bits(filename, content, "root", "root", str(0o600))
+        assert_owner(filename, "root:root")
+        assert_mode(filename, "600")
+        assert_content(filename, content)
+
 
 if __name__ == '__main__':
     testlib.test_main()


### PR DESCRIPTION
Cockpit-files wants to support uploading or creating a file owned by the current directory which might be different from the logged in user.

For example as superuser uploading a database into `/var/lib/postgresql` which would be owned by `postgres` and the database file should receive the same permissions.

Leftovers:

* [x] rename owner -> user
* [x] decide if user and group should be set both or optionally only the user.
* [x] mode in?
