### PR TITLE
containers/ws: Move to Fedora 41

### DIFF
--- a/containers/ws/Dockerfile
+++ b/containers/ws/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:40 AS builder
+FROM registry.fedoraproject.org/fedora:41 AS builder
 LABEL maintainer="cockpit-devel@lists.fedorahosted.org"
 LABEL VERSION=main
 


### PR DESCRIPTION
With the /ws-container scenario we now have an actually *good* way of validating this in CI :partying_face: 

However, as Knuth said "I have only proven this correct, not tested it", so I still want to test this manually next week. Thus draft for now.