### PR TITLE
test: cover the btrfs device card in our tests

### DIFF
--- a/test/verify/check-storage-btrfs
+++ b/test/verify/check-storage-btrfs
@@ -462,6 +462,14 @@ class TestStorageBtrfs(storagelib.StorageCase):
         b.wait_visible(self.card_row("btrfs volume", name=disk1))
         b.wait_visible(self.card_row("btrfs volume", name=disk2))
 
+        # device details page
+        self.click_card_row("btrfs volume", name="sda")
+        b.wait_visible(self.card("btrfs device"))
+        b.wait_text(self.card_desc("btrfs device", "btrfs volume"), "raid1")
+        b.click(self.card_desc("btrfs device", "btrfs volume") + " button")
+        b.wait_visible(self.card("btrfs volume"))
+        b.wait_text(self.card_desc("btrfs volume", "Label"), label)
+
         # unmount via main page
         b.go("#/")
         b.wait_visible(self.card("Storage"))

--- a/test/verify/check-storage-btrfs
+++ b/test/verify/check-storage-btrfs
@@ -445,6 +445,7 @@ class TestStorageBtrfs(storagelib.StorageCase):
         self.click_dropdown(self.card_row("Storage", name=label) + " + tr", "Mount")
         self.dialog({"mount_point": mount_point})
         b.wait_visible(self.card_row("Storage", location=mount_point))
+        self.addCleanup(m.execute, f"while mountpoint -q {mount_point} && ! umount {mount_point}; do sleep 0.2; done;")
 
         # create subvolume
         m.execute(f"""
@@ -456,6 +457,7 @@ class TestStorageBtrfs(storagelib.StorageCase):
         self.click_dropdown(self.card_row("Storage", name=os.path.basename(subvol)), "Mount")
         self.dialog({"mount_point": subvol_mount_point})
         b.wait_visible(self.card_row("Storage", location=subvol_mount_point))
+        self.addCleanup(m.execute, f"while mountpoint -q {subvol_mount_point} && ! umount {subvol_mount_point}; do sleep 0.2; done;")
 
         # devices overview
         self.click_card_row("Storage", name=label)


### PR DESCRIPTION
This [part](https://cockpit-logs.us-east-1.linodeobjects.com/pull-21389-0c41f814-20250109-101243-fedora-41-devel/Coverage/pkg/storaged/btrfs/device.jsx.gcov.html) was never covered in our tests.

Simply click through and verify it shows the data we expect.