### PR TITLE
workflows: Move release and node-modules workflows from Ubuntu 20.04 to 24.04

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -10,8 +10,7 @@ jobs:
       contents: read
       pull-requests: write
     timeout-minutes: 5
-    # 22.04's podman has issues with piping and causes tar errors
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: ${{ contains(github.event.pull_request.labels.*.name, 'node_modules') }}
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,7 @@ on:
 
 jobs:
   source:
-    # 22.04's podman has issues with piping and causes tar errors
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       # create GitHub release
       contents: write

--- a/.github/workflows/reposchutz.yml
+++ b/.github/workflows/reposchutz.yml
@@ -6,8 +6,7 @@ on:
 jobs:
   check:
     name: Protection checks
-    # 22.04's podman has issues with piping and causes tar errors
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
20.04 will soon be EOL. "ubuntu-latest" is 24.04 now with a newer podman.

---

 These workflows are hard to test in "proper" PRs (`on: pull_request_target` and needing a tag), so I tested them on my fork. I pushed this branch to my fork's main and tagged a 999 release, which [succeeded](https://github.com/martinpitt/cockpit/actions/runs/12664608480/job/35293008663) (the "source" part anyway -- of course flathub etc. fails, as it doesn't have credentials).

I also created https://github.com/martinpitt/cockpit/pull/23 that runs reposchutz, and it fails in the expected way. I.e. the build and tar diffing worked fine, and it fails with the expected package.json diff.