### PR TITLE
cockpit: send `now` along with the internalmetrics meta

### DIFF
--- a/pkg/playground/plot.html
+++ b/pkg/playground/plot.html
@@ -11,5 +11,6 @@
 <body class="pf-v5-m-tabular-nums">
   <div id="plot-direct"></div>
   <div id="plot-pmcd"></div>
+  <div id="plot-internal"></div>
 </body>
 </html>

--- a/pkg/playground/plot.js
+++ b/pkg/playground/plot.js
@@ -16,10 +16,16 @@ const pmcd_metric = {
     units: "bytes"
 };
 
+const internal_metric = {
+    internal: ["memory.used"],
+    units: "bytes",
+};
+
 document.addEventListener("DOMContentLoaded", function() {
     const plot_state = new PlotState();
     plot_state.plot_single('direct', direct_metric);
     plot_state.plot_single('pmcd', pmcd_metric);
+    plot_state.plot_single('internal', internal_metric);
 
     // For the tests
     window.plot_state = plot_state;
@@ -34,5 +40,11 @@ document.addEventListener("DOMContentLoaded", function() {
         <SvgPlot className="mem-graph"
                  title="PMCD" config={bytes_config}
                  plot_state={plot_state} plot_id="pmcd" />
+    );
+
+    createRoot(document.getElementById('plot-internal')).render(
+        <SvgPlot className="mem-graph"
+                 title="Internal" config={bytes_config}
+                 plot_state={plot_state} plot_id="internal" />
     );
 });

--- a/src/cockpit/channels/metrics.py
+++ b/src/cockpit/channels/metrics.py
@@ -107,7 +107,9 @@ class InternalMetricsChannel(AsyncChannel):
                     'semantics': metricinfo.desc.semantics
                 })
 
-        self.send_json(source='internal', interval=self.interval, timestamp=timestamp * 1000, metrics=metrics)
+        now = int(time.time()) * 1000
+        self.send_json(source='internal', interval=self.interval, timestamp=timestamp * 1000,
+                       now=now, metrics=metrics)
         self.need_meta = False
 
     def sample(self) -> Samples:

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -752,6 +752,12 @@ OnCalendar=daily
         with b.wait_timeout(60):
             b.wait_js_func("ph_plot_data_plateau", "pmcd", mem_avail * 0.85, mem_avail * 1.15, 15, "mem")
 
+        # Internal metrics only has memory used (memory.used) as a metric not available memory.
+        meminfo = read_mem_info(m)
+        mem_avail = meminfo['MemTotal'] - meminfo['MemAvailable']
+        with b.wait_timeout(60):
+            b.wait_js_func("ph_plot_data_plateau", "internal", mem_avail * 0.85, mem_avail * 1.15, 15, "mem")
+
     @testlib.skipBrowser("Headless chromium is missing the synthetic mouseenter", "chromium")
     def testPageStatus(self):
         b = self.browser


### PR DESCRIPTION
The metrics for the networking and storage pages didn't show anything since we switched to the Python implementation. There was no integration test for internalmetrics so this regressed without us noticing as these graphs can also take data from PCP (archive or direct).

Fixes: #19627