### PR TITLE
users: disable deleting/logging out current logged in account

### DIFF
--- a/pkg/users/account-details.js
+++ b/pkg/users/account-details.js
@@ -212,11 +212,11 @@ export function AccountDetails({ accounts, groups, current_user, user, shells })
     const actions = superuser.allowed && (
         <>
             <Button variant="secondary" onClick={() => logout_account()} id="account-logout"
-              isDisabled={!account.loggedIn || account.uid == 0}>
+              isDisabled={!account.loggedIn || account.uid == 0 || user === current_user}>
                 {_("Terminate session")}
             </Button>
             { "\n" }
-            <Button isDisabled={account.uid == 0} variant="danger" id="account-delete"
+            <Button isDisabled={account.uid == 0 || user === current_user} variant="danger" id="account-delete"
                   onClick={() => delete_account_dialog(account)}>
                 {_("Delete")}
             </Button>

--- a/pkg/users/accounts-list.js
+++ b/pkg/users/accounts-list.js
@@ -52,7 +52,7 @@ import { KebabDropdown } from "cockpit-components-dropdown";
 
 const _ = cockpit.gettext;
 
-const UserActions = ({ account }) => {
+const UserActions = ({ account, current }) => {
     const actions = [
         <DropdownItem key="edit-user"
                       onClick={ev => { ev.preventDefault(); cockpit.location.go(account.name) }}>
@@ -63,7 +63,7 @@ const UserActions = ({ account }) => {
     superuser.allowed && actions.push(
         <Divider key="separator-0" />,
         <DropdownItem key="log-user-out"
-                      isDisabled={account.uid === 0 || !account.loggedIn}
+                      isDisabled={account.uid === 0 || !account.loggedIn || current }
                       onClick={() => logoutAccountDialog(account) }>
             {_("Log user out")}
         </DropdownItem>,
@@ -74,8 +74,8 @@ const UserActions = ({ account }) => {
             {_("Lock account")}
         </DropdownItem>,
         <DropdownItem key="delete-account"
-                      isDisabled={account.uid === 0}
-                      className={account.uid === 0 ? "" : "delete-resource-red"}
+                      isDisabled={account.uid === 0 || current}
+                      className={account.uid === 0 || current ? "" : "delete-resource-red"}
                       onClick={() => delete_account_dialog(account) }>
             {_("Delete account")}
         </DropdownItem>,
@@ -201,7 +201,7 @@ const getAccountRow = (account, current, groups) => {
             props: { width: 20 },
         },
         {
-            title: <UserActions account={account} />,
+            title: <UserActions account={account} current={current} />,
             props: { className: "pf-v5-c-table__action" }
         },
     ];

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -192,6 +192,13 @@ class TestAccounts(testlib.MachineCase):
         b.set_checked("#account-locked", val=True)
         b.wait(lambda: m.execute("passwd -S root").split()[1] in ["L", "LK"])
 
+        # Check admin user
+        b.go("#/admin")
+        b.wait_text("#account-user-name", "admin")
+        # delete/logout are disabled for the current user
+        b.wait_visible("#account-delete[disabled]")
+        b.wait_visible("#account-logout[disabled]")
+
         # go back to accounts overview, check pf-v5-c-breadcrumb
         b.click("#account .pf-v5-c-breadcrumb a")
         b.wait_visible("#accounts-create")


### PR DESCRIPTION
For the current logged in user, Cockpit already has a logout button to cleanly log out a user. Deleting the current user is neither user friendly and nothing we accidentally want a user to do.