### PR TITLE
selinux: Drop obsolete /var/run entries

### DIFF
--- a/containers/ws/label-install
+++ b/containers/ws/label-install
@@ -10,7 +10,7 @@ IMAGE=${1:-}
 cd /
 PATH="/bin:/sbin"
 
-if [ ! -d /host/etc -o ! -d /host/proc -o ! -d /host/var/run ]; then
+if [ ! -d /host/etc -o ! -d /host/proc -o ! -d /host/run ]; then
     echo "cockpit-run: host file system is not mounted at /host" >&2
     exit 1
 fi

--- a/containers/ws/label-uninstall
+++ b/containers/ws/label-uninstall
@@ -7,7 +7,7 @@
 cd /
 PATH="/bin:/sbin"
 
-if [ ! -d /host/etc -o ! -d /host/proc -o ! -d /host/var/run ]; then
+if [ ! -d /host/etc -o ! -d /host/proc -o ! -d /host/run ]; then
     echo "host file system is not mounted at /host" >&2
     exit 1
 fi

--- a/selinux/cockpit.fc
+++ b/selinux/cockpit.fc
@@ -11,9 +11,7 @@
 
 /var/lib/cockpit(/.*)?      gen_context(system_u:object_r:cockpit_var_lib_t,s0)
 
-/var/run/cockpit(/.*)?   gen_context(system_u:object_r:cockpit_var_run_t,s0)
 /run/cockpit(/.*)?   gen_context(system_u:object_r:cockpit_var_run_t,s0)
-/var/run/cockpit-ws(/.*)?   gen_context(system_u:object_r:cockpit_var_run_t,s0)
 /run/cockpit-ws(/.*)?   gen_context(system_u:object_r:cockpit_var_run_t,s0)
 
 /etc/cockpit/ws-certs\.d(/.*)?   gen_context(system_u:object_r:cert_t,s0)

--- a/selinux/cockpit_session_selinux.8cockpit
+++ b/selinux/cockpit_session_selinux.8cockpit
@@ -111,19 +111,19 @@ The SELinux process type cockpit_session_t can manage files labeled with the fol
 .br
 	/var/log/tallylog.*
 .br
-	/var/run/faillock(/.*)?
+	/run/faillock(/.*)?
 .br
 
 .br
 .B initrc_var_run_t
 
-	/var/run/utmp
+	/run/utmp
 .br
-	/var/run/random-seed
+	/run/random-seed
 .br
-	/var/run/runlevel\.dir
+	/run/runlevel\.dir
 .br
-	/var/run/setmixer_flag
+	/run/setmixer_flag
 .br
 
 .br
@@ -139,15 +139,15 @@ The SELinux process type cockpit_session_t can manage files labeled with the fol
 .br
 	/var/lib/sudo(/.*)?
 .br
-	/var/run/sudo(/.*)?
+	/run/sudo(/.*)?
 .br
-	/var/run/pam_ssh(/.*)?
+	/run/pam_ssh(/.*)?
 .br
-	/var/run/sepermit(/.*)?
+	/run/sepermit(/.*)?
 .br
-	/var/run/pam_mount(/.*)?
+	/run/pam_mount(/.*)?
 .br
-	/var/run/pam_timestamp(/.*)?
+	/run/pam_timestamp(/.*)?
 .br
 
 .br

--- a/selinux/cockpit_ws_selinux.8cockpit
+++ b/selinux/cockpit_ws_selinux.8cockpit
@@ -82,29 +82,29 @@ The SELinux process type cockpit_ws_t can manage files labeled with the followin
 .br
 .B cluster_var_run_t
 
-	/var/run/crm(/.*)?
+	/run/crm(/.*)?
 .br
-	/var/run/cman_.*
+	/run/cman_.*
 .br
-	/var/run/rsctmp(/.*)?
+	/run/rsctmp(/.*)?
 .br
-	/var/run/aisexec.*
+	/run/aisexec.*
 .br
-	/var/run/heartbeat(/.*)?
+	/run/heartbeat(/.*)?
 .br
-	/var/run/pcsd-ruby.socket
+	/run/pcsd-ruby.socket
 .br
-	/var/run/corosync-qnetd(/.*)?
+	/run/corosync-qnetd(/.*)?
 .br
-	/var/run/corosync-qdevice(/.*)?
+	/run/corosync-qdevice(/.*)?
 .br
-	/var/run/corosync\.pid
+	/run/corosync\.pid
 .br
-	/var/run/cpglockd\.pid
+	/run/cpglockd\.pid
 .br
-	/var/run/rgmanager\.pid
+	/run/rgmanager\.pid
 .br
-	/var/run/cluster/rgmanager\.sk
+	/run/cluster/rgmanager\.sk
 .br
 
 .br
@@ -116,9 +116,9 @@ The SELinux process type cockpit_ws_t can manage files labeled with the followin
 .br
 .B cockpit_var_run_t
 
-	/var/run/cockpit(/.*)?
+	/run/cockpit(/.*)?
 .br
-	/var/run/cockpit-ws(/.*)?
+	/run/cockpit-ws(/.*)?
 .br
 
 .br
@@ -146,9 +146,9 @@ The SELinux process type cockpit_ws_t can manage files labeled with the followin
 .br
 .B systemd_passwd_var_run_t
 
-	/var/run/systemd/ask-password(/.*)?
+	/run/systemd/ask-password(/.*)?
 .br
-	/var/run/systemd/ask-password-block(/.*)?
+	/run/systemd/ask-password-block(/.*)?
 .br
 
 .SH FILE CONTEXTS

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -243,7 +243,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         m.start_cockpit()
 
         # Clean out the relevant logfiles
-        m.execute("truncate -s0 /var/log/{[bw]tmp,lastlog} /var/run/utmp")
+        m.execute("truncate -s0 /var/log/{[bw]tmp,lastlog} /run/utmp")
 
         if m.image == "arch":
             self.sed_file("s/# deny = 3/deny = 4/", "/etc/security/faillock.conf")
@@ -653,7 +653,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         module = 'faillock'
 
         def logfile(user):
-            return '/var/run/faillock/' + user
+            return '/run/faillock/' + user
 
         def expect_fail_count(expected, user="admin", must_exist=True):
             if must_exist:

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -410,7 +410,7 @@ class TestAccounts(testlib.MachineCase):
         m = self.machine
 
         # Clean out the relevant logfiles
-        m.execute("truncate -s0 /var/log/{[bw]tmp,lastlog} /var/run/utmp")
+        m.execute("truncate -s0 /var/log/{[bw]tmp,lastlog} /run/utmp")
         m.execute("rm -f /var/lib/lastlog/lastlog2.db /var/lib/wtmpdb/wtmp.db")
 
         self.login_and_go("/users")
@@ -1076,7 +1076,7 @@ class TestAccounts(testlib.MachineCase):
         m = self.machine
 
         # Clean out the relevant logfiles
-        m.execute("truncate -s0 /var/log/{[bw]tmp,lastlog} /var/run/utmp")
+        m.execute("truncate -s0 /var/log/{[bw]tmp,lastlog} /run/utmp")
         m.execute("rm -f /var/lib/lastlog/lastlog2.db /var/lib/wtmpdb/wtmp.db")
 
         # Login once to create an entry


### PR DESCRIPTION
Commit 2c4f752473231 moved the SELinux policy to /run,  in accordance
with [1]. However, the "duplicate" /var/run/ entries break on RHEL 10
now, so drop them.

Fixes https://issues.redhat.com/browse/RHEL-70238

[1] https://discussion.fedoraproject.org/t/f40-change-proposal-move-var-run-selinux-policy-entries-to-run-self-contained/100171

----

Draft, as this definitively breaks on RHEL 9 at least. I want to check the other distros. This is gonna take some thoughs/debugging effort, see discussion in Jira.