### PR TITLE
workflows: Build ws container from latest tag, not main

### DIFF
--- a/.github/workflows/build-ws-container.yml
+++ b/.github/workflows/build-ws-container.yml
@@ -18,6 +18,14 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Dockerfile  must correspond to latest release, not main
+      - name: Check out latest tag
+        run: |
+          git checkout $(git rev-list --tags --max-count=1)
+          git describe
 
       - name: Log into container registry
         run: $RUNC login -u ${{ secrets.QUAY_BOTUSER }} -p ${{ secrets.QUAY_TOKEN }} quay.io


### PR DESCRIPTION
So far we always built cockpit/ws with the latest main Dockerfile. But this broke the most recent cockpit/ws build (tag 329): It already removed cockpit session due to commit 035dc2d9be846320, but the rpms don't yet contain the prerequisite commit d7cb5617c007e (that isn't in any release yet).

Let's not get ahead of ourselves and always build the container from the current release, not main.

---

See https://github.com/cockpit-project/bots/pull/7141 where that broke badly. This can be trivially reproduced with

    sudo podman container runlabel RUN quay.io/cockpit/ws:329

and going to http://localhost:9090 . This only affects privileged mode, unprivileged is fine.

I already reverted the ":latest" tag back to the previous build (327, sic!). I'll do a rebuild against this branch now and validate the result.