### PR TITLE
test: Drop dummy interface

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -773,11 +773,6 @@ class TestCurrentMetrics(testlib.MachineCase):
         self.busybox_image = m.execute("podman images --format '{{.Repository}}' | grep busybox").strip()
         self.login_and_go("/metrics")
 
-        # hack around https://bugzilla.redhat.com/show_bug.cgi?id=2277954 for our offline test VMs
-        if not m.execute("ip route show default").strip():
-            m.execute("nmcli con add type dummy con-name fake ifname fake0 ip4 1.2.3.4/24 gw4 1.2.3.1")
-            self.addCleanup(m.execute, "nmcli con delete fake")
-
     def testCPU(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
passt got fixed in [1] to get along with multiple network interfaces and no default routes.

[1] https://bodhi.fedoraproject.org/updates/FEDORA-2024-4632bfa865
[2] https://bugzilla.redhat.com/show_bug.cgi?id=2277954

---

Commit message copied from abcb4b1ea8e4c358c783efa4f2f3c45c8a580753 in cockpit-podman so this should be fixed in Cockpit as well.