### PR TITLE
networkmanager: Handle cancelling of superuser changes

### DIFF
--- a/pkg/networkmanager/networkmanager.jsx
+++ b/pkg/networkmanager/networkmanager.jsx
@@ -47,7 +47,7 @@ const App = () => {
                                 []);
     useEvent(nmService, "changed");
 
-    const model = useObject(() => new NetworkManagerModel(), null, []);
+    const model = useObject(() => new NetworkManagerModel(), null, [superuser.allowed]);
     useEvent(model, "changed");
 
     const nmRunning_ref = useRef(undefined);

--- a/test/verify/check-networkmanager-basic
+++ b/test/verify/check-networkmanager-basic
@@ -324,6 +324,17 @@ class TestNetworkingBasic(netlib.NetworkCase):
         m.execute(f"nmcli connection up '{con_id}'")
         self.wait_onoff(f".pf-v5-c-card__header:contains('{iface}')", val=True)
 
+        # cancelling superuser dialog goes back to unpriv state
+        b.switch_to_top()
+        b.open_superuser_dialog()
+        b.click("div[role=dialog] button[aria-label=Close]")
+        b.wait_not_present("div[role=dialog]")
+
+        b.enter_page("/network")
+        b.wait_visible("#network-interface")
+        # On/Off button is disabled, but shows the correct value
+        b.wait_visible(f".pf-v5-c-card__header:contains('{iface}') .pf-v5-c-switch input:disabled")
+
         # UI becomes editable when gaining privileges
         b.become_superuser()
         b.wait_visible('#autoreconnect:not(disabled)')


### PR DESCRIPTION
Opening the superuser dialog (necessarily) already initiates the sudo (or similar) process, changes `superuser.allowed` to `null`, and thus triggers all kinds of reinitialization. However, `model` becomes invalid (`model.ready == false`) after cancelling the dialog, so that the page is stuck in the empty state.

Fix that by reinitializing the model after superuser changes.

Fixes the first part of #19655 (this applies to more pages)