### PR TITLE
build: Allow TS functions to be used before their definition

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -72,8 +72,12 @@
             // https://typescript-eslint.io/rules/no-use-before-define
             // Note: you must disable the base rule as it can report incorrect errors
             "no-use-before-define": "off",
-            "@typescript-eslint/no-use-before-define": "error",
-
+            "@typescript-eslint/no-use-before-define": [
+              "error",
+              {
+                "functions": false
+              }
+            ],
             // as recommended by https://typescript-eslint.io/rules/no-unused-vars/
             "@typescript-eslint/no-unused-vars": [
               "error",


### PR DESCRIPTION
This is fine, TypeScript will check them correctly.  And it is very useful for global functions, at least.  And we allow functions to be used before their definitions in JavaScript files.