### PR TITLE
base1: fix deprecated qunit long test without a timeout

### DIFF
--- a/pkg/base1/test-http.js
+++ b/pkg/base1/test-http.js
@@ -424,6 +424,8 @@ QUnit.test("parallel stress test", async assert => {
         return;
     }
 
+    assert.timeout(6000);
+
     const num = 1000;
     assert.expect(num + 1);
 


### PR DESCRIPTION
Since QUnit 2.21 a deprecation warning is shown when a test takes longer then 3 seconds and has no timeout set.

---

See https://qunitjs.com/api/config/testTimeout/