### PR TITLE
test: Increase DHCP machine RAM for network tests

### DIFF
--- a/test/verify/check-networkmanager-bond
+++ b/test/verify/check-networkmanager-bond
@@ -262,7 +262,7 @@ class TestBonding(netlib.NetworkCase):
 class TestBondingVirt(netlib.NetworkCase):
     provision = {
         "machine1": {"address": "10.111.113.1/20", "memory_mb": 512},
-        "machine2": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/20", "dhcp": True, "memory_mb": 256}
+        "machine2": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/20", "dhcp": True, "memory_mb": 512}
     }
 
     @testlib.skipImage("Main interface can't be managed", "debian-*", "ubuntu-*")

--- a/test/verify/check-networkmanager-mac
+++ b/test/verify/check-networkmanager-mac
@@ -25,7 +25,7 @@ from lib.constants import TEST_OS_DEFAULT
 class TestNetworkingMAC(netlib.NetworkCase):
     provision = {
         "machine1": {"memory_mb": 512},
-        "machine2": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/20", "dhcp": True, "memory_mb": 256}
+        "machine2": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/20", "dhcp": True, "memory_mb": 512}
     }
 
     def testMac(self):

--- a/test/verify/check-networkmanager-mtu
+++ b/test/verify/check-networkmanager-mtu
@@ -25,7 +25,7 @@ from lib.constants import TEST_OS_DEFAULT
 class TestNetworkingMTU(netlib.NetworkCase):
     provision = {
         "machine1": {"memory_mb": 512},
-        "machine2": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/20", "dhcp": True, "memory_mb": 256}
+        "machine2": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/20", "dhcp": True, "memory_mb": 512}
     }
 
     def testMtu(self):

--- a/test/verify/check-networkmanager-settings
+++ b/test/verify/check-networkmanager-settings
@@ -25,7 +25,7 @@ from lib.constants import TEST_OS_DEFAULT
 class TestNetworkingSettings(netlib.NetworkCase):
     provision = {
         "machine1": {"memory_mb": 512},
-        "machine2": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/20", "dhcp": True, "memory_mb": 256}
+        "machine2": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/20", "dhcp": True, "memory_mb": 512}
     }
 
     def testNoConnectionSettings(self):


### PR DESCRIPTION
Fedora 40 often runs into OOM conditions with 256 MiB. This breaks booting if the OOM killer shoots an unlucky process.

We don't need to be *that* scrimpy with handing out RAM -- a default destructive test gets a VM with 1152 MiB RAM, so the two provisioned ones together are still under that limit.

Fixes #21165

---

Fixes [this failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-7049-2a2ac73f-20241030-085356-fedora-40-updates-testing-cockpit-project-cockpit/log.html#88), which has plagued us for some time now, see the issue.

Besides the usual /networking scenario, I'll also start a "full" scenario here, plus an /updates-testing, to prove that this works.