### PR TITLE
Only authorize once in noninteractive superuser responder

### DIFF
--- a/src/cockpit/superuser.py
+++ b/src/cockpit/superuser.py
@@ -99,9 +99,11 @@ class AuthorizeResponder(CockpitResponder):
     def __init__(self, router: Router):
         self.router = router
 
-    async def do_askpass(self, messages: str, prompt: str, hint: str) -> str:
+    async def do_askpass(self, messages: str, prompt: str, hint: str) -> 'str | None':
         hexuser = ''.join(f'{c:02x}' for c in getpass.getuser().encode('ascii'))
-        return await self.router.request_authorization(f'plain1:{hexuser}')
+        password = await self.router.request_authorization(f'plain1:{hexuser}')
+        # translate "no password" from authorize protocol (empty string) to ferny protocol (None)
+        return None if password == '' else password
 
 
 class SuperuserRoutingRule(RoutingRule, CockpitResponder, bus.Object, interface='cockpit.Superuser'):

--- a/src/cockpit/superuser.py
+++ b/src/cockpit/superuser.py
@@ -98,8 +98,14 @@ class CockpitResponder(ferny.AskpassHandler):
 class AuthorizeResponder(CockpitResponder):
     def __init__(self, router: Router):
         self.router = router
+        self.authorize_attempted = False
 
     async def do_askpass(self, messages: str, prompt: str, hint: str) -> 'str | None':
+        if self.authorize_attempted:
+            logger.info("noninteractive authorize during init already attempted, rejecting")
+            return None
+        self.authorize_attempted = True
+
         hexuser = ''.join(f'{c:02x}' for c in getpass.getuser().encode('ascii'))
         password = await self.router.request_authorization(f'plain1:{hexuser}')
         # translate "no password" from authorize protocol (empty string) to ferny protocol (None)

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -666,11 +666,13 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
             self.sed_file(f"s/# deny = 3/deny = {count}/", "/etc/security/faillock.conf")
         else:
             # see https://access.redhat.com/solutions/62949
-            self.sed_file("/pam_unix/ {"
-                          "s/sufficient/[success=1 default=ignore]/\n"
-                          f"aauth [default=die] pam_faillock.so authfail audit deny={count} unlock_time=600\n"
-                          f"aauth sufficient pam_faillock.so authsucc audit deny={count} unlock_time=600\n"
-                          "}", "/etc/pam.d/password-auth")
+            sed = ("/^auth.*pam_unix/ {"
+                   "s/sufficient/[success=1 default=ignore]/\n"
+                   f"aauth [default=die] pam_faillock.so authfail audit deny={count} unlock_time=600\n"
+                   f"aauth sufficient pam_faillock.so authsucc audit deny={count} unlock_time=600\n"
+                   "}")
+            self.sed_file(sed, "/etc/pam.d/password-auth")
+            self.sed_file(sed, "/etc/pam.d/system-auth")
 
         m.execute("grep -r faillock /etc/pam.d")
 

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -771,6 +771,44 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         self.allow_journal_messages(".*[aA]ccount .*locked due to .* failed logins.*")
         self.allow_journal_messages(".*minutes left to unlock.*")
 
+    @testlib.skipWsContainer("no local config with cockpit/ws container")
+    def testAutomaticSudoFaillock(self):
+        m = self.machine
+        b = self.browser
+
+        # only tolerate one failure; unfortunately sending no password (the second time) counts as second failure
+        self.enable_faillock(3)
+        self.addCleanup(m.execute, "faillock --user admin --reset")
+        # configure the account to force a password change
+        m.execute("chage -d 0 admin")
+        m.start_cockpit()
+        b.open("/")
+        b.try_login()
+
+        # set new password
+        new_pass = "fooBetterBar1@#"
+        if m.ws_container:
+            b.wait_in_text("#conversation-prompt", "You are required to change your password")
+        else:
+            b.wait_in_text("#conversation-message", "You are required to change your password")
+        b.set_val('#conversation-input', 'foobar')
+        b.click('#login-button')
+        b.wait_in_text("#conversation-prompt", "New password")
+        b.set_val('#conversation-input', new_pass)
+        b.click('#login-button')
+        b.wait_in_text("#conversation-prompt", "Retype")
+        b.set_val('#conversation-input', new_pass)
+        b.click('#login-button')
+        b.wait_visible('#content')
+        # automatic sudo will still try the old password
+        b.check_superuser_indicator("Limited access")
+        b.logout()
+
+        # can now login with new password and sudo, account isn't locked
+        b.login_and_go(password=new_pass)
+        b.check_superuser_indicator("Administrative access")
+        b.logout()
+
     @testlib.skipWsContainer("root logins disabled by default with ssh")
     def testPamAccess(self):
         b = self.browser

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -648,6 +648,32 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
     def testFailingWebsocketSafariNoCA(self):
         self.testFailingWebsocket(safari=True, cacert=False)
 
+    def enable_faillock(self, count: int):
+        m = self.machine
+        # ensure we have no faillock in our pam config already
+        # arch has faillock enabled by default
+        if m.image != "arch":
+            m.execute("! grep -r faillock /etc/pam.d")
+
+        # add it to the pam config
+        if m.image.startswith('debian-') or m.image.startswith('ubuntu'):
+            # enable pam_faillock.  see example in pam_faillock(8)
+            self.sed_file(r"/fallback if no module succeeds/ s/^/"
+                          f"auth [default=die] pam_faillock.so authfail deny={count}\\n"
+                          f"auth sufficient pam_faillock.so authsucc deny={count}\\n/",
+                          "/etc/pam.d/common-auth")
+        elif m.image == "arch":
+            self.sed_file(f"s/# deny = 3/deny = {count}/", "/etc/security/faillock.conf")
+        else:
+            # see https://access.redhat.com/solutions/62949
+            self.sed_file("/pam_unix/ {"
+                          "s/sufficient/[success=1 default=ignore]/\n"
+                          f"aauth [default=die] pam_faillock.so authfail audit deny={count} unlock_time=600\n"
+                          f"aauth sufficient pam_faillock.so authsucc audit deny={count} unlock_time=600\n"
+                          "}", "/etc/pam.d/password-auth")
+
+        m.execute("grep -r faillock /etc/pam.d")
+
     def testFaillock(self):
         m = self.machine
         b = self.browser
@@ -687,30 +713,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
             b.logout()
 
         self.enable_root_login()
-
-        # ensure we have no module in our pam config already
-        # arch has faillock enabled by default
-        if m.image != "arch":
-            m.execute(f"! grep -r '{module}' /etc/pam.d")
-
-        # add it to the pam config
-        if m.image.startswith('debian-') or m.image.startswith('ubuntu'):
-            # enable pam_faillock.  see example in pam_faillock(8)
-            self.sed_file(r"/fallback if no module succeeds/ s/^/"
-                          r"auth [default=die] pam_faillock.so authfail deny=4\n"
-                          r"auth sufficient pam_faillock.so authsucc deny=4\n/",
-                          "/etc/pam.d/common-auth")
-        elif m.image == "arch":
-            self.sed_file("s/# deny = 3/deny = 4/", "/etc/security/faillock.conf")
-        else:
-            # see https://access.redhat.com/solutions/62949
-            self.sed_file("""/pam_unix/ {
-                      s/sufficient/[success=1 default=ignore]/\n
-                      aauth [default=die] pam_faillock.so authfail audit deny=4 unlock_time=600\n
-                      aauth sufficient pam_faillock.so authsucc audit deny=4 unlock_time=600\n
-                      }""", "/etc/pam.d/password-auth")
-
-        m.execute(f"grep -r '{module}' /etc/pam.d")
+        self.enable_faillock(4)
 
         m.start_cockpit()
 


### PR DESCRIPTION
ws stores the login password during the "explicit-superuser" init phase, so that the session can get administrative privileges automatically. This happens by noninteractively authorizing to the superuser bridge.
    
However, it does not make sense to try this more than once: If e.g. sudo or pkexec has another question, then that means something like "password is wrong", or "user must change their password", or "need 2FA token". It never makes sense to answer follow-up questions with *the same* password. It will never satisfy any of the above cases. Moreover, it causes repeated sudo/pkexec/etc. failures in the system logs, and can even lead to completely locking the user account if pam_faillock(8) is configured.

https://issues.redhat.com/browse/RHEL-32834

This PR fixes the problem in two different ways (in ws and the bridge). I like both, and I think it's fine to just keep both. However, if either of these raises doubts, we could just keep one.