### PR TITLE
login: Split alert into title/description

### DIFF
--- a/pkg/static/login.html
+++ b/pkg/static/login.html
@@ -14,11 +14,13 @@
 </head>
 
 <body class="login-pf">
-  <div id="banner" class="pf-v5-c-alert pf-m-info pf-m-inline dialog-error" aria-label="inline danger alert" hidden="true">
-    <svg fill="currentColor" viewBox="0 0 448 512" aria-hidden="true">
-      <path d="M224 512c35.32 0 63.97-28.65 63.97-64H160.03c0 35.35 28.65 64 63.97 64zm215.39-149.71c-19.32-20.76-55.47-51.99-55.47-154.29 0-77.7-54.48-139.9-127.94-155.16V32c0-17.67-14.32-32-31.98-32s-31.98 14.33-31.98 32v20.84C118.56 68.1 64.08 130.3 64.08 208c0 102.3-36.15 133.53-55.47 154.29-6 6.45-8.66 14.16-8.61 21.71.11 16.4 12.98 32 32.1 32h383.8c19.12 0 32-15.6 32.1-32 .05-7.55-2.61-15.27-8.61-21.71z" />
-    </svg>
-    <span id="banner-message" class="pf-v5-c-alert__title"></span>
+  <div id="banner" class="pf-v5-c-alert pf-m-info pf-m-inline dialog-error" aria-label="inline info alert" hidden="true">
+    <div class="pf-v5-c-alert__icon">
+      <svg fill="currentColor" viewBox="0 0 448 512" aria-hidden="true">
+        <path d="M224 512c35.32 0 63.97-28.65 63.97-64H160.03c0 35.35 28.65 64 63.97 64zm215.39-149.71c-19.32-20.76-55.47-51.99-55.47-154.29 0-77.7-54.48-139.9-127.94-155.16V32c0-17.67-14.32-32-31.98-32s-31.98 14.33-31.98 32v20.84C118.56 68.1 64.08 130.3 64.08 208c0 102.3-36.15 133.53-55.47 154.29-6 6.45-8.66 14.16-8.61 21.71.11 16.4 12.98 32 32.1 32h383.8c19.12 0 32-15.6 32.1-32 .05-7.55-2.61-15.27-8.61-21.71z" />
+      </svg>
+    </div>
+    <span id="banner-message" class="pf-v5-c-alert__description"></span>
   </div>
 
   <span id="badge"></span>
@@ -27,12 +29,19 @@
     <h1 id="brand" class="hide-before"></h1>
 
     <div id="error-group" class="pf-v5-c-alert pf-m-danger pf-m-inline dialog-error noscript" aria-label="inline danger alert">
-      <svg fill="currentColor" viewBox="0 0 512 512" aria-hidden="true">
-        <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h28.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z" />
-      </svg>
-      <h2 id="login-error-message" class="pf-v5-c-alert__title">
-        <span class="noscript" translate="yes">Please enable JavaScript to use the Web Console.</span>
-      </h2>
+      <div class="pf-v5-c-alert__icon">
+        <svg fill="currentColor" viewBox="0 0 512 512" aria-hidden="true">
+          <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h28.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z" />
+        </svg>
+      </div>
+      <p class="pf-v5-c-alert__title">
+         <span id="login-error-title" class="pf-v5-screen-reader"></span>
+      </p>
+      <div class="pf-v5-c-alert__description">
+        <p id="login-error-message">
+          <span class="noscript" translate="yes">Please enable JavaScript to use the Web Console.</span>
+        </p>
+      </div>
     </div>
 
     <div class="unsupported-browser" id="unsupported-browser" hidden="true">
@@ -64,7 +73,7 @@
       </details>
     </div>
 
-    <div id="info-group" class="pf-v5-c-alert pf-m-info pf-m-inline dialog-error" aria-label="inline danger alert" hidden="true">
+    <div id="info-group" class="pf-v5-c-alert pf-m-info pf-m-inline dialog-error" aria-label="inline info alert" hidden="true">
       <svg fill="currentColor" viewBox="0 0 512 512" aria-hidden="true">
         <path d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z" />
       </svg>
@@ -77,9 +86,11 @@
         <div id="hostkey-group" class="form-group" hidden="true">
           <h1 id="hostkey-title"></h1>
           <div id="hostkey-warning-group" class="pf-v5-c-alert pf-m-warning pf-m-inline dialog-error" aria-label="inline warning alert" hidden="true">
-            <svg fill="currentColor" viewBox="0 0 576 512" aria-hidden="true"><path d="M569.52 440.01c18.46 32-4.71 71.99-41.58 71.99H48.05c-36.93 0-60-40.05-41.57-71.99L246.42 24c18.47-32.01 64.72-31.96 83.16 0L569.52 440zM288 354a46 46 0 100 92 46 46 0 000-92zm-43.67-165.35l7.41 136A12 12 0 00263.74 336h48.54a12 12 0 0011.98-11.35l7.42-136A12 12 0 00319.7 176h-63.38a12 12 0 00-11.98 12.65z"/></svg>
-            <h2 translate="yes" class="pf-v5-c-alert__title">Changed keys are often the result of an operating system reinstallation. However, an unexpected change may indicate a third-party attempt to intercept your connection.</h2>
-              </div>
+            <div class="pf-v5-c-alert__icon">
+              <svg fill="currentColor" viewBox="0 0 576 512" aria-hidden="true"><path d="M569.52 440.01c18.46 32-4.71 71.99-41.58 71.99H48.05c-36.93 0-60-40.05-41.57-71.99L246.42 24c18.47-32.01 64.72-31.96 83.16 0L569.52 440zM288 354a46 46 0 100 92 46 46 0 000-92zm-43.67-165.35l7.41 136A12 12 0 00263.74 336h48.54a12 12 0 0011.98-11.35l7.42-136A12 12 0 00319.7 176h-63.38a12 12 0 00-11.98 12.65z"/></svg>
+            </div>
+            <span translate="yes" class="pf-v5-c-alert__description">Changed keys are often the result of an operating system reinstallation. However, an unexpected change may indicate a third-party attempt to intercept your connection.</span>
+          </div>
           <p id="hostkey-message-1"></p>
           <p translate="yes">To ensure that your connection is not intercepted by a malicious third-party, please verify the host key fingerprint:</p>
           <pre id="hostkey-fingerprint"></pre>

--- a/pkg/static/login.scss
+++ b/pkg/static/login.scss
@@ -416,61 +416,61 @@ label.checkbox {
   inline-size: 1.5rem;
 }
 
-/* Alerts */
+// Alerts: structure
+
 .pf-v5-c-alert {
-  color: #151515;
-  position: relative;
-  grid-template-columns: max-content 1fr max-content;
-  grid-template-rows: 1fr auto;
-  grid-template-areas:
-    "icon title   action"
-    ".    content content";
-  background-color: #fff;
-  margin-block: 0 1.5rem;
-  margin-inline: 0;
   display: grid;
-  border: 3px solid #009596;
-  border-width: 2px 0 0;
-  box-shadow: rgb(3 3 3 / 16%) 0 0.5rem 1rem 0, rgb(3 3 3 / 8%) 0 0 0.5rem 0;
+  grid-template: "icon content" / auto 1fr;
+  gap: 0.5rem 1rem;
+  align-items: start;
 }
 
-.pf-v5-c-alert.pf-m-inline {
-  box-shadow: none;
+.pf-v5-c-alert__title,
+.pf-v5-c-alert__description {
+  grid-column: content;
 }
 
-.pf-v5-c-alert > svg {
-  grid-area: icon;
-  block-size: 1.125rem;
-  inline-size: 1.125rem;
-  margin-block: 1.25rem 1rem;
-  margin-inline: 1rem;
-  float: inline-start;
-  color: #009596;
-}
+// Alerts: styling
 
-@supports (display: grid) {
-  .pf-v5-c-alert > svg {
-    float: none;
-    margin-inline-end: 0;
+.pf-v5-c-alert {
+  margin: 1rem;
+  padding-block: 0.75rem;
+  padding-inline: 1rem;
+  border-block-start: 2px solid;
+
+  p {
+    margin: 0;
   }
 }
 
-.pf-v5-c-alert__title {
-  grid-area: title;
-  font-size: 1rem;
-  margin: 1rem;
+.pf-v5-c-alert__icon {
+  // vertically align the icon's top edge with the text; https://blog.kizu.dev/cap-height-align/
+  margin-block-start: calc((1cap - 1ex) / 2);
 }
+
+.pf-v5-c-alert__icon svg {
+  display: block;
+  block-size: 1.125rem;
+  inline-size: 1.125rem;
+}
+
+.pf-v5-c-alert__title {
+  font-weight: 700; // pf-v5-global--FontWeight--bold
+}
+
+// Alert: colors for types
 
 .pf-v5-c-alert.pf-m-inline.pf-m-danger {
   background: #faeae8;
   border-color: #c9190b;
 }
 
-.pf-v5-c-alert.pf-m-danger > svg {
+.pf-v5-c-alert.pf-m-danger svg {
   color: #c9190b;
 }
 
-.pf-v5-c-alert.pf-m-danger .pf-v5-c-alert__title {
+.pf-v5-c-alert.pf-m-danger .pf-v5-c-alert__title,
+.pf-v5-c-alert.pf-m-danger .pf-v5-c-alert__description {
   color: #a30000;
 }
 
@@ -479,11 +479,12 @@ label.checkbox {
   border-color: #f0ab00;
 }
 
-.pf-v5-c-alert.pf-m-warning > svg {
+.pf-v5-c-alert.pf-m-warning svg {
   color: #f0ab00;
 }
 
-.pf-v5-c-alert.pf-m-warning .pf-v5-c-alert__title {
+.pf-v5-c-alert.pf-m-warning .pf-v5-c-alert__title,
+.pf-v5-c-alert.pf-m-warning .pf-v5-c-alert__description {
   color: #795600;
 }
 
@@ -492,11 +493,12 @@ label.checkbox {
   border-color: #73bcf7;
 }
 
-.pf-v5-c-alert.pf-m-info > svg {
+.pf-v5-c-alert.pf-m-info svg {
   color: #73bcf7;
 }
 
-.pf-v5-c-alert.pf-m-info .pf-v5-c-alert__title {
+.pf-v5-c-alert.pf-m-info .pf-v5-c-alert__title,
+.pf-v5-c-alert.pf-m-info .pf-v5-c-alert__description {
   color: #004368;
 }
 
@@ -1002,7 +1004,8 @@ input[type="password"] + .login-password-toggle .password-hide {
   }
 
   .pf-v5-c-alert.pf-m-danger > svg,
-  .pf-v5-c-alert.pf-m-danger .pf-v5-c-alert__title {
+  .pf-v5-c-alert.pf-m-danger .pf-v5-c-alert__title,
+  .pf-v5-c-alert.pf-m-danger .pf-v5-c-alert__description {
     color: #fe5142;
   }
 

--- a/src/cockpit/beiboot.py
+++ b/src/cockpit/beiboot.py
@@ -247,8 +247,8 @@ class AuthorizeResponder(ferny.AskpassHandler):
             logger.debug("cockpit.check-os-release: local: %r", local_os)
             # for now, just support the same OS
             if remote_os.get('ID') != local_os.get('ID') or remote_os.get('VERSION_ID') != local_os.get('VERSION_ID'):
-                unsupported = f'{remote_os.get("ID", "?")} {remote_os.get("VERSION_ID", "")}'
-                supported = f'{local_os.get("ID", "?")} {local_os.get("VERSION_ID", "")}'
+                unsupported = f'{remote_os.get("NAME", remote_os.get("ID", "?"))} {remote_os.get("VERSION_ID", "")}'
+                supported = f'{local_os.get("NAME", local_os.get("ID", "?"))} {local_os.get("VERSION_ID", "")}'
                 raise CockpitProblem('no-cockpit', unsupported=unsupported, supported=supported)
 
 

--- a/test/verify/check-client
+++ b/test/verify/check-client
@@ -158,7 +158,7 @@ exec "$@"
             b.wait_text("#conversation-prompt", "admin@10.111.113.2's password: ")
             b.set_val("#conversation-input", "wrong")
             b.click("#login-button")
-        b.wait_in_text("#login-error-message", "Authentication failed")
+        b.wait_in_text("#login-error-title", "Authentication failed")
         b.wait_val("#server-field", "10.111.113.2")
 
         # connect to most recent host
@@ -217,7 +217,8 @@ exec "$@"
         # unreachable host
         b.set_val("#server-field", "unknownhost")
         b.click("#login-button")
-        b.wait_in_text("#login-error-message", "Host is unknown")
+        b.wait_text("#login-error-title", "Refusing to connect")
+        b.wait_text("#login-error-message", "Host is unknown")
         b.wait_val("#server-field", "unknownhost")
         # does not appear in recent hosts
         b.wait_in_text("#recent-hosts-list", "10.111.113.2")

--- a/test/verify/check-loopback
+++ b/test/verify/check-loopback
@@ -47,7 +47,8 @@ class TestLoopback(testlib.MachineCase):
         b.set_val('#login-user-input', "admin")
         b.set_val('#login-password-input', "foobar")
         b.click('#login-button')
-        b.wait_in_text('#login-error-message', "Wrong user name or password")
+        b.wait_text("#login-error-title", "Authentication failed")
+        b.wait_text('#login-error-message', "Wrong user name or password")
 
         self.allow_journal_messages("Cannot run program cockpit-bridge: No such file or directory",
                                     ".*server offered unsupported authentication methods: public-key.*")

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -327,7 +327,8 @@ class TestMultiMachine(testlib.MachineCase):
         b.wait_visible("#user-group")
         b.wait_visible("#option-group")
         b.wait_visible("#server-group")
-        b.wait_in_text("#login-error-message", "Hostkey does not match")
+        b.wait_text("#login-error-title", "Refusing to connect")
+        b.wait_text("#login-error-message", "Hostkey does not match")
 
         # Clear bad host key in /etc and set bad host key in
         # localStorage.
@@ -365,9 +366,12 @@ class TestMultiMachine(testlib.MachineCase):
         if m.image not in ["arch", "debian-testing"]:
             m2.execute("sed -i '/^VERSION_ID/ s/$/1/' /etc/os-release")
             b.try_login(password="alt-password")
-            b.wait_in_text('#login-error-message', "A compatible version of Cockpit is not installed on 10.111.113.2")
             source_os = m.execute('. /etc/os-release; echo "$NAME $VERSION_ID"').strip()
-            b.wait_in_text('#login-error-message', f"This is only supported for {source_os} on the target machine")
+            b.wait_text('#login-error-title', "Packageless session unavailable")
+            b.wait_in_text('#login-error-message', "Transient packageless sessions")
+            b.wait_in_text('#login-error-message', source_os)
+            b.wait_in_text('#login-error-message', "Install the cockpit-system package")
+            b.wait_in_text('#login-error-message', "on 10.111.113.2")
 
         fix_bridge(m2)
 
@@ -384,7 +388,8 @@ class TestMultiMachine(testlib.MachineCase):
         b.wait_not_visible("#server-group")
         b.click('#login-button')
         b.wait_visible("#server-group")
-        b.wait_in_text("#login-error-message", "Refusing to connect")
+        b.wait_text("#login-error-title", "Refusing to connect")
+        b.wait_text("#login-error-message", "Host is unknown")
 
         # Might happen when we switch away.
         self.allow_hostkey_messages()

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -366,7 +366,7 @@ class TestMultiMachine(testlib.MachineCase):
             m2.execute("sed -i '/^VERSION_ID/ s/$/1/' /etc/os-release")
             b.try_login(password="alt-password")
             b.wait_in_text('#login-error-message', "A compatible version of Cockpit is not installed on 10.111.113.2")
-            source_os = m.execute('. /etc/os-release; echo "$ID $VERSION_ID"').strip()
+            source_os = m.execute('. /etc/os-release; echo "$NAME $VERSION_ID"').strip()
             b.wait_in_text('#login-error-message', f"This is only supported for {source_os} on the target machine")
 
         fix_bridge(m2)

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -87,7 +87,8 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
         # Try to login as a non-existing user
         b.try_login("nonexisting", "blahblah")
-        b.wait_text_not("#login-error-message", "")
+        b.wait_text("#login-error-title", "Authentication failed")
+        b.wait_text("#login-error-message", "Wrong user name or password")
         self.assertNotIn("web", m.execute("who"))
 
         # Try to login as user with a wrong password
@@ -98,10 +99,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
         # Try to login as user with correct password
         b.try_login("user", "abcdefg")
-        if m.ostree_image:
-            b.wait_in_text("#login-error-message", "Wrong user name or password")
-        else:
-            b.wait_text("#login-error-message", "Permission denied")
+        b.wait_text("#login-error-title", "Authentication failed" if m.ostree_image else "Permission denied")
         self.assertNotIn("web", m.execute("who"))
 
         # Try to login with disabled shell; this does not work on OSTree where
@@ -110,7 +108,9 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
             m.execute("usermod --shell /bin/false admin; sync")
             b.reload()
             b.try_login("admin", "foobar")
-            b.wait_text_not("#login-error-message", "")
+            b.wait_text_not("#login-error-title", "")
+            self.assertIn(b.text("#login-error-title"),
+                          ["Permission denied", "Authentication failed"])
             m.execute("usermod --shell /bin/bash admin; sync")
 
         # Login as admin
@@ -155,6 +155,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         # logging in does not go via ssh (which would cause a connection failure)
         b.try_login()
         # this isn't the most helpful error message, but this is essentially hacking
+        b.wait_text("#login-error-title", "Authentication failed")
         b.wait_text("#login-error-message", "Wrong user name or password")
 
         # Default options be to display these options
@@ -241,11 +242,11 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
         # Do some bogus login attempts
         b.try_login('admin', 'xyz')
-        b.wait_text_not("#login-error-message", "")
+        b.wait_text("#login-error-title", "Authentication failed")
         b.try_login('admin', 'xyz')
-        b.wait_text_not("#login-error-message", "")
+        b.wait_text("#login-error-title", "Authentication failed")
         b.try_login('admin', 'xyz')
-        b.wait_text_not("#login-error-message", "")
+        b.wait_text("#login-error-title", "Authentication failed")
 
         # We should see those bogus attempts now
         verify_correct(has_last=False, n_fail=3)
@@ -386,7 +387,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
             b.wait_in_text("#conversation-prompt", "nonexisting@127.0.0.1's password")
             b.set_val('#conversation-input', 'blahblah')
             b.click('#login-button')
-        b.wait_text_not("#login-error-message", "")
+        b.wait_text_not("#login-error-title", "")
 
         b.try_login("admin", "foobar")
         b.wait_visible("#conversation-group")
@@ -646,7 +647,10 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
         def expect_failed_login(user, password, n_failed):
             b.try_login(user, password)
-            b.wait_text_not("#login-error-message", "")
+            b.wait_text_not("#login-error-title", "")
+            # this depends on the use case and OS implementation -- should just be something sensible
+            self.assertIn(b.text("#login-error-title"),
+                          ["Permission denied", "Authentication failed", "Wrong user name or password"])
             expect_fail_count(n_failed, user=user)
 
         def expect_successful_login(user, password):
@@ -745,14 +749,16 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         # root login is disabled by default via /etc/cockpit/disallowed-users on everything except RHEL 8
         if not m.image.startswith("rhel-8"):
             b.try_login("root", "foobar")
-            b.wait_in_text("#login-error-message", "Permission denied")
+            b.wait_in_text("#login-error-title", "Permission denied")
+            b.wait_not_visible("#login-error-message")
 
         # disable root login with pam_access
         self.enable_root_login()
         self.write_file("/etc/security/access.conf", "- : root : ALL\n", append=True)
         self.sed_file("1 aaccount required pam_access.so", "/etc/pam.d/cockpit")
         b.try_login(user="root")
-        b.wait_in_text("#login-error-message", "Permission denied")
+        b.wait_in_text("#login-error-title", "Permission denied")
+        b.wait_not_visible("#login-error-message")
 
         self.allow_journal_messages(r"cockpit-session: user account access failed.*root.*")
 
@@ -1013,6 +1019,7 @@ matchrule = <SUBJECT>^DC=LAN,DC=COCKPIT,CN=alice$
 
         # host key is now known, but wrong password
         try_login("admin", "wrong")
+        b.wait_text("#login-error-title", "Authentication failed")
         b.wait_text("#login-error-message", "Wrong user name or password")
         check_no_processes()
         # goes back to normal login form
@@ -1051,7 +1058,9 @@ matchrule = <SUBJECT>^DC=LAN,DC=COCKPIT,CN=alice$
         b.wait_text("#hostkey-title", f"{my_ip} key changed")
         b.wait_in_text("#hostkey-fingerprint", "SHA256:")
         b.click("#login-button.pf-m-danger")
-        b.wait_text("#login-error-message", "Authentication failed")
+        b.wait_text("#login-error-title", "Authentication failed")
+        # no details, it's a PAM conversation
+        b.wait_not_visible("#login-error-message")
         check_no_processes()
         # new host key is accepted and updated in db
         # confirmation replaces (not amends) known key

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -659,7 +659,8 @@ class TestIPA(TestRealms, CommonTests):
         # wrong token (wrong number of digits)
         b.set_val("#conversation-input", "1234")
         b.click('#login-button')
-        b.wait_text("#login-error-message", "Authentication failed")
+        b.wait_text("#login-error-title", "Authentication failed")
+        b.wait_not_visible("#login-error-message")
 
         b.set_val('#login-user-input', "alice")
         b.set_val('#login-password-input', "alicessecret")

--- a/test/verify/check-ws-bastion
+++ b/test/verify/check-ws-bastion
@@ -60,7 +60,8 @@ class TestWsBastionContainer(testlib.MachineCase):
 
         # Requires a host
         b.click("#login-button")
-        b.wait_in_text("#login-error-message", "host to connect")
+        b.wait_text("#login-error-title", "Please specify the host to connect to")
+        b.wait_not_visible("#login-error-message")
         # so connect to our own container host
         b.set_val("#server-field", HOST)
         b.set_val("#login-password-input", "foobar")
@@ -199,12 +200,14 @@ class TestWsBastionContainer(testlib.MachineCase):
             # the account password does not work
             b.set_val("#login-password-input", "foobar")
             b.click("#login-button")
-            b.wait_text_not("#login-error-message", "")
+            b.wait_text("#login-error-title", "Authentication failed")
+            b.wait_text("#login-error-message", "Wrong user name or password")
 
             # SSH key password, but key is not authorized
             b.set_val("#login-password-input", KEY_PASSWORD)
             b.click("#login-button")
-            b.wait_text_not("#login-error-message", "")
+            b.wait_text("#login-error-title", "Authentication failed")
+            b.wait_text("#login-error-message", "Wrong user name or password")
 
             # authorize key
             self.restore_file("/home/admin/.ssh/authorized_keys")
@@ -215,7 +218,8 @@ class TestWsBastionContainer(testlib.MachineCase):
             # fails with wrong key password
             b.set_val("#login-password-input", "notthispassword")
             b.click("#login-button")
-            b.wait_text_not("#login-error-message", "")
+            b.wait_text("#login-error-title", "Authentication failed")
+            b.wait_text("#login-error-message", "Wrong user name or password")
 
             # works with correct key password
             b.set_val("#login-password-input", KEY_PASSWORD)


### PR DESCRIPTION
This makes it conformant to the current PF design.

Bring the DOM structure closer to current PF5's alert, and
adjust/simplify CSS accordingly. Thanks Garrett for working this out!

Also tighten the error message checks in the tests, in particular for
check-ws-bastion.

Rework the "no-cockpit" message: Telling the user which OSes are
supported is nice at some level, but doesn't help operationally when
they want to connect to *that* server. Thus, suggest to install
cockpit-system, which is the recommended way out of this error.

----

Reproducer for showing the banner on login page (do this in a test VM):
```
printf '[Session]\nBanner = /tmp/banner\n' | sudo tee -a /etc/cockpit/cockpit.conf
printf 'Hello from my laptop\nsecond line\n' > /tmp/banner
sudo systemctl stop cockpit
# so that cockpit can read /tmp/banner
sudo setenforce 0
```

Banner:

![image](https://github.com/user-attachments/assets/a3d7c4d6-66c2-4248-8487-9aa8d6143ab6)

Login alert without message (title only):

![image](https://github.com/user-attachments/assets/eb86ecae-fde4-48f7-82d5-c80ced120d8e)

Login alert with message (unknown server, or wrong password):

![image](https://github.com/user-attachments/assets/1600aec0-2991-4b2b-91f2-0599d01a7c79)

Redesigned "no cockpit" error when in beiboot mode:

![Screen Shot 2024-10-24 at 08 50 13](https://github.com/user-attachments/assets/0b76e917-0b42-498c-bebe-d3abc2d09270)
