### PR TITLE
branding: place distro logo in login in front of dark overlay

### DIFF
--- a/pkg/static/login.scss
+++ b/pkg/static/login.scss
@@ -767,6 +767,7 @@ body.login-pf {
 
 .login-pf #badge {
   grid-area: logo;
+  z-index: 2;
 }
 
 .login-pf .container .login-area {


### PR DESCRIPTION
Fixes #21378 

Before:
![image](https://github.com/user-attachments/assets/23901ae1-fd8d-46a8-9858-3abe39fe49d3)
![image](https://github.com/user-attachments/assets/6577f09a-ca87-40d6-b9c2-145e9dc05d4f)


After:
![image](https://github.com/user-attachments/assets/95e09d9f-1b33-4f40-bb6b-3c61fea52162)
![image](https://github.com/user-attachments/assets/414bff91-ef12-4fe4-b736-4a7297373588)