### PR TITLE
dependabot: Don't update major React version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,10 @@ updates:
       - dependency-name: "@patternfly/*"
         versions: ["6.x"]
 
+      # PF5 requires fixed major React version
+      - dependency-name: "*react*"
+        update-types: ["version-update:semver-major"]
+
   - package-ecosystem: "github-actions"
     directory: "/"
     open-pull-requests-limit: 3


### PR DESCRIPTION
PatternFly 5 has a React 18 peer dependency, so they need to be updated together.

Same as https://github.com/cockpit-project/starter-kit/pull/1052

Closes #21400