### PR TITLE
test: Factorize and robustify mount point cleanup

### DIFF
--- a/test/common/storagelib.py
+++ b/test/common/storagelib.py
@@ -131,6 +131,10 @@ class StorageHelpers:
 
         self.addCleanup(self.machine.execute, f"if [ -d /dev/{vgname} ]; then vgremove --force {vgname}; fi")
 
+    def addCleanupMount(self, mount_point):
+        self.addCleanup(self.machine.execute,
+                        f"if mountpoint -q {mount_point}; then umount {mount_point}; fi")
+
     # Dialogs
 
     def dialog_wait_open(self):

--- a/test/verify/check-storage-btrfs
+++ b/test/verify/check-storage-btrfs
@@ -178,7 +178,7 @@ class TestStorageBtrfs(storagelib.StorageCase):
 
         self.click_dropdown(root_sel, "Mount")
         self.dialog({"mount_point": mount_point})
-        self.addCleanup(self.machine.execute, f"umount {mount_point} || true")
+        self.addCleanupMount(mount_point)
         b.wait_in_text(self.card_row("Storage", location=mount_point), "btrfs subvolume")
         self.click_dropdown(self.card_row("Storage", location=mount_point), "Create subvolume")
 
@@ -213,7 +213,7 @@ class TestStorageBtrfs(storagelib.StorageCase):
         self.dialog_set_val("mount_point", subvol_mount_point)
         self.dialog_apply()
         self.dialog_wait_close()
-        self.addCleanup(self.machine.execute, f"umount {subvol_mount_point} || true")
+        self.addCleanupMount(subvol_mount_point)
         b.wait_in_text(self.card_row("Storage", location=subvol_mount_point), "btrfs subvolume")
 
         # Finding the correct subvolume parent from a non-mounted subvolume
@@ -229,8 +229,8 @@ class TestStorageBtrfs(storagelib.StorageCase):
         self.dialog({"name": os.path.basename(left_subvol_mount), "mount_point": left_subvol_mount})
         self.click_dropdown(self.card_row("Storage", location=mount_point), "Create subvolume")
         self.dialog({"name": os.path.basename(right_subvol_mount), "mount_point": right_subvol_mount})
-        self.addCleanup(self.machine.execute, f"umount {left_subvol_mount} || true")
-        self.addCleanup(self.machine.execute, f"umount {right_subvol_mount} || true")
+        self.addCleanupMount(left_subvol_mount)
+        self.addCleanupMount(right_subvol_mount)
 
         b.wait_in_text(self.card_row("Storage", location=left_subvol_mount), "btrfs subvolume")
         b.wait_in_text(self.card_row("Storage", location=right_subvol_mount), "btrfs subvolume")
@@ -279,7 +279,7 @@ class TestStorageBtrfs(storagelib.StorageCase):
         root_sel = self.card_row("Storage", name="sda") + " + tr"
         self.click_dropdown(root_sel, "Mount")
         self.dialog({"mount_point": mount_point})
-        self.addCleanup(self.machine.execute, f"umount {mount_point} || true")
+        self.addCleanupMount(mount_point)
 
         # No Delete button for the root subvolume
         b.click(self.dropdown_toggle(root_sel))

--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -194,7 +194,7 @@ ExecStart=/usr/bin/sleep infinity
         if fstype == "btrfs":
             self._navigate_root_subvolume()
             b.wait_in_text(self.card_desc("btrfs subvolume", "Mount point"), "/run/foo")
-            self.addCleanup(m.execute, "umount /run/foo || true")
+            self.addCleanupMount("/run/foo")
         else:
             b.wait_text(self.card_desc(filesystem, "Name"), "FILESYSTEM")
             b.wait_in_text(self.card_desc(filesystem, "Mount point"), "/run/foo")
@@ -494,9 +494,8 @@ class TestStorageMountingLUKS(storagelib.StorageCase):
         self.login_and_go("/storage")
 
         self.addCleanupVG("test")
-        self.addCleanup(m.execute,
-                        "umount /run/data || true;"
-                        "cryptsetup close $(lsblk -lno NAME /dev/test/one | tail -1) || true")
+        self.addCleanup(m.execute, "cryptsetup close $(lsblk -lno NAME /dev/test/one | tail -1) || true")
+        self.addCleanupMount("/run/data")
 
         # Quickly make two logical volumes
         disk = self.add_ram_disk()

--- a/test/verify/check-storage-nfs
+++ b/test/verify/check-storage-nfs
@@ -38,7 +38,8 @@ class TestStorageNfs(storagelib.StorageCase):
         # Removing the nfs mount removes the target dir, if the test fails it
         # won't. It's important to umount before restoring /etc/exports as
         # otherwise nfs is confused and we can't umount the share.
-        self.addCleanup(m.execute, "if [ -e /mnt/test ]; then umount /mnt/test 2>/dev/null || true; rm -r /mnt/test; fi")
+        self.addCleanup(m.execute, "if [ -e /mnt/test ]; then rm -r /mnt/test; fi")
+        self.addCleanupMount("/mnt/test")
 
         orig_fstab = m.execute("cat /etc/fstab")
 

--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -131,7 +131,7 @@ class TestStorageStratis(storagelib.StorageCase):
         b.assert_pixels("#dialog", "create-fsys")
         self.dialog_apply()
         self.dialog_wait_close()
-        self.addCleanup(m.execute, "umount /run/fsys1 || true")
+        self.addCleanupMount("/run/fsys1")
 
         b.wait_text(self.card_row_col("Stratis filesystems", 1, 1), "fsys1")
         b.wait_text(self.card_row_col("Stratis filesystems", 1, 3), "/run/fsys1")
@@ -142,7 +142,7 @@ class TestStorageStratis(storagelib.StorageCase):
         b.click(self.card_button("Stratis filesystems", "Create new filesystem"))
         self.dialog({'name': 'fsys2',
                      'mount_point': '/run/fsys2'})
-        self.addCleanup(m.execute, "umount /run/fsys2 || true")
+        self.addCleanupMount("/run/fsys2")
         b.wait_text(self.card_row_col("Stratis filesystems", 2, 1), "fsys2")
         b.wait_text(self.card_row_col("Stratis filesystems", 2, 3), "/run/fsys2")
         b.assert_pixels(self.card("Stratis filesystems"), "fsys-rows")


### PR DESCRIPTION
Don't ignore unmount failures. That just leads to failures later on, like not being able to remove `scsi_debug`. This will make the tests fail closer to the real problem, during the umount.

---

By-product from investigating [this](https://artifacts.dev.testing-farm.io/5fb0024f-2538-47dd-bdc3-75a20a30847d/) and [this](https://artifacts.dev.testing-farm.io/8b6926b5-fbaf-4a23-8e6c-01741079c29c/) error, which happens rather often recently. That bug is a much bigger story, see #21355. But this is a good (and now independent) robustification.