### PR TITLE
bridge: re-introduce the max_read_size limit

### DIFF
--- a/doc/guide/cockpit-file.xml
+++ b/doc/guide/cockpit-file.xml
@@ -75,7 +75,8 @@ cockpit.file("/path/to/file").read()
     <para>You can use the <code>max_read_size</code> option to limit
       the amount of data that is read.  If the file is larger than the
       given number of bytes, no data is read and the channel is closed with
-      problem code <code>too-large</code>.  The default limit is 16 MiB.</para>
+      problem code <code>too-large</code>.  The default limit is 16 MiB. The
+      limit can be completely removed by setting it to -1.</para>
     <para>To write to a file, use code like this:
 <programlisting>
 cockpit.file("/path/to/file").replace("my new content\n")

--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -1018,6 +1018,10 @@ Returns the contents of a file and its current 'transaction tag'.
 The following options can be specified in the "open" control message:
 
  * "path": The path name of the file to read.
+ * "max_read_size": option to limit the amount of data that is read.  If the
+   file is larger than the given number of bytes, no data is read and the
+   channel is closed with problem code "too-large".  The default limit is 16
+   MiB.  The limit can be completely removed by setting it to -1.
 
 The ready message contains a "size-hint" when the channel is opened
 with the "binary" option set to "raw".

--- a/src/cockpit/channels/filesystem.py
+++ b/src/cockpit/channels/filesystem.py
@@ -125,14 +125,14 @@ class FsReadChannel(GeneratorChannel):
 
     def do_yield_data(self, options: JsonObject) -> Generator[bytes, None, JsonObject]:
         path = get_str(options, 'path')
-        max_read_size = get_int(options, 'max_read_size', None)
+        max_read_size = get_int(options, 'max_read_size', 16 * 1024 * 1024)
 
         logger.debug('Opening file "%s" for reading', path)
 
         try:
             with open(path, 'rb') as filep:
                 buf = os.stat(filep.fileno())
-                if max_read_size is not None and buf.st_size > max_read_size:
+                if max_read_size != -1 and buf.st_size > max_read_size:
                     raise ChannelError('too-large')
 
                 if self.is_binary and stat.S_ISREG(buf.st_mode):


### PR DESCRIPTION
This is a regression from our port of the bridge from C to Python. The C bridge had a limit and as fsread1 is not blocking implemented this prevents issues of accidentally reading /dev/zero or /dev/sda which will fill up ram endlessly.

* [x] https://github.com/cockpit-project/cockpit-files/pull/1026

---

See 7c7ab45e3f2d4bd11a4e5c6716cbd645735dd694 and DEFAULT_MAX_READ_SIZE