### PR TITLE
build: Let `make` rebuild the bundle on PO changes

### DIFF
--- a/pkg/Makefile.am
+++ b/pkg/Makefile.am
@@ -20,7 +20,7 @@ DIST_STAMP = $(srcdir)/dist/static/manifest.json
 
 # dynamic pkg → dist dependency, to rebuild the bundles if any web related file changes
 # exclude automake unit test log files
-PKG_INPUTS = $(shell find $(srcdir)/pkg -type f ! -name 'test*.trs' ! -name 'test*.log')
+PKG_INPUTS = $(shell find $(srcdir)/pkg $(srcdir)/po -type f ! -name 'test*.trs' ! -name 'test*.log')
 
 V_BUNDLE = $(V_BUNDLE_$(V))
 V_BUNDLE_ = $(V_BUNDLE_$(AM_DEFAULT_VERBOSITY))


### PR DESCRIPTION
Fixes #19406

----

Before:

```
$ touch po/de.po; make
make  all-am
make[1]: Entering directory '/var/home/martin/upstream/cockpit/main'
make[1]: Leaving directory '/var/home/martin/upstream/cockpit/main'
```

Now:
```
make  all-am
make[1]: Entering directory '/var/home/martin/upstream/cockpit/main'
  BUNDLE   dist
12:03:23: Build finished
  COPY     dist/static/fonts/RedHatText-Regular.woff2 → doc/guide/html/
  COPY     dist/static/fonts/RedHatText-Medium.woff2 → doc/guide/html/
  GEN      doc/guide/html/index.html
make[1]: Leaving directory '/var/home/martin/upstream/cockpit/main'

```