### PR TITLE
containers/ws: Clean /var/cache/libdnf5

### DIFF
--- a/containers/ws/install.sh
+++ b/containers/ws/install.sh
@@ -44,5 +44,5 @@ else
     rm $INSTALLROOT/usr/libexec/cockpit-session
 fi
 
-rm -rf /build/var/cache/dnf /build/var/lib/dnf /build/var/lib/rpm* /build/var/log/*
+rm -rf /build/var/cache/*dnf* /build/var/lib/dnf /build/var/lib/rpm* /build/var/log/*
 rm -rf /container/rpms || true


### PR DESCRIPTION
This currently contains 84 MB of dead weight (repository indexes). That made the container balloon from 57 to 116 MB.

---

Not super important, but for me it's a matter of pride! See https://quay.io/repository/cockpit/ws?tab=tags

Verified with `podman build -t localhost/ws containers/ws/`, and

```
quay.io/cockpit/ws                 329.1       496397eface4  2 weeks ago         147 MB
quay.io/cockpit/ws                 331         bba2e19b4d7b  54 minutes ago      233 MB
localhost/ws                       latest      4e1c0fdfff34  About a minute ago  145 MB
```

Note that `podman images` shows uncompressed size, whereas `podman pull` and the quay.io page show compressed. 