### PR TITLE
systemd: Open path in terminal followup fixes

### DIFF
--- a/pkg/systemd/manifest.json
+++ b/pkg/systemd/manifest.json
@@ -76,7 +76,8 @@
                 {
                     "matches": ["console", "command", "bash", "shell"]
                 }
-            ]
+            ],
+            "capabilities": ["path"]
         }
     },
 

--- a/pkg/systemd/terminal.jsx
+++ b/pkg/systemd/terminal.jsx
@@ -272,7 +272,7 @@ const _ = cockpit.gettext;
                     </div>
                     <div className="ct-terminal-dir-alert">
                         {this.state.pathError && <Alert isInline
-                            title={_("Error opening directory")}
+                            title={_("Unable to open directory")}
                             variant="warning"
                             actionClose={<AlertActionCloseButton onClose={this.dismiss} />}>
                             <p>{_(this.state.pathError)}</p>
@@ -280,17 +280,17 @@ const _ = cockpit.gettext;
                         }
 
                         {this.state.changePathBusy && <Alert isInline
-                            title={_("Change directory?")}
+                            title={_("Running process prevents directory change")}
                             variant="danger"
                             actionClose={<AlertActionCloseButton onClose={() =>
                                 this.setState({ changePathBusy: false })} />}
                             actionLinks={
                                 <>
-                                    <Button variant="secondary" size="sm" onClick={this.forceChangeDirectory}>{_("Continue")}</Button>
+                                    <Button variant="danger" size="sm" onClick={this.forceChangeDirectory}>{_("Change directory")}</Button>
                                     <AlertActionLink onClick={this.dismiss}>{_("Cancel")}</AlertActionLink>
                                 </>
                             }>
-                            {_("There is still a process running in this terminal. Changing the directory will kill it.")}
+                            {_("Changing the directory will forcefully stop the currently running process. The process can also be stopped manually in the terminal before continuing.")}
                         </Alert>
                         }
                     </div>

--- a/test/verify/check-system-terminal
+++ b/test/verify/check-system-terminal
@@ -315,9 +315,8 @@ PROMPT_COMMAND='printf "\033]0;%s@%s:%s\007" "${USER}" "${HOSTNAME%%.*}" "${PWD/
         b.input_text("sh -c 'echo busybusybusy; echo $$; exec sleep infinity'\n")
         b.wait_in_text(line_sel(8), 'busybusybusy')
         pid = b.text(line_sel(9))
-        # m.execute(["false"])
         b.go("#/?path=/tmp")
-        b.wait_in_text(".pf-v5-c-alert.pf-m-danger", "still a process running")
+        b.wait_in_text(".pf-v5-c-alert.pf-m-danger", "Running process prevents directory change")
         # Cancel change
         b.click("button:contains('Cancel')")
         b.wait_not_present(".pf-v5-c-alert")
@@ -327,8 +326,8 @@ PROMPT_COMMAND='printf "\033]0;%s@%s:%s\007" "${USER}" "${HOSTNAME%%.*}" "${PWD/
         b.wait_in_text(line_sel(8), 'busybusybusy')
         # Confirm change
         b.go("#/?path=/var")
-        b.wait_in_text(".pf-v5-c-alert.pf-m-danger", "still a process running")
-        b.click("button:contains('Continue')")
+        b.wait_in_text(".pf-v5-c-alert.pf-m-danger", "Running process prevents directory change")
+        b.click("button:contains('Change directory')")
         b.wait_not_present(".pf-v5-c-alert.pf-m-danger")
         self.wait_line(1, "disconnected")
         self.clear_terminal()


### PR DESCRIPTION
- Fix error messages
- Mark path as a terminal capability in manifest

Fixes: https://github.com/cockpit-project/cockpit/issues/21281

![Screenshot from 2024-11-18 14-49-56](https://github.com/user-attachments/assets/7df6d187-e51b-494d-acf2-074deff25840)
