### PR TITLE
Add back RHEL 8 test via cockpit/ws beibooting

### DIFF
--- a/src/cockpit/polyfills.py
+++ b/src/cockpit/polyfills.py
@@ -43,15 +43,23 @@ def install():
         class AsyncExitStack:
             async def __aenter__(self):
                 self.cms = []
+                self.async_cms = []
                 return self
 
             async def enter_async_context(self, cm):
                 result = await cm.__aenter__()
+                self.async_cms.append(cm)
+                return result
+
+            def enter_context(self, cm):
+                result = cm.__enter__()
                 self.cms.append(cm)
                 return result
 
             async def __aexit__(self, exc_type, exc_value, traceback):
-                for cm in self.cms:
+                for cm in self.async_cms:
                     cm.__aexit__(exc_type, exc_value, traceback)
+                for cm in self.cms:
+                    cm.__exit__(exc_type, exc_value, traceback)
 
         contextlib.AsyncExitStack = AsyncExitStack

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1814,7 +1814,7 @@ class MachineCase(unittest.TestCase):
         # cockpit configuration
         self.restore_dir("/etc/cockpit")
 
-        if not m.ostree_image:
+        if not m.ws_container:
             # for storage tests
             self.restore_file("/etc/fstab")
             self.restore_file("/etc/crypttab")
@@ -2388,9 +2388,8 @@ class MachineCase(unittest.TestCase):
         By default root login is disabled in cockpit, removing the root entry of /etc/cockpit/disallowed-users allows root to login.
         """
 
-        # fedora-coreos runs cockpit-ws in a containter so does not install cockpit-ws on the host
         disallowed_conf = '/etc/cockpit/disallowed-users'
-        if not self.machine.ostree_image and self.file_exists(disallowed_conf):
+        if not self.machine.ws_container and self.file_exists(disallowed_conf):
             self.sed_file('/root/d', disallowed_conf)
 
     def setup_provisioned_hosts(self, disable_preload: bool = False) -> None:
@@ -2488,6 +2487,13 @@ def skipOstree(reason: str) -> Callable[[_FT], _FT]:
     Skip test for *reason* on OSTree images defined in OSTREE_IMAGES in bots/lib/constants.py.
     """
     if testvm.DEFAULT_IMAGE in OSTREE_IMAGES:
+        return unittest.skip(f"{testvm.DEFAULT_IMAGE}: {reason}")
+    return lambda testEntity: testEntity
+
+
+def skipWsContainer(reason: str) -> Callable[[_FT], _FT]:
+    """Decorator for skipping a test with cockpit/ws"""
+    if testvm.DEFAULT_IMAGE in OSTREE_IMAGES or "ws-container" in os.getenv("TEST_SCENARIO", ""):
         return unittest.skip(f"{testvm.DEFAULT_IMAGE}: {reason}")
     return lambda testEntity: testEntity
 

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1918,6 +1918,8 @@ class MachineCase(unittest.TestCase):
         shutil.rmtree(self.tmpdir, ignore_errors=True)
 
     def enable_multihost(self, machine: testvm.Machine) -> None:
+        if isBeibootLogin():
+            raise NotImplementedError("multi-host config change not currently implemented for beiboot scenario")
         if not self.multihost_enabled:
             machine.write("/etc/cockpit/cockpit.conf",
                           '[WebService]\nAllowMultiHost=yes\n')
@@ -2491,9 +2493,20 @@ def skipOstree(reason: str) -> Callable[[_FT], _FT]:
     return lambda testEntity: testEntity
 
 
+def isBeibootLogin() -> bool:
+    return "ws-container" in os.getenv("TEST_SCENARIO", "")
+
+
 def skipWsContainer(reason: str) -> Callable[[_FT], _FT]:
     """Decorator for skipping a test with cockpit/ws"""
-    if testvm.DEFAULT_IMAGE in OSTREE_IMAGES or "ws-container" in os.getenv("TEST_SCENARIO", ""):
+    if testvm.DEFAULT_IMAGE in OSTREE_IMAGES or isBeibootLogin():
+        return unittest.skip(f"{testvm.DEFAULT_IMAGE}: {reason}")
+    return lambda testEntity: testEntity
+
+
+def skipBeiboot(reason: str) -> Callable[[_FT], _FT]:
+    """Decorator for skipping a test with cockpit/ws in beiboot mode"""
+    if isBeibootLogin():
         return unittest.skip(f"{testvm.DEFAULT_IMAGE}: {reason}")
     return lambda testEntity: testEntity
 

--- a/test/image-prepare
+++ b/test/image-prepare
@@ -142,6 +142,43 @@ def build_install_ostree(dist_tar, image, verbose, quick):
     return args
 
 
+def build_install_container(dist_tar, image, verbose, quick):
+    """Build VM with cockpit/ws container
+
+    This can test an image with beibooting from a cockpit/ws container, without
+    any installed cockpit packages.
+    """
+    # this needs to be the image that corresponds to the actual cockpit/ws container
+    # parse from containers/ws/Dockerfile
+    with open(os.path.join(BASE_DIR, "containers/ws/Dockerfile")) as f:
+        for line in f:
+            if line.startswith("FROM"):
+                fedora_version = line.split('fedora:')[1].split()[0]
+                break
+        else:
+            raise ValueError("failed to parse Fedora version from ws container")
+
+    with create_machine(f"fedora-{fedora_version}") as m:
+        build_rpms(dist_tar, m, verbose, quick)
+        # copy them where ws-container.install expects them
+        m.execute(r"find /var/tmp/build -name '*.rpm' -not -name '*.src.rpm' -exec mv {} /var/tmp/ \;")
+        # create container
+        m.upload([os.path.join(BASE_DIR, "containers")], "/var/tmp/")
+        with open(os.path.join(TEST_DIR, "ws-container.install")) as f:
+            m.execute(f.read())
+        # download container
+        m.execute("podman save cockpit/ws -o /var/tmp/ws.tar")
+        m.download("/var/tmp/ws.tar", os.path.abspath("tmp/"))
+
+    return [
+        # install container
+        "--upload", os.path.abspath("tmp/ws.tar") + ":/var/tmp/",
+        "--run-command", "podman load -i /var/tmp/ws.tar; rm /var/tmp/ws.tar",
+        # remove preinstalled rpms
+        "--run-command", "dnf -C remove -y cockpit-bridge cockpit-ws",
+    ]
+
+
 def validate_packages():
     """Post-install package checks"""
 
@@ -171,6 +208,7 @@ def main():
     parser.add_argument('-q', '--quick', action='store_true', help='Skip unit tests to build faster')
     parser.add_argument('-o', '--overlay', action='store_true',
                         help='Install into existing test/image/ overlay instead of from pristine base image')
+    parser.add_argument('--container', action='store_true', help='Install cockpit/ws container instead of rpms')
     parser.add_argument('image', nargs='?', default=DEFAULT_IMAGE, help='The image to use')
     args = parser.parse_args()
 
@@ -186,6 +224,8 @@ def main():
 
     if args.image == "fedora-coreos":
         customize += build_install_ostree(dist_tar, args.image, args.verbose, args.quick)
+    elif args.container:
+        customize += build_install_container(dist_tar, args.image, args.verbose, args.quick)
     else:
         customize += build_install_package(dist_tar, args.image)
 

--- a/test/run
+++ b/test/run
@@ -61,6 +61,10 @@ case "${TEST_SCENARIO:=}" in
     *other*)
         RUN_OPTS="$RUN_OPTS $(echo "$ALL_TESTS" | grep -Ev "$RE_NETWORKING|$RE_STORAGE|$RE_EXPENSIVE")"
         ;;&
+    *ws-container*)
+        PREPARE_OPTS="$PREPARE_OPTS --quick --container"
+        RUN_OPTS="$RUN_OPTS "
+        ;;&
 
 esac
 

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -23,7 +23,7 @@ import testlib
 
 
 @testlib.skipImage("TODO: bug in refreshing removed/installed state on Arch Linux", "arch")
-@testlib.skipOstree("Not supported")
+@testlib.skipWsContainer("Not supported")
 @testlib.nondestructive
 class TestApps(packagelib.PackageCase):
 

--- a/test/verify/check-client
+++ b/test/verify/check-client
@@ -21,7 +21,7 @@ import testlib
 
 
 # enable this once our cockpit/ws container can beiboot
-@testlib.skipOstree("client setup does not work with ws container")
+@testlib.skipWsContainer("client setup does not work with ws container")
 class TestClient(testlib.MachineCase):
 
     provision = {

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -160,7 +160,7 @@ class TestConnection(testlib.MachineCase):
 
         self.assertNoAdminProcessLeaks()
 
-        if not m.ostree_image:  # cannot write to /usr on OSTree, and cockpit-session is in a container
+        if not m.ws_container:  # no cockpit-session
             # damage cockpit-session permissions, expect generic error message
             m.execute(f"chmod g-x {self.libexecdir}/cockpit-session")
             b.open("/system")
@@ -196,7 +196,7 @@ class TestConnection(testlib.MachineCase):
         self.allow_core_dumps = True
         self.allow_journal_messages(".*org.freedesktop.hostname1.*DBus.Error.NoReply.*")
 
-    @testlib.skipOstree("OSTree doesn't use systemd units")
+    @testlib.skipWsContainer("cockpit/ws doesn't use systemd units")
     @testlib.nondestructive
     def testUnitLifecycle(self):
         m = self.machine
@@ -312,7 +312,7 @@ class TestConnection(testlib.MachineCase):
             out = m.execute(f"su -c '! nc -U /run/cockpit/wsinstance/{s} 2>&1 || exit 1' admin")
             self.assertIn("Permission denied", out)
 
-    @testlib.skipOstree("OSTree doesn't use systemd units")
+    @testlib.skipWsContainer("cockpit/ws doesn't use systemd units")
     @testlib.nondestructive
     def testHttpsInstanceDoS(self):
         m = self.machine
@@ -402,8 +402,7 @@ class TestConnection(testlib.MachineCase):
             output, r"no cipher match|no ciphers available|ssl handshake failure|Cipher is \(NONE\)")
 
         # get along with read-only config directory, as long as certificate exists
-        # this does not work on coreos as the user/group IDs are not mapped correctly
-        if not m.ostree_image:
+        if not m.ws_container:
             m.stop_cockpit()
             try:
                 m.execute("mount -o bind -r /etc/cockpit /etc/cockpit")
@@ -430,7 +429,7 @@ class TestConnection(testlib.MachineCase):
         check_cert_chain()
 
         # backwards compat: merged cert+key file also still works with cockpit-tls (but not any more with cockpit-ws/container)
-        if not m.ostree_image:
+        if not m.ws_container:
             m.execute("""cat /etc/cockpit/ws-certs.d/cert-chain.key >> /etc/cockpit/ws-certs.d/cert-chain.crt
                          chmod 640 /etc/cockpit/ws-certs.d/cert-chain.crt
                          rm /etc/cockpit/ws-certs.d/cert-chain.key""")
@@ -545,7 +544,7 @@ class TestConnection(testlib.MachineCase):
 
         self.allow_journal_messages('peer did not close io when expected')
 
-    @testlib.skipOstree("OSTree doesn't have cockpit-ws")
+    @testlib.skipWsContainer("cockpit/ws doesn't have certs on the host")
     @testlib.nondestructive
     def test100YearsCert(self):
         m = self.machine
@@ -590,7 +589,7 @@ class TestConnection(testlib.MachineCase):
         m.execute(f'test ! {selfsign} -nt /tmp/timestamp')
         m.execute('rm /tmp/timestamp')
 
-    @testlib.skipOstree("OSTree doesn't use systemd units")
+    @testlib.skipWsContainer("cockpit/ws doesn't use systemd units")
     @testlib.nondestructive
     def testSocket(self):
         m = self.machine
@@ -661,7 +660,7 @@ class TestConnection(testlib.MachineCase):
 
         self.allow_journal_messages(".*Peer failed to perform TLS handshake")
 
-    @testlib.skipOstree("Can't remove/upgrade packages on OSTree")
+    @testlib.skipWsContainer("no cockpit-ws package with cockpit/ws container")
     def testWsPackage(self):
         m = self.machine
 
@@ -737,7 +736,7 @@ class TestConnection(testlib.MachineCase):
         if root_login_disallowed:
             self.assertIn('root', m.execute("cat /etc/cockpit/disallowed-users"))
 
-    @testlib.skipOstree("OSTree doesn't have cockpit-ws")
+    @testlib.skipWsContainer("no cockpit-ws binary with cockpit/ws container")
     @testlib.nondestructive
     def testCommandline(self):
         m = self.machine
@@ -818,7 +817,7 @@ class TestConnection(testlib.MachineCase):
         headers = m.execute("curl -s --head http://172.27.0.15:9090/cockpit+123/channel/foo")
         self.assertIn("HTTP/1.1 404 Not Found\r\n", headers)
 
-    @testlib.skipOstree("ssh root login not allowed")
+    @testlib.skipWsContainer("ssh root login not allowed")
     @testlib.nondestructive
     def testFlowControlDownload(self):
         m = self.machine
@@ -855,7 +854,7 @@ class TestConnection(testlib.MachineCase):
         self.assertEqual(int(m.execute("stat -c %s /tmp/spawninput")), 65536000)
         self.assertEqual(m.execute("tail -c10 /tmp/spawninput").strip(), "a" * 10)
 
-    @testlib.skipOstree("OSTree doesn't have cockpit-ws")
+    @testlib.skipWsContainer("no cockpit-ws binary with cockpit/ws container")
     @testlib.nondestructive
     def testLocalSession(self):
         m = self.machine
@@ -892,7 +891,7 @@ export XDG_CONFIG_DIRS=/usr/local
 
         self.allow_journal_messages("couldn't register polkit authentication agent.*")
 
-    @testlib.skipOstree("OSTree doesn't have cockpit-ws")
+    @testlib.skipWsContainer("no cockpit-ws binary with cockpit/ws container")
     @testlib.skipImage("Kernel does not allow user namespaces", "debian-*")
     @testlib.nondestructive
     def testCockpitDesktop(self):
@@ -1061,7 +1060,7 @@ until pgrep -f '^(/usr/[^ ]+/[^ /]*python[^ /]* )?/usr/bin/cockpit-bridge'; do s
         # force cert regeneration
         m.execute("systemctl stop cockpit; rm -f /etc/cockpit/ws-certs.d/*")
         m.start_cockpit()
-        if not m.ostree_image:
+        if not m.ws_container:
             # Really start Cockpit to make sure it has generated all its certificates.
             m.execute("systemctl start cockpit")
 
@@ -1086,7 +1085,7 @@ until pgrep -f '^(/usr/[^ ]+/[^ /]*python[^ /]* )?/usr/bin/cockpit-bridge'; do s
 
         # We don't have access to the stuff on the filesystem if it's living in
         # the container.
-        if not m.ostree_image:
+        if not m.ws_container:
             # make sure that there are no broken links in "our" directory
             self.assertEqual(m.execute(f'find {branddir} -xtype l'), '')
 
@@ -1111,7 +1110,7 @@ until pgrep -f '^(/usr/[^ ]+/[^ /]*python[^ /]* )?/usr/bin/cockpit-bridge'; do s
             self.addCleanup(m.execute, f"rm /tmp/{name}")
 
             # compare that it matches what we expected
-            if not m.ostree_image:
+            if not m.ws_container:
                 m.execute(f'cmp /tmp/{name} {reference}')
 
         # some brands miss the images, but the OSes we CI have them all
@@ -1125,7 +1124,7 @@ until pgrep -f '^(/usr/[^ ]+/[^ /]*python[^ /]* )?/usr/bin/cockpit-bridge'; do s
         b.wait_visible("#login")
         b.assert_pixels("body", "login-screen")
 
-    @testlib.skipOstree("no cockpit-ws package")
+    @testlib.skipWsContainer("cockpit/ws doesn't use systemd units")
     @testlib.nondestructive
     def testAuthUnixPath(self):
         """test UnixPath for auth method in cockpit.conf"""
@@ -1148,7 +1147,7 @@ UnixPath=/run/cockpit/session
         m.start_cockpit()
         self.login_and_go("/system")
 
-    @testlib.skipOstree("test assumes local install")
+    @testlib.skipWsContainer("no local config with cockpit/ws")
     @testlib.nondestructive
     def testXdgConfig(self):
         xdg_env = f"XDG_CONFIG_DIRS={self.vm_tmpdir}/xdg:/etc/test-xdg\n"

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -359,6 +359,7 @@ class TestConnection(testlib.MachineCase):
         self.assertIn("HTTP/1.1 200 OK", out)
 
     @testlib.nondestructive
+    @testlib.skipBeiboot("beiboot doesn't have certs on the host")
     def testTls(self):
         m = self.machine
         b = self.browser
@@ -975,6 +976,7 @@ until pgrep -f '^(/usr/[^ ]+/[^ /]*python[^ /]* )?/usr/bin/cockpit-bridge'; do s
         self.allow_journal_messages(r".*cannot reauthorize identity\(s\): unix-user:.*")
         self.allow_journal_messages("admin: Executing command .*COMMAND=.*cockpit-bridge --privileged.*")
 
+    @testlib.skipBeiboot("test does not make sense in beiboot mode")
     def testReverseProxy(self):
         m = self.machine
         b = self.browser
@@ -1054,6 +1056,7 @@ until pgrep -f '^(/usr/[^ ]+/[^ /]*python[^ /]* )?/usr/bin/cockpit-bridge'; do s
         self.assertIn("HTTP/1.1 200 OK", m.execute("curl --silent --head http://172.27.0.15:9091"))
 
     @testlib.nondestructive
+    @testlib.skipBeiboot("beiboot doesn't use systemd units")
     def testCaCert(self):
         m = self.machine
 
@@ -1198,6 +1201,7 @@ UnixPath=/run/cockpit/session
         self.assertFalse(b.is_present("#nav-system li:contains(Services)"))
 
     @testlib.nondestructive
+    @testlib.skipBeiboot("no cockpit-bridge binary on host in beiboot mode")
     def testBridgeCLI(self):
         m = self.machine
 

--- a/test/verify/check-embed
+++ b/test/verify/check-embed
@@ -23,6 +23,7 @@ import testlib
 
 
 @testlib.nondestructive
+@testlib.skipBeiboot("no local overrides/config in beiboot mode")
 class TestEmbed(testlib.MachineCase):
 
     def testBasic(self, allow_multi_host=True):

--- a/test/verify/check-examples
+++ b/test/verify/check-examples
@@ -7,6 +7,7 @@ import testlib
 EXAMPLES_DIR = os.path.join(os.path.dirname(testlib.TEST_DIR), "examples")
 
 
+@testlib.skipBeiboot("no local overrides/config in beiboot mode")
 @testlib.nondestructive
 class TestPinger(testlib.MachineCase):
 
@@ -34,6 +35,7 @@ class TestPinger(testlib.MachineCase):
         self.testBasic()
 
 
+@testlib.skipBeiboot("no local overrides/config in beiboot mode")
 @testlib.nondestructive
 class TestXHRProxy(testlib.MachineCase):
     def setUp(self):
@@ -77,6 +79,7 @@ class TestXHRProxy(testlib.MachineCase):
         b.wait_in_text("#output", "File not found")
 
 
+@testlib.skipBeiboot("no local overrides/config in beiboot mode")
 @testlib.nondestructive
 class TestLongRunning(testlib.MachineCase):
 

--- a/test/verify/check-loopback
+++ b/test/verify/check-loopback
@@ -20,7 +20,7 @@
 import testlib
 
 
-@testlib.skipOstree("OSTree always uses loopback")
+@testlib.skipWsContainer("cockpit/ws always uses loopback")
 @testlib.nondestructive
 class TestLoopback(testlib.MachineCase):
 

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1191,6 +1191,10 @@ BEGIN {{
             b.wait_visible(progress_sel)
             b.logout()
 
+            # no host-local configs/overrides in beiboot mode
+            if testlib.isBeibootLogin():
+                return
+
             # without cockpit-storaged, mounts are not links
             self.restore_file("/usr/share/cockpit/storaged/manifest.json")
             m.write("/usr/share/cockpit/storaged/manifest.json", "")

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -81,6 +81,7 @@ def applySettings(browser, dialog_selector):
 
 @testlib.skipOstree("no PCP support")
 @testlib.skipImage("pcp not currently in testing", "debian-testing")
+@testlib.skipImage("FIXME: python3-pcp not currently on image", "rhel-8-10")
 class TestHistoryMetrics(testlib.MachineCase):
     def setUp(self):
         super().setUp()
@@ -1247,6 +1248,7 @@ BEGIN {{
 
 
 @testlib.skipImage("TODO: Arch Linux packagekit support", "arch")
+@testlib.skipImage("FIXME: python3-pcp not currently on image", "rhel-8-10")
 class TestMetricsPackages(packagelib.PackageCase):
     pcp_dialog_selector = "#pcp-settings-modal"
 
@@ -1378,6 +1380,7 @@ class TestMetricsPackages(packagelib.PackageCase):
 
 @testlib.skipOstree("no PCP support")
 @testlib.skipImage("pcp not currently in testing", "debian-testing")
+@testlib.skipImage("FIXME: python3-pcp not currently on image", "rhel-8-10")
 class TestMultiCPU(testlib.MachineCase):
 
     provision = {

--- a/test/verify/check-networkmanager-firewall
+++ b/test/verify/check-networkmanager-firewall
@@ -63,6 +63,7 @@ class TestFirewall(netlib.NetworkCase):
         if m.image == "arch":
             m.execute("firewall-cmd --zone 'public' --change-interface='eth0'; firewall-cmd --runtime-to-permanent")
 
+    @testlib.skipImage("FIXME: get_num_zones() race condition, moves from 1 to 2", "rhel-8-10")
     def testNetworkingPage(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -656,6 +656,7 @@ ExecStart=/usr/local/bin/{packageName}
         b.wait_visible("#restart-services-modal .pf-v5-c-alert")
 
     @testlib.skipImage("No security changelog support in packagekit", "arch")
+    @testlib.skipImage("FIXME: currently fails", "rhel-8-10")
     def testInfoSecurity(self):
         b = self.browser
         m = self.machine
@@ -824,6 +825,7 @@ ExecStart=/usr/local/bin/{packageName}
         b.wait_visible("table.updates-history tbody:not(.pf-m-expanded)")
 
     @testlib.skipImage("No security changelog support in packagekit", "arch")
+    @testlib.skipImage("FIXME: currently fails", "rhel-8-10")
     @testlib.nondestructive
     def testSecurityOnly(self):
         b = self.browser

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1046,7 +1046,9 @@ ExecStart=/usr/local/bin/{packageName}
                            mv /usr/share/dbus-1/system-services/org.freedesktop.PackageKit.service.disabled /usr/share/dbus-1/system-services/org.freedesktop.PackageKit.service
                            systemctl daemon-reload""")
 
-        self.assertNotIn("\nupdates", m.execute("cockpit-bridge --packages"))
+        # no bridge in beiboot mode
+        if not testlib.isBeibootLogin():
+            self.assertNotIn("\nupdates", m.execute("cockpit-bridge --packages"))
         # should not appear in the menu at all
         self.login_and_go(None)
         b.wait_in_text("#host-apps .pf-m-current", "Overview")
@@ -1202,6 +1204,7 @@ class TestKpatchInstall(NoSubManCase):
 
 
 @testlib.onlyImage("No subscriptions", "rhel-*")
+@testlib.skipBeiboot("sub-man-cockpit not contained in cockpit/ws")
 class TestUpdatesSubscriptions(packagelib.PackageCase):
     provision = {
         "0": {"address": "10.111.112.1/20", "dns": "10.111.112.1", "memory_mb": 512},

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1097,7 +1097,7 @@ ExecStart=/usr/local/bin/{packageName}
 
 
 @testlib.skipImage("TODO: Arch Linux has no cockpit-ws package, it's in cockpit", "arch")
-@testlib.skipOstree("Image uses OSTree")
+@testlib.skipWsContainer("no cockpit-ws package with cockpit/ws container")
 class TestWsUpdate(NoSubManCase):
     def testBasic(self):
         # The main case for this is that cockpit-ws itself gets upgraded, which

--- a/test/verify/check-packages
+++ b/test/verify/check-packages
@@ -48,6 +48,7 @@ test_html = """
 
 
 @testlib.nondestructive
+@testlib.skipBeiboot("no local cockpit packages in beiboot mode")
 class TestPackages(testlib.MachineCase):
 
     def testBasic(self):

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -860,8 +860,8 @@ OnCalendar=daily
         b.switch_to_top()
         assert_location("/system")
 
-        # CoreOS does not keep login history
-        if not self.machine.ostree_image:
+        # ws container does not keep login history
+        if not self.machine.ws_container:
 
             b.enter_page("/system")
             b.click("button:contains(View login history)")

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -421,6 +421,7 @@ OnCalendar=daily
 
         self.allow_restart_journal_messages()
 
+    @testlib.skipBeiboot("no local overrides/config in beiboot mode")
     def testShellReload(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -680,6 +680,7 @@ OnCalendar=daily
 
     @testlib.skipOstree("No PCP available")
     @testlib.skipImage("pcp not currently in testing", "debian-testing")
+    @testlib.skipImage("FIXME: python3-pcp not currently on image", "rhel-8-10")
     def testPlots(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-reauthorize
+++ b/test/verify/check-reauthorize
@@ -59,7 +59,7 @@ class TestReauthorize(testlib.MachineCase):
         b.wait_in_text(".cockpit-internal-reauthorize span", 'result:')
         self.assertEqual(b.text(".cockpit-internal-reauthorize span"), 'result: access-denied')
 
-    @testlib.skipOstree("ssh root login not allowed")
+    @testlib.skipWsContainer("ssh root login not allowed")
     def testSuper(self):
         b = self.browser
 

--- a/test/verify/check-session
+++ b/test/verify/check-session
@@ -48,12 +48,12 @@ class TestSession(testlib.MachineCase):
         wait_session(should_exist=True)
 
         # Check session type
-        if not m.ostree_image:
+        if not m.ws_container:
             # Systemd 256 also shows a class=manager session for admin
             session_id = m.execute("loginctl list-sessions | grep -v manager | awk '/admin/ {print $1}'").strip()
             self.assertEqual(m.execute(f"loginctl show-session -p Type {session_id}").strip(), "Type=web")
 
-        if not m.ostree_image and m.image != "arch":
+        if not m.ws_container and m.image != "arch":
             # starts ssh-agent in session
             bridge = m.execute("pgrep -u admin cockpit-bridge").strip()
             out = m.execute(f"grep --null-data SSH_AGENT_PID /proc/{bridge}/environ | xargs -0")
@@ -88,7 +88,7 @@ class TestSession(testlib.MachineCase):
 
         # try to pwn $SSH_AGENT_PID via pam_env's user_readenv=1 (CVE-2024-6126)
 
-        if m.ostree_image:
+        if m.ws_container:
             # not using cockpit's PAM config
             return
 

--- a/test/verify/check-shell-host-switching
+++ b/test/verify/check-shell-host-switching
@@ -97,6 +97,7 @@ class HostSwitcherHelpers:
         b.click("#hosts-sel button")
 
 
+@testlib.skipBeiboot("host switching disabled in beiboot mode")
 class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
     provision = {
         'machine1': {"address": "10.111.113.1/20", "memory_mb": 512},

--- a/test/verify/check-shell-keys
+++ b/test/verify/check-shell-keys
@@ -190,7 +190,7 @@ class TestKeys(testlib.MachineCase):
             return b.text(f"tr[data-name='{identifier}'] + tr dt:contains({dtype}) + dd > div")
 
         # Operating systems where auto loading doesn't work
-        auto_load = not m.ostree_image
+        auto_load = not m.ws_container
 
         if m.image == "arch":
             self.write_file("/etc/pam.d/cockpit", """

--- a/test/verify/check-shell-menu
+++ b/test/verify/check-shell-menu
@@ -22,6 +22,7 @@ import time
 import testlib
 
 
+@testlib.skipBeiboot("no local overrides/config in beiboot mode")
 @testlib.nondestructive
 class TestMenu(testlib.MachineCase):
 

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -117,6 +117,7 @@ def change_ssh_port(machine, address, sshd_socket, sshd_service, port=None, time
     raise error
 
 
+@testlib.skipBeiboot("host switching disabled in beiboot mode")
 class TestMultiMachineAdd(testlib.MachineCase):
     provision = {
         "machine1": {"address": "10.111.113.1/20", "memory_mb": 660},
@@ -236,6 +237,7 @@ class TestMultiMachineAdd(testlib.MachineCase):
         self.allow_hostkey_messages()
 
 
+@testlib.skipBeiboot("host switching disabled in beiboot mode")
 class TestMultiMachine(testlib.MachineCase):
     provision = {
         "machine1": {"address": "10.111.113.1/20", "memory_mb": 660},

--- a/test/verify/check-shell-multi-machine-key
+++ b/test/verify/check-shell-multi-machine-key
@@ -58,6 +58,7 @@ KEY_IDS_MD5 = [
 
 
 @testlib.skipImage("TODO: ssh key check fails on Arch Linux", "arch")
+@testlib.skipBeiboot("host switching disabled in beiboot mode")
 class TestMultiMachineKeyAuth(testlib.MachineCase):
     provision = {
         "machine1": {"address": "10.111.113.1/20", "memory_mb": 512},

--- a/test/verify/check-shell-multi-os
+++ b/test/verify/check-shell-multi-os
@@ -20,6 +20,7 @@
 import testlib
 
 
+@testlib.skipBeiboot("host switching disabled in beiboot mode")
 class TestRHEL8(testlib.MachineCase):
     provision = {
         "0": {"address": "10.111.113.1/20", "memory_mb": 768},

--- a/test/verify/check-sosreport
+++ b/test/verify/check-sosreport
@@ -163,6 +163,7 @@ exit 1""", perm="755")
         m.execute("while pgrep -a -x sos; do sleep 1; done", timeout=10)
         self.assertEqual(m.execute(f"ls {self.report_dir}/sosreport* 2>/dev/null || true"), "")
 
+    @testlib.skipBeiboot("apps not available in beiboot mode")
     def testAppStream(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-ssh-api
+++ b/test/verify/check-ssh-api
@@ -41,6 +41,7 @@ class TestSshDialog(testlib.MachineCase):
         # session connection with the ws container
         self.machine.execute("pkill -ef [s]sh.*ferny.*127.0.0.1")
 
+    @testlib.skipImage("FIXME: Assertion failed: UnknownHostDialog needs a host-key and host-fingerprint in error", "rhel-8-10")
     def testPassword(self):
         m = self.machine
         b = self.browser
@@ -225,6 +226,7 @@ class TestSshDialog(testlib.MachineCase):
         b.wait_not_present("#credentials-modal")
         b.switch_to_frame("cockpit1:localhost/playground/remote")
 
+    @testlib.skipImage("FIXME: Assertion failed: UnknownHostDialog needs a host-key and host-fingerprint in error", "rhel-8-10")
     def testKey(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -56,7 +56,8 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
             else:
                 self.sed_file(f'/nologin/a {admins_only_pam}', remote_filename)
 
-        deny_non_root("/etc/pam.d/cockpit")
+        if not m.ws_container:
+            deny_non_root("/etc/pam.d/cockpit")
         deny_non_root("/etc/pam.d/sshd")
 
         m.start_cockpit()
@@ -67,7 +68,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.wait_visible("#login-user-input")
         b.wait_not_visible("#banner")
 
-        if m.ostree_image:
+        if m.ws_container:
             m.execute("podman exec ws printf '[Session]\nBanner = /host/etc/issue\n' > /etc/cockpit/cockpit.conf")
         else:
             m.execute("printf '[Session]\nBanner = /etc/issue\n' > /etc/cockpit/cockpit.conf")
@@ -99,12 +100,12 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
         # Try to login as user with correct password
         b.try_login("user", "abcdefg")
-        b.wait_text("#login-error-title", "Authentication failed" if m.ostree_image else "Permission denied")
+        b.wait_text("#login-error-title", "Authentication failed" if m.ws_container else "Permission denied")
         self.assertNotIn("web", m.execute("who"))
 
         # Try to login with disabled shell; this does not work on OSTree where
         # we log in through ssh
-        if not m.ostree_image:
+        if not m.ws_container:
             m.execute("usermod --shell /bin/false admin; sync")
             b.reload()
             b.try_login("admin", "foobar")
@@ -118,7 +119,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.login_and_go()
         self.check_shell()
 
-        if not m.ostree_image:  # logs in via ssh, not cockpit-session
+        if not m.ws_container:  # logs in via ssh, not cockpit-session
             # older coreutils shows the session type (web), newer ones the service name
             self.assertRegex(m.execute("who"), r"(^|\n)admin *(web|cockpit).*(\d+\.\d+|::)")
 
@@ -126,7 +127,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.reload()
         self.check_shell()
 
-        if not m.ostree_image:  # logs in via ssh, not cockpit-session
+        if not m.ws_container:  # logs in via ssh, not cockpit-session
             self.assertRegex(m.execute("who"), r"(^|\n)admin *(web|cockpit).*(\d+\.\d+|::)")
 
         b.go("/users#/admin")
@@ -165,7 +166,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.wait_visible("#option-group")
 
         # And now we remove ssh which affects the default
-        if not m.ostree_image:
+        if not m.ws_container:
             self.restore_file("/usr/bin/ssh")
             m.execute("rm /usr/bin/ssh")
             m.restart_cockpit()
@@ -198,7 +199,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
                                     r"pam_succeed_if\(cockpit:auth\): requirement .* not met by user .*",
                                     "noise-rc-.*")
 
-    @testlib.skipOstree("logs in via ssh, not cockpit-session")
+    @testlib.skipWsContainer("logs in via ssh, not cockpit-session")
     def testLogging(self):
         m = self.machine
         b = self.browser
@@ -260,7 +261,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b = self.browser
 
         # On OSTree this happens over ssh
-        if m.ostree_image:
+        if m.ws_container:
             self.restore_dir("/etc/ssh", restart_unit=self.sshd_service)
             m.execute("sed -i 's/.*ChallengeResponseAuthentication.*/ChallengeResponseAuthentication yes/' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*")
             m.execute(self.restart_sshd)
@@ -284,7 +285,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.wait_visible("#conversation-group")
         b.wait_not_visible("#password-group")
         b.wait_not_visible("#user-group")
-        if m.ostree_image:
+        if m.ws_container:
             b.wait_in_text("#conversation-prompt", "You are required to change your password")
         else:
             b.wait_in_text("#conversation-message", "You are required to change your password")
@@ -301,7 +302,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.click('#login-button')
 
         # We should see a message
-        if m.ostree_image:
+        if m.ws_container:
             b.wait_in_text("#conversation-prompt", "BAD PASSWORD")
         else:
             b.wait_in_text("#conversation-message", "BAD PASSWORD")
@@ -324,7 +325,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.click('#login-button')
 
         # We should see a message
-        if m.ostree_image:
+        if m.ws_container:
             b.wait_in_text("#conversation-prompt", "passwords do not match")
         else:
             b.wait_in_text("#conversation-message", "passwords do not match")
@@ -358,7 +359,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         m = self.machine
         b = self.browser
         conf = "/etc/pam.d/cockpit"
-        if m.ostree_image:
+        if m.ws_container:
             conf = "/etc/pam.d/sshd"
             self.restore_dir("/etc/ssh", restart_unit=self.sshd_service)
             m.execute("sed -i 's/.*ChallengeResponseAuthentication.*/ChallengeResponseAuthentication yes/' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*")
@@ -382,7 +383,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.wait_in_text("#conversation-prompt", "life the universe")
         b.set_val('#conversation-input', '43')
         b.click('#login-button')
-        if m.ostree_image:
+        if m.ws_container:
             # ssh asks for password again, despite NumberOfPasswordPrompts=1
             b.wait_in_text("#conversation-prompt", "nonexisting@127.0.0.1's password")
             b.set_val('#conversation-input', 'blahblah')
@@ -473,8 +474,10 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         # not an admin
         b.wait_visible(".pf-v5-c-alert:contains('Web console is running in limited access mode.')")
 
-        b.wait_in_text('#system_last_login', "Last successful login")
-        b.wait_in_text('#system_last_login_from', "web console")
+        # ws container does not keep login history
+        if not m.ws_container:
+            b.wait_in_text('#system_last_login', "Last successful login")
+            b.wait_in_text('#system_last_login_from', "web console")
 
         b.logout()
         # not allowed to restricted users
@@ -496,8 +499,10 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         # passing login info memfd should work
         b.logout()
         b.login_and_go("/system", user="priv")
-        b.wait_in_text('#system_last_login', "Last successful login")
-        b.wait_in_text('#system_last_login_from', "web console")
+        # ws container does not keep login history
+        if not m.ws_container:
+            b.wait_in_text('#system_last_login', "Last successful login")
+            b.wait_in_text('#system_last_login_from', "web console")
 
         b.go("/playground/test")
         b.enter_page("/playground/test")
@@ -573,7 +578,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
         self.check_shell()
 
-    @testlib.skipOstree("Starting on OSTree is weird")
+    @testlib.skipWsContainer("no local config with cockpit/ws container")
     def testFailingWebsocket(self, safari=False, cacert=False):
         m = self.machine
         b = self.browser
@@ -611,12 +616,12 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
             b.wait_not_present("#safari-cert-help")
 
     @testlib.skipBrowser("Enough when only chromium pretends to be a different browser", "firefox")
-    @testlib.skipOstree("Starting on OSTree is weird")
+    @testlib.skipWsContainer("no local config with cockpit/ws container")
     def testFailingWebsocketSafari(self):
         self.testFailingWebsocket(safari=True, cacert=True)
 
     @testlib.skipBrowser("Enough when only chromium pretends to be a different browser", "firefox")
-    @testlib.skipOstree("Starting on OSTree is weird")
+    @testlib.skipWsContainer("no local config with cockpit/ws container")
     def testFailingWebsocketSafariNoCA(self):
         self.testFailingWebsocket(safari=True, cacert=False)
 
@@ -728,8 +733,8 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         # and login again
         expect_successful_login("admin", "foobar")
 
-        # ostree images log in via sshd, which forbids root logging in with a password
-        if not m.ostree_image:
+        # ws container logs in via sshd, which forbids root logging in with a password
+        if not m.ws_container:
             # make sure root never gets locked out
             for n in range(1, 10):
                 expect_failed_login("root", "bad", n)
@@ -738,7 +743,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         self.allow_journal_messages(".*[aA]ccount .*locked due to .* failed logins.*")
         self.allow_journal_messages(".*minutes left to unlock.*")
 
-    @testlib.skipOstree("root logins disabled by default with ssh")
+    @testlib.skipWsContainer("root logins disabled by default with ssh")
     def testPamAccess(self):
         b = self.browser
         m = self.machine
@@ -762,7 +767,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
         self.allow_journal_messages(r"cockpit-session: user account access failed.*root.*")
 
-    @testlib.skipOstree("sssd not available")
+    @testlib.skipWsContainer("sssd/cockpit-session not available with ws container")
     @testlib.skipImage("sssd not currently in testing", "debian-testing")
     def testClientCertAuthentication(self):
         m = self.machine
@@ -966,7 +971,7 @@ matchrule = <SUBJECT>^DC=LAN,DC=COCKPIT,CN=alice$
         check_server("[::1]:22", expect_fp_ack=True)
 
     # enable this once our cockpit/ws container can beiboot
-    @testlib.skipOstree("client setup does not work with ws container")
+    @testlib.skipWsContainer("client setup does not work with ws container")
     def testSSH(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -38,6 +38,7 @@ class TestLogin(testlib.MachineCase):
             b.click("#hosts-sel button")
             b.set_layout("desktop")
 
+    # @testlib.skipBeiboot("no local cockpit PAM config in beiboot mode")
     def testBasic(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -257,6 +257,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         verify_correct(has_last=True, n_fail=0)
 
     @testlib.skipImage("Arch Linux has no pwquality by default", "arch")
+    @testlib.skipImage("FIXME: does not support /etc/ssh/sshd_condfig.d", "rhel-8-10")
     def testExpired(self):
         m = self.machine
         b = self.browser
@@ -356,6 +357,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
                                     '.*Sorry, passwords do not match.')
         self.allow_restart_journal_messages()
 
+    @testlib.skipImage("FIXME: does not support /etc/ssh/sshd_condfig.d", "rhel-8-10")
     def testConversation(self):
         m = self.machine
         b = self.browser
@@ -405,6 +407,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
     @testlib.skipImage("No tlog", "debian-*", "ubuntu-*", "arch")
     @testlib.skipOstree("No tlog")
+    @testlib.skipImage("FIXME: tlog messes up bridge frame protocol", "rhel-8-10")
     def testSessionRecordingShell(self):
         m = self.machine
         b = self.browser
@@ -460,6 +463,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
     @testlib.skipImage("No SELinux", "debian-*", "ubuntu-*", "arch")
     @testlib.skipOstree("No semanage")
+    @testlib.skipImage("FIXME: Authentication failed: unknown-host", "rhel-8-10")
     def testSELinuxRestrictedUser(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-storage-anaconda
+++ b/test/verify/check-storage-anaconda
@@ -167,6 +167,7 @@ class TestStorageAnaconda(storagelib.StorageCase):
         b.wait_not_present(self.card_row("Storage", location="/var"))
 
     @testlib.skipImage("No Stratis", "debian-*", "ubuntu-*")
+    @testlib.skipImage("commit 817c957899a4 removed Statis 2 support", "rhel-8-*")
     def testStratis(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -719,6 +719,8 @@ class TestStorageNBDE(storagelib.StorageCase, packagelib.PackageCase):
         b.wait_not_present(panel + 'ul li:contains("Slot 1")')
 
     @testlib.skipImage("TODO: don't know how to encrypt the rootfs", "debian-*", "ubuntu-*", "arch")
+    # this doesn't work in ostree either, but we don't run storage tests there
+    @testlib.skipWsContainer("newly built root doesn't contain ws container")
     @testlib.timeout(1200)
     def testRootReboot(self):
         m = self.machine

--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -294,6 +294,7 @@ ExecStart=/usr/bin/sleep infinity
             m.execute(r"sed -i '/run\/data/ s/auto.*$/auto/' /etc/fstab")
         b.wait_in_text(self.card_desc(desc, "Mount point"), "/run/data (stop boot on failure)")
 
+    @testlib.skipImage("FIXME: ought to work, investigate", "rhel-8-10")
     def testBadOption(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -198,6 +198,7 @@ class TestStorageResize(storagelib.StorageCase):
         size = int(m.execute("lvs TEST/vol -o lv_size --noheading --units b --nosuffix"))
         self.assertLess(size, 250000000)
 
+    @testlib.skipImage("cryptsetup uses too much memory, OOM on our test VMs", "rhel-8-*")
     def testGrowShrinkEncryptedHelp(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -47,6 +47,7 @@ def create_pool_key(machine, keyname, passphrase):
 
 
 @testlib.skipImage("No Stratis", "debian-*", "ubuntu-*")
+@testlib.skipImage("commit 817c957899a4 removed Statis 2 support", "rhel-8-*")
 @testlib.nondestructive
 class TestStorageStratis(storagelib.StorageCase):
     def setUp(self):
@@ -537,6 +538,7 @@ systemctl restart stratisd
 
 
 @testlib.skipImage("No Stratis", "debian-*", "ubuntu-*")
+@testlib.skipImage("commit 817c957899a4 removed Statis 2 support", "rhel-8-*")
 class TestStorageStratisReboot(storagelib.StorageCase):
     # LUKS uses memory hard PBKDF, 1 GiB is not enough; see https://bugzilla.redhat.com/show_bug.cgi?id=1881829
     provision = {

--- a/test/verify/check-storage-swap
+++ b/test/verify/check-storage-swap
@@ -27,8 +27,8 @@ import testlib
 class TestStorageswap(storagelib.StorageCase):
 
     def checkSwapUsed(self):
-        # this relies on PCP, which is not currently in testing
-        if self.machine.image == "debian-testing":
+        # this relies on PCP, which is missing on some images
+        if self.machine.image in ["debian-testing", "rhel-8-10"]:
             return
 
         self.browser.wait_text(self.card_desc("Swap", "Used"), "0 B")

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -217,7 +217,8 @@ session include system-auth
         b.wait_in_text(".pf-v5-c-modal-box", "Password for admin")
         status = m.execute("loginctl --lines=0 user-status admin")
         self.assertIn("sudo", status)
-        self.assertIn("cockpit-askpass", status)
+        if not m.ws_container:
+            self.assertIn("cockpit-askpass", status)
 
         b.click(".pf-v5-c-modal-box button:contains('Cancel')")
         b.wait_not_present(".pf-v5-c-modal-box")
@@ -227,7 +228,8 @@ session include system-auth
         # logging out cleans up pending sudo auth; user should either go to "State: closing" or disappear completely
         b.open_superuser_dialog()
         b.wait_in_text(".pf-v5-c-modal-box", "Password for admin")
-        self.assertIn("cockpit-askpass", m.execute("loginctl --lines=0 user-status admin"))
+        if not m.ws_container:
+            self.assertIn("cockpit-askpass", m.execute("loginctl --lines=0 user-status admin"))
         b.click(".pf-v5-c-modal-box button:contains('Cancel')")
         b.wait_not_present(".pf-v5-c-modal-box")
         b.logout()

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -405,6 +405,7 @@ session include system-auth
         b.wait_not_present(".pf-v5-c-alert:contains('Web console is running in limited access mode.')")
 
 
+@testlib.skipBeiboot("host switching disabled in beiboot mode")
 class TestSuperuserDashboard(testlib.MachineCase):
     provision = {
         "machine1": {"address": "10.111.113.1/20", "memory_mb": 512},

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -124,6 +124,7 @@ class TestSuperuser(testlib.MachineCase):
         self.write_file("/etc/sudoers.d/admin", "admin ALL=(ALL) NOPASSWD:ALL")
         b.become_superuser(passwordless=True)
 
+    @testlib.skipBeiboot("no local PAM config in beiboot mode")
     def testTwoPasswds(self):
         b = self.browser
         m = self.machine
@@ -236,6 +237,7 @@ session include system-auth
         testlib.wait(lambda: "sudo" not in m.execute("loginctl --lines=0 user-status admin || true"), tries=10)
         self.assertNotIn("cockpit", m.execute("loginctl --lines=0 user-status admin || true"))
 
+    @testlib.skipBeiboot("no local overrides/PAM config in beiboot mode")
     def testBrokenBridgeConfig(self):
         b = self.browser
         m = self.machine
@@ -270,6 +272,7 @@ session include system-auth
         b.wait_not_present(".pf-v5-c-modal-box:contains('Problem becoming administrator')")
         b.check_superuser_indicator("Limited access")
 
+    @testlib.skipBeiboot("no local overrides/PAM config in beiboot mode")
     def testRemoveBridgeConfig(self):
         m = self.machine
         b = self.browser
@@ -299,6 +302,7 @@ session include system-auth
         b.wait_visible("#system_information_os_text")
         b.wait_not_present(".pf-v5-c-alert:contains('Web console is running in limited access mode')")
 
+    @testlib.skipBeiboot("no local overrides/PAM config in beiboot mode")
     def testSingleLabelBridgeConfig(self):
         b = self.browser
 
@@ -326,6 +330,7 @@ session include system-auth
         b.click(".pf-v5-c-modal-box button:contains('Close')")
         b.check_superuser_indicator("Limited access")
 
+    @testlib.skipBeiboot("no local overrides/PAM config in beiboot mode")
     def testMultipleBridgeConfig(self):
         b = self.browser
 

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -797,9 +797,9 @@ password=foobar
         profile = m.execute(cmd + " --show").strip()
         b.wait_text("#crypto-policy-button", shown_profile_text(profile))
 
-        # RHEL 10 has no SHA1 policy, so do not show it.
+        # RHEL 8/10 have no SHA1 policy, so do not show it.
         b.click("#crypto-policy-button")
-        func = b.wait_not_present if re.match('(centos|rhel)-10.*', m.image) else b.wait_visible
+        func = b.wait_not_present if re.match('(centos|rhel)-(8|10).*', m.image) else b.wait_visible
         func(".pf-v5-c-menu__item-main .pf-v5-c-menu__item-text:contains('DEFAULT:SHA1')")
         b.click("#crypto-policy-dialog button:contains('Cancel')")
         b.wait_not_present("#crypto-policy-dialog")

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -628,6 +628,7 @@ fi
                                     'done')
 
     @testlib.onlyImage("insights-client is only on RHEL", "rhel*")
+    @testlib.skipBeiboot("no local overrides/config in beiboot mode")
     @testlib.nondestructive
     def testInsightsStatus(self):
         m = self.machine

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -484,6 +484,7 @@ class CommonTests:
 
 
 @testlib.skipOstree("No realmd available")
+@testlib.skipWsContainer("No sssd PAM integration in beiboot mode")
 @testlib.skipImage("No realmd available", "arch")
 @testlib.no_retry_when_changed
 class TestRealms(testlib.MachineCase):
@@ -982,6 +983,7 @@ sed -i '/^sudoers:/ s/files sss/sss files/' /etc/nsswitch.conf
 
 
 @testlib.skipOstree("No realmd available")
+@testlib.skipWsContainer("No sssd PAM integration in beiboot mode")
 @testlib.skipImage("No realmd available", "arch")
 @testlib.skipImage("freeipa not currently available", "debian-*")
 @testlib.no_retry_when_changed

--- a/test/verify/check-system-shutdown-restart
+++ b/test/verify/check-system-shutdown-restart
@@ -20,6 +20,7 @@
 import testlib
 
 
+@testlib.skipBeiboot("host switching disabled in beiboot mode")
 class TestShutdownRestart(testlib.MachineCase):
     provision = {
         "machine1": {"address": "10.111.113.1/20", "memory_mb": 512},

--- a/test/verify/check-system-terminal
+++ b/test/verify/check-system-terminal
@@ -193,7 +193,7 @@ PROMPT_COMMAND='printf "\033]0;%s@%s:%s\007" "${USER}" "${HOSTNAME%%.*}" "${PWD/
         # don't use wait_line() for the full match here, as line breaks get in the way; just wait until command has run
         wait_line(echo_result_line, prompt)
         path = m.execute("cat /tmp/path").strip()
-        if m.ostree_image:
+        if m.ws_container:
             self.assertIn("/usr/local/bin:/usr/bin", path)
         elif m.image == "arch":
             self.assertIn("/usr/local/sbin:/usr/local/bin:/usr/bin", path)

--- a/test/verify/check-testlib
+++ b/test/verify/check-testlib
@@ -278,6 +278,7 @@ class TestTestlib(testlib.MachineCase):
         self.assertNotIn("cockpittest", self.machine.execute("cat /etc/passwd"))
         self.machine.execute("test ! -e /home/cockpittest")
 
+    @testlib.skipBeiboot("no cockpit-system package installed in beiboot mode")
     def testMiscAPI(self):
         assert self.system_before(1000)
         assert not self.system_before(100)

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -662,7 +662,7 @@ class TestAccounts(testlib.MachineCase):
         # with container this happens over ssh
         if m.ws_container:
             self.restore_dir("/etc/ssh", restart_unit=self.sshd_service)
-            m.execute("sed -i 's/.*ChallengeResponseAuthentication.*/ChallengeResponseAuthentication yes/' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*")
+            m.execute("sed -i 's/.*ChallengeResponseAuthentication.*/ChallengeResponseAuthentication yes/' /etc/ssh/sshd_config $(ls /etc/ssh/sshd_config.d/* 2>/dev/null) || true")
             m.execute(self.restart_sshd)
 
         b.wait_visible("#login")

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -614,7 +614,7 @@ class TestAccounts(testlib.MachineCase):
         b.click('#accounts-list td[data-label="Username"] a[href="#/damaged"]')
         b.wait_in_text("#account-title", "Damaged")
 
-        if not m.ostree_image:  # User is not shown as logged in when logged in through Cockpit
+        if not m.ws_container:  # User is not shown as logged in when logged in through Cockpit
             b.go("#/admin")
             b.wait_visible("#account-logout[disabled]")
 
@@ -655,12 +655,12 @@ class TestAccounts(testlib.MachineCase):
         b.logout()
 
         # login in second window to check if last login is updated in accounts list
-        if not m.ostree_image:  # User is not shown as logged in when logged in through Cockpit
+        if not m.ws_container:  # User is not shown as logged in when logged in through Cockpit
             b2.login_and_go("/users")
             b2.wait_in_text("#accounts-list tbody tr:contains(robert) td[data-label='Last active']", "Never logged in")
 
-        # On OSTree this happens over ssh
-        if m.ostree_image:
+        # with container this happens over ssh
+        if m.ws_container:
             self.restore_dir("/etc/ssh", restart_unit=self.sshd_service)
             m.execute("sed -i 's/.*ChallengeResponseAuthentication.*/ChallengeResponseAuthentication yes/' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*")
             m.execute(self.restart_sshd)
@@ -933,7 +933,7 @@ class TestAccounts(testlib.MachineCase):
         b.click('#account-set-password-dialog button.apply')
         b.wait_in_text("#account-set-password-dialog .pf-v5-c-modal-box__body", "must wait longer")
 
-    @testlib.skipOstree("ssh root login not allowed")
+    @testlib.skipWsContainer("ssh root login not allowed")
     def testRootLogin(self):
         m = self.machine
         b = self.browser
@@ -1073,7 +1073,7 @@ class TestAccounts(testlib.MachineCase):
         b.wait_in_text("#password-expiration-text", "Password must be changed")
         self.assertEqual(self.accountExpiryInfo("scruffy", "Password expires"), "password must be changed")
 
-    @testlib.skipOstree("User is not shown as logged in when logged in through Cockpit")
+    @testlib.skipWsContainer("User is not shown as logged in with cockpit/ws")
     def testAccountLogs(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
Finally re-introduce testing on RHEL 8, as that's a very interesting target for beibooting and the ws container or Cockpit Client.

Look at the rhel-8-10/ws-container-{storage,networking,other,expensive} tests.

Requirements:
 - [x] https://github.com/cockpit-project/bots/pull/7022
 - [x] #21149