### PR TITLE
test: correct add_machine password argument typing

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1176,7 +1176,7 @@ class Browser:
         if expect_closed_dialog:
             self.wait_not_present('#hosts_setup_server_dialog')
 
-    def add_machine(self, address: str, known_host: bool = False, password: str = "foobar",
+    def add_machine(self, address: str, known_host: bool = False, password: str | None = "foobar",
                     expect_warning: bool = True) -> None:
         self.switch_to_top()
         self.go(f"/@{address}")


### PR DESCRIPTION
`start_machine_troubleshoot` has `password` defined as an optional argument so should `add_machine`.