### PR TITLE
login: Fix quote removal in brand name

### DIFF
--- a/pkg/shell/shell.scss
+++ b/pkg/shell/shell.scss
@@ -45,10 +45,6 @@ html.index-page body {
   overflow: hidden;
 }
 
-.hide-before::before {
-  display: none;
-}
-
 #machine-change-auth > p {
   margin-block-end: 5px;
 }

--- a/pkg/static/login.js
+++ b/pkg/static/login.js
@@ -188,7 +188,7 @@ function debug(...args) {
             const len = content.length;
             if ((content[0] === '"' || content[0] === '\'') &&
                 len > 2 && content[len - 1] === content[0])
-                content = content.substring(1, len - 2);
+                content = content.substring(1, len - 1);
             elt.innerHTML = content || def;
         } else {
             elt.removeAttribute("class");

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -1176,6 +1176,18 @@ until pgrep -f '^(/usr/[^ ]+/[^ /]*python[^ /]* )?/usr/bin/cockpit-bridge'; do s
         b.wait_visible("#login")
         b.assert_pixels("body", "login-screen")
 
+        # our supported OSes should all have branding make sure it matches os-release
+        if m.image.startswith("ubuntu"):
+            # reflects src/branding/ubuntu/branding.scss
+            expected = m.execute('. /usr/lib/os-release; echo "$PRETTY_NAME"').strip()
+        else:
+            expected = m.execute('. /usr/lib/os-release; echo "$NAME $VARIANT"').strip()
+            # quirk: trailing space hard to avoid due to the empty variant wrapped in <b>
+            if m.image == 'arch':
+                expected += ' '
+
+        b.wait_text("#brand", expected)
+
     @testlib.skipOstree("tests cockpit-ws package")
     @testlib.skipWsContainer("tests cockpit-ws package")
     @testlib.nondestructive


### PR DESCRIPTION
Don't cut off the last character from brand names if they are enclosed
in quotes.

https://issues.redhat.com/browse/COCKPIT-1219
https://issues.redhat.com/browse/RHEL-72582

---

What an embarrassing bug... :see_no_evil: 