### PR TITLE
storage: Use private mounts for btrs polling

### DIFF
--- a/pkg/storaged/btrfs/subvolume.jsx
+++ b/pkg/storaged/btrfs/subvolume.jsx
@@ -372,14 +372,19 @@ function make_btrfs_subvolume_page(parent, volume, subvol, path_prefix, subvols)
     // be reflected in the UI. However, we don't allow deleting the
     // last mounted subvolume, since that would also break the
     // subvolume listing.
+    //
+    // In Anaconda mode, however, we always have a proper list of
+    // subvolumes, so we always allow creation and deletion.
 
     let create_excuse = "";
     let delete_excuse = "";
-    if (!block_fsys || block_fsys.MountPoints.length == 0)
-        create_excuse = delete_excuse = _("At least one subvolume needs to be mounted");
-    else if (block_fsys && block_fsys.MountPoints.length == 1 &&
-             decode_filename(block_fsys.MountPoints[0]) == mount_point) {
-        delete_excuse = _("The last mounted subvolume can not be deleted");
+    if (!client.in_anaconda_mode()) {
+        if (!block_fsys || block_fsys.MountPoints.length == 0)
+            create_excuse = delete_excuse = _("At least one subvolume needs to be mounted");
+        else if (block_fsys && block_fsys.MountPoints.length == 1 &&
+            decode_filename(block_fsys.MountPoints[0]) == mount_point) {
+            delete_excuse = _("The last mounted subvolume can not be deleted");
+        }
     }
 
     actions.push({


### PR DESCRIPTION
In Anaconda mode, Cockpit mounts a btrfs filesystem to list its subvolumes. Now these mounts are private to the process that does the listing, just like the mounts for making changes already are.

Since the mounts are no longer shared, we don't need to maintain a database of their users.
