### PR TITLE
[rhel8] test: handle installed python3-pcp in metrics test

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1298,7 +1298,7 @@ class TestMetricsPackages(packagelib.PackageCase):
             # HACK: pcp does not clean up correctly on Debian https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=986074
             m.execute("rm -f /etc/systemd/system/pmlogger.service.requires/pmlogger_farm.service")
         else:
-            m.execute("rpm --erase --verbose cockpit-pcp pcp redis")
+            m.execute("rpm --erase --verbose cockpit-pcp pcp python3-pcp redis")
         if "centos-8" in m.image or "rhel-8" in m.image:
             # RHEL 8 ships this in a module, make sure that doesn't hide our fake package
             m.execute("dnf module disable -y redis || true")


### PR DESCRIPTION
https://github.com/cockpit-project/bots/pull/7045 added python3-pcp to the rhel-8-10 image.

Cherry-picked from main commits 70ec634259f6e and 99d648bd86f4458.

---

Fixes [this fallout](https://cockpit-logs.us-east-1.linodeobjects.com/pull-7045-71b1a964-20241029-124303-rhel-8-10-other-cockpit-project-cockpit-rhel-8/log.html#55-2). I landed the bots PR already to avoid a criss-cross block, and with that we now have python3-pcp on all images.