### PR TITLE
common: Fix memory leak in cockpit_web_response_error_with_body()

### DIFF
--- a/src/common/cockpitwebresponse.c
+++ b/src/common/cockpitwebresponse.c
@@ -1115,6 +1115,7 @@ cockpit_web_response_error_with_body (CockpitWebResponse *self,
                                       GBytes *body)
 {
   g_autofree gchar *escaped = NULL;
+  g_autofree gchar *reason_local = NULL;
   const gchar *message;
 
   g_return_if_fail (COCKPIT_IS_WEB_RESPONSE (self));
@@ -1155,14 +1156,14 @@ cockpit_web_response_error_with_body (CockpitWebResponse *self,
           break;
         default:
           if (code < 100)
-            reason = g_strdup_printf ("%u Continue", code);
+            reason_local = g_strdup_printf ("%u Continue", code);
           else if (code < 200)
-            reason = g_strdup_printf ("%u OK", code);
+            reason_local = g_strdup_printf ("%u OK", code);
           else if (code < 300)
-            reason = g_strdup_printf ("%u Moved", code);
+            reason_local = g_strdup_printf ("%u Moved", code);
           else
-            reason = g_strdup_printf ("%u Failed", code);
-          message = reason;
+            reason_local = g_strdup_printf ("%u Failed", code);
+          message = reason_local;
           break;
         }
     }


### PR DESCRIPTION
Commit 7c22f854d11c9821f7d introduced a resource leak: cockpit_web_response_error_with_body() now receives a constant "reason" as argument, but in some cases shadows that with a locally allocated string. The latter never got freed.

Rename the variable and ensure it gets cleaned up at the end of the function.

Spotted by Coverity.