### PR TITLE
Revert "Bump sass from 1.79.6 to 1.80.6"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,7 +38,7 @@ updates:
     ignore:
       # https://github.com/cockpit-project/cockpit/issues/21151
       - dependency-name: "sass"
-      - versions: ["1.80.x", "2.x"]
+        versions: ["1.80.x", "2.x"]
 
       # lots of work, do this explicitly
       - dependency-name: "@patternfly/*"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "jed": "1.1.1",
     "qunit": "2.22.0",
     "qunit-tap": "1.5.1",
-    "sass": "1.80.6",
+    "sass": "1.79.6",
     "sizzle": "2.3.10",
     "stylelint": "16.10.0",
     "stylelint-config-recommended-scss": "14.0.0",


### PR DESCRIPTION
I accidentally landed that, sorry.

Fix the syntax error in the dependabot configuration, that should prevent further updates.

This reverts commit 182dac465b994483b286f798857b2a76acd83279.