### PR TITLE
[rhel-8] test: Adapt to new Grafana

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1523,7 +1523,8 @@ class TestGrafanaClient(testlib.MachineCase):
             # .. and the dashboard name becomes clickable
             bg.click("a:contains('PCP Redis: Host Overview')")
 
-            bg.wait_in_text("#var-host", "grafana-client")
+            # expect the hostname in the dashboard controls
+            bg._wait_present("[data-testid*='link text grafana-client']")
 
             # expect a "Load average" panel with sensible numbers
             bg.wait_in_text("section[data-testid*='Load average'],div[data-testid*='Load average']", "minute")


### PR DESCRIPTION
The #var-host id is gone, but the "dataid ... link text" stays.

Cherry-picked from main commit 9d83a1c16a2ea8708.

---

Unblocks https://github.com/cockpit-project/bots/pull/7114