### PR TITLE
users: Fix truncated "From" in account logs

### DIFF
--- a/pkg/users/account-logs-panel.jsx
+++ b/pkg/users/account-logs-panel.jsx
@@ -31,7 +31,7 @@ const _ = cockpit.gettext;
 export function AccountLogs({ name }) {
     const [logins, setLogins] = useState([]);
     useInit(() => {
-        cockpit.spawn(["last", "--time-format", "iso", "-n25", name], { environ: ["LC_ALL=C"] })
+        cockpit.spawn(["last", "--time-format", "iso", "-n25", "--fullnames", name], { environ: ["LC_ALL=C"] })
                 .then(data => {
                     let logins = [];
                     data.split('\n').forEach(line => {

--- a/pkg/users/account-logs-panel.jsx
+++ b/pkg/users/account-logs-panel.jsx
@@ -31,7 +31,7 @@ const _ = cockpit.gettext;
 export function AccountLogs({ name }) {
     const [logins, setLogins] = useState([]);
     useInit(() => {
-        cockpit.spawn(["last", "--time-format", "iso", "-n", 25, name], { environ: ["LC_ALL=C"] })
+        cockpit.spawn(["last", "--time-format", "iso", "-n25", name], { environ: ["LC_ALL=C"] })
                 .then(data => {
                     let logins = [];
                     data.split('\n').forEach(line => {

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -909,7 +909,8 @@ on_authorize_timeout (int signo)
 {
   /* Can't use errx() here: https://man7.org/linux/man-pages/man7/signal-safety.7.html */
   static const char msg[] = "timed out waiting for authorize response\n";
-  write (STDERR_FILENO, msg, sizeof (msg) - 1);
+  /* ignore write errors(-Wunused-result); if that fails, we can do absolutely nothing about it */
+  (void) !write (STDERR_FILENO, msg, sizeof (msg) - 1);
   _exit(EX);
 }
 

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -220,7 +220,9 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         def assert_messages(has_last, n_fail):
             if has_last:
                 b.wait_in_text('#system_last_login', "Last successful login")
-                b.wait_in_text('#system_last_login_from', "from")  # only present if IP was logged
+                b.wait_in_text('#system_last_login_from',
+                               # this is the correct IP for our CI, and we don't run this on tmt
+                               "from ::ffff:172.27.0.2 on web console")  # only present if IP was logged
 
             if n_fail:
                 b.wait_in_text('#system_last_login', f'{n_fail} failed login')

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -1079,14 +1079,26 @@ class TestAccounts(testlib.MachineCase):
         m.execute("truncate -s0 /var/log/{[bw]tmp,lastlog} /run/utmp")
         m.execute("rm -f /var/lib/lastlog/lastlog2.db /var/lib/wtmpdb/wtmp.db")
 
-        # Login once to create an entry
-        self.login_and_go("/users")
+        # First login: no entries yet
+        self.login_and_go("/users#/admin")
+        # just the header, nothing else
+        b.wait_text("#account-logs", "Login history")
+        self.assertFalse(b.is_present("#account-logs tr"))
         b.logout()
 
+        year = m.execute("date +%Y").strip()
+
+        # second login: one entry from the first one
         self.login_and_go("/users#/admin")
-        b.wait_visible("#account-logs")
         # Header + one line of logins
         b.wait_js_func("ph_count_check", "#account-logs tr", 2)
+        started = b.text("#account-logs [data-label='Started']")
+        ended = b.text("#account-logs [data-label='Ended']")
+        self.assertIn(year, started)
+        self.assertIn(year, ended)
+        self.assertGreaterEqual(ended, started)
+        # this is the correct IP for our CI, and we don't run this on tmt
+        b.wait_text("#account-logs [data-label='From']", "::ffff:172.27.0.2")
 
     def testGroups(self):
         b = self.browser


### PR DESCRIPTION
Call `last` with `--fullnames` to avoid truncating values (like IPv6
addresses). We don't rely on a "nicely" (argh) formatted ASCII table
with fixed column widths, but parse the structure.

Flesh out TestAccounts.testAccountLogs to actually test some values on
the page. It was almost empty before. Like in the previous commit, we
can afford to hardcode the expected IPv6 "from" address.

Fixes #21383