### PR TITLE
common: Do not add a body for chunked HEAD request

### DIFF
--- a/src/common/cockpitwebresponse.c
+++ b/src/common/cockpitwebresponse.c
@@ -615,7 +615,7 @@ cockpit_web_response_complete (CockpitWebResponse *self)
   g_object_ref (self);
   self->complete = TRUE;
 
-  if (self->chunked)
+  if (self->chunked && !g_str_equal(self->method, "HEAD"))
     {
       bytes = g_bytes_new_static ("0\r\n\r\n", 5);
       queue_bytes (self, bytes);


### PR DESCRIPTION
Fixes: https://github.com/cockpit-project/cockpit/issues/21216

I do not trust myself to test this on a codebase I'm unfamiliar with and test cases for `HEAD` requests might need to be updated if there are any.