### PR TITLE
lib: restrict SASS plugin to scss files

### DIFF
--- a/pkg/lib/esbuild-common.js
+++ b/pkg/lib/esbuild-common.js
@@ -20,6 +20,7 @@ export const esbuildStylesPlugins = [
     }),
     sassPlugin({
         loadPaths: [...nodePaths, 'node_modules'],
+        filter: /\.scss/,
         quietDeps: true,
         async transform(source, resolveDir, path) {
             if (path.includes('patternfly-5-cockpit.scss')) {


### PR DESCRIPTION
To aid our effort to move away from SASS to pure CSS explicitly restrict the esbuild SASS plugin to only take SASS files. Every Cockpit project can now slowly convert SASS files to CSS where possible.