### PR TITLE
Fix build warnings

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -33,6 +33,6 @@ jobs:
 
             vendor/checkout
             test/common/make-bots
-            ./autogen.sh
+            ./autogen.sh --enable-strict
             make -j$(nproc) '${{ matrix.target }}'
           EOF

--- a/src/ws/cockpithandlers.c
+++ b/src/ws/cockpithandlers.c
@@ -345,10 +345,7 @@ build_environment (CockpitAuth *auth, GHashTable *request_headers)
   GByteArray *buffer;
   GBytes *bytes;
   JsonObject *object;
-  const gchar *value;
   gchar *hostname;
-  JsonObject *osr;
-  gint i;
 
   object = json_object_new ();
 


### PR DESCRIPTION
Just saw this on my machine, and it breaks `tools/make-sysext`:

```
src/ws/cockpithandlers.c: In function ‘build_environment’:
src/ws/cockpithandlers.c:351:8: error: unused variable ‘i’ [-Werror=unused-variable]
  351 |   gint i;
      |        ^
src/ws/cockpithandlers.c:350:15: error: unused variable ‘osr’ [-Werror=unused-variable]
  350 |   JsonObject *osr;
      |               ^~~
src/ws/cockpithandlers.c:348:16: error: unused variable ‘value’ [-Werror=unused-variable]
  348 |   const gchar *value;
      |                ^~~~~
cc1: all warnings being treated as errors
  CC       src/common/libcockpit_common_a-cockpittemplate.o
make[1]: *** [Makefile:3353: src/ws/libcockpit_ws_a-cockpithandlers.o] Error 1
```