### PR TITLE
Support a SessionUserCommand for external session user mapping

### DIFF
--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -158,6 +158,28 @@ the next section for details.
 See the [Certificate/smart card authentication guide](https://cockpit-project.org/guide/latest/cert-authentication.html)
 for details how to set this up.
 
+Session User Command
+---------------------------------
+It is possible to set up a custom authentication scheme, that calls an external command to validate the incoming authentication header, and if successful, returns a specific username to Cockpit, in turn using PAM to then log in as that user.
+
+A common use-case for this is where you have Cockpit sitting behind a reverse-proxy that performs authentication, and passes an authentication token; for example a JWT token.
+
+To configure this, create a section in `cockpit.conf` for your custom authentication scheme, for example:
+
+```
+[x-my-auth-method]
+SessionUserCommand = /usr/local/bin/my-auth-method-script
+```
+
+The command specified in `SessionUserCommand` will be called with two arguments, which are the remote host IP address, and the authentication data extracted from the Authorization header (excluding the auth scheme prefix). For example, if a curl command like this is issued:
+`curl -vvv -k https://localhost:9090/cockpit/login -H 'Authorization: x-my-auth-method some-auth-data'`
+
+The command will be called like this:
+
+`/usr/local/bin/my-auth-method-script <remote-host-ip> some-auth-data`
+
+The command should **only** output the username to log in as on stdout, and exit with status code 0 on success. If the authentication fails, the command should exit with a non-zero status code. Any output to stderr will be logged by Cockpit.
+
 Actions
 -------
 

--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -1094,6 +1094,7 @@ cockpit_session_launch (CockpitAuth *self,
 
   const gchar *command = cockpit_conf_string (section, "Command");
   const gchar *unix_path = cockpit_conf_string (section, "UnixPath");
+  const gchar *session_user_command = cockpit_conf_string (section, "SessionUserCommand");
 
   gboolean capture_stderr = FALSE;
   if (g_str_equal (section, COCKPIT_CONF_SSH_SECTION))
@@ -1115,7 +1116,8 @@ cockpit_session_launch (CockpitAuth *self,
     }
   else if (g_str_equal (type, "basic") ||
            g_str_equal (type, "negotiate") ||
-           g_str_equal (type, "tls-cert"))
+           g_str_equal (type, "tls-cert") ||
+           session_user_command != NULL)
     {
       if (command == NULL && unix_path == NULL)
         {

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -1191,6 +1191,82 @@ matchrule = <SUBJECT>^DC=LAN,DC=COCKPIT,CN=alice$
         # cleans up session
         m.execute("while loginctl --no-legend list-sessions | grep admin; do sleep 1; done")
 
+    # @testlib.skipWsContainer("sssd/cockpit-session not available with ws container")
+    # @testlib.skipImage("sssd not currently in testing", "debian-testing")
+    def testSessionUserCommand(self):
+        m = self.machine
+
+        m.execute("useradd alice; echo alice:foobar123 | chpasswd")
+
+        # These tests have to be run with curl, as this is a backend-auth feature, likely implemented by a middleware proxy
+        def do_test(authopts, expected, not_expected=None):
+            # avoid running into start-limit-hit
+            m.execute("systemctl reset-failed")
+            m.start_cockpit(tls=True)
+            output = m.execute(['curl', '-ksS', '-D-', *authopts, 'https://localhost:9090/cockpit/login'])
+            for s in expected:
+                self.assertIn(s, output)
+            for s in (not_expected or []):
+                self.assertNotIn(s, output)
+
+            m.stop_cockpit()
+
+        # sample auth method should not be enabled by default
+        do_test(['-H', 'Authorization: x-my-auth-method some-auth-data'], ["HTTP/1.1 401 Authentication disabled"])
+        # password auth should work
+        do_test(['-u', 'alice:foobar123'], ['HTTP/1.1 200 OK', '"csrf-token"'])
+
+        # enable cert based auth
+        m.write("/etc/cockpit/cockpit.conf", '[x-my-auth-method]\nSessionUserCommand = /etc/cockpit/test-session-user\n', append=True)
+        m.write("/etc/cockpit/test-session-user", """
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+dbg() {
+    # STDERR debug logging
+    printf "my-auth-method-script DEBUG: %s\n" "$1" >&2
+}
+
+exit_with_problem() {
+    printf "my-auth-method-script ERROR: %s\n" "$1" >&2
+    exit 1
+}
+
+main() {
+    if [[ $# -ne 2 ]]; then
+        exit_with_problem "Invalid number of arguments, pass rhost and auth value"
+    fi
+
+    local rhost="$1"
+    local auth_data="$2"
+
+    dbg "Got auth_data ${auth_data} for rhost ${rhost}"
+
+    if [[ "$auth_data" != "some-auth-data" ]]; then
+        exit_with_problem "Invalid auth data"
+    fi
+
+    echo "alice"
+}
+
+main "$@"
+
+""", perm="0755")
+
+        self.allow_journal_messages("my-auth-method-script DEBUG: Got auth_data some-auth-data for rhost .*")
+        # cert auth should work now
+        do_test(['-H', 'Authorization: x-my-auth-method some-auth-data'], ['HTTP/1.1 200 OK', '"csrf-token"'])
+        # password auth, too
+        do_test(['-u', 'alice:foobar123'], ['HTTP/1.1 200 OK', '"csrf-token"'])
+
+        # Other auth data fails
+        self.allow_journal_messages("my-auth-method-script DEBUG: Got auth_data bad-auth-data for rhost .*")
+        self.allow_journal_messages("my-auth-method-script ERROR: Invalid auth data")
+        do_test(['-H', 'Authorization: x-my-auth-method bad-auth-data'],
+                ["HTTP/1.1 401 Authentication failed"],
+                not_expected=["crsf-token"])
+
 
 if __name__ == '__main__':
     testlib.test_main()


### PR DESCRIPTION
Continuing on from #21626, I've started on adding support into `cockpit-session` to call an external command (if defined), to allow external authentication mechanisms to map to PAM users, and follow the normal session flow. I didn't want to have to re-implement all of the session logic, because all I want to do is call a script and return a username.

This relatively closely mimics the certificate authentication, except relies on a defined application to validate the auth.

## Usage

### cockpit.conf

Define a new auth scheme section and then specify a `SessionUserCommand` to call

```
[x-my-auth-scheme]
SessionUserCommand  = /usr/bin/my-auth-scheme
```

### /usr/bin/my-auth-scheme
```python
#!/usr/bin/env python3

import sys

args = sys.argv
rhost = sys.argv[1]
auth_line = sys.argv[2]

if auth_line == "this_is_a_test":
  print("user-1")
  sys.exit(0)

print("Your auth line is incorrect", file=sys.stderr)
sys.exit(1)
```

When an auth request to cockpit with the header `Authorization: x-my-auth-scheme this_is_a_test` is sent, `/usr/bin/my-auth-scheme` is called by `cockpit-session`, which in turn returns `user-1`, and if that user exists, the PAM session is set up and the user is logged in.

We are using this with JWTs. The `sub` of the JWT has the username in it, and the python script validates that the JWT was signed by a known authority.

Happy to take guidance on the security aspect of calling an external script or whether or not some of the timing logic in the cert auth should be used here too - my C is a tad rusty!

