### PR TITLE
containers/ws: Fix build on Fedora 41

### DIFF
--- a/containers/ws/install.sh
+++ b/containers/ws/install.sh
@@ -4,7 +4,7 @@ set -ex
 
 OSVER=$(. /etc/os-release && echo "$VERSION_ID")
 INSTALLROOT=/build
-INSTALL="dnf install -y --installroot=$INSTALLROOT --releasever=$OSVER --setopt=install_weak_deps=False"
+INSTALL="dnf install -y --installroot=$INSTALLROOT --releasever=$OSVER --setopt=install_weak_deps=False --use-host-config"
 
 # keep in sync with test/ws-container.install
 PACKAGES="


### PR DESCRIPTION
dnf5 changed `--installroot` behaviour that it now only considers the repositories in the root instead of the host. This broke the container build.

Unfortunately my fix for that [1] got lost in a git pilot failure, mea culpa!

[1] https://github.com/cockpit-project/cockpit/pull/21360#issuecomment-2511242349

----

See https://github.com/cockpit-project/cockpit/actions/workflows/build-ws-container.yml  - after that lands, I'll do a hack to fix the container build for 331, as it now builds from the latest tag instead of main.

Tested locally with `podman build -t localhost/ws containers/ws`