### PR TITLE
packit: Re-disable Fedora 42

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -20,15 +20,18 @@ srpm_build_deps:
   - nodejs
   - npm
   - systemd-devel
+
 # use the nicely formatted release NEWS from our upstream release, instead of git shortlog
 copy_upstream_release_description: true
+
 jobs:
   - job: tests
     identifier: self
     trigger: pull_request
     targets:
       - fedora-41
-      - fedora-42
+      # https://pagure.io/fedora-infrastructure/issue/12389
+      # - fedora-42
       - fedora-latest-stable-aarch64
       - fedora-rawhide
       - centos-stream-9-x86_64
@@ -55,7 +58,7 @@ jobs:
     trigger: pull_request
     targets:
       # big-endian
-      - fedora-development-s390x
+      - fedora-latest-stable-s390x
 
   # for cross-project testing
   - job: copr_build


### PR DESCRIPTION
The cloud images are missing [1] and not even COPR works.

Also move the s390x build from -development (which is 42 now, which doesn't work) to -latest-stable (which is 41), same as for the -aarch64 build.

[1] https://pagure.io/fedora-infrastructure/issue/12389

----

Sorry for jumping too fast here. We have to *release* to Fedora 42 already, but apparently there's no way to *test* there yet. I keep underestimating how much manual work still goes into opening a new release..