### PR TITLE
test: apply a workaround for Fedora-CoreOS rebased on Fedora 41

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1764,7 +1764,7 @@ class MachineCase(unittest.TestCase):
         # only enabled by default on released OSes; see pkg/shell/manifest.json
         self.multihost_enabled = image.startswith(("rhel-9", "centos-9")) or image in [
                 "ubuntu-2204", "ubuntu-2404", "debian-stable",
-                "fedora-39", "fedora-40", "fedora-coreos"]
+                "fedora-39", "fedora-40"]
         # Transitional code while we move ubuntu-stable from 24.04 to 24.10
         if image == "ubuntu-stable" and m.execute(". /etc/os-release; echo $VERSION_ID").strip() == "24.04":
             self.multihost_enabled = True

--- a/test/ws-container.install
+++ b/test/ws-container.install
@@ -16,6 +16,13 @@ system
 for rpm in ws bridge tests $PACKAGES; do
     rpm2cpio /var/tmp/cockpit-$rpm-*.rpm | cpio -i --make-directories --directory=/var/tmp/install
 done
+
+# HACK: Fedora CoreOS is already on Python 3.13, while Fedora-40 is Python3.12
+if [ -d /var/tmp/install/usr/lib/python3.13/site-packages/cockpit ]; then
+    mkdir -p /var/tmp/install/usr/lib/python3.12/site-packages/
+    mv /var/tmp/install/usr/lib/python3.13/site-packages/cockpit /var/tmp/install/usr/lib/python3.12/site-packages/
+fi
+
 podman run --name build-cockpit -i \
     -v /var/tmp/:/run/build:Z \
     quay.io/cockpit/ws sh -exc '


### PR DESCRIPTION
Fedora CoreOS has been rebased on Fedora 41 which brings in Python 3.13 build rpm's while our WS container uses Python 3.12 and thus we aren't testing main.