### PR TITLE
ws: Fix reported error if the authentication process is not available; containers/ws: Drop cockpit-session

### DIFF
--- a/containers/ws/install.sh
+++ b/containers/ws/install.sh
@@ -40,6 +40,8 @@ else
         dnf download cockpit-$rpm
         unpack cockpit-$rpm-*.rpm
     done
+    # do everything through SSH, no local authentication in the container
+    rm $INSTALLROOT/usr/libexec/cockpit-session
 fi
 
 rm -rf /build/var/cache/dnf /build/var/lib/dnf /build/var/lib/rpm* /build/var/log/*

--- a/src/ws/test-auth.c
+++ b/src/ws/test-auth.c
@@ -756,8 +756,8 @@ static const SuccessFixture fixture_data_then_success = {
 };
 
 static const ErrorFixture fixture_bad_command = {
-  .error_code = COCKPIT_ERROR_FAILED,
-  .error_message = "Internal error in login process",
+  .error_code = COCKPIT_ERROR_AUTHENTICATION_FAILED,
+  .error_message = "Authentication not available",
   .header = "badcommand bad",
 };
 

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -161,10 +161,12 @@ class TestConnection(testlib.MachineCase):
         self.assertNoAdminProcessLeaks()
 
         if not m.ws_container:  # no cockpit-session
-            # damage cockpit-session permissions, expect generic error message
+            # damage cockpit-session permissions → "Authentication not available"
             m.execute(f"chmod g-x {self.libexecdir}/cockpit-session")
             b.open("/system")
-            b.wait_in_text('#login-fatal-message', "Internal error in login process")
+            b.try_login()
+            # .. but the login page does not expose the error very specifically
+            b.wait_in_text('#login-error-title', "Authentication failed")
             m.execute(f"chmod g+x {self.libexecdir}/cockpit-session")
 
             self.allow_journal_messages(".*cockpit-session: bridge program failed.*")

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -172,11 +172,7 @@ class TestConnection(testlib.MachineCase):
             # pretend cockpit-bridge is not installed, expect specific error message
             m.execute("while B=$(command -v cockpit-bridge); do mv $B ${B}.disabled; done")
             b.open("/system")
-            b.wait_visible("#login")
-            b.set_val("#login-user-input", "admin")
-            b.set_val("#login-password-input", "foobar")
-            b.click('#login-button')
-            b.wait_visible('#login-error-message')
+            b.try_login()
             b.wait_in_text('#login-error-message', "Install the cockpit-system package")
             m.execute("while B=$(command -v cockpit-bridge.disabled); do mv $B ${B%.disabled}; done")
 

--- a/test/ws-container.install
+++ b/test/ws-container.install
@@ -28,6 +28,8 @@ podman run --name build-cockpit -i \
     quay.io/cockpit/ws sh -exc '
 cp -a /run/build/install/* /
 cp /run/build/containers/ws/label-* /run/build/containers/ws/default-bastion.conf /run/build/containers/ws/cockpit-auth-ssh-key /container/
+# done in containers/ws/install.sh; this can be removed once that change is in our VM images
+rm -f /usr/libexec/cockpit-session
 '
 podman commit --change CMD=/container/label-run build-cockpit localhost/cockpit/ws
 podman rm -f build-cockpit


### PR DESCRIPTION
See individual commits for details. This was another tiny lose thread in #16808 which upon pulling [brought down the whole edifice](https://cockpit-logs.us-east-1.linodeobjects.com/pull-16808-ac0f93c2-20241120-085141-rhel-8-10-ws-container-networking/log.html). The cockpit-session removal from the container reproduces this situation.