### PR TITLE
build: Use "projectService" instead of "project" for eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -66,7 +66,7 @@
           "extends": "plugin:@typescript-eslint/recommended",
           "parser": "@typescript-eslint/parser",
           "parserOptions": {
-            "project": ["./tsconfig.json"]
+            "projectService": ["./tsconfig.json"]
           },
           "rules": {
             // https://typescript-eslint.io/rules/no-use-before-define


### PR DESCRIPTION
Because magic.

Fixes #21246