### PR TITLE
test: Unmount LVM2 thin volume before pixel test

### DIFF
--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -236,11 +236,13 @@ class TestStorageLvm2(storagelib.StorageCase):
         b.click(self.card_parent_link())
         b.wait_text(self.card_row_col("Thinly provisioned LVM2 logical volumes", 1, 3), mount_point_thin)
 
-        # prevent unstable usage numbers from failing the pixel test
+        # Unmount to prevent unstable usage numbers from failing the pixel test
+        self.click_dropdown(self.card_row("Thinly provisioned LVM2 logical volumes", 1),
+                            "Unmount")
+        self.confirm()
+
         b.assert_pixels('body', "pool-page",
-                        mock={".usage-text": "1 / 100 MB"},
-                        ignore=[".usage-bar",
-                                self.card_desc("Pool for thinly provisioned LVM2 logical volumes", "Data used"),
+                        ignore=[self.card_desc("Pool for thinly provisioned LVM2 logical volumes", "Data used"),
                                 self.card_desc("Pool for thinly provisioned LVM2 logical volumes", "Metadata used")])
 
         # remove pool


### PR DESCRIPTION
Mocking the usage numbers is not reliable. The page renders (and undoes the mocking) at the wrong time.

Fixes #21639