### PR TITLE
test: Fail on cdp_command() errors

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -343,7 +343,10 @@ class Browser:
 
         if self.browser == "chromium":
             assert isinstance(self.driver, webdriver_bidi.ChromiumBidi)
-            return self.run_async(self.driver.cdp(method, **params))
+            reply = self.run_async(self.driver.cdp(method, **params))
+            if 'error' in reply:
+                raise Error(str(reply['error'])) from None
+            return reply['result']
         else:
             raise webdriver_bidi.WebdriverError("CDP is only supported in Chromium")
 
@@ -1572,7 +1575,7 @@ class Browser:
 
     def write_coverage_data(self) -> None:
         if self.coverage_label and self._is_running():
-            coverage = self.cdp_command("Profiler.takePreciseCoverage")["result"]
+            coverage = self.cdp_command("Profiler.takePreciseCoverage")
             write_lcov(coverage['result'], self.coverage_label)
 
     def assert_no_oops(self) -> None:


### PR DESCRIPTION
Don't silently ignore failing CDP commands. If they fail, their return value has an `error` field.

On success, just return the result, not the whole reply. There is only one place where we use it anyway (collecting coverage results).

---

This would have saved me some headache this morning with https://github.com/cockpit-project/cockpit-files/pull/973 . Now, if the command fails, it looks like this:

```
INFO:bidi.command:CDP ← '{"id": 0, "method": "Network.emulateNetworkConditions", "params": {"uploadThroughput": 50000}}'
INFO:bidi.command:CDP → {'id': 0, 'error': {'code': -32602, 'message': 'Invalid parameters', 'data': 'Failed to deserialize params.downloadThroughput - BINDINGS: mandatory field missing at position 28'}}
Traceback (most recent call last):
  File "/var/home/martin/upstream/cockpit-files/test/check-application", line 2408, in testUpload
    b.cdp_command("Network.emulateNetworkConditions",
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                  uploadThroughput=50000)
                  ^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/home/martin/upstream/cockpit-files/test/common/testlib.py", line 348, in cdp_command
    raise Error(str(reply['error'])) from None
testlib.Error: {'code': -32602, 'message': 'Invalid parameters', 'data': 'Failed to deserialize params.downloadThroughput - BINDINGS: mandatory field missing at position 28'}
```

before it just silently went over the error, and I was wondering why the command didn't work.