### PR TITLE
Revert "test: apply a workaround for Fedora-CoreOS rebased on Fedora 41"

### DIFF
--- a/pkg/static/login.js
+++ b/pkg/static/login.js
@@ -1130,7 +1130,7 @@ function debug(...args) {
             if (login_data_host) {
                 const hostkey = response["login-data"]["known-hosts"];
                 if (hostkey) {
-                    console.debug("setup_localstorage(): updating known_hosts database for deferred host key for", login_data_host, ":", hostkey);
+                    debug("setup_localstorage(): updating known_hosts database for deferred host key for", login_data_host, ":", hostkey);
                     set_hostkeys(login_data_host, hostkey);
                 } else {
                     console.error("login.js internal error: setup_localstorage() received a pending login-data host, but login-data does not contain known-hosts");

--- a/test/ws-container.install
+++ b/test/ws-container.install
@@ -16,13 +16,6 @@ system
 for rpm in ws bridge $PACKAGES; do
     rpm2cpio /var/tmp/cockpit-$rpm-*.rpm | cpio -i --make-directories --directory=/var/tmp/install
 done
-
-# HACK: Fedora CoreOS is already on Python 3.13, while Fedora-40 is Python3.12
-if [ -d /var/tmp/install/usr/lib/python3.13/site-packages/cockpit ]; then
-    mkdir -p /var/tmp/install/usr/lib/python3.12/site-packages/
-    mv /var/tmp/install/usr/lib/python3.13/site-packages/cockpit /var/tmp/install/usr/lib/python3.12/site-packages/
-fi
-
 podman run --name build-cockpit -i \
     -v /var/tmp/:/run/build:Z \
     quay.io/cockpit/ws sh -exc '


### PR DESCRIPTION
Commit d76cadd59009 moved the ws container to Fedora 41, so the hack is
obsolete. Moreover, it is detrimental as PRs don't run against modified
bridge code any more.
    
This reverts commit 8ea9eaccf9edad86df76bfb142941ff3f1b0fd9f.
