### PR TITLE
lib: Ignore invalid input keys in Terminal

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -108,6 +108,7 @@ WEBDRIVER_KEYS = {
     "Control": "\uE009",
     "Alt": "\uE00A",
     "Escape": "\uE00C",
+    "Space": "\uE00D",
     "ArrowLeft": "\uE012",
     "ArrowUp": "\uE013",
     "ArrowRight": "\uE014",

--- a/test/verify/check-system-terminal
+++ b/test/verify/check-system-terminal
@@ -187,9 +187,17 @@ PROMPT_COMMAND='printf "\033]0;%s@%s:%s\007" "${USER}" "${HOSTNAME%%.*}" "${PWD/
 
         # Wait for text to show up
         self.wait_line(echo_result_line + 1, prompt + "foo")
+        b.key("Backspace", repeat=3)
+
+        # Key-who-must-not-be-named, non-breakable space does weird things,
+        # see https://github.com/cockpit-project/cockpit/issues/21213
+        # this must not crash the session, should be ignored
+        b.input_text("echo space")
+        b.key("Space", modifiers=["Control"])
+        b.key("Enter")
+        self.wait_line(echo_result_line + 2, "space")
 
         # check that we get a sensible $PATH; this varies across OSes, so don't be too strict about it
-        b.key("Enter")
         b.input_text('clear\n')
         b.input_text("echo $PATH > /tmp/path\n")
         # don't use wait_line() for the full match here, as line breaks get in the way; just wait until command has run


### PR DESCRIPTION
Pressing Ctrl+Space in the terminal was previously considered a major insult and killed the session. Both the "externally visible" representation in JS as a string (a null byte) as well as the actual bytes sent to the websocket (0xA0) are broken and useless. The latter caused a session disconnect due to invalid UTF-8 data, and the former makes it impossible to properly work around this issue (which would be to send [0xC2, 0xA0] to the web socket).

So the best thing that we can do is to ignore invalid keys (which show up as NUL).

Fixes #21213

---

See https://github.com/cockpit-project/cockpit/issues/21213#issuecomment-2482208738 for the gory details and my debugging notes.