### PR TITLE
systemd: Lock down cockpit-ws and -tls

### DIFF
--- a/src/systemd/cockpit-wsinstance-http.service.in
+++ b/src/systemd/cockpit-wsinstance-http.service.in
@@ -7,5 +7,16 @@ After=cockpit-session.socket
 
 [Service]
 ExecStart=@libexecdir@/cockpit-ws --no-tls --port=0
-DynamicUser=true
+DynamicUser=yes
 Group=cockpit-session-socket
+
+PrivateDevices=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+ProtectSystem=strict
+MemoryDenyWriteExecute=yes
+SystemCallFilter=@system-service
+
+# cockpit-tls does all our outside web related networking, but ws also calls ssh
+PrivateIPC=yes
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6

--- a/src/systemd/cockpit-wsinstance-https@.service.in
+++ b/src/systemd/cockpit-wsinstance-https@.service.in
@@ -10,3 +10,14 @@ Slice=system-cockpithttps.slice
 ExecStart=@libexecdir@/cockpit-ws --for-tls-proxy --port=0
 DynamicUser=yes
 Group=cockpit-session-socket
+
+PrivateDevices=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+ProtectSystem=strict
+MemoryDenyWriteExecute=yes
+SystemCallFilter=@system-service
+
+# cockpit-tls does all our outside web related networking, but ws also calls ssh
+PrivateIPC=yes
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6

--- a/src/systemd/cockpit.service.in
+++ b/src/systemd/cockpit.service.in
@@ -14,11 +14,9 @@ DynamicUser=yes
 # otherwise systemd uses 'cockpit' even if it exists as a normal user account
 User=cockpit-systemd-service
 Group=cockpit-wsinstance-socket
-NoNewPrivileges=true
+NoNewPrivileges=yes
 ProtectSystem=strict
-ProtectHome=true
-PrivateTmp=true
-PrivateDevices=true
-ProtectKernelTunables=true
+PrivateDevices=yes
+ProtectKernelTunables=yes
 RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
-MemoryDenyWriteExecute=true
+MemoryDenyWriteExecute=yes

--- a/src/systemd/cockpit.service.in
+++ b/src/systemd/cockpit.service.in
@@ -18,5 +18,9 @@ NoNewPrivileges=yes
 ProtectSystem=strict
 PrivateDevices=yes
 ProtectKernelTunables=yes
-RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
 MemoryDenyWriteExecute=yes
+
+# cockpit-tls speaks to the outside world via socket activation, and to cockpit-ws via Unix socket
+PrivateIPC=yes
+PrivateNetwork=yes
+RestrictAddressFamilies=AF_UNIX


### PR DESCRIPTION
Now that cockpit-ws does not directly fork cockpit-session, and sessions
run in their own service/cgroup, we can heavily lock down our webserver
(which is the weakest component in Cockpit). It only needs to talk to
cockpit-tls over stdin/out and cockpit-session over the Unix socket,
and call SSH for remote host support (so we can't lock down networking
completely).

`DynamicUser=` already implies the biggest restrictions, such as
`ProtectSystem=full`, `ProtectHome`, `PrivateTmp`, and more. We can even
work with `ProtectSystem=strict` (i.e. everything being read-only except
the service's /run directory and tmp dir).

Fixes #21299
https://issues.redhat.com/browse/COCKPIT-1206