### PR TITLE
networkmanager: fix primary bond option

### DIFF
--- a/pkg/networkmanager/bond.jsx
+++ b/pkg/networkmanager/bond.jsx
@@ -56,10 +56,10 @@ const bond_monitoring_choices =
     ];
 
 const modes_with_primary = [
-        'active-backup',
-        'balance-tlb',
-        'balance-alb'
-    ];
+    'active-backup',
+    'balance-tlb',
+    'balance-alb'
+];
 
 export const BondDialog = ({ connection, dev, settings }) => {
     const Dialogs = useDialogs();
@@ -87,7 +87,7 @@ export const BondDialog = ({ connection, dev, settings }) => {
 
     const onSubmit = (ev) => {
         const options = settings.bond.options;
-        delete options['primary'];
+        delete options.primary;
 
         const createSettingsObj = () => ({
             ...settings,

--- a/test/verify/check-networkmanager-bond
+++ b/test/verify/check-networkmanager-bond
@@ -223,6 +223,38 @@ class TestBonding(netlib.NetworkCase):
         b.wait_visible(f"#network-interface-members tr[data-interface='{iface}']")
         b.wait_in_text("#network-interface .pf-v5-c-card:contains('tbond')", ip)
 
+    def testPrimary(self):
+        b = self.browser
+
+        self.login_and_go("/network")
+
+        b.wait_visible("#networking")
+        iface = "cockpit"
+        self.add_veth(iface, dhcp_cidr="10.111.112.2/20")
+        self.nm_activate_eth(iface)
+        self.wait_for_iface(iface)
+
+        # Create a bond
+        b.click("button:contains('Add bond')")
+        b.wait_visible("#network-bond-settings-dialog")
+        b.set_input_text("#network-bond-settings-interface-name-input", "tbond")
+        # add interface to bond
+        b.set_checked(f"input[data-iface='{iface}']", val=True)
+        # select it as primary
+        b.select_from_dropdown("#network-bond-settings-primary-select", iface)
+        # finish creating the bond
+        b.click("#network-bond-settings-dialog button:contains('Add')")
+        b.wait_not_present("#network-bond-settings-dialog")
+
+        # Navigate to bond and edit it
+        b.click("#networking-interfaces tr[data-interface='tbond'] button")
+        b.wait_visible("#network-interface")
+        b.click("#network-interface #networking-edit-bond")
+
+        # edit bond dialog
+        b.wait_visible("#network-bond-settings-dialog")
+        b.wait_val("#network-bond-settings-primary-select", iface)
+
     def testAmbiguousMember(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
- allow setting also for balance-tlb / balance-alb modes
- read the current value
- remove when not set (it can't be set to an empty string)
- remove when switching to a non compatible mode

This fixes #21528

Patch tested on top of version 323 (~EL 9.5)