### PR TITLE
test: Allow longer reboot time with fips-mode-setup --disable

### DIFF
--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -894,7 +894,8 @@ password=foobar
         b.click(".system-health-crypto-policies button.pf-v5-c-button.pf-m-link")
         b.wait_in_text(".pf-v5-c-menu__item.pf-m-selected .pf-v5-c-label.pf-m-orange", "inconsistent")
         b.click("#crypto-policy-save-reboot")
-        self.wait_reboot()
+        # Initramfs re-generation takes a while
+        self.wait_reboot(timeout_sec=600)
         m.start_cockpit()
         self.login_and_go("/system")
         b.wait_text("#crypto-policy-button", "Default")


### PR DESCRIPTION
In TestSystemInfo.testInconsistentCryptoPolicy, `fips-mode-setup --disable` also rebuilds the initrd. In recent Fedora 41 updates, this now takes seveal minutes, so bump the timeout just like in the previous case when enabling FIPS.

Fixes #21484

I triggered an [extra /daily run](https://cockpit-logs.us-east-1.linodeobjects.com/pull-21494-0b4c66fb-20250108-050717-fedora-41-daily-other/log.html) to prove that this works (it runs 3x affected)