### PR TITLE
lib: cockpit: remove cockpit.resolve/cockpit.reject()

### DIFF
--- a/pkg/lib/cockpit.js
+++ b/pkg/lib/cockpit.js
@@ -122,14 +122,6 @@ function factory() {
         return result.promise.then(fulfilled, rejected, updated);
     };
 
-    cockpit.resolve = function resolve(result) {
-        return cockpit.defer().resolve(result).promise;
-    };
-
-    cockpit.reject = function reject(ex) {
-        return cockpit.defer().reject(ex).promise;
-    };
-
     cockpit.defer = function() {
         return new Deferred();
     };


### PR DESCRIPTION
The modern equivalent of this API is `Promise.resolve` and `Promise.reject`.

---

Haven't found any users in our projects