### PR TITLE
workflows: Regularly mirror docker.io/bitnami/grafana

### DIFF
--- a/.github/workflows/docker-mirors.yml
+++ b/.github/workflows/docker-mirors.yml
@@ -1,0 +1,22 @@
+# Keep https://quay.io/repository/cockpit/grafana up to date from
+# https://hub.docker.com/r/bitnami/grafana/ . Our bots images use that mirror
+# to work around docker.io pull rate limits (but bots.git doesn't have a quay
+# secret)
+name: docker-mirror
+on:
+  schedule:
+    - cron: '0 3 * * 3'
+  # can be run manually on https://github.com/cockpit-project/cockpit/actions
+  workflow_dispatch:
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    environment: quay.io
+    permissions: {}
+    timeout-minutes: 20
+    steps:
+      - name: Log into quay
+        run: docker login -u="${{ secrets.QUAY_BOTUSER }}" -p="${{ secrets.QUAY_TOKEN }}" quay.io
+
+      - name: Synchronize grafana container
+        run: skopeo copy docker://docker.io/bitnami/grafana docker://quay.io/cockpit/grafana


### PR DESCRIPTION
We recently changed our services VM image setup to pull the grafana container image from a quay.io mirror [1] to circumvent pull rate limits. This isn't so temporary after all [2], there now seems to be no day of week or time of day when it works inside of the Red Hat VPN.

So dust off our old machinery for that [3].

[1] https://github.com/cockpit-project/bots/commit/ead7a20fb1ac61 [2] https://github.com/cockpit-project/bots/pull/7384 [3] https://github.com/cockpit-project/bots/blob/cb89c6e5cf47cef3/.github/workflows/daily.yml
    https://github.com/cockpit-project/bots/blob/cb89c6e5cf47/sync-quay

----

Unfortunately this cannot be tested from a PR, as both `cron:` and `on_schedule:` workflows have to exist on main. I pieced this together from existing code (the referenced ones above plus https://github.com/cockpit-project/cockpit/blob/main/.github/workflows/build-ws-container.yml). Once this lands, I'll immediately run it manually, and if I screwed up, I'll send a fix-up PR (then I *can* run the workflow from the branch, as at that point it will exist on main).

Closes https://github.com/cockpit-project/bots/pull/7384