### PR TITLE
Docs: Add userpass for VM web login

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -87,6 +87,11 @@ Once the machine is booted and the cockpit socket has been activated, a
 message will be printed describing how to access the virtual machine, via
 ssh and web.  See the "Helpful tips" section below.
 
+To login using the web client you have to use the username and password listed below. If you wish to enable `root` login using the web you can remove `root` from `/etc/cockpit/disallowed-users`.
+
+- Username: `admin`
+- Password: `foobar`
+
 By default, it's only possible to contact the virtual machine from the host
 machine on which it's running.   If you want to conduct manual testing from
 other devices on your network, set `TEST_BIND_GLOBAL=1`, for example:


### PR DESCRIPTION
The `test/README.md` docs missed information on how to actually login
using the web interface. This adds the current userpass `admin:foobar`
to the README.

Future improvement could be to add this to the outputted message as
well.