### PR TITLE
systemd: initialise eventlistener after user is available

### DIFF
--- a/pkg/systemd/terminal.jsx
+++ b/pkg/systemd/terminal.jsx
@@ -148,7 +148,8 @@ const _ = cockpit.gettext;
             }
             const changeNow = await this.readyPath();
             if (changeNow) {
-                this.setState(prevState => ({ channel: this.createChannel(prevState.user, cockpit.location.options.path) }));
+                const user = await cockpit.user();
+                this.setState(({ channel: this.createChannel(user, cockpit.location.options.path) }));
             }
         }
 

--- a/pkg/systemd/terminal.jsx
+++ b/pkg/systemd/terminal.jsx
@@ -75,6 +75,7 @@ const _ = cockpit.gettext;
                 changePathBusy: false,
                 pathError: null,
                 pid: null,
+                user: null,
             };
             this.onTitleChanged = this.onTitleChanged.bind(this);
             this.onResetClick = this.onResetClick.bind(this);
@@ -149,7 +150,7 @@ const _ = cockpit.gettext;
             const changeNow = await this.readyPath();
             if (changeNow) {
                 const user = await cockpit.user();
-                this.setState(({ channel: this.createChannel(user, cockpit.location.options.path) }));
+                this.setState({ channel: this.createChannel(user, cockpit.location.options.path) });
             }
         }
 


### PR DESCRIPTION
While debugging an oops in Firefox with the Files testsuite, running it with a development build uncovered a situation where `onNavigate` is called with `user` being unset.

Initialising the eventListener after `setState` should remedy this.