### PR TITLE
tools: Move cockpit-tests conflict to cockpit-ws

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -309,7 +309,6 @@ Provides: cockpit-kdump = %{version}-%{release}
 Provides: cockpit-networkmanager = %{version}-%{release}
 Provides: cockpit-selinux = %{version}-%{release}
 Provides: cockpit-sosreport = %{version}-%{release}
-Obsoletes: cockpit-tests < 331
 %endif
 %if 0%{?fedora}
 Recommends: (reportd if abrt)
@@ -335,6 +334,7 @@ Recommends: system-logos
 Suggests: sssd-dbus >= 2.6.2
 # for cockpit-desktop
 Suggests: python3
+Obsoletes: cockpit-tests < 331
 
 # prevent hard python3 dependency for cockpit-desktop, it falls back to other browsers
 %global __requires_exclude_from ^%{_libexecdir}/cockpit-client$

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -131,8 +131,6 @@ Provides: cockpit-shell,
           cockpit-tuned,
           cockpit-users
 Suggests: lastlog2
-Conflicts: cockpit-tests (<< 331)
-Replaces: cockpit-tests (<< 331)
 Description: Cockpit admin interface for a system
  Cockpit admin interface package for configuring and
  troubleshooting a system.
@@ -148,6 +146,8 @@ Depends: ${misc:Depends},
          libnss-systemd,
 Suggests: sssd-dbus (>= 2.6.2),
          python3,
+Conflicts: cockpit-tests (<< 331)
+Replaces: cockpit-tests (<< 331)
 Description: Cockpit Web Service
  The Cockpit Web Service listens on the network, and authenticates
  users.


### PR DESCRIPTION
This makes more sense, as there is an actual file conflict on upgrade: cockpit-session.{socket,service} moved from -tests to -ws in commit 4dd6685e540 (release 330).

https://bugs.debian.org/1089220

---

Also see [failing installability test in Fedora](https://artifacts.dev.testing-farm.io/bd1bfa0d-52eb-4ab2-aea5-97f085f4b544/)