### PR TITLE
lib: Fix TypeScript error in TypeaheadSelect correctly

### DIFF
--- a/pkg/lib/cockpit-components-typeahead-select.tsx
+++ b/pkg/lib/cockpit-components-typeahead-select.tsx
@@ -130,7 +130,7 @@ export interface TypeaheadSelectProps extends Omit<SelectProps, 'toggle' | 'onSe
   /** Message to display when no options match the filter. */
   noOptionsFoundMessage?: string | ((filter: string) => string);
   /** Flag indicating the select should be disabled. */
-  isDisabled: boolean;
+  isDisabled?: boolean;
   /** Width of the toggle. */
   toggleWidth?: string;
   /** Additional props passed to the toggle. */


### PR DESCRIPTION
The "isDisabled" in the props needs to remain optional, otherwise every user has to provide it. The default value in the function does nothing for this.

The real problem was assigning that to MenuToggleProps, but there the default value will make sure that isDisabled is not undefined anymore.