### PR TITLE
cockpit-desktop: Support Firefox flatpak

### DIFF
--- a/src/ws/cockpit-desktop.in
+++ b/src/ws/cockpit-desktop.in
@@ -70,6 +70,13 @@ detect_browser()
         return 0
     fi
 
+    for id in org.mozilla.firefox org.mozilla.Firefox; do
+        if flatpak info $id >/dev/null 2>&1; then
+            BROWSER="flatpak run $id --no-remote"
+            return 0
+        fi
+    done
+
     # TODO: is there a simple way to use webkitgtk?
     echo "No suitable browser found (Chromium/Chrome, or Firefox)" >&2
     exit 1

--- a/src/ws/cockpit-desktop.in
+++ b/src/ws/cockpit-desktop.in
@@ -40,6 +40,10 @@ set -eu
 exec_prefix="@prefix@"
 libexecdir="@libexecdir@"
 
+# start browser in a temporary home dir, so that it does not interfere with your real one
+BROWSER_HOME=$(mktemp --directory --tmpdir cockpit.desktop.XXXXXX)
+export BROWSER_HOME
+
 # find suitable browser, unless already set by $BROWSER
 # We can't use xdg-open, it does too much magic behind the back to connect to
 # existing instances (outside of our namespace) and does not allow us to reduce
@@ -63,16 +67,24 @@ detect_browser()
         fi
     done
 
+    # create firefox profile
+    FIREFOX_PROFILE="$BROWSER_HOME/profile"
+    mkdir "$FIREFOX_PROFILE"
+    cat <<EOF > "$FIREFOX_PROFILE/user.js"
+user_pref("datareporting.policy.dataSubmissionEnabled", false);
+user_pref("toolkit.telemetry.reportingpolicy.firstRun", false);
+user_pref("browser.toolbars.bookmarks.visibility", "never");
+EOF
+
     if type firefox >/dev/null 2>&1; then
-        # TODO: Find a way to disable the privacy notice tab, via mozilla.cfg?
         # TODO: Find a way to disable the URL bar
-        BROWSER="firefox --no-remote"
+        BROWSER="firefox --profile $FIREFOX_PROFILE --no-remote"
         return 0
     fi
 
     for id in org.mozilla.firefox org.mozilla.Firefox; do
         if flatpak info $id >/dev/null 2>&1; then
-            BROWSER="flatpak run $id --no-remote"
+            BROWSER="flatpak run --filesystem=$BROWSER_HOME $id --profile $FIREFOX_PROFILE --no-remote"
             return 0
         fi
     done
@@ -115,9 +127,6 @@ SCRIPT='
 set -eu
 # new namespaces have lo down by default
 ip link set lo up >&2
-
-# start browser in a temporary home dir, so that it does not interfere with your real one
-export BROWSER_HOME=$(mktemp --directory --tmpdir cockpit.desktop.XXXXXX)
 
 # forward parent stdin and stdout (from bridge) to cockpit-ws
 # it pretty well does not matter which port we use in our own namespace, so use standard http


### PR DESCRIPTION
RHEL 10 does not ship Firefox as RPM any more, and will instead use a flatpak. For now, check for/run the IDs of the official upstream Mozilla Firefox on flathub and the RHEL flatpak [1].
    
Surprisingly, `flatpak run` works fine inside our little network namespace.
    
https://issues.redhat.com/browse/RHEL-65847
    
[1] https://catalog.redhat.com/search?gs&q=firefox-flatpak

----

cockpit-desktop: Add firefox profile to hide privacy bar/tab and bookmarks

This makes the cockpit-desktop experience a bit more tasteful with
Firefox -- avoid the second broken tab (with the privacy note, which you can't
open anyway as this is an isolated network namespace), and disable data
submission to avoid the privacy hint notification bar.

Also disable the bookmark toolbar. It doesn't appear by default with the
upstream Firefox flatpak, but it does show with the Fedora version.

Move `BROWSER_HOME` out of the inner script into the top-level, so that
the browser profile can be created inside it.

----

I installed current RHEL 10 nightly  ISO and confirmed the broken cockpit-desktop subscription link. With the flatpak fix, it works again, but looks rather ugly in the default profile:

![noprofile](https://github.com/user-attachments/assets/c48dc6ea-255a-406a-8cd8-7aac621af676)

This wasn't a problem in RHEL 8/9 as that used webkit GTK. With the custom profile it looks like this:

![pr](https://github.com/user-attachments/assets/adc6662d-32f9-4764-8629-a7e6c67ebf2c)

I didn't find a way to hide the tab bar. Hiding some more elements would also be nice, but let's do that as a follow-up.