### PR TITLE
test: remove empty else clause

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -2854,8 +2854,6 @@ def wait(func: Callable[[], _T | None], msg: str | None = None, delay: int = 1, 
         except Exception:
             if t == tries - 1:
                 raise
-            else:
-                pass
         t = t + 1
         time.sleep(delay)
     raise Error(msg or "Condition did not become true.")


### PR DESCRIPTION
ruff 0.9.3 includes RUF047 by default now which complains about useless else statements.
