### PR TITLE
.cockpit-ci: Move tasks container to ghcr.io

### DIFF
--- a/.cockpit-ci/container
+++ b/.cockpit-ci/container
@@ -1,1 +1,1 @@
-quay.io/cockpit/tasks:2024-03-15
+ghcr.io/cockpit-project/tasks:2024-03-16


### PR DESCRIPTION
The quay repository was removed as it's been stale for over a year.

---

Fixes [this failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-7367-5491fe30-20250129-104918-rhel-8-10-cockpit-project-cockpit-rhel-8/log.html)