### PR TITLE
tls: Certificate error robustification

### DIFF
--- a/src/tls/cockpit-certificate-helper.in
+++ b/src/tls/cockpit-certificate-helper.in
@@ -76,6 +76,8 @@ cmd_selfsign() {
     local KEYFILE="0-self-signed.key"
     local CA_FILE="0-self-signed-ca.pem"
 
+    mkdir -pZ "$COCKPIT_WS_CERTS_D"
+
     # We renew certificates up to 30 days before expiry, so give ourselves a
     # year, plus 30 days.  The maximum is variously mentioned to be 397 or 398.
     local DAYS=395
@@ -110,6 +112,7 @@ cmd_ipa_request() {
         ipa-getkeytab -p "HTTP/${HOST}" -k "${KEYTAB}"
 
     # request the certificate and put it into our certificate directory, so that auto-refresh works
+    mkdir -pZ "$COCKPIT_WS_CERTS_D"
     ipa-getcert request -f "${COCKPIT_WS_CERTS_D}/10-ipa.cert" -k "${COCKPIT_WS_CERTS_D}/10-ipa.key" -K "HTTP/${HOST}" -m 640 -o root:root -M 644 -w -v
 }
 

--- a/src/tls/cockpit-certificate-helper.in
+++ b/src/tls/cockpit-certificate-helper.in
@@ -76,6 +76,12 @@ cmd_selfsign() {
     local KEYFILE="0-self-signed.key"
     local CA_FILE="0-self-signed-ca.pem"
 
+    # do not stomp over a partial key -- the admin tried to do something wrong
+    if [ -e "${COCKPIT_WS_CERTS_D}/${KEYFILE}" ] && [ ! -e "${COCKPIT_WS_CERTS_D}/${CERTFILE}" ]; then
+        echo "Error: Found $KEYFILE but no $CERTFILE. Please remove the key file first." >&2
+        exit 1
+    fi
+
     mkdir -pZ "$COCKPIT_WS_CERTS_D"
 
     # We renew certificates up to 30 days before expiry, so give ourselves a

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -403,6 +403,11 @@ class TestConnection(testlib.MachineCase):
         self.assertRegex(
             output, r"no cipher match|no ciphers available|ssl handshake failure|Cipher is \(NONE\)")
 
+        # gets along with missing directory
+        m.execute("rm -r /etc/cockpit/ws-certs.d")
+        m.start_cockpit(tls=True)
+        self.assertIn("HTTP/1.1 200 OK", m.execute("curl -k --head https://127.0.0.1:9090"))
+
         # get along with read-only config directory, as long as certificate exists
         if not m.ws_container:
             m.stop_cockpit()

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -403,6 +403,23 @@ class TestConnection(testlib.MachineCase):
         self.assertRegex(
             output, r"no cipher match|no ciphers available|ssl handshake failure|Cipher is \(NONE\)")
 
+        # fails with useful error message with broken certs/keys
+        if not m.ostree_image:  # not using systemd unit
+            def check_fail(expected: list[str]):
+                m.start_cockpit(tls=True)
+                m.execute('! openssl s_client -connect 172.27.0.15:9090 2>&1')
+                out = m.execute("! systemctl status cockpit.service")
+                self.assertIn("failed", out)
+                for s in expected:
+                    self.assertIn(s, out)
+
+            # missing key
+            m.execute("rm /etc/cockpit/ws-certs.d/0-self-signed.key")
+            check_fail(["0-self-signed.key", "No such file or directory"])
+            # broken key
+            m.write("/etc/cockpit/ws-certs.d/0-self-signed.key", "-----BEGIN PRIVATE KEY-----\nnope")
+            check_fail(["/etc/cockpit/ws-certs.d/0-self-signed.cert/.key", "decoding error"])
+
         # gets along with missing directory
         m.execute("rm -r /etc/cockpit/ws-certs.d")
         m.start_cockpit(tls=True)

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -414,11 +414,20 @@ class TestConnection(testlib.MachineCase):
                     self.assertIn(s, out)
 
             # missing key
-            m.execute("rm /etc/cockpit/ws-certs.d/0-self-signed.key")
+            orig_key = m.execute("cat /etc/cockpit/ws-certs.d/0-self-signed.key")
+            m.execute("mv /etc/cockpit/ws-certs.d/0-self-signed.key /etc/cockpit/ws-certs.d/key.bak")
             check_fail(["0-self-signed.key", "No such file or directory"])
             # broken key
             m.write("/etc/cockpit/ws-certs.d/0-self-signed.key", "-----BEGIN PRIVATE KEY-----\nnope")
             check_fail(["/etc/cockpit/ws-certs.d/0-self-signed.cert/.key", "decoding error"])
+            m.execute("mv /etc/cockpit/ws-certs.d/key.bak /etc/cockpit/ws-certs.d/0-self-signed.key")
+            # missing cert; does not stomp over the existing key
+            m.execute("rm /etc/cockpit/ws-certs.d/0-self-signed.cert")
+            check_fail(["Found 0-self-signed.key but no 0-self-signed.cert", "Please remove the key file first"])
+            self.assertEqual(m.execute("cat /etc/cockpit/ws-certs.d/0-self-signed.key"), orig_key)
+            # broken cert
+            m.write("/etc/cockpit/ws-certs.d/0-self-signed.cert", "-----BEGIN CERTIFICATE-----\nnope")
+            check_fail(["/etc/cockpit/ws-certs.d/0-self-signed.cert/.key", "header error"])
 
         # gets along with missing directory
         m.execute("rm -r /etc/cockpit/ws-certs.d")


### PR DESCRIPTION
Inspired from #21069, thanks to @jmlemetayer for pointing out!

Note that we also *could* go the other way and automatically rebuild the certificate on any such error. I'm not a big fan of that, but can be convinced  -- opinions?