### PR TITLE
test: Add bootc image

### DIFF
--- a/selinux/cockpit.te
+++ b/selinux/cockpit.te
@@ -223,3 +223,12 @@ optional_policy(`
 optional_policy(`
     gnome_exec_keyringd(cockpit_session_t)
 ')
+
+#########################################################
+#
+#  Misc
+#
+
+# systemd can clean up cockpit's tmp files
+manage_dirs_pattern(init_t, cockpit_tmp_t, cockpit_tmp_t)
+manage_files_pattern(init_t, cockpit_tmp_t, cockpit_tmp_t)

--- a/test/bootc.install
+++ b/test/bootc.install
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -eux
+
+cd /var/tmp/
+
+# bootc images have their own deployed image in a local registry
+podman run -d --rm --name ostree-registry -p 5000:5000 -v /var/lib/cockpit-test-registry/:/var/lib/registry localhost/test-registry
+
+# build updated bootc image with our RPMs
+podman build -t localhost/bootc-test --layers=false -f - . <<EOF
+FROM localhost:5000/bootc:latest
+COPY ./rpms /tmp/rpms
+RUN rpm --upgrade --verbose /tmp/rpms/*.rpm && rm -r /tmp/rpms
+COPY ./playground /usr/share/cockpit/playground
+EOF
+
+# deploy it
+bootc switch --transport containers-storage localhost/bootc-test
+
+# clean up
+podman rm -ft0 ostree-registry
+podman rmi localhost:5000/bootc localhost/bootc-test
+
+# ensure that we don't accidentally test with container
+podman rmi quay.io/cockpit/ws:latest

--- a/test/image-prepare
+++ b/test/image-prepare
@@ -165,6 +165,25 @@ def build_install_ostree(dist_tar, image, verbose, quick):
     return args
 
 
+def build_install_bootc(dist_tar, image, verbose, quick):
+    """Special treatment of build/install on Bootc
+
+    bootc image can't build packages, build them on corresponding OSes, build a new bootc
+    image with the rpms, and deploy it.
+    """
+    with create_machine(testmap.get_build_image(image)) as machine:
+        rpms = build_rpms(dist_tar, machine, verbose, quick)
+    args = ["--run-command", "mkdir -p /var/tmp/rpms"]
+    for rpm in rpms:
+        if not any(r in rpm for r in [".src", "debug", "packagekit", "storaged"]):
+            args += ["--upload", f"{rpm}:/var/tmp/rpms/"]
+    args += [
+        "--upload", os.path.join(BASE_DIR, "dist/playground") + ":/var/tmp/",
+        "--script", os.path.join(TEST_DIR, "bootc.install"),
+    ]
+    return args
+
+
 def build_install_container(dist_tar, image, verbose, quick):
     """Build VM with cockpit/ws container
 
@@ -253,6 +272,8 @@ def main():
 
     if args.image == "fedora-coreos":
         customize += build_install_ostree(dist_tar, args.image, args.verbose, args.quick)
+    elif args.image.endswith("-bootc"):
+        customize += build_install_bootc(dist_tar, args.image, args.verbose, args.quick)
     elif args.container:
         customize += build_install_container(dist_tar, args.image, args.verbose, args.quick)
     else:

--- a/test/verify/check-shell-multi-machine-key
+++ b/test/verify/check-shell-multi-machine-key
@@ -135,8 +135,8 @@ class TestMultiMachineKeyAuth(testlib.MachineCase):
 
         self.login_and_go("/system")
 
-        # pam-ssh-add isn't used on OSTree
-        if m1.ostree_image:
+        # pam-ssh-add isn't used with ws container
+        if m1.ws_container:
             self.load_key('id_rsa', 'foobar')
             self.check_keys(["2048 93:40:9e:67:82:78:a8:99:89:39:d5:ba:e0:50:70:e1 id_rsa (RSA)"],
                             ["2048 SHA256:SRvBhCmkCEVnJ6ascVH0AoVEbS3nPbowZkNevJnXtgw id_rsa (RSA)"])

--- a/test/verify/check-shell-multi-machine-key
+++ b/test/verify/check-shell-multi-machine-key
@@ -51,12 +51,6 @@ KEY_IDS = [
     "256 SHA256:Wd028KYmG3OVLp7dBmdx0gMR7VcarJVIfaTtKqYCmak /home/admin/.ssh/id_ed25519 (ED25519)"
 ]
 
-KEY_IDS_MD5 = [
-    "2048 93:40:9e:67:82:78:a8:99:89:39:d5:ba:e0:50:70:e1 /home/admin/.ssh/id_rsa (RSA)",
-    "256 bd:56:df:c3:ff:e4:1d:9d:f5:c4:b9:cc:64:00:d5:93 /home/admin/.ssh/id_ecdsa (ECDSA)",
-    "256 b5:80:1b:f5:98:89:2a:39:f3:78:b3:64:5c:64:33:17 /home/admin/.ssh/id_ed25519 (ED25519)",
-]
-
 
 @testlib.skipImage("TODO: ssh key check fails on Arch Linux", "arch")
 @testlib.skipBeiboot("host switching disabled in beiboot mode")
@@ -88,12 +82,11 @@ class TestMultiMachineKeyAuth(testlib.MachineCase):
         self.browser.eval_js("cockpit.user().then(load)")
         self.browser.wait_js_cond('loaded === true')
 
-    def check_keys(self, keys_md5, keys):
+    def check_keys(self, keys):
         def normalize(k):
             return re.sub(r"(/var)?/home/admin/\.ssh/[^ ]*|test@test|ecdsa w/o comment", "", k)
-        self.assertIn(normalize(self.browser.eval_js("cockpit.spawn([ 'ssh-add', '-l' ])")),
-                      [normalize("\n".join(keys_md5) + "\n"),
-                       normalize("\n".join(keys) + "\n")])
+        self.assertEqual(normalize(self.browser.eval_js("cockpit.spawn([ 'ssh-add', '-l' ])")),
+                         normalize("\n".join(keys) + "\n"))
 
     def setUp(self):
         super().setUp()
@@ -138,12 +131,11 @@ class TestMultiMachineKeyAuth(testlib.MachineCase):
         # pam-ssh-add isn't used with ws container
         if m1.ws_container:
             self.load_key('id_rsa', 'foobar')
-            self.check_keys(["2048 93:40:9e:67:82:78:a8:99:89:39:d5:ba:e0:50:70:e1 id_rsa (RSA)"],
-                            ["2048 SHA256:SRvBhCmkCEVnJ6ascVH0AoVEbS3nPbowZkNevJnXtgw id_rsa (RSA)"])
+            self.check_keys(["2048 SHA256:SRvBhCmkCEVnJ6ascVH0AoVEbS3nPbowZkNevJnXtgw id_rsa (RSA)"])
         else:
             # Check our keys were loaded.
             self.load_key("id_ed25519", "locked")
-            self.check_keys(KEY_IDS_MD5, KEY_IDS)
+            self.check_keys(KEY_IDS)
 
         # Add machine
         b.switch_to_top()

--- a/test/verify/check-shell-multi-machine-key
+++ b/test/verify/check-shell-multi-machine-key
@@ -90,7 +90,7 @@ class TestMultiMachineKeyAuth(testlib.MachineCase):
 
     def check_keys(self, keys_md5, keys):
         def normalize(k):
-            return re.sub(r"/home/admin/\.ssh/[^ ]*|test@test|ecdsa w/o comment", "", k)
+            return re.sub(r"(/var)?/home/admin/\.ssh/[^ ]*|test@test|ecdsa w/o comment", "", k)
         self.assertIn(normalize(self.browser.eval_js("cockpit.spawn([ 'ssh-add', '-l' ])")),
                       [normalize("\n".join(keys_md5) + "\n"),
                        normalize("\n".join(keys) + "\n")])


### PR DESCRIPTION
We want to test deploying cockpit rpms in bootc images. This will prevent hiccups like https://github.com/cockpit-project/cockpit/issues/21201 in the future and also test a lot of OS subsystems.

The centos-9-bootc bots image includes its own deployment container image, so we can easily derive an image with our locally built RPMs included.
    
https://issues.redhat.com/browse/COCKPIT-1237

----

Note that I only cover/trigger `centos-9-bootc/{networking,other,expensive}` here. /storage requires adding cockpit-storaged, udisks, etc., which we skip on fedora-coreos as well. Managing storage isn't the most important thing on a bootc system, so I'll left that for a follow-up.

Prerequisites/split out work:

 - [x] https://github.com/cockpit-project/bots/pull/7361
 - [x] Pre-install package and test dependencies into centos-9-bootc image: https://github.com/cockpit-project/bots/pull/7365
 - [x] https://github.com/cockpit-project/bots/pull/7368
 - [x] #21561 
 - [x] #21566
 - [x] Make test prep offline (`dnf install`→ `rpm -i`)
 - [x] NetworkManager [SELinux issue](https://cockpit-logs.us-east-1.linodeobjects.com/pull-21559-045df1ef-20250130-100950-centos-9-bootc-networking/log.html) (two times the same): reported to https://issues.redhat.com/browse/RHEL-76966 , naughtied in https://github.com/cockpit-project/bots/pull/7375
 - [x] systemd SELinux issue [here](https://cockpit-logs.us-east-1.linodeobjects.com/pull-21559-045df1ef-20250130-091007-centos-9-bootc-expensive/log.html#48):
 - [x] `TestMultiMachineKeyAuth.testBasic` [failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-21559-045df1ef-20250130-091007-centos-9-bootc-expensive/log.html#59-2)