### PR TITLE
selinux: Move update-motd out of cockpit_ws_t

### DIFF
--- a/selinux/cockpit.fc
+++ b/selinux/cockpit.fc
@@ -7,7 +7,7 @@
 
 /usr/libexec/cockpit-session	--	gen_context(system_u:object_r:cockpit_session_exec_t,s0)
 
-/usr/share/cockpit/motd/update-motd    -- gen_context(system_u:object_r:cockpit_ws_exec_t,s0)
+/usr/share/cockpit/motd/update-motd    -- gen_context(system_u:object_r:shell_exec_t,s0)
 
 /var/lib/cockpit(/.*)?      gen_context(system_u:object_r:cockpit_var_lib_t,s0)
 

--- a/selinux/cockpit_ws_selinux.8cockpit
+++ b/selinux/cockpit_ws_selinux.8cockpit
@@ -18,7 +18,7 @@ The cockpit_ws_t SELinux type can be entered via the \fBcockpit_ws_exec_t\fP fil
 
 The default entrypoint paths for the cockpit_ws_t domain are the following:
 
-/usr/libexec/cockpit-ws, /usr/libexec/cockpit-tls, /usr/share/cockpit/motd/update-motd, /usr/libexec/cockpit-wsinstance-factory
+/usr/libexec/cockpit-ws, /usr/libexec/cockpit-tls, /usr/libexec/cockpit-wsinstance-factory
 .SH PROCESS TYPES
 SELinux defines process types (domains) for each process running on the system
 .PP
@@ -173,7 +173,7 @@ SELinux cockpit_ws policy is very flexible allowing users to setup their cockpit
 .br
 .TP 5
 Paths:
-/usr/libexec/cockpit-ws, /usr/libexec/cockpit-tls, /usr/share/cockpit/motd/update-motd, /usr/libexec/cockpit-wsinstance-factory
+/usr/libexec/cockpit-ws, /usr/libexec/cockpit-tls, /usr/libexec/cockpit-wsinstance-factory
 
 .PP
 Note: File context can be temporarily modified with the chcon command.  If you want to permanently change the file context you need to use the


### PR DESCRIPTION
This script has nothing to do with cockpit-ws, so stop putting it into the same security domain. We don't need to introduce a new one, just use the standard `shell_exec_t`. It's just a short-lived helper script with no user input, this doesn't justify its own policy.

This may also help with certain configurations where `hostname` wants to read /proc.

https://bugzilla.redhat.com/show_bug.cgi?id=2274774