### PR TITLE
cockpit.js: Put back cockpit.{resolve,reject}

### DIFF
--- a/pkg/lib/cockpit.js
+++ b/pkg/lib/cockpit.js
@@ -116,6 +116,16 @@ function factory() {
         },
     };
 
+    cockpit.resolve = function resolve(result) {
+        console.warn("cockpit.resolve() is deprecated. Use Promise.resolve()");
+        return Promise.resolve(result);
+    };
+
+    cockpit.reject = function reject(ex) {
+        console.warn("cockpit.reject() is deprecated. Use Promise.reject()");
+        return Promise.reject(ex);
+    };
+
     cockpit.defer = function() {
         return new Deferred();
     };


### PR DESCRIPTION
Commit 132300e09cc45cbd was premature, subscription-manager still uses that [1]. Put it back, but in terms of the standard Promise API.

Add a deprecation warning.

[1] https://github.com/candlepin/subscription-manager-cockpit/pull/84