### PR TITLE
test: wait for tuned-button to show text

### DIFF
--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -107,6 +107,10 @@ class TestSystemInfo(testlib.MachineCase):
         # need to wait until CPU usage settles down, to avoid a layout-shifting error/warning icon
         b.wait_not_present("#system-usage-cpu-progress + td .pf-v5-c-progress__status-icon")
         testlib.wait(lambda: b.get_pf_progress_value("#system-usage-cpu-progress + td") < 30)
+        # Wait for tuned text to appear, even thought we ignore it we need to button to have some text.
+        if b.pixels_label:
+            recommended_profile = m.execute("tuned-adm recommend").strip()
+            b.wait_text("#tuned-status-button", recommended_profile)
         b.assert_pixels("#overview", "overview", ignore=[
             ".system-health .pf-v5-c-card__body",
             "#system_uptime",


### PR DESCRIPTION
Our pixel test mechanism can ignore certain HTML elements by id/class by measuring them before the take a screenshot. If the text is not fully loaded yet the measured html element is 0x0 and if it is loaded when taking a screenshot the pixel test fails.

---

Maybe instead we should first take a screenshot and then collect the ignored pixels? Let's discuss, that might be racy as well.