### PR TITLE
fix: configure.ac for leap15.6

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -38,10 +38,7 @@ AC_PROG_RANLIB
 # This is required to find the correct `ar` for cross-compiling
 AC_CHECK_TOOL(AR, ar)
 
-AC_CHECK_FUNCS(
-    closefrom
-    pidfd_getpid
-)
+AC_CHECK_FUNCS(closefrom pidfd_getpid)
 
 AM_SILENT_RULES([yes])
 


### PR DESCRIPTION
There is a bug in the version of autotools in leap 15.6. It can be tested in the following way

1. on leap 15.6 run autoreconf on the cockpit source code
2. run `./configure`
3. syntax error

after a few seconds the configure script exists with
```
./configure: line 4783: syntax error near unexpected token `pidfd_getpid'
./configure: line 4783: `    pidfd_getpid'
```
The fix was found by @Nykseli 