### PR TITLE
dependabot: Ignore all sass 1.x versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,7 +38,7 @@ updates:
     ignore:
       # https://github.com/cockpit-project/cockpit/issues/21151
       - dependency-name: "sass"
-        versions: ["1.80.x", "2.x"]
+        versions: ["1.x", "2.x"]
 
       # lots of work, do this explicitly
       - dependency-name: "@patternfly/*"


### PR DESCRIPTION
We don't want sass 1.82 etc. either. Judging by the release history there won't be any 1.79.x any more, and we don't need them either.

Closes #21404