### PR TITLE
users: Add screen reader accessible column

### DIFF
--- a/pkg/users/accounts-list.js
+++ b/pkg/users/accounts-list.js
@@ -382,6 +382,7 @@ const AccountsList = ({ accounts, current_user, groups, min_uid, max_uid, shells
         { title: _("ID"), sortable: true },
         { title: _("Last active"), sortable: true },
         { title: _("Group") },
+        { title: "", sortable: false, props: { screenReaderText: _("Actions") } },
     ];
 
     const sortRows = (rows, direction, idx) => {


### PR DESCRIPTION
Current users page lists the users in a table together with a column for actions. However, the table header doesn't include the last actions column and instead shows the table header line ending preemptively.

As we likely don't want a visibly named column for the actions this will instead visually just extend the line so it is consistent while also adding a screen reader friendly text to indicate what the column is portraying.

This does mean we need to include
`@patternfly/patternfly/patternfly-addons.css` in the PatternFly CSS import.

---

This line seems only to occur on Chrome and not Firefox, but definitely a bug
![image](https://github.com/user-attachments/assets/b60143a2-951f-4875-91fa-0c6bb8224a92)

PR applied:
![image](https://github.com/user-attachments/assets/6d43a1c4-670c-4f7f-8926-aafe1d09c689)