### PR TITLE
bridge: Drop translations from manifests.js, introduce m-i18n.js

### DIFF
--- a/pkg/base1/test-locale.js
+++ b/pkg/base1/test-locale.js
@@ -37,6 +37,15 @@ const ru = {
     "$0 bit": ["$0 bits", "$0 бит", "$0 бита", "$0 бит"]
 };
 
+const zh_CN = {
+    "": {
+        language: "zh_CN",
+        "language-direction": "ltr",
+        "plural-forms": (n) => 0,
+    },
+    "$0 important hit": [null, "$0 次命中（含关键命中）"],
+};
+
 QUnit.test("public api", function (assert) {
     assert.equal(typeof cockpit.locale, "function", "cockpit.locale is a function");
 });
@@ -83,12 +92,18 @@ QUnit.test("ngettext simple", function (assert) {
 QUnit.test("ngettext complex", function (assert) {
     cockpit.locale(null); /* clear it */
     cockpit.locale(ru);
-    assert.equal(cockpit.ngettext("$0 bit", "$0 bits", 0), "$0 бит", "zero things");
-    assert.equal(cockpit.ngettext("$0 bit", "$0 bits", 1), "$0 бит", "one thing");
-    assert.equal(cockpit.ngettext("$0 bit", "$0 bits", 5), "$0 бит", "multiple things");
-    assert.equal(cockpit.ngettext("$0 bit", "$0 bits", 23), "$0 бита", "genitive singular");
-    assert.equal(cockpit.ngettext("$0 byte", "$0 bytes", 1), "$0 byte", "default one");
-    assert.equal(cockpit.ngettext("$0 byte", "$0 bytes", 2), "$0 bytes", "default multiple");
+    assert.equal(cockpit.ngettext("$0 bit", "$0 bits", 0), "$0 бит", "ru, zero things");
+    assert.equal(cockpit.ngettext("$0 bit", "$0 bits", 1), "$0 бит", "ru, one thing");
+    assert.equal(cockpit.ngettext("$0 bit", "$0 bits", 5), "$0 бит", "ru, multiple things");
+    assert.equal(cockpit.ngettext("$0 bit", "$0 bits", 23), "$0 бита", "ru, genitive singular");
+    assert.equal(cockpit.ngettext("$0 byte", "$0 bytes", 1), "$0 byte", "ru, default one");
+    assert.equal(cockpit.ngettext("$0 byte", "$0 bytes", 2), "$0 bytes", "ru, default multiple");
+
+    cockpit.locale(null); /* clear it */
+    cockpit.locale(zh_CN);
+    [0, 1, 2].forEach(i =>
+        assert.equal(cockpit.ngettext("$0 important hit", "$0 XXX", i), "$0 次命中（含关键命中）", `zh_CN, ${i} things`)
+    );
 });
 
 QUnit.test("translate document", function (assert) {

--- a/pkg/shell/index.html
+++ b/pkg/shell/index.html
@@ -7,7 +7,7 @@
     <link href="shell.css" rel="stylesheet" />
     <link href="../../static/branding.css" rel="stylesheet" />
     <script src="../base1/cockpit.js"></script>
-    <script src="../manifests.js"></script>
+    <script src="../manifests-i18n.js"></script>
     <script src="po.js"></script>
     <script src="shell.js"></script>
   </head>

--- a/test/pytest/test_packages.py
+++ b/test/pytest/test_packages.py
@@ -233,7 +233,7 @@ def test_translation(pkgdir):
     assert document.data.read() == b''
 
     # make sure the manifest translations get sent along with manifests.js
-    document = packages.load_path('/manifests.js', {'Accept-Language': 'de'})
+    document = packages.load_path('/manifests-i18n.js', {'Accept-Language': 'de'})
     contents = document.data.read()
     assert b'eins\n' in contents
     assert b'zwo\n' in contents


### PR DESCRIPTION
Pages don't (shouldn't) care about manifest translations when including
`manifests.js` -- they usually do that to query for a package's
existence or some feature flags.

Only the Shell cares about the translations. So drop translations from
`manifests.js`, and support a new `manifests-i18n.js` which only the
shell uses.

This isolates translations from different pages from another.
Concretely, subscription-manager-cockpit and our systemd page both
translate "$0 important hit" differently, and even to different data
types (in s-m it results in an array, in systemd in a normal string).
This caused a page crash, and also wrong strings, as s-m's translations
are really not expected to be used on the Overview page.

This also speeds up the loading of frames, as they now don't have to go
through umpteen `cockpit.locale()` calls any more.

Note that this still leaves i18n conflicts in the shell itself, so this
isn't a full fix, just an "80%" mitigation.

Fixes #21486
