### PR TITLE
workflows: Move away from pinned old Ubuntu 22.04 release

### DIFF
--- a/.github/workflows/build-ws-container.yml
+++ b/.github/workflows/build-ws-container.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     environment: quay.io
     permissions: {}
     timeout-minutes: 20

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,7 +8,7 @@ jobs:
   trigger:
     permissions:
       statuses: write
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Clone repository
         uses: actions/checkout@v4

--- a/.github/workflows/trigger-anaconda.yml
+++ b/.github/workflows/trigger-anaconda.yml
@@ -15,7 +15,7 @@ on:
       - pkg/storaged/**
 jobs:
   trigger:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       statuses: write

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,7 +2,7 @@ name: unit-tests
 on: [pull_request, workflow_dispatch]
 jobs:
   unit-tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions: {}
     strategy:
       matrix:


### PR DESCRIPTION
See individual commits for details. Most of these are self-validating, and I'm just taking my chance on the ws container build one. I'll run it after landing and do a follow-up in the unlikely case that it breaks.

This leaves the flatpak-test, but that does fail on Ubuntu 24.04. It's on the pilot board, I'll look at that separately.