### PR TITLE
test: Re-disable Firefox BiDi async events

### DIFF
--- a/test/common/webdriver_bidi.py
+++ b/test/common/webdriver_bidi.py
@@ -456,6 +456,8 @@ class FirefoxBidi(WebdriverBidi):
         (self.profiledir / "user.js").write_text(f"""
             user_pref("remote.enabled", true);
             user_pref("remote.frames.enabled", true);
+            // https://bugzilla.mozilla.org/show_bug.cgi?id=1947402
+            user_pref('remote.events.async.enabled', false);
             user_pref("app.update.auto", false);
             user_pref("datareporting.policy.dataSubmissionEnabled", false);
             user_pref("toolkit.telemetry.reportingpolicy.firstRun", false);


### PR DESCRIPTION
Firefox 135 enabled async BiDi event dispatching [1]. This causes some regression where sometimes input events never get a response [2], which often breaks e.g. cockpit-podman's `testFailingPodmanService`.

Re-disable async events for the time being to stabilize tests, until this gets debugged and fixed properly.

Fixes https://github.com/cockpit-project/cockpit-podman/issues/1999

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1922077
[2] https://bugzilla.mozilla.org/show_bug.cgi?id=1947402

----

I ran the podman test umteen times in a loop (in the latest tasks container with Firefox 135), and it seems stable now.