### PR TITLE
testlib: add '-efi' string to pixel tests labels for UEFI tests

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1634,7 +1634,7 @@ class MachineCase(unittest.TestCase):
                 pass
             else:
                 if machine.image == reference_image:
-                    pixels_label = self.label()
+                    pixels_label = self.label() + ('-efi' if machine.is_efi else '')
         browser = Browser(machine.web_address,
                           label=label, pixels_label=pixels_label, coverage_label=self.label() if coverage else None,
                           port=machine.web_port, machine=self)


### PR DESCRIPTION
Anaconda tests run in both BIOS and UEFI boot scenarios using a single ISO image. When generating pixel test images from tests that run in both boot modes, these conflict due to identical naming, but they need to be distinguished as the contents differ slightly.