### PR TITLE
lib: Revert menu toggles to be transparent again

### DIFF
--- a/pkg/lib/patternfly/patternfly-5-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-5-overrides.scss
@@ -398,12 +398,3 @@ select.pf-v5-c-form-control {
     background-color: var(--pf-v5-global--BackgroundColor--400);
   }
 }
-
-/* Menu toggles are transparent in light mode (but not in dark
-   mode). This makes them white on a white page (fine), but grey in a
-   grey toolbar. The deprecated Select had a white background. Let's
-   make MenuToggles match.
-*/
-html:not(.pf-v5-theme-dark) .pf-v5-c-menu-toggle:not(.pf-m-primary) {
-    background-color: var(--pf-v5-global--BackgroundColor--100);
-}

--- a/pkg/metrics/metrics.scss
+++ b/pkg/metrics/metrics.scss
@@ -852,3 +852,12 @@ $graphs: cpu, memory, disks, network;
     }
   }
 }
+
+/* Menu toggles are transparent in light mode (but not in dark
+   mode). This makes them white on a white page (fine), but grey in a
+   grey toolbar. The deprecated Select had a white background. Let's
+   make MenuToggles match.
+*/
+html:not(.pf-v5-theme-dark) .pf-v5-c-menu-toggle:not(.pf-m-primary) {
+    background-color: var(--pf-v5-global--BackgroundColor--100);
+}

--- a/pkg/systemd/logs.scss
+++ b/pkg/systemd/logs.scss
@@ -156,3 +156,12 @@
       color: var(--pf-v5-global--Color--100);
     }
 }
+
+/* Menu toggles are transparent in light mode (but not in dark
+   mode). This makes them white on a white page (fine), but grey in a
+   grey toolbar. The deprecated Select had a white background. Let's
+   make MenuToggles match.
+*/
+html:not(.pf-v5-theme-dark) .pf-v5-c-menu-toggle:not(.pf-m-primary) {
+    background-color: var(--pf-v5-global--BackgroundColor--100);
+}


### PR DESCRIPTION
This broke Anaconda.  Instead, only change them in "logs" and "metrics".