### PR TITLE
test: Use real mouse events with Chromium in the shell

### DIFF
--- a/test/common/webdriver_bidi.py
+++ b/test/common/webdriver_bidi.py
@@ -326,6 +326,9 @@ class WebdriverBidi:
         self.context = self.top_context
         log_command.info("← switch_to_top")
 
+    def in_top_context(self) -> bool:
+        return self.context == self.top_context
+
     @contextlib.contextmanager
     def restore_context(self) -> Iterator[None]:
         saved = self.context

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -758,7 +758,6 @@ OnCalendar=daily
         with b.wait_timeout(60):
             b.wait_js_func("ph_plot_data_plateau", "internal", mem_avail * 0.85, mem_avail * 1.15, 15, "mem")
 
-    @testlib.skipBrowser("Headless chromium is missing the synthetic mouseenter", "chromium")
     def testPageStatus(self):
         b = self.browser
 

--- a/test/verify/check-shell-host-switching
+++ b/test/verify/check-shell-host-switching
@@ -594,8 +594,7 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
         b.click("#hosts-sel button")
         b.click("a[href='/']")
         b.relogin()
-        time.sleep(60)
-        self.assertNotIn(m2.execute("loginctl"), "admin")
+        m2.execute("while loginctl | grep admin; do sleep 1; done")
 
 
 if __name__ == '__main__':

--- a/test/verify/check-shell-host-switching
+++ b/test/verify/check-shell-host-switching
@@ -198,14 +198,6 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
         b.wait_not_present("#nav-system.interact")
         b.set_layout("desktop")
 
-        # this looks different (focused) when the mouse is inside (default 0,0 possition), so move it away
-        # chromium is stubborn here, we *have* to move the real mouse, not just do this with synthetic MouseEvents
-        b.bidi("input.performActions", context=b.driver.context, actions=[{
-            "id": "move-away",
-            "type": "pointer",
-            "parameters": {"pointerType": "mouse"},
-            "actions": [{"type": "pointerMove", "x": 200, "y": 200, "origin": "viewport"}]
-        }])
         b.assert_pixels("#hosts-sel", "hosts-sel-closed")
 
         self.open_host_switcher()
@@ -237,6 +229,8 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
         b.wait_in_text('#hosts_setup_server_dialog', "Unable to contact the given host 10.111.113.2:4321. Make sure it has ssh running on port 4321, or specify another port in the address.")
         # Now do it right
         b.set_input_text('#add-machine-address', "10.111.113.2")
+        # move the mouse away to avoid highlighting any UI element (pixel ref does not expect that)
+        b.mouse("#hosts-sel", "mouseenter")
         b.assert_pixels("#hosts_setup_server_dialog", "host-add-dialog")
         b.click('#hosts_setup_server_dialog .pf-m-primary:contains("Add")')
         b.wait_in_text('#hosts_setup_server_dialog', "You are connecting to 10.111.113.2 for the first time")

--- a/test/verify/check-shell-host-switching
+++ b/test/verify/check-shell-host-switching
@@ -24,6 +24,21 @@ import testlib
 
 class HostSwitcherHelpers:
 
+    def open_host_switcher(self, browser=None):
+        b = browser or self.browser
+        b.click("#hosts-sel button")
+        b.wait_visible("#nav-hosts.interact")
+        # the opening animation takes quite long, don't move elements underneath mouse clicks
+        b.wait_js_cond('ph_count_animations("#nav-hosts") == 0')
+        time.sleep(0.2)
+
+    def edit_hosts(self, browser=None):
+        b = browser or self.browser
+        b.click("button:contains('Edit hosts')")
+        # the opening animation takes quite long, don't move elements underneath mouse clicks
+        b.wait_js_cond('ph_count_animations("#nav-hosts") == 0')
+        b.wait_visible("button:contains('Stop editing hosts')")
+
     def check_discovered_addresses(self, b, addresses):
         b.click("button:contains('Add new host')")
         b.wait_visible('#hosts_setup_server_dialog')
@@ -42,7 +57,7 @@ class HostSwitcherHelpers:
             # wait for host switcher to close
             b.wait_not_present("#nav-hosts.interact")
             # open it again
-            b.click("#hosts-sel button")
+            self.open_host_switcher(b)
         b.wait_js_cond(f'ph_select("#nav-hosts .nav-item a").length == {len(expected)}')
         for address in expected:
             if address == "localhost":
@@ -51,7 +66,7 @@ class HostSwitcherHelpers:
                 b.wait_visible(f"#nav-hosts .nav-item a[href='/@{address}']")
 
     def machine_remove(self, b, address, second_to_last=False):
-        b.click("button:contains('Edit hosts')")
+        self.edit_hosts(b)
         b.click(f".nav-item a[href='/@{address}'] + span button.nav-action.pf-m-danger")
         if second_to_last:
             b.wait_not_present("button:contains('Stop editing hosts')")
@@ -102,7 +117,7 @@ class HostSwitcherHelpers:
             b.wait_text("#current-username", expected_user)
         # Switch back to localhost, since the rest of the test expects that
         b.click("a[href='/']")
-        b.click("#hosts-sel button")
+        self.open_host_switcher(b)
 
     def connect_and_wait(self, b, address, expected_user=None, expect_warning=False):
         b.click(f"a[href='/@{address}']")
@@ -113,7 +128,7 @@ class HostSwitcherHelpers:
         # wait for host switcher to close after connecting
         b.wait_not_present("#nav-hosts.interact")
         # open it again
-        b.click("#hosts-sel button")
+        self.open_host_switcher(b)
         self.wait_connected(b, address, expected_user)
 
 
@@ -193,7 +208,7 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
         }])
         b.assert_pixels("#hosts-sel", "hosts-sel-closed")
 
-        b.click("#hosts-sel button")
+        self.open_host_switcher()
         self.wait_host_addresses(b, ["localhost"])
 
         b.wait_not_present("button:contains('Edit hosts')")
@@ -233,7 +248,7 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
         self.wait_connected(b, "10.111.113.2", "admin")
 
         # Main host should have both buttons disabled, the second both enabled
-        b.click("button:contains('Edit hosts')")
+        self.edit_hosts()
         b.wait_visible(".nav-item a[href='/'] + span button.nav-action.pf-m-danger:disabled")
         b.wait_visible(".nav-item a[href='/'] + span button.nav-action.pf-m-secondary:disabled")
         b.wait_visible(".nav-item a[href='/@10.111.113.2'] + span button.nav-action.pf-m-danger:not(:disabled)")
@@ -281,8 +296,8 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
         b.click("#nav-hosts .nav-item a[href='/@10.111.113.3']")
         b.wait_visible("iframe.container-frame[name='cockpit1:10.111.113.3/system']")
 
-        b.click("#hosts-sel button")
-        b.click("button:contains('Edit hosts')")
+        self.open_host_switcher()
+        self.edit_hosts()
 
         b.click("#nav-hosts .nav-item a[href='/@10.111.113.3'] + span button.nav-action.pf-m-secondary")
 
@@ -299,11 +314,11 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
         b.click("#nav-hosts .nav-item a[href='/']")
         b.wait_js_cond('window.location.pathname == "/system"')
 
-        b.click("#hosts-sel button")
+        self.open_host_switcher()
         b.click("#nav-hosts .nav-item a[href='/@10.111.113.2']")
         b.wait_js_cond('window.location.pathname.indexOf("/@10.111.113.2") === 0')
 
-        b.click("#hosts-sel button")
+        self.open_host_switcher()
         b.click("#nav-hosts .nav-item a[href='/@10.111.113.3']")
         b.wait_js_cond('window.location.pathname.indexOf("/@10.111.113.3") === 0')
 
@@ -317,8 +332,8 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
 
         # Remove host underneath ourselves
         b.switch_to_top()
-        b.click("#hosts-sel button")
-        b.click("button:contains('Edit hosts')")
+        self.open_host_switcher()
+        self.edit_hosts()
         b.click("#nav-hosts .nav-item a[href='/@10.111.113.3'] + span button.nav-action.pf-m-danger")
         b.wait_not_present("iframe.container-frame[name='cockpit1:10.111.113.3/network']")
         b.wait_js_cond('window.location.pathname == "/system"')
@@ -327,7 +342,7 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
 
         # remove machine2 as well, to return to a blank slate
         b.switch_to_top()
-        b.click("#hosts-sel button")
+        self.open_host_switcher()
         self.machine_remove(b, "10.111.113.2", second_to_last=True)
         self.wait_host_addresses(b, ["localhost"])
 
@@ -358,7 +373,7 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
 
         # reset session store to forget previous user/host connections
         b.relogin()
-        b.click("#hosts-sel button")
+        self.open_host_switcher()
 
         # ssh:// prefix and implied user, no warning because we switched it off above
         self.add_new_machine(b, "ssh://10.111.113.2", known_host=True, expect_warning=False)
@@ -412,7 +427,7 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
 
         self.login_and_go()
 
-        b.click("#hosts-sel button")
+        self.open_host_switcher()
         self.wait_host_addresses(b, ["localhost"])
 
         b.wait_not_present("button:contains('Edit hosts')")
@@ -422,7 +437,7 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
         b2.default_user = "admin"
         b2.login_and_go()
 
-        b2.click("#hosts-sel button")
+        self.open_host_switcher(b2)
         self.wait_host_addresses(b2, ["localhost"])
 
         self.add_new_machine(b, "10.111.113.2", expect_warning=True)
@@ -432,7 +447,7 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
         self.connect_and_wait(b2, "10.111.113.2", expect_warning=True)
 
         # Main host should have both buttons disabled, the second both enabled
-        b.click("button:contains('Edit hosts')")
+        self.edit_hosts()
         b.wait_visible(".nav-item a[href='/'] + span button.nav-action.pf-m-danger:disabled")
         b.wait_visible(".nav-item a[href='/'] + span button.nav-action.pf-m-secondary:disabled")
         b.wait_visible(".nav-item a[href='/@10.111.113.2'] + span button.nav-action.pf-m-danger:not(:disabled)")
@@ -504,12 +519,12 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
         # This should all work without being admin on m1
         self.login_and_go(superuser=False)
 
-        b.click("#hosts-sel button")
+        self.open_host_switcher()
         self.add_new_machine(b, "10.111.113.3", expect_warning=True)
         self.wait_host_addresses(b, ["localhost", "10.111.113.3"], host_switcher_is_open=False)
         self.wait_connected(b, "10.111.113.3")
 
-        b.click("button:contains('Edit hosts')")
+        self.edit_hosts()
         b.click("#nav-hosts .nav-item a[href='/@10.111.113.3'] + span button.nav-action.pf-m-secondary")
 
         b.wait_visible('#hosts_setup_server_dialog .pf-v5-c-modal-box__title:contains("Edit host")')
@@ -551,9 +566,9 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
         b.wait_visible("iframe.container-frame[name='cockpit1:franz@10.111.113.3/system']")
 
         b.wait_text("#hosts-sel button .pf-v5-c-select__toggle-text", "franz@machine3")
-        b.click("#hosts-sel button")
+        self.open_host_switcher()
         b.wait_text(".nav-item a[href='/@10.111.113.3']", "franz @machine3")
-        b.click("button:contains('Edit hosts')")
+        self.edit_hosts()
         b.click("#nav-hosts .nav-item a[href='/@10.111.113.3'] + span button.nav-action.pf-m-secondary")
 
         b.wait_val('#add-machine-address', "10.111.113.3")
@@ -575,7 +590,7 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
         # Changing the address of a host will navigate to that host,
         # and that will close the host switcher.  Let's open it again
         # to check it.
-        b.click("#hosts-sel button")
+        self.open_host_switcher()
         b.wait_not_present(".nav-item a[href='/@10.111.113.3']")
         b.wait_text(".nav-item a[href='/@10.111.113.2']", "admin @machine2")
 
@@ -587,11 +602,11 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
         self.login_and_go(None)
 
         # Add and connect to a second machine
-        b.click("#hosts-sel button")
+        self.open_host_switcher()
         self.add_new_machine(b, "10.111.113.2", expect_warning=True)
         b.wait_visible("iframe.container-frame[name='cockpit1:10.111.113.2/system']")
         self.assertIn("admin", m2.execute("loginctl"))
-        b.click("#hosts-sel button")
+        self.open_host_switcher()
         b.click("a[href='/']")
         b.relogin()
         m2.execute("while loginctl | grep admin; do sleep 1; done")

--- a/test/verify/check-shell-keys
+++ b/test/verify/check-shell-keys
@@ -281,6 +281,8 @@ session    optional     pam_ssh_add.so
 
         # Log off and log back in, and we should have both loaded automatically
         if auto_load:
+            b.click("#credentials-modal button[aria-label=Close]")
+            b.wait_not_present("#credentials-modal")
             b.logout()
             b.login_and_go()
             keys = list_keys()
@@ -357,6 +359,9 @@ session    optional     pam_ssh_add.so
         b.wait_not_present("h1:contains('Unlock key /tmp/new_with_passphrase.rsa')")
         b.wait_not_present("#ssh-file-add")
         b.wait_js_func("ph_count_check", "#credential-keys tbody", 4)
+
+        b.click("#credentials-modal button[aria-label=Close]")
+        b.wait_not_present("#credentials-modal")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
BiDi mouse events work fine on the top-level document (i.e. not in frames). So let's use them to test the shell.