### PR TITLE
test: Also retry a browser wait when the helper function is missing

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -788,6 +788,8 @@ class Browser:
                     "Cannot find context",
                     # firefox
                     "MessageHandlerFrame' destroyed",
+                    # page helpers not yet loaded
+                    "ph_wait_cond is not defined",
                    ]):
                     if time.time() - start < timeout:
                         webdriver_bidi.log_command.info("wait_js_cond: Ignoring/retrying %r", e)


### PR DESCRIPTION
This has started to sporadically happen on Firefox during login/logout.