### PR TITLE
fix: Spacing for network status

### DIFF
--- a/pkg/networkmanager/network-interface.jsx
+++ b/pkg/networkmanager/network-interface.jsx
@@ -264,8 +264,7 @@ export const NetworkInterfacePage = ({
             <DescriptionListGroup>
                 <DescriptionListTerm>{_("Status")}</DescriptionListTerm>
                 <DescriptionListDescription className="networking-interface-status">
-                    {activeConnection}
-                    {state ? <span>{state}</span> : null}
+                    {[activeConnection, state].filter(val => val).join(", ")}
                 </DescriptionListDescription>
             </DescriptionListGroup>
         );


### PR DESCRIPTION
When a status is displayed for network interface, such as "Deactivating" it did not have spacing between the active connection and the state.

This ensures that there is always a spacing when needed.

Note, this also removes a span that is not used for anything.

Fixes #20038

![image](https://github.com/user-attachments/assets/c96c9837-caa2-42ae-b101-16d265e7d480)
