### PR TITLE
test: follow RUF051 recommendations

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1749,12 +1749,9 @@ class MachineCase(unittest.TestCase):
             # First create all machines, wait for them later
             for key in sorted(provision.keys()):
                 options = dict(provision[key])
-                if 'address' in options:
-                    del options['address']
-                if 'dns' in options:
-                    del options['dns']
-                if 'dhcp' in options:
-                    del options['dhcp']
+                options.pop('address', None)
+                options.pop('dns', None)
+                options.pop('dhcp', None)
                 if 'restrict' not in options:
                     options['restrict'] = restrict
                 machine = self.new_machine(**options)

--- a/test/verify/files/mock-insights
+++ b/test/verify/files/mock-insights
@@ -180,8 +180,7 @@ Content-Type: """
             machine_id = m[1]
             self.send_response(200)
             self.end_headers()
-            if machine_id in systems:
-                del systems[machine_id]
+            systems.pop(machine_id, None)
             return
 
         m = self.match("/r/insights/platform/inventory/v1/hosts/([^/]+)")


### PR DESCRIPTION
Ruff 0.8.3 enables a new preview rule RUF051 `if-key-in-dict-del`, preferring `.pop()` over a conditional check plus a separate del statement.