### PR TITLE
Update .gitignore for node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,5 @@ Makefile.in
 /tools/missing
 /tools/py-compile
 /tools/test-driver
+
+/node_modules


### PR DESCRIPTION
Add /node_modules to the .gitignore as these should be downloaded at development/build time.