### PR TITLE
spec: Drop unneeded build dependency on tox and pytest-cov

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -132,10 +132,8 @@ BuildRequires:  python3-pip
 %if 0%{?rhel} == 0 && !0%{?suse_version}
 # All of these are only required for running pytest (which we only do on Fedora)
 BuildRequires:  procps-ng
-BuildRequires:  pyproject-rpm-macros
 BuildRequires:  python3-pytest-asyncio
 BuildRequires:  python3-pytest-timeout
-BuildRequires:  python3-tox-current-env
 %endif
 
 %prep
@@ -158,7 +156,8 @@ BuildRequires:  python3-tox-current-env
 make -j$(nproc) check
 
 %if 0%{?rhel} == 0
-%tox
+export NO_QUNIT=1
+%pytest
 %endif
 
 %install

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -134,7 +134,6 @@ BuildRequires:  python3-pip
 BuildRequires:  procps-ng
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  python3-pytest-asyncio
-BuildRequires:  python3-pytest-cov
 BuildRequires:  python3-pytest-timeout
 BuildRequires:  python3-tox-current-env
 %endif


### PR DESCRIPTION
Thanks to @hroncok who sent this to Fedora: https://src.fedoraproject.org/rpms/cockpit/pull-request/300# There the build was tested, and it still ran our pytests fine. Of course the packit/copr builds here will validate it as well.