### PR TITLE
test: Skip more LUKS tests on rhel-8-10

### DIFF
--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -33,6 +33,7 @@ def console_screenshot(machine, name):
 
 
 @testlib.nondestructive
+@testlib.skipImage("cryptsetup uses too much memory, OOM on our test VMs", "rhel-8-*")
 class TestStorageLuks(storagelib.StorageCase):
 
     def testLuks(self):

--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -407,6 +407,7 @@ ExecStart=/usr/bin/sleep infinity
 
 
 @testlib.nondestructive
+@testlib.skipImage("cryptsetup uses too much memory, OOM on our test VMs", "rhel-8-*")
 class TestStorageMountingLUKS(storagelib.StorageCase):
     def testEncryptedMountingHelp(self):
         m = self.machine

--- a/test/verify/check-storage-swap
+++ b/test/verify/check-storage-swap
@@ -98,6 +98,7 @@ class TestStorageswap(storagelib.StorageCase):
         self.checkSwapUsed()
         testlib.wait(lambda: "defaults" in m.execute(f"findmnt --fstab -n -o OPTIONS {disk}"))
 
+    @testlib.skipImage("cryptsetup uses too much memory, OOM on our test VMs", "rhel-8-*")
     def testEncrypted(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
RHEL 8.10's cryptsetup uses too much memory
(https://issues.redhat.com/browse/RHEL-8258). So the LUKS tests are too flaky in RHEL 8. Skip them, like in check-storage-resize.

---

See [failures](https://cockpit-logs.us-east-1.linodeobjects.com/pull-7042-173353ea-20241028-102339-rhel-8-10-ws-container-storage-cockpit-project-cockpit/log.html) from https://github.com/cockpit-project/bots/pull/7042 .
