### PR TITLE
Allow external python to be used in make

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,6 +5,7 @@ man_MANS =
 noinst_DATA =
 noinst_LIBRARIES =
 noinst_PROGRAMS =
+PYTHON3 ?= python3
 
 # See https://www.gnu.org/software/make/manual/html_node/Force-Targets.html
 FORCE:
@@ -45,7 +46,7 @@ distdir: $(DISTFILES)
 # Needed to ensure the tarball is correct for $(VERSION) override
 dist-hook: $(distdir)/src/cockpit/_version.py
 $(distdir)/src/cockpit/_version.py: FORCE
-	python3 '$(srcdir)'/src/build_backend.py --copy '$(srcdir)' '$(distdir)'
+	$(PYTHON3) '$(srcdir)'/src/build_backend.py --copy '$(srcdir)' '$(distdir)'
 	@rm -f $(distdir)/src/cockpit/_version.py
 	$(AM_V_GEN) echo "__version__ = '$(VERSION)'" > $@
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -3,6 +3,7 @@ bin_PROGRAMS =
 libexec_PROGRAMS =
 libexec_SCRIPTS =
 sbin_PROGRAMS =
+PYTHON3 ?= python3
 
 # -----------------------------------------------------------------------------
 #  Python
@@ -26,8 +27,8 @@ install-python:
 	@# This needs to work on RHEL8 up through modern Fedora, offline, with
 	@# system packages available to the build.
 	@# See https://github.com/pypa/pip/issues/3063 for --ignore-installed
-	python3 -m pip install --no-index --force-reinstall --ignore-installed --root='$(DESTDIR)/' --prefix='$(prefix)' \
-		"$$(python3 '$(srcdir)'/src/build_backend.py --wheel '$(srcdir)' tmp/wheel)"
+	$(PYTHON3) -m pip install --no-index --force-reinstall --ignore-installed --root='$(DESTDIR)/' --prefix='$(prefix)' \
+		"$$($(PYTHON3) '$(srcdir)'/src/build_backend.py --wheel '$(srcdir)' tmp/wheel)"
 	mkdir -p $(DESTDIR)$(libexecdir)
 	mv -t $(DESTDIR)$(libexecdir) $(DESTDIR)$(bindir)/cockpit-askpass
 


### PR DESCRIPTION
In build environments where a different python is required to the one on the host (in our case, yocto), the makefile needs to support an external python3 location.

We were running into issues where our build host used python 3.11, but the yocto version was 3.10, so the files were going into the wrong dist-packages folder.

In our case, adding the following line to our yocto recipe for cockpit (with this fix) now works as required:

```bb
EXTRA_OEMAKE += "PYTHON3=${STAGING_BINDIR_NATIVE}/python3-native/python3"
```