### PR TITLE
test: Fix coverage report for pkg/lib

### DIFF
--- a/test/common/lcov.py
+++ b/test/common/lcov.py
@@ -479,7 +479,7 @@ def create_coverage_report() -> None:
         diff_file = f"{BASE_DIR}/lcov/diff.info"
         excludes = []
         # Exclude pkg/lib in Cockpit projects such as podman/machines.
-        if title != "cockpit.git":
+        if title != "cockpit.git" and title != "cockpit":
             excludes = ["--exclude", "pkg/lib"]
         subprocess.check_call(["lcov", "--quiet", "--output", all_file, *excludes,
                                *itertools.chain(*[["--add", f] for f in lcov_files])])


### PR DESCRIPTION
The test for whether pkg/lib should be excluded or not depends on how the source repo was cloned, and will see "cockpit" in CI.