### PR TITLE
systemd: Hide "limited access mode" banner without superuser bridges

### DIFF
--- a/pkg/lib/superuser.js
+++ b/pkg/lib/superuser.js
@@ -39,6 +39,11 @@ import cockpit from "cockpit";
  * access should be shown when the "allowed" field is exactly false,
  * but not when it is null.
  *
+ * - superuser.configured
+ *
+ * This is true when the shell has at least one superuser bridge configured,
+ * false if there are no superuser bridges, or null during initialization.
+ *
  * - superuser.addEventListener("changed", () => ...)
  *
  * The event handler is called whenever superuser.allowed has changed.
@@ -79,8 +84,15 @@ function Superuser() {
         return proxy.Current != "none";
     };
 
+    const compute_configured = () => {
+        if (proxy.Current == "init")
+            return null;
+        return (proxy.Bridges?.length ?? 0) > 0;
+    };
+
     const self = {
         allowed: compute_allowed(),
+        configured: null,
         reload_page_on_change
     };
 
@@ -93,6 +105,7 @@ function Superuser() {
             } else {
                 const prev = self.allowed;
                 self.allowed = allowed;
+                self.configured = compute_configured();
                 self.dispatchEvent("changed");
                 if (prev != null)
                     self.dispatchEvent("reconnect");

--- a/pkg/systemd/superuser-alert.jsx
+++ b/pkg/systemd/superuser-alert.jsx
@@ -30,7 +30,7 @@ import { superuser } from "superuser.js";
 const _ = cockpit.gettext;
 
 export const SuperuserAlert = () => {
-    if (superuser.allowed)
+    if (superuser.allowed || !superuser.configured)
         return null;
 
     return <Alert className="ct-limited-access-alert"

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -291,6 +291,12 @@ session include system-auth
         # superuser bridge goes away
         m.execute("while pgrep -u root -a cockpit-bridge; do sleep 1; done", timeout=5)
 
+        # no banner for "running in limited access mode", there are no bridge configs
+        b.go("/system")
+        b.enter_page("/system")
+        b.wait_visible("#system_information_os_text")
+        b.wait_not_present(".pf-v5-c-alert:contains('Web console is running in limited access mode')")
+
     def testSingleLabelBridgeConfig(self):
         b = self.browser
 


### PR DESCRIPTION
When a user configures shell.override.json to disable superuser bridges (`{ "bridges": [] }`), then the banner in the overview is just inactionable noise. Hide it then.

Fixes #21134