### PR TITLE
test: Make ostree/ws container preparation run offline

### DIFF
--- a/test/image-prepare
+++ b/test/image-prepare
@@ -38,7 +38,8 @@ BOTS_DIR = f'{BASE_DIR}/bots'
 @contextmanager
 def create_machine(image):
     subprocess.check_call([os.path.join(BOTS_DIR, "image-download"), image])
-    machine = machine_virtual.VirtMachine(image=image)
+    network = machine_virtual.VirtNetwork(image=image)
+    machine = machine_virtual.VirtMachine(image=image, networking=network.host(restrict=True))
     try:
         machine.start()
         machine.wait_boot()


### PR DESCRIPTION
https://github.com/cockpit-project/bots/pull/7046 added the ws container to our fedora-40 image. So now `test/image-prepare --container` does not need to download anything from the internet any more.

The other use case of `create_machine()` for fedora-coreos preparation has always been offline already.

Disable networking for these builds to ensure it stays that way and builds are reproducible.