### PR TITLE
Various documentation updates

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -203,17 +203,25 @@ git submodules:
 Refer to the [testing README](test/README.md) for details on running the Cockpit
 integration tests locally.
 
-## Python bridge
+## Bridge
 
-Most distro releases now ship a replacement for the C bridge written in Python.
-It resides in `src/cockpit` with most of its rules in `src/Makefile.am`.  This
-directory was chosen because it matches the standard so-called "src layout"
-convention for Python packages, where each package (`cockpit`) is a
+The Cockpit bridge is the initial program launched in a Cockpit Linux session:
+Its stdin/out is connected to the web socket (and thus to JavaScript in the
+[pages](pkg/)), where it speaks a [JSON protocol](doc/protocol.md) that
+multiplexes "channels" -- abstractions of operating system APIs that the pages
+use to implement their functionality. This protocol is translated into
+operating system calls such as opening or writing files, D-Bus calls, or HTTP
+queries. Think of the bridge as the moral equivalent of "bash" in a human SSH
+session.
+
+The bridge resides in `src/cockpit` with most of its rules in `src/Makefile.am`.
+This directory was chosen because it matches the standard so-called "src
+layout" convention for Python packages, where each package (`cockpit`) is a
 subdirectory of the `src` directory.
 
 ### Running the bridge
 
-The Python bridge can be used interactively on a local machine:
+The bridge can be used interactively on a local machine out of the source tree:
 
     PYTHONPATH=src python3 -m cockpit.bridge
 
@@ -227,21 +235,15 @@ These shell aliases might be useful when experimenting with the protocol:
     alias cpy='PYTHONPATH=src python3 -m cockpit.bridge'
     alias cpf='PYTHONPATH=src python3 -m cockpit.misc.print'
 
-When working with the Python bridge on test images, note that `rhel-8*` still
-uses the C bridge. So if you want to explicitly have the Python bridge on those
-images use:
-
-    ./test/image-prepare --python
-
 To enable debug logging in journal on a test image, you can pass `--debug` to
 `image-prepare`. This will set `COCKPIT_DEBUG=all` to `/etc/environment`, if
 you are only interested channel debug messages change `all` to
 `cockpit.channel`.
 
-### Testing the Python bridge
+### Testing the bridge
 
-There are a growing number of Python `unittest` tests being written to test
-parts of the new bridge code.  You can run these with `make pytest` or
+There are a growing number of [pytest](https://docs.pytest.org) tests being written to test
+the bridge code.  You can run these with `make pytest` or
 `make pytest-cov`.  Those are both just rules to make sure that the
 `systemd_ctypes` submodule is checked out before running `pytest` from the
 source directory.

--- a/doc/guide/cockpit-session.xml
+++ b/doc/guide/cockpit-session.xml
@@ -64,8 +64,7 @@ promise.then(user => { ... });
     <title>Permission lookup</title>
 
     <para>Cockpit provides a mechanism for checking if the current user satisfies a
-      given criteria. Currently capable of checking for root users, and group
-      membership. This is meant for updating UI elements based on what actions the
+      given criteria. This is meant for updating UI elements based on what actions the
       user can perform. It is <emphasis>not an access control mechanism</emphasis>.</para>
 
     <refsection id="cockpit-permission-constructor">
@@ -74,10 +73,22 @@ promise.then(user => { ... });
 permission = cockpit.permission([options])
 </programlisting>
 
-      <para>Create a new permission object to check if the current user has permission.
-        The "root" user is always given permission. The <code>options</code> argument
-        can contain a <code>"group"</code> field, and members of that group are also
-        given permission.</para>
+      <para>Create a new permission object to check if the current user has a particular
+      permission specified by <code>options</code>:</para>
+      <variablelist>
+        <varlistentry>
+          <term><code>admin: true</code></term>
+          <listitem><para>True if the session has superuser privileges, i.e. can run channels as root
+            with <code>{ superuser: "require" }</code>.</para></listitem>
+        </varlistentry>
+        <varlistentry>
+           <term><code>group:</code>&nbsp;<emphasis>name</emphasis></term>
+           <listitem><para>True if the currently logged user is a member of group <emphasis>name</emphasis>.</para></listitem>
+        </varlistentry>
+      </variablelist>
+
+      <para>The permission result is always true for the "root" user. When <code>options</code> is not given,
+      check if the current user is root.</para>
     </refsection>
 
     <refsection id="cockpit-permission-allowed">

--- a/test/README.md
+++ b/test/README.md
@@ -22,8 +22,7 @@ You first need to build cockpit, and install it into a VM:
 
     test/image-prepare
 
-This uses the default OS image, which is currently Fedora 39. See `$TEST_OS`
-below how to select a different one.
+This uses the default OS image. See `$TEST_OS` below how to select a different one.
 
 In most cases you want to run an individual test in a suite, for example:
 
@@ -164,18 +163,11 @@ to push pixel tests.
 
 You can set these environment variables to configure the test suite:
 
- * `TEST_OS`: The OS to run the tests in.  Currently supported values:
-    - "centos-9-stream"
-    - "centos-10"
-    - "debian-stable"
-    - "debian-testing"
-    - "fedora-40"
-    - "fedora-coreos"
-    - "rhel-9-4"
-    - "ubuntu-2204"
-    - "ubuntu-stable"
-
-  "fedora-40" is the default (TEST_OS_DEFAULT in bots/lib/constants.py)
+ * `TEST_OS`: The OS to run the tests in, like "fedora-coreos" or
+    "debian-stable". See the "cockpit-project/cockpit" section in the
+    [test map](https://github.com/cockpit-project/bots/blob/main/lib/testmap.py)
+    for all supported values. "fedora-40" is the default (`TEST_OS_DEFAULT` in
+    bots' [constants.py](https://github.com/cockpit-project/bots/blob/main/lib/constants.py)).
 
  * `TEST_JOBS`:  How many tests to run in parallel.  The default is 1.
 

--- a/test/README.md
+++ b/test/README.md
@@ -24,6 +24,11 @@ You first need to build cockpit, and install it into a VM:
 
 This uses the default OS image. See `$TEST_OS` below how to select a different one.
 
+See `test/image-prepare --help` for some special modes, like skipping unit
+tests, building overlays, or preparing an image with the
+[cockpit/ws container](https://quay.io/repository/cockpit/ws) instead of RPMs.
+See our scenarios in [test/run](./run) for how they are being used.
+
 In most cases you want to run an individual test in a suite, for example:
 
     test/verify/check-metrics TestCurrentMetrics.testCPU

--- a/test/README.md
+++ b/test/README.md
@@ -164,32 +164,30 @@ to push pixel tests.
 
 You can set these environment variables to configure the test suite:
 
-    TEST_OS    The OS to run the tests in.  Currently supported values:
-                  "centos-9-stream"
-                  "centos-10"
-                  "debian-stable"
-                  "debian-testing"
-                  "fedora-40"
-                  "fedora-coreos"
-                  "rhel-9-4"
-                  "ubuntu-2204"
-                  "ubuntu-stable"
-               "fedora-40" is the default (TEST_OS_DEFAULT in bots/lib/constants.py)
+ * `TEST_OS`: The OS to run the tests in.  Currently supported values:
+    - "centos-9-stream"
+    - "centos-10"
+    - "debian-stable"
+    - "debian-testing"
+    - "fedora-40"
+    - "fedora-coreos"
+    - "rhel-9-4"
+    - "ubuntu-2204"
+    - "ubuntu-stable"
 
-    TEST_JOBS  How many tests to run in parallel.  The default is 1.
+  "fedora-40" is the default (TEST_OS_DEFAULT in bots/lib/constants.py)
 
-    TEST_BROWSER  What browser should be used for testing. Currently supported values:
-                     "chromium"
-                     "firefox"
-                  "chromium" is the default.
+ * `TEST_JOBS`:  How many tests to run in parallel.  The default is 1.
 
-    TEST_SHOW_BROWSER  Set to run browser interactively. When not specified,
-                       browser is run in headless mode. When set to "pixels",
-                       the browser will be resized to the exact dimensions that
-                       are used for pixel tests.
+ * `TEST_BROWSER`: What browser should be used for testing. Currently supported
+   values are "chromium" and "firefox". "chromium" is the default.
 
-    TEST_TIMEOUT_FACTOR Scale normal timeouts by given integer. Useful for
-                        slow/busy testbeds or architectures.
+ * `TEST_SHOW_BROWSER`: Set to run browser interactively. When not specified,
+   browser is run in headless mode. When set to "pixels", the browser will be
+   resized to the exact dimensions that are used for pixel tests.
+
+ * `TEST_TIMEOUT_FACTOR`: Scale normal timeouts by given integer. Useful for
+   slow/busy testbeds or architectures.
 
 See the [bots documentation](https://github.com/cockpit-project/bots/blob/main/README.md)
 for details about the tools and configuration for these.


### PR DESCRIPTION
Rendered view: 
 - https://github.com/martinpitt/cockpit/blob/docs/test/README.md
 - https://github.com/martinpitt/cockpit/blob/docs/HACKING.md

Rendered cockpit.permission documentation:

![image](https://github.com/user-attachments/assets/3660aec5-0131-4035-ae6f-73282d298f4d)

The weird font in the description list happens to all our lists, that just happens in a local doc build. It looks correct in the [public guide](https://cockpit-project.org/guide/latest/cockpit-login.html), and we'll soon replace this with markdown or asciidoc anyway.