### PR TITLE
base1: Clean up pybridge special cases

### DIFF
--- a/doc/guide/cockpit-http.xml
+++ b/doc/guide/cockpit-http.xml
@@ -38,11 +38,6 @@ http = cockpit.http(options)
         <listitem><para>Object properties for an https connection. See
         <code><ulink url="https://github.com/cockpit-project/cockpit/blob/main/doc/protocol.md#payload-http-stream2">http-stream2 TLS options</ulink></code>.</para></listitem>
       </varlistentry>
-      <varlistentry>
-        <term><code>"connection"</code></term>
-        <listitem><para>A connection identifier. Subsequent channel requests with the same
-          identifier will try to use the same connection if it is still open.</para></listitem>
-      </varlistentry>
 
       <varlistentry>
         <term><code>"headers"</code></term>

--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -161,10 +161,6 @@ reserved.
 One such special group name is "default", which contains all channels which
 were opened without specifying a group.
 
-Another one is the "fence" group. While any channels are open in the "fence"
-group, any channels opened after that point will be blocked and wait until all
-channels in the "fence" group are closed before resuming.
-
 The "flow-control" option controls whether a channel should attempt to throttle
 itself via flow control when sending or receiving large amounts of data. The
 current default (when this option is not provided) is to not do flow control.
@@ -778,8 +774,6 @@ payload type:
 
 You may also specify these options:
 
- * "connection": A stable identifier for connection sharing, i.e.
-   sending multiple requests to a single open connection.
  * "headers": JSON object with additional request headers
  * "tls": Set to a object to use an https connection.
 

--- a/pkg/base1/test-dbus.js
+++ b/pkg/base1/test-dbus.js
@@ -1,5 +1,5 @@
 import cockpit from "cockpit";
-import QUnit, { mock_info, skipWithPybridge } from "qunit-tests";
+import QUnit, { skipWithPybridge } from "qunit-tests";
 
 import { common_dbus_tests, dbus_track_tests } from "./test-dbus-common.js";
 
@@ -547,15 +547,9 @@ QUnit.test("nonexisting address", async assert => {
         await dbus.call("/org/freedesktop/DBus", "org.freedesktop.DBus", "Hello", []);
         assert.ok(false, "should not be reached");
     } catch (ex) {
-        if (await mock_info("pybridge")) {
-            assert.equal(ex.problem, "protocol-error", "got right close code");
-            assert.equal(ex.message, "failed to connect to none bus: [Errno 2] sd_bus_start: No such file or directory",
-                         "error message");
-        } else {
-            // C bridge has a weird error code
-            assert.equal(ex.problem, "internal-error", "got right close code");
-            assert.equal(ex.message, "Could not connect: No such file or directory", "error message");
-        }
+        assert.equal(ex.problem, "protocol-error", "got right close code");
+        assert.equal(ex.message, "failed to connect to none bus: [Errno 2] sd_bus_start: No such file or directory",
+                     "error message");
     }
 });
 

--- a/pkg/base1/test-stream.js
+++ b/pkg/base1/test-stream.js
@@ -1,5 +1,5 @@
 import cockpit from "cockpit";
-import QUnit, { mock_info } from "qunit-tests";
+import QUnit from "qunit-tests";
 
 const QS_REQUEST = "HEAD /mock/qs HTTP/1.0\nHOST: localhost\n\n";
 
@@ -12,18 +12,13 @@ QUnit.test("TCP stream port without a service", async assert => {
     const done = assert.async();
     assert.expect(2);
 
-    const is_pybridge = await mock_info("pybridge");
-
     const channel = cockpit.channel({ payload: "stream", address: "127.0.0.99", port: 2222 });
 
     channel.addEventListener("close", (ev, options) => {
         assert.equal(options.problem, "not-found", "channel should have failed");
-        if (is_pybridge)
-            assert.equal(options.message,
-                         "[Errno 111] Connect call failed ('127.0.0.99', 2222)",
-                         "detailed error message");
-        else
-            assert.equal(options.message, undefined, "C bridge does not give detailed error message");
+        assert.equal(options.message,
+                     "[Errno 111] Connect call failed ('127.0.0.99', 2222)",
+                     "detailed error message");
         done();
     });
 });

--- a/pkg/lib/qunit-tests.ts
+++ b/pkg/lib/qunit-tests.ts
@@ -28,19 +28,11 @@ export const mock_info = async (key: string) => {
     return (await response.json())[key];
 };
 
-// Convenience for skipping tests that the python bridge can't yet
-// handle.
-
-let is_pybridge: boolean | null = null;
+// Convenience for skipping tests that our python bridge can't yet
+// handle (the C bridge implemented these features)
 
 export const skipWithPybridge = async (name: string, callback: (assert: unknown) => void | Promise<void>) => {
-    if (is_pybridge === null)
-        is_pybridge = await mock_info("pybridge");
-
-    if (is_pybridge)
-        QUnit.skip(name, callback);
-    else
-        QUnit.test(name, callback);
+    QUnit.skip(name, callback);
 };
 
 /* Always use explicit start */

--- a/src/ws/test-server.c
+++ b/src/ws/test-server.c
@@ -121,7 +121,6 @@ mock_http_info (CockpitWebRequest *request,
                 CockpitWebResponse *response)
 {
   g_autoptr(JsonObject) info = json_object_new ();
-  json_object_set_boolean_member (info, "pybridge", strstr (bridge_argv[0], "py") != NULL);
   json_object_set_boolean_member (info, "skip_slow_tests", g_getenv ("COCKPIT_SKIP_SLOW_TESTS") != NULL);
 
   g_autoptr(GBytes) bytes = cockpit_json_write_bytes (info);

--- a/test/common/pixel-tests
+++ b/test/common/pixel-tests
@@ -115,7 +115,7 @@ import os
 seen = set()
 for s in json.load(sys.stdin):
     c = s['context']
-    if 'pybridge' in c or 'firefox' in c or 'devel' in c:
+    if 'firefox' in c or 'devel' in c:
         continue
     if c.split('/')[0] == sys.argv[1] and s['target_url']:
         url=os.path.dirname(s['target_url'])

--- a/test/run
+++ b/test/run
@@ -7,7 +7,6 @@
 # devel           - runs tests with coverage enabled and generates a html file
 #                   with coverage information and `NODE_ENV=development`
 #                   to get additional React checks and useful stack traces.
-# pybridge        - runs tests with the Python bridge
 # firefox         - runs tests using the Firefox browser instead of Chrome
 # networking      - networking related tests
 # storage         - storage related tests


### PR DESCRIPTION
As we only have the Python bridge now, we can drop the dynamic special
casese and C bridge fallbacks from the unit tests.

Drop the fencing and HTTP connection sharing tests -- we haven't missed
these features in years, so it's unlikely we'll bring them back.

However, do keep `skipWithPybridge` for now -- the D-Bus tests still
need to be adjusted or the Python bridge fixed, and that makes them easy
to grep.