### PR TITLE
Switch to the Web Crypto API for generating SHA checksums

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,6 @@
     "@patternfly/react-table": "5.4.13",
     "@patternfly/react-tokens": "5.4.1",
     "dequal": "2.0.3",
-    "js-sha1": "0.7.0",
-    "js-sha256": "0.11.0",
     "json-stable-stringify-without-jsonify": "1.0.1",
     "prop-types": "15.8.1",
     "react": "18.3.1",

--- a/tools/build-debian-copyright
+++ b/tools/build-debian-copyright
@@ -28,7 +28,6 @@ license_patterns = {
 copyright_patterns = {
     # Common patterns
     r'Copyright (.*)$': [r'\1'],
-    r'@copyright (.*)$': [r'\1'],
     r'\(c\) (.*)$': [r'\1'],
 
     # https://github.com/focus-trap/focus-trap/blob/master/LICENSE


### PR DESCRIPTION
This allows us to drop the two pure JavaScript implementations of SHA-1 and SHA-256. These native Web Crypto API is available as baseline and allows us to easily switch over to SHA-512 without adding a new dependency.