### PR TITLE
tools: Drop obsolete glib-networking dependency of bridge

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -255,7 +255,6 @@ troubleshooting, interactive command-line sessions, and more.
 
 %package bridge
 Summary: Cockpit bridge server-side component
-Requires: glib-networking
 
 %description bridge
 The Cockpit bridge component installed server side and runs commands on the

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -59,7 +59,6 @@ Architecture: any
 Depends: ${misc:Depends},
          ${shlibs:Depends},
          ${python3:Depends},
-         glib-networking
 Recommends: openssh-client
 Replaces: cockpit-pcp (<< 236)
 Provides: cockpit-pcp


### PR DESCRIPTION
This hasn't been necessary since the switch to the Python bridge.