### PR TITLE
base1: Modernize cockpit.file().read()

### DIFF
--- a/pkg/base1/test-file.js
+++ b/pkg/base1/test-file.js
@@ -161,22 +161,20 @@ QUnit.test("replace with tag", async assert => {
     const done = assert.async();
     const file = cockpit.file(dir + "/barfoo");
 
-    file.read()
-            .then(async (content, tag_1) => {
-                assert.equal(content, null, "file does not exist");
-                assert.equal(tag_1, "-", "first tag is -");
-                const tag_2 = await file.replace("klmn\n", tag_1);
-                assert.notEqual(tag_2, "-", "second tag is not -");
-                const tag_3 = await file.replace("KLMN\n", tag_2);
-                assert.notEqual(tag_3, tag_2, "third tag is different");
-                try {
-                    await file.replace("opqr\n", tag_2);
-                    assert.ok(false, "should have failed");
-                } catch (error) {
-                    assert.equal(error.problem, "change-conflict", "wrong tag is rejected");
-                    done();
-                }
-            });
+    const [content, tag_1] = await file.read2();
+    assert.equal(content, null, "file does not exist");
+    assert.equal(tag_1, "-", "first tag is -");
+    const tag_2 = await file.replace("klmn\n", tag_1);
+    assert.notEqual(tag_2, "-", "second tag is not -");
+    const tag_3 = await file.replace("KLMN\n", tag_2);
+    assert.notEqual(tag_3, tag_2, "third tag is different");
+    try {
+        await file.replace("opqr\n", tag_2);
+        assert.ok(false, "should have failed");
+    } catch (error) {
+        assert.equal(error.problem, "change-conflict", "wrong tag is rejected");
+        done();
+    }
 });
 
 QUnit.test("modify", async assert => {

--- a/pkg/lib/cockpit.d.ts
+++ b/pkg/lib/cockpit.d.ts
@@ -248,6 +248,7 @@ declare module 'cockpit' {
 
     interface FileHandle<T> {
         read(): Promise<T>;
+        read2(): Promise<[T, FileTag]>;
         replace(new_content: T | null, expected_tag?: FileTag): Promise<FileTag>;
         watch(callback: FileWatchCallback<T>, options?: { read?: boolean }): FileWatchHandle;
         modify(callback: (data: T | null) => T | null, initial_content?: string, initial_tag?: FileTag): Promise<[T, FileTag]>;

--- a/pkg/lib/cockpit.js
+++ b/pkg/lib/cockpit.js
@@ -2157,6 +2157,7 @@ function factory() {
         const self = {
             path,
             read,
+            read2,
             replace,
             modify,
 
@@ -2241,6 +2242,10 @@ function factory() {
 
             read_promise = dfd.promise;
             return read_promise;
+        }
+
+        function read2() {
+            return read().then((content, tag) => [content, tag]);
         }
 
         let replace_channel = null;


### PR DESCRIPTION
So that we can write

    const [content, tag] = await file.read2()