### PR TITLE
shell: style login close button as secondary button

### DIFF
--- a/pkg/lib/cockpit-connect-ssh.tsx
+++ b/pkg/lib/cockpit-connect-ssh.tsx
@@ -511,7 +511,7 @@ const NotSupportedDialog = ({ host, error, dialogResult }: {
             onClose={() => dialogResult.reject(error)}
             title={_("Cockpit is not installed")}
             footer={
-                <Button variant="link" className="btn-cancel" onClick={() => dialogResult.reject(error)}>
+                <Button variant="secondary" className="btn-cancel" onClick={() => dialogResult.reject(error)}>
                     { _("Close") }
                 </Button>
             }

--- a/pkg/shell/hosts_dialog.jsx
+++ b/pkg/shell/hosts_dialog.jsx
@@ -186,7 +186,7 @@ class NotSupported extends React.Component {
                    onClose={this.props.onClose}
                    title={_("Cockpit is not installed")}
                    footer={
-                       <Button variant="link" className="btn-cancel" onClick={this.props.onClose}>
+                       <Button variant="secondary" className="btn-cancel" onClick={this.props.onClose}>
                            { _("Close") }
                        </Button>
                    }


### PR DESCRIPTION
Why: The login close button was previously styled like a link, but it should have been styled as a secondary button. I have updated the styling to make the close button look like a proper button.

Resolves: #21160 