### PR TITLE
containers/ws: Include cockpit-files

### DIFF
--- a/containers/ws/install.sh
+++ b/containers/ws/install.sh
@@ -17,6 +17,10 @@ storaged
 system
 "
 
+EXTERNAL_COCKPIT_PACKAGES="
+cockpit-files
+"
+
 dnf install -y 'dnf-command(download)' cpio
 $INSTALL coreutils-single util-linux-core sed sscg python3 openssh-clients
 
@@ -43,6 +47,11 @@ else
     # do everything through SSH, no local authentication in the container
     rm $INSTALLROOT/usr/libexec/cockpit-session
 fi
+
+for rpm in $EXTERNAL_COCKPIT_PACKAGES; do
+    dnf download $rpm
+    unpack $rpm-*.rpm
+done
 
 rm -rf /build/var/cache/*dnf* /build/var/lib/dnf /build/var/lib/rpm* /build/var/log/*
 rm -rf /container/rpms || true


### PR DESCRIPTION
This brings the ws container closer to the Client flatpak. In beiboot mode, Files works everywhere including RHEL 8 [1].

[1] https://github.com/cockpit-project/cockpit-files/pull/917

---

Tested locally with
```
podman build -t localhost/ws containers/ws
podman run -d --name cockpit-bastion -p 9999:9090 localhost/ws
```
and then logging into `host.containers.internal` (i.e. my laptop) on https://localhost:9999.

## cockpit/ws container: Include cockpit-files

The [cockpit/ws container](https://quay.io/repository/cockpit/ws) now includes [cockpit-files](https://github.com/cockpit-project/cockpit-files/). When you log into a remote machine that does not have any cockpit packages installed (package-less mode), the "Files" page is now available.