### PR TITLE
Revert "test: Make restore_dir() work for OSTree images"

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -2360,7 +2360,7 @@ class MachineCase(unittest.TestCase):
         If the directory needs to survive reboot, `reboot_safe=True` needs to be specified; then this
         will just backup/restore the directory instead of bind-mounting, which is less robust.
         """
-        if not self.is_nondestructive() and not self.machine.ostree_image:
+        if not self.is_nondestructive():
             return  # skip for efficiency reasons
 
         exe = self.machine.execute


### PR DESCRIPTION
This reverts commit 413111f230ccabaaded2b63f081472ffedd3fccd.

We don't need this anymore since overrides are in /etc.

Letting restore_dir work on OSTree images might cause the destructive tests TestServices.testBasic and TestServices.testLogs and maybe others to be flaky.