### PR TITLE
Incorrect polkit rules paths

### DIFF
--- a/doc/guide/feature-systemd.xml
+++ b/doc/guide/feature-systemd.xml
@@ -105,7 +105,7 @@ $ <command>systemctl status cockpit</command>
   </variablelist>
 
   <para>For example, placing the following polkit rule to
-    <filename>/etc/polkit-1.rules.d/10-http.rule</filename> allows all users in the
+    <filename>/etc/polkit-1/rules.d/10-http.rule</filename> allows all users in the
     <code>operators</code> group start, stop, and restart the Apache HTTP service:</para>
 
 <programlisting>

--- a/doc/guide/privileges.xml
+++ b/doc/guide/privileges.xml
@@ -38,7 +38,7 @@
 
     <para>Polkit rules files are
       <ulink url="https://www.freedesktop.org/software/polkit/docs/latest/polkit.8.html">javascript with specific methods and objects</ulink>. For example, placing the following polkit rule to
-      <filename>/etc/polkit-1.rules.d/10-operators.rule</filename> allows all users in the
+      <filename>/etc/polkit-1/rules.d/10-operators.rule</filename> allows all users in the
       <code>operators</code> group to start, stop, restart and otherwise manage systemd services:</para>
 
 <programlisting>


### PR DESCRIPTION
Doubled checked in the polkit repo, it doesn't look like /etc/polkit-1.rules.d/ exists. I am assuming this is just a typo.