### PR TITLE
test: Add Browser.have_test_api()

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -300,6 +300,17 @@ class Browser:
 
         return self.driver is not None and self.driver.bidi_session is not None
 
+    def have_test_api(self) -> bool:
+        """Check if the browser is running and has a Cockpit page
+
+        I.e. are our test-functions.js available? This is only true after
+        opening cockpit, not for the initial blank page (before login_and_go)
+        or other URLs like Grafana.
+        """
+        if not self._is_running():
+            return False
+        return self.eval_js("!!window.ph_find")
+
     def run_async(self, coro: Coroutine[Any, Any, Any]) -> JsonObject:
         """Run coro in main loop in our BiDi thread
 
@@ -1527,7 +1538,7 @@ class Browser:
         if self.allow_oops:
             return
 
-        if self._is_running():
+        if self.have_test_api():
             self.switch_to_top()
             if self.eval_js("!!document.getElementById('navbar-oops')"):
                 assert not self.is_visible("#navbar-oops"), "Cockpit shows an Oops"

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -417,7 +417,8 @@ class Browser:
         """Allow browser downloads"""
         # this is only necessary for headless chromium
         if self.browser == "chromium":
-            self.cdp_command("Browser.setDownloadBehavior", behavior="allow", downloadPath=str(self.driver.download_dir))
+            self.cdp_command("Browser.setDownloadBehavior", behavior="allow",
+                             downloadPath=str(self.driver.download_dir))
 
     def upload_files(self, selector: str, files: Sequence[str]) -> None:
         """Upload a local file to the browser
@@ -774,7 +775,8 @@ class Browser:
                 duration = time.time() - start
                 percent = int(duration / timeout * 100)
                 if percent >= 50:
-                    print(f"WARNING: Waiting for {cond} took {duration:.1f} seconds, which is {percent}% of the timeout.")
+                    print(f"WARNING: Waiting for {cond} took {duration:.1f} seconds, "
+                          f"which is {percent}% of the timeout.")
                 return
             except Error as e:
                 last_error = e
@@ -1029,7 +1031,7 @@ class Browser:
                 # we don't need it here, if the session menu is visible then so is the dropdown
                 self.mouse('#logout', "click", scrollVisible=False)
             except RuntimeError as e:
-                # logging out does destroy the current frame context, it races with the CDP driver finishing the command
+                # logging out does destroy the current frame context, it races with the driver finishing the command
                 if "Execution context was destroyed" not in str(e):
                     raise
         self.wait_visible('#login')
@@ -1580,7 +1582,8 @@ class MachineCase(unittest.TestCase):
         if opts.address:
             if forward:
                 raise unittest.SkipTest("Cannot run this test when specific machine address is specified")
-            machine = testvm.Machine(address=opts.address, image=image or self.image, verbose=opts.trace, browser=opts.browser)
+            machine = testvm.Machine(address=opts.address, image=image or self.image,
+                                     verbose=opts.trace, browser=opts.browser)
             if cleanup:
                 self.addCleanup(machine.disconnect)
         else:


### PR DESCRIPTION
Check if the browser is running and has cockpit loaded, i.e. our various
ph_*() test-functions.js are actually available and thus we can call
`Browser.is_visible()` and friends. That may not be the case when
Cockpit hasn't been opened yet and thus the browser is still showing a
blank page, or has e.g. Grafana opened.

This is what `Browser.assert_no_oops()` actually needs to check, as on
non-Cockpit pages this doesn't make sense.

This will also help cockpit-machines to replace its incorrect usage of
the just removed `Browser.valid` flag with something useful.

----

This will help with cleaning up the very messy `testAddDiskNFS` failures [here](https://artifacts.dev.testing-farm.io/ec5d4610-4ba1-456d-9971-c6c7d471a1ff/) and [here](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1927-0c220616-20241128-025513-fedora-41/log.html). I sent a corresponding cockpit-machines PR which uses this: https://github.com/cockpit-project/cockpit-machines/pull/1929