### PR TITLE
storaged: btrfs helper cleanups

### DIFF
--- a/pkg/storaged/btrfs/btrfs-tool.py
+++ b/pkg/storaged/btrfs/btrfs-tool.py
@@ -33,7 +33,7 @@ def debug(msg):
     pass
 
 
-TMP_MP_DIR = "/var/lib/cockpit/btrfs"
+TMP_MP_DIR = "/run/cockpit/btrfs"
 
 
 def read_all(fd):
@@ -106,7 +106,7 @@ def add_tmp_mountpoint(db, fs, dev, opt_repair):
         else:
             db[uuid] = 1
         if not fs['has_tmp_mountpoint'] and (db[uuid] == 1 or opt_repair):
-            path = TMP_MP_DIR + "/" + uuid
+            path = os.path.join(TMP_MP_DIR, uuid)
             debug(f"MOUNTING {path}")
             os.makedirs(path, exist_ok=True)
             subprocess.check_call(["mount", dev, path])
@@ -118,7 +118,7 @@ def remove_tmp_mountpoint(db, uuid):
         debug(f"REMOVING {uuid}")
         tmp_mountpoints.remove(uuid)
         if db[uuid] == 1:
-            path = TMP_MP_DIR + "/" + uuid
+            path = os.path.join(TMP_MP_DIR, uuid)
             try:
                 debug(f"UNMOUNTING {path}")
                 subprocess.check_call(["umount", path])
@@ -139,7 +139,7 @@ def remove_all_tmp_mountpoints():
 
 def force_mount_point(db, fs, opt_repair):
     add_tmp_mountpoint(db, fs, fs['devices'][0], opt_repair)
-    return TMP_MP_DIR + "/" + fs['uuid']
+    return os.path.join(TMP_MP_DIR, fs['uuid'])
 
 
 def get_mount_point(db, fs, opt_mount, opt_repair):
@@ -251,7 +251,7 @@ def cmd_do(uuid, cmd):
     filesystems = list_filesystems()
     for fs in filesystems.values():
         if fs['uuid'] == uuid:
-            path = "/run/cockpit/btrfs"
+            path = os.path.join(TMP_MP_DIR, uuid)
             dev = fs['devices'][0]
             os.makedirs(path, mode=0o700, exist_ok=True)
             unshare_mounts()

--- a/pkg/storaged/btrfs/btrfs-tool.py
+++ b/pkg/storaged/btrfs/btrfs-tool.py
@@ -225,6 +225,7 @@ def cmd_monitor(opt_mount):
 
 
 def cmd_poll(opt_mount):
+    unshare_mounts()
     infos = poll(opt_mount, opt_repair=True)
     sys.stdout.write(json.dumps(infos) + "\n")
     sys.stdout.flush()
@@ -245,6 +246,8 @@ def unshare_mounts():
             errno = get_errno_loc()[0]
             raise OSError(errno, os.strerror(errno))
 
+    subprocess.check_call(["mount", "--make-rprivate", "/"])
+
 
 def cmd_do(uuid, cmd):
     debug(f"DO {uuid} {cmd}")
@@ -255,7 +258,6 @@ def cmd_do(uuid, cmd):
             dev = fs['devices'][0]
             os.makedirs(path, mode=0o700, exist_ok=True)
             unshare_mounts()
-            subprocess.check_call(["mount", "--make-rprivate", "/"])
             subprocess.check_call(["mount", dev, path])
             subprocess.check_call(cmd, cwd=path)
 

--- a/pkg/storaged/utils.js
+++ b/pkg/storaged/utils.js
@@ -25,7 +25,7 @@ import * as timeformat from "timeformat";
 const _ = cockpit.gettext;
 const C_ = cockpit.gettext;
 
-export const BTRFS_TOOL_MOUNT_PATH = "/var/lib/cockpit/btrfs/";
+export const BTRFS_TOOL_MOUNT_PATH = "/run/cockpit/btrfs/";
 
 /* UTILITIES
  */

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -546,6 +546,13 @@ The Cockpit component for managing storage.  This package uses udisks.
 %files -n cockpit-storaged -f storaged.list
 %{_datadir}/metainfo/org.cockpit_project.cockpit_storaged.metainfo.xml
 
+%post storaged
+
+# version 332 moved the btrfs temp mounts db to /run
+if [ "$1" = 2 ] && [ -d /var/lib/cockpit/btrfs ]; then
+    rm -rf --one-file-system  /var/lib/cockpit/btrfs || true
+fi
+
 %package -n cockpit-packagekit
 Summary: Cockpit user interface for packages
 BuildArch: noarch

--- a/tools/debian/cockpit-storage.postinst
+++ b/tools/debian/cockpit-storage.postinst
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+#DEBHELPER#
+
+# version 332 moved the btrfs temp mounts db to /run
+if [ "$1" = "configure" ] && dpkg --compare-versions "$2" lt-nl 322 && [ -d /var/lib/cockpit/btrfs ]; then
+   rm -rf --one-file-system  /var/lib/cockpit/btrfs || true
+fi


### PR DESCRIPTION
I don't yet understand enough of what's going on here to eliminate *all* persistent mounts (in particular, the `monitor` ones), but this should at least improve the situation.