### PR TITLE
lib: Make DynamicListForm.itemcomponent a component type instead of instance

### DIFF
--- a/pkg/lib/cockpit-components-dynamic-list.jsx
+++ b/pkg/lib/cockpit-components-dynamic-list.jsx
@@ -13,7 +13,7 @@ import './cockpit-components-dynamic-list.scss';
  *   - emptyStateString
  *   - onChange
  *   - id
- *   - itemcomponent
+ *   - itemcomponent (React element type)
  *   - formclass (optional)
  *   - options (optional)
  *   - onValidationChange: A handler function which updates the parent's component's validation object.
@@ -86,7 +86,7 @@ export class DynamicListForm extends React.Component {
                                 if (item === undefined)
                                     return null;
 
-                                return React.cloneElement(this.props.itemcomponent, {
+                                return React.createElement(this.props.itemcomponent, {
                                     idx,
                                     item,
                                     id: id + "-" + idx,
@@ -135,7 +135,7 @@ DynamicListForm.propTypes = {
     emptyStateString: PropTypes.string.isRequired,
     onChange: PropTypes.func.isRequired,
     id: PropTypes.string.isRequired,
-    itemcomponent: PropTypes.object.isRequired,
+    itemcomponent: PropTypes.elementType.isRequired,
     formclass: PropTypes.string,
     options: PropTypes.object,
     validationFailed: PropTypes.array,


### PR DESCRIPTION
Existing callers in podman/machines used it like that:

    <DynamicListForm ... itemcomponent={ <PublishPort />} />

But from a conceptual as well as type-check perspective this is nonsense: This is a totally invalid object as it does not get any (required) properties. It needlessly runs initialization, and can never actually get rendered. Running typechecker on this rightfully complained about

> src/ImageRunModal.jsx(1062,51): error TS2740:
> Type '{}' is missing the following properties from type '{ id: any; item: any; ...

Change this to specify the type, so that it can be instantiated properly with `React.createElement()`.

Existing callers in podman/machines have to be changed to

    <DynamicListForm ... itemcomponent={PublishPort} />

----

We don't use this component anywhere in cockpit, thus no-test. I sent https://github.com/cockpit-project/cockpit-podman/pull/1981 to validate it, it runs against this branch. I am adding typechecking to podman, and this is the bulk of errors.