### PR TITLE
shell: allow changing the default landing page

### DIFF
--- a/pkg/shell/state.jsx
+++ b/pkg/shell/state.jsx
@@ -549,7 +549,8 @@ export function ShellState() {
             const menu_items = compiled.ordered("menu");
             if (menu_items.length > 0 && menu_items[0])
                 location.path = menu_items[0].path;
-            location.path = "system";
+            else
+                location.path = "system";
             replace_window_location(location);
         }
 

--- a/test/verify/check-shell-menu
+++ b/test/verify/check-shell-menu
@@ -204,6 +204,16 @@ class TestMenu(testlib.MachineCase):
         # different browsers behave a bit different here -- Firefox is at "Overview", Chromium at "Logs"
         b.wait_js_cond("document.activeElement.classList.contains('pf-v5-c-nav__link')")
 
+    def testCustomLandingPage(self):
+        b = self.browser
+        m = self.machine
+
+        # # Make the logs page the default page
+        m.write("/etc/cockpit/systemd.override.json", '{"menu":{"index":{"order":100},"logs":{"order":1}}}')
+
+        self.login_and_go()
+        b.wait_js_cond('window.location.pathname == "/system/logs"')
+
 
 if __name__ == '__main__':
     testlib.test_main()


### PR DESCRIPTION
Due to a missing else we never allowed a user to change the default landing page.