### PR TITLE
login: Beibooting to all supported OSes

### DIFF
--- a/pkg/static/login.js
+++ b/pkg/static/login.js
@@ -1042,16 +1042,9 @@ function debug(...args) {
                 const status = decodeURIComponent(xhr.statusText).trim();
                 login_failure(_("Permission denied"), status === "Permission denied" ? "" : status);
             } else if (xhr.status == 500 && xhr.statusText.indexOf("no-cockpit") > -1) {
-                let message = format(
+                const message = format(
                     _("Install the cockpit-system package (and optionally other cockpit packages) on $0 to enable web console access."),
                     login_machine || "localhost");
-
-                // with os-release (all but really weird targets) we get some more info
-                const error = JSON.parse(xhr.responseText);
-                if (error.supported)
-                    message = format(
-                        _("Transient packageless sessions require the same operating system and version, for compatibility reasons: $0."),
-                        error.supported) + " " + message;
 
                 login_failure(_("Packageless session unavailable"), message);
             } else if (xhr.statusText) {

--- a/src/cockpit/osinfo.py
+++ b/src/cockpit/osinfo.py
@@ -1,0 +1,25 @@
+# supported OSes for beibooting; entries are os-release keys
+# keep this in sync with bots/lib/testmap.py
+supported_oses: 'list[dict[str, str | None]]' = [
+    # rolling release
+    {"ID": "arch", "VERSION_ID": None},
+
+    # match/describe CentOS separately, it's the upstream of all RHEL clones
+    {"ID": "centos", "PLATFORM_ID": "platform:el9"},
+    {"ID": "centos", "PLATFORM_ID": "platform:el10"},
+    {"PLATFORM_ID": "platform:el8"},
+    {"PLATFORM_ID": "platform:el9"},
+    {"PLATFORM_ID": "platform:el10"},
+
+    {"ID": "debian", "VERSION_ID": "12"},
+    # rolling release
+    {"ID": "debian", "VERSION_ID": None},
+
+    {"ID": "fedora", "VERSION_ID": "40"},
+    {"ID": "fedora", "VERSION_ID": "41"},
+    {"ID": "fedora", "VERSION_ID": "42"},
+
+    {"ID": "ubuntu", "VERSION_ID": "22.04"},
+    {"ID": "ubuntu", "VERSION_ID": "24.04"},
+    {"ID": "ubuntu", "VERSION_ID": "24.10"},
+]

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -363,17 +363,33 @@ class TestMultiMachine(testlib.MachineCase):
         b.wait_visible('#content')
         b.logout()
 
-        # beiboot mode: future OS version → incompatible, not supported
+        # beiboot mode: known remote OS; m2 runs TEST_OS, so we cover all supported ones in our testmap
+        # damage local os-release to avoid the "same unknown OS" code path
+        m.execute('''sed -i '/^ID=/ s/=.*/=testux/; /^PLATFORM_ID/d; /^VERSION_ID=/ s/=.*$/="0815"/' '''
+                  "/etc/os-release")
         # rolling OSes don't have a VERSION_ID
-        if m.image not in ["arch", "debian-testing"]:
-            m2.execute("sed -i '/^VERSION_ID/ s/$/1/' /etc/os-release")
-            b.try_login(password="alt-password")
-            source_os = m.execute('. /etc/os-release; echo "$NAME $VERSION_ID"').strip()
-            b.wait_text('#login-error-title', "Packageless session unavailable")
-            b.wait_in_text('#login-error-message', "Transient packageless sessions")
-            b.wait_in_text('#login-error-message', source_os)
-            b.wait_in_text('#login-error-message', "Install the cockpit-system package")
-            b.wait_in_text('#login-error-message', "on 10.111.113.2")
+        if m.image in ["arch", "debian-testing"]:
+            m.execute('''echo 'VERSION_ID="0815"' >> /etc/os-release''')
+        b.try_login(password="alt-password")
+        b.wait_visible('#content')
+        b.logout()
+
+        # beiboot mode: different OS version → incompatible, not supported
+        if m2.image in ["arch", "debian-testing"]:
+            # rolling OSes don't have a VERSION_ID
+            m2.execute('''echo 'VERSION_ID="0815"' >> /etc/os-release''')
+        else:
+            m2.execute('''sed -i '/^VERSION_ID/ s/=.*$/="0815"/; /^PLATFORM_ID/d' /etc/os-release''')
+        b.try_login(password="alt-password")
+        b.wait_text('#login-error-title', "Packageless session unavailable")
+        b.wait_in_text('#login-error-message', "Install the cockpit-system package")
+        b.wait_in_text('#login-error-message', "on 10.111.113.2")
+
+        # beiboot mode: local and remote OS are unknown but the same
+        m2.execute('''sed -i '/^ID=/ s/=.*/=testux/' /etc/os-release''')
+        b.try_login(password="alt-password")
+        b.wait_visible('#content')
+        b.logout()
 
         fix_bridge(m2)
 


### PR DESCRIPTION
Previously we only allowed beibooting to the same target OS as the host.
But we know which OSes Cockpit works on -- exactly the ones which we
have in CI. So check the remote OS against a list of known supported
ones.

Building that supported list isn't quite easy, though: It *roughly*
corresponds to our bots/lib/testmap.py, but not quite -- e.g.
"debian-stable" is "Debian 12" right now. So for the time being, keep
that list static. We'll have to update it for each new OS that we
support, but our integration tests will tell us.

In the future we might be doing something clever, like automatically
collecting `os-release` files from all our supported images in bots, and
use that to auto-build `osinfo.py`.

Enable the "incompatible future OS version" check for Debian/Arch as
well, by appending a `VERSION_ID`.

https://issues.redhat.com/browse/COCKPIT-1193

## Packageless session for all supported operating systems

[Cockpit 327](https://cockpit-project.org/blog/cockpit-327.html) introduced support for connecting to remote machines without any installed Cockpit packages. That only worked if the local and remote machine had the same operating system version. This version extends this "packageless session" feature to all operating systems which Cockpit [continuously tests](https://cockpit-project.org/running.html#installation--setup). At the time of writing this includes:

  * Arch
  * CentOS Stream 9, 10
  * Debian 12, testing/unstable
  * Red Hat Enterprise Linux 8, 9, 10
  * Fedora Linux 40, 41, 42 (rawhide)
  * Ubuntu 22.04 LTS, 24.04 LTS, 24.10

This list will change over time, along with new operating system releases and their end-of-lives.