### PR TITLE
Change German translation for Light Mode

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -4326,7 +4326,7 @@ msgstr "Lizenziert unter der GNU LGPL Version 2.1"
 
 #: pkg/systemd/terminal.jsx:176 pkg/shell/topnav.jsx:188
 msgid "Light"
-msgstr "Leicht"
+msgstr "Hell"
 
 #: pkg/shell/superuser.jsx:261
 msgid "Limit access"


### PR DESCRIPTION
"Leicht" is a very Literal translation of the word Light in English and could be used as an antonym to Heavy. In the context of dark and light mode the translation "Hell" would be more fitting.