### PR TITLE
test: drop duplicate tuned disabling

### DIFF
--- a/test/vm.install
+++ b/test/vm.install
@@ -30,9 +30,6 @@ if [ "$ID" = "debian" ] || [ "$ID" = "ubuntu" ]; then
     systemctl start firewalld
     firewall-cmd --zone=public --permanent --add-interface=eth1
 
-    # HACK: tuned breaks QEMU (https://launchpad.net/bugs/1774000)
-    systemctl disable tuned.service 2>/dev/null || true
-
     # disarm 10-cloudimg-settings.conf
     sed -i '/.*PasswordAuthentication no/d' /etc/ssh/sshd_config $(ls /etc/ssh/sshd_config.d/* 2>/dev/null || true)
 fi


### PR DESCRIPTION
The referenced issue is no longer an issue and we already disable tuned in bots when we create the image.