### PR TITLE
flatpak: Enable screenshots URL mirror

### DIFF
--- a/containers/flatpak/install
+++ b/containers/flatpak/install
@@ -22,6 +22,7 @@ flatpak run \
     org.flatpak.Builder \
         "$@" \
         --force-clean \
+        --mirror-screenshots-url=https://dl.flathub.org/media \
         --install flatpak-build-dir "${MANIFEST}"
 
 flatpak run \


### PR DESCRIPTION
Flathub already mirrors our screenshots to https://dl.flathub.org/media. Tell flatpak builder to rewrite the manifests to actually point to the mirror. This fixes the recent `appstream-external-screenshot-url` error.

Fixes #21643