### PR TITLE
Preparations for launching cockpit-session via unix socket activation

### DIFF
--- a/selinux/cockpit.te
+++ b/selinux/cockpit.te
@@ -31,6 +31,7 @@ type cockpit_session_t;
 type cockpit_session_exec_t;
 domain_type(cockpit_session_t)
 domain_entry_file(cockpit_session_t,cockpit_session_exec_t)
+init_daemon_domain(cockpit_session_t,cockpit_session_exec_t)
 
 ########################################
 #
@@ -109,7 +110,8 @@ sysnet_exec_ifconfig(cockpit_ws_t)
 cockpit_session_domtrans(cockpit_ws_t)
 allow cockpit_ws_t cockpit_session_t:process signal_perms;
 
-# cockpit-session communicates back with cockpit-ws
+# cockpit-session communicates with cockpit-ws over a unix socket
+allow cockpit_ws_t cockpit_session_t:unix_stream_socket connectto;
 allow cockpit_session_t cockpit_ws_t:unix_stream_socket rw_stream_socket_perms;
 
 # cockpit-tls and cockpit-ws communicate over a Unix socket
@@ -168,6 +170,13 @@ read_files_pattern(cockpit_session_t, cockpit_var_run_t, cockpit_var_run_t)
 list_dirs_pattern(cockpit_session_t, cockpit_var_run_t, cockpit_var_run_t)
 
 kernel_read_network_state(cockpit_session_t)
+
+# SELinux-restricted users can communicate with existing cockpit-session socket connection
+gen_require(`
+    type user_t;
+    type sysadm_t;
+')
+allow { user_t sysadm_t } cockpit_session_t:unix_stream_socket rw_stream_socket_perms;
 
 # cockpit-session runs a full pam stack, including pam_selinux.so
 auth_login_pgm_domain(cockpit_session_t)

--- a/src/common/cockpitframe.c
+++ b/src/common/cockpitframe.c
@@ -277,8 +277,9 @@ cockpit_frame_read (int fd,
       return -1;
     }
 
-  /* We now have size equal to the number of bytes we need to return. */
-  unsigned char *buffer = malloc (size);
+  /* We now have size equal to the number of bytes we need to return. Add an extra byte for a NUL terminator,
+   * to be friendly to callers for text frames. */
+  unsigned char *buffer = calloc (1, size + 1);
   if (buffer == NULL)
     return -1; /* ENOMEM */
 

--- a/src/common/test-frame.c
+++ b/src/common/test-frame.c
@@ -122,6 +122,8 @@ test_valid (Fixture *pipe, const TestCase *tc)
       g_assert_cmpint (size, ==, i);
       for (gint j = 0; j < size; j++)
         g_assert (output[j] == ' ');
+      /* ensure it's NUL terminated */
+      g_assert (output[size] == '\0');
 
       /* Make sure our pattern is there */
       char buffer[7];

--- a/src/session/client-certificate.c
+++ b/src/session/client-certificate.c
@@ -300,27 +300,27 @@ cockpit_session_client_certificate_map_user (const char *client_certificate_file
       return NULL;
     }
 
-  size_t my_cgroup_length;
-  char *my_cgroup = read_proc_self_cgroup (&my_cgroup_length);
-  if (my_cgroup == NULL)
+  size_t ws_cgroup_length;
+  char *ws_cgroup = read_proc_self_cgroup (&ws_cgroup_length);
+  if (ws_cgroup == NULL)
     {
       warnx ("Could not determine cgroup of this process");
       return NULL;
     }
-  /* A simple prefix comparison is appropriate here because my_cgroup
+  /* A simple prefix comparison is appropriate here because ws_cgroup
    * will contain exactly one newline (at the end), and the expected
-   * value of my_cgroup is on the first line in cert_pem.
+   * value of ws_cgroup is on the first line in cert_pem.
    */
-  if (strncmp (cert_pem, my_cgroup, my_cgroup_length) != 0)
+  if (strncmp (cert_pem, ws_cgroup, ws_cgroup_length) != 0)
     {
       warnx ("This client certificate is only meant to be used from another cgroup");
-      free (my_cgroup);
+      free (ws_cgroup);
       return NULL;
     }
-  free (my_cgroup);
+  free (ws_cgroup);
 
   /* ask sssd to map cert to a user */
-  if (!sssd_map_certificate (cert_pem + my_cgroup_length, &sssd_user))
+  if (!sssd_map_certificate (cert_pem + ws_cgroup_length, &sssd_user))
     return NULL;
 
   return sssd_user;

--- a/src/session/session-utils.c
+++ b/src/session/session-utils.c
@@ -64,6 +64,11 @@ read_authorize_response (const char *what)
   len = cockpit_frame_read (STDIN_FILENO, &message);
   if (len < 0)
     err (EX, "couldn't read %s", what);
+  if (len == 0)
+    {
+       debug ("EOF reading %s authorize message", what);
+       exit (0);
+    }
 
   /*
    * The authorize messages we receive always have an exact prefix and suffix:

--- a/src/session/session-utils.h
+++ b/src/session/session-utils.h
@@ -64,6 +64,7 @@ void utmp_log (int login, const char *rhost, FILE *messages);
 void btmp_log (const char *username, const char *rhost);
 
 char* read_authorize_response (const char *what);
+char* get_authorize_key (const char *json, const char *key, bool required);
 void write_authorize_begin (void);
 void write_control_string (const char *field, const char *str);
 void write_control_bool (const char *field, bool val);

--- a/src/systemd/cockpit-session@.service.in
+++ b/src/systemd/cockpit-session@.service.in
@@ -7,3 +7,5 @@ StandardInput=socket
 StandardOutput=inherit
 StandardError=journal
 User=root
+# bridge error, authentication failure, or timeout, that's not a problem with the unit
+SuccessExitStatus=1 5 127

--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -110,7 +110,7 @@ mock_echo_SOURCES = src/ws/mock-echo.c
 check_PROGRAMS += mock-auth-command
 mock_auth_command_CPPFLAGS = $(libcockpit_common_a_CPPFLAGS) $(TEST_CPP)
 mock_auth_command_LDADD = $(libcockpit_common_a_LIBS) $(TEST_LIBS)
-mock_auth_command_SOURCES = src/ws/mock-auth-command.c
+mock_auth_command_SOURCES = src/ws/mock-auth-command.c src/session/session-utils.c
 
 TEST_PROGRAM += test-auth
 test_auth_CPPFLAGS = $(libcockpit_ws_a_CPPFLAGS) $(TEST_CPP)

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -176,8 +176,8 @@ class TestConnection(testlib.MachineCase):
             b.set_val("#login-user-input", "admin")
             b.set_val("#login-password-input", "foobar")
             b.click('#login-button')
-            b.wait_visible('#login-fatal-message')
-            b.wait_text('#login-fatal-message', "The cockpit package is not installed")
+            b.wait_visible('#login-error-message')
+            b.wait_in_text('#login-error-message', "Install the cockpit-system package")
             m.execute("while B=$(command -v cockpit-bridge.disabled); do mv $B ${B%.disabled}; done")
 
         # Lets crash a systemd-controlled process and see if we get a proper backtrace in the logs

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -275,6 +275,10 @@ class CommonTests:
         self.allow_journal_messages(".*No authentication agent found.*")
         # sometimes polling for info and joining a domain creates this noise
         self.allow_journal_messages('.*org.freedesktop.DBus.Error.Spawn.ChildExited.*')
+        # HACK: idling too long on the login page in Negotiate cockpit-session while polling for stuff
+        # (this should be fixed properly in cockpit-ws)
+        self.allow_journal_messages('.*session timed out during authentication')
+        self.allow_journal_messages('.*authentication timed out')
 
     def testUnqualifiedUsers(self):
         m = self.machine


### PR DESCRIPTION
Broken out from #16808. But that requires a few more rounds of review and has ideas for more cleanups. These are the cockpit-session JSON parser (which is a bit finnicky, but got reviewed a few rounds already), plus a few extra commits which I believe are not problematic. Let's get them out of the way.