### PR TITLE
ws: Disable session timeout for --local-session

### DIFF
--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -980,6 +980,12 @@ on_web_service_idling (CockpitWebService *service,
   if (session->timeout_tag)
     g_source_remove (session->timeout_tag);
 
+  if (!g_strcmp0 (session->cookie, LOCAL_SESSION))
+    {
+      g_debug ("local session is idle, keeping");
+      return;
+    }
+
   g_debug ("session is idle");
 
   /*

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -859,15 +859,25 @@ class TestConnection(testlib.MachineCase):
     @testlib.nondestructive
     def testLocalSession(self):
         m = self.machine
-        b = self.browser
 
         def check_session():
             m.wait_for_cockpit_running('localhost', 9090)
+            b = self.browser
             # session works directly, no login page
             b.open("/")
             b.wait_visible('#content')
             b.enter_page("/system")
             b.switch_to_top()
+
+            # disconnect browser, and wait past ws session timeout
+            b.kill()
+            time.sleep(17)  # cockpit_ws_service_idle plus a bit
+            self.browser = self.new_browser()
+            b = self.browser
+
+            # can start new session
+            b.open("/")
+            b.wait_visible('#content')
 
             # shut it down, wait until it is gone
             m.execute("pkill cockpit-ws; while pgrep -a cockpit-ws; do sleep 1; done")

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -859,36 +859,36 @@ class TestConnection(testlib.MachineCase):
     @testlib.nondestructive
     def testLocalSession(self):
         m = self.machine
+        b = self.browser
+
+        def check_session():
+            m.wait_for_cockpit_running('localhost', 9090)
+            # session works directly, no login page
+            b.open("/")
+            b.wait_visible('#content')
+            b.enter_page("/system")
+            b.switch_to_top()
+
+            # shut it down, wait until it is gone
+            m.execute("pkill cockpit-ws; while pgrep -a cockpit-ws; do sleep 1; done")
+            b.wait_in_text(".curtains-ct", "Disconnected")
 
         # start ws with --local-session, let it spawn bridge; ensure that this works without /etc/cockpit/
-        m.spawn("su - -c 'G_MESSAGES_DEBUG=all XDG_CONFIG_DIRS=/usr/local %s -p 9999 -a 127.0.0.90 "
+        m.stop_cockpit()
+        m.spawn("su - -c 'G_MESSAGES_DEBUG=all XDG_CONFIG_DIRS=/usr/local %s --no-tls "
                 "--local-session=cockpit-bridge' admin" % self.ws_executable,
                 "cockpit-ws-local")
-        m.wait_for_cockpit_running('127.0.0.90', 9999)
-        # System frame should work directly, no login page
-        out = m.execute("curl --compressed http://127.0.0.90:9999/cockpit/@localhost/system/index.html")
-        self.assertIn('id="overview"', out)
-
-        # shut it down, wait until it is gone
-        m.execute("pkill cockpit-ws; while pgrep -a cockpit-ws; do sleep 1; done")
+        check_session()
 
         # start ws with --local-session and existing running bridge
         self.write_file("/tmp/local.sh", f"""#!/bin/bash -eu
 coproc env G_MESSAGES_DEBUG=all cockpit-bridge
 export G_MESSAGES_DEBUG=all
 export XDG_CONFIG_DIRS=/usr/local
-{self.ws_executable} -p 9999 -a 127.0.0.90 --local-session=- <&${{COPROC[0]}} >&${{COPROC[1]}}
-""")
-        m.execute("chmod a+x /tmp/local.sh")
+{self.ws_executable} --no-tls --local-session=- <&${{COPROC[0]}} >&${{COPROC[1]}}
+""", perm="755")
         m.spawn("su - -c /tmp/local.sh admin", "local.sh")
-        m.wait_for_cockpit_running('127.0.0.90', 9999)
-
-        # System frame should work directly, no login page
-        out = m.execute("curl --compressed http://127.0.0.90:9999/cockpit/@localhost/system/index.html")
-        self.assertIn('id="overview"', out)
-
-        # shut it down, wait until it is gone
-        m.execute("pkill cockpit-ws; while pgrep -a cockpit-ws; do sleep 1; done")
+        check_session()
 
         self.allow_journal_messages("couldn't register polkit authentication agent.*")
 


### PR DESCRIPTION
Don't kill a `--local-session` on timeout, i.e. after the browser
disconnects. While it would be possible to restart the process if a
binary is given, it's impossible to do so with `-`, i.e. talking to
stdin/out.

Spotted in https://github.com/rhinstaller/anaconda-webui/pull/485#issuecomment-2436805547
