### PR TITLE
test: Configure Firefox BiDi logging

### DIFF
--- a/test/common/webdriver_bidi.py
+++ b/test/common/webdriver_bidi.py
@@ -458,6 +458,13 @@ class FirefoxBidi(WebdriverBidi):
         (self.profiledir / "user.js").write_text(f"""
             // https://bugzilla.mozilla.org/show_bug.cgi?id=1947402
             user_pref('remote.events.async.enabled', false);
+
+            // set this to "Trace" for debugging BiDi interactions
+            user_pref('remote.log.level', 'Warn');
+            user_pref('remote.log.truncate', false);
+            // enable remote logs on stdout
+            user_pref('browser.dom.window.dump.enabled', true);
+
             user_pref("app.update.auto", false);
             user_pref("datareporting.policy.dataSubmissionEnabled", false);
             user_pref("toolkit.telemetry.reportingpolicy.firstRun", false);

--- a/test/common/webdriver_bidi.py
+++ b/test/common/webdriver_bidi.py
@@ -456,8 +456,6 @@ class FirefoxBidi(WebdriverBidi):
         self.profiledir = self.homedir / "profile"
         self.profiledir.mkdir()
         (self.profiledir / "user.js").write_text(f"""
-            user_pref("remote.enabled", true);
-            user_pref("remote.frames.enabled", true);
             // https://bugzilla.mozilla.org/show_bug.cgi?id=1947402
             user_pref('remote.events.async.enabled', false);
             user_pref("app.update.auto", false);


### PR DESCRIPTION
Enable BiDi logs to stdout (`browser.dom.window.dump.enabled`) and set
the default log level to "Warn" [1]. This doesn't result in any extra
log noise, but gives us a an easy to find knob how to turn logging to 11
(like for https://bugzilla.mozilla.org/show_bug.cgi?id=1947402). It took
several days and back-and-forth with upstream to figure this out.

[1] https://firefox-source-docs.mozilla.org/remote/Prefs.html