### PR TITLE
Sort beipack input file list

### DIFF
--- a/src/build_backend.py
+++ b/src/build_backend.py
@@ -31,6 +31,8 @@ def find_sources(*, srcpkg: bool) -> Iterable[str]:
         )
 
     for path, _dirs, files in os.walk('src', followlinks=True):
+        _dirs.sort()
+        files.sort()
         if '__init__.py' in files:
             yield from [os.path.join(path, file) for file in files]
 


### PR DESCRIPTION
Sort input file list, so that `cockpit-bridge.beipack.xz` builds in a reproducible way in spite of non-deterministic filesystem readdir order.

See https://reproducible-builds.org/ for why this is good.

This patch was done while working on reproducible builds for openSUSE.