### PR TITLE
shell: Show some pages in fullscreen

### DIFF
--- a/files.js
+++ b/files.js
@@ -26,6 +26,7 @@ const info = {
         "playground/notifications-receiver.js",
         "playground/journal.jsx",
         "playground/remote.tsx",
+        "playground/fullscreen.tsx",
 
         "selinux/selinux.js",
         "shell/shell.jsx",
@@ -117,6 +118,7 @@ const info = {
         "playground/notifications-receiver.html",
         "playground/journal.html",
         "playground/remote.html",
+        "playground/fullscreen.html",
 
         "selinux/index.html",
 

--- a/pkg/base1/test-http.js
+++ b/pkg/base1/test-http.js
@@ -79,9 +79,15 @@ QUnit.test("simple request", assert => {
                         },
                         test: {
                             label: "Playground"
+                        },
+                        fullscreen: {
+                            label: "Fullscreen Shell"
                         }
                     },
                     preload: ["preloaded"],
+                    fullscreen: {
+                        fullscreen: ["/fullscreen"]
+                    },
                     "content-security-policy": "img-src 'self' data:"
                 }, "returned right data");
             })

--- a/pkg/playground/fullscreen.html
+++ b/pkg/playground/fullscreen.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Cockpit playground</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link href="fullscreen.css" type="text/css" rel="stylesheet" />
+    <script src="../base1/cockpit.js"></script>
+    <script src="fullscreen.js"></script>
+  </head>
+  <body class="pf-v5-m-tabular-nums">
+    <div id="app" />
+  </body>
+</html>

--- a/pkg/playground/fullscreen.tsx
+++ b/pkg/playground/fullscreen.tsx
@@ -1,0 +1,66 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import cockpit from "cockpit";
+import React from "react";
+import { createRoot, Container } from 'react-dom/client';
+import { usePageLocation } from "hooks";
+
+import '../lib/patternfly/patternfly-6-cockpit.scss';
+
+import { Page, PageSection, Bullseye, Button } from '@patternfly/react-core';
+
+import 'cockpit-dark-theme'; // once per page
+import 'page.scss';
+
+const FullscreenDemo = () => {
+    const { path } = usePageLocation();
+
+    function go_fullscreen() {
+        cockpit.location.go("/fullscreen");
+    }
+
+    function go_halfscreen() {
+        cockpit.location.go("/");
+    }
+
+    return (
+        <Page className="no-masthead-sidebar">
+            <PageSection>
+                <Bullseye>
+                    { (path[0] != "fullscreen")
+                        ? <Button onClick={go_fullscreen}>Go fullscreen</Button>
+                        : <Button onClick={go_halfscreen}>Go back</Button>
+                    }
+                </Bullseye>
+            </PageSection>
+        </Page>
+    );
+};
+
+function init_app(rootElement: Container) {
+    const root = createRoot(rootElement);
+    root.render(<FullscreenDemo />);
+}
+
+document.addEventListener("DOMContentLoaded", function() {
+    cockpit.transport.wait(function() {
+        init_app(document.getElementById('app')!);
+    });
+});

--- a/pkg/playground/manifest.json
+++ b/pkg/playground/manifest.json
@@ -44,7 +44,13 @@
         },
         "remote": {
             "label": "Remote channel"
+        },
+        "fullscreen": {
+            "label": "Fullscreen Shell"
         }
+    },
+    "_fullscreen": {
+      "fullscreen": [ "/fullscreen" ]
     },
     "preload": [ "preloaded" ],
     "content-security-policy": "img-src 'self' data:"

--- a/pkg/shell/manifests.ts
+++ b/pkg/shell/manifests.ts
@@ -102,6 +102,7 @@ export interface Manifest {
     tools: ManifestSection | undefined;
 
     preload: string[] | undefined;
+    _fullscreen: Record<string, string[]> | undefined;
     parent: ManifestParentSection | undefined;
     ".checksum": string | undefined;
 }
@@ -113,6 +114,7 @@ function import_Manifest(val: JsonValue): Manifest {
         menu: get_optional(obj, "menu", import_ManifestSection),
         tools: get_optional(obj, "tools", import_ManifestSection),
         preload: get_optional(obj, "preload", v => import_array(v, import_string)),
+        _fullscreen: get_optional(obj, "_fullscreen", v => import_record(v, x => import_array(x, import_string))),
         parent: get_optional(obj, "parent", import_ManifestParentSection),
         ".checksum": get_optional(obj, ".checksum", import_string),
     };

--- a/pkg/shell/shell.scss
+++ b/pkg/shell/shell.scss
@@ -135,6 +135,10 @@ $desktop: $phone + 1px;
     grid-template-columns: 1fr auto auto;
     overflow: hidden;
 
+    &.ct-fullscreen .area-ct-content {
+        grid-area: main / main / header / header;
+    }
+
     .area-ct-subnav {
       grid-area: main;
     }
@@ -179,6 +183,10 @@ $desktop: $phone + 1px;
     grid-template-areas: "switcher switcher header" "sidebar main main";
     grid-template-rows: max-content 1fr;
     grid-template-columns: minmax(min-content, var(--nav-width)) auto 1fr;
+
+    &.ct-fullscreen .area-ct-content {
+        grid-area: switcher / switcher / main / main;
+    }
 
     > .navbar {
       grid-area: switcher;

--- a/pkg/shell/shell.tsx
+++ b/pkg/shell/shell.tsx
@@ -88,6 +88,7 @@ const Shell = () => {
 
         config,
 
+        current_fullscreen,
         current_machine,
         current_manifest_item,
     } = state;
@@ -122,7 +123,7 @@ const Shell = () => {
     }
 
     return (
-        <div id="main" className="page"
+        <div id="main" className={"page" + (current_fullscreen ? " ct-fullscreen" : "")}
              style={
                  {
                      '--ct-color-host-accent': (current_machine.address == "localhost" ? undefined : current_machine.color)
@@ -132,28 +133,32 @@ const Shell = () => {
             <SkipLink focus_id="content">{_("Skip to content")}</SkipLink>
             <SkipLink focus_id="hosts-sel">{_("Skip main navigation")}</SkipLink>
 
-            <div id="sidebar-toggle" className="pf-v6-c-select pf-m-dark sidebar-toggle">
-                <SidebarToggle />
-            </div>
+            { !current_fullscreen &&
+                <>
+                    <div id="sidebar-toggle" className="pf-v6-c-select pf-m-dark sidebar-toggle">
+                        <SidebarToggle />
+                    </div>
 
-            <div id="nav-system" className="area-ct-subnav nav-system-menu sidebar interact">
-                <nav id="host-apps" className="host-apps">
-                    <PageNav state={state} />
-                </nav>
-            </div>
+                    <div id="nav-system" className="area-ct-subnav nav-system-menu sidebar interact">
+                        <nav id="host-apps" className="host-apps">
+                            <PageNav state={state} />
+                        </nav>
+                    </div>
 
-            <nav id="hosts-sel" className="navbar navbar-default navbar-pf navbar-pf-vertical" tabIndex={-1}>
-                { config.host_switcher_enabled
-                    ? <CockpitHosts state={state} host_modal_state={host_modal_state} selector="nav-hosts" />
-                    : <CockpitCurrentHost current_user={current_user} machine={current_machine} />
-                }
-            </nav>
+                    <nav id="hosts-sel" className="navbar navbar-default navbar-pf navbar-pf-vertical" tabIndex={-1}>
+                        { config.host_switcher_enabled
+                            ? <CockpitHosts state={state} host_modal_state={host_modal_state} selector="nav-hosts" />
+                            : <CockpitCurrentHost current_user={current_user} machine={current_machine} />
+                        }
+                    </nav>
 
-            <div id="nav-hosts" className="area-ct-subnav nav-hosts-menu sidebar" />
+                    <div id="nav-hosts" className="area-ct-subnav nav-hosts-menu sidebar" />
 
-            <div id="topnav" className="header">
-                <TopNav state={state} />
-            </div>
+                    <div id="topnav" className="header">
+                        <TopNav state={state} />
+                    </div>
+                </>
+            }
 
             <Frames hidden={!!failure} state={state} idle_state={idle_state} />
 
@@ -184,7 +189,8 @@ function init() {
 
     /* Tell the pages about our features. */
     (window as ShellWindow).features = {
-        navbar_is_for_current_machine: true
+        navbar_is_for_current_machine: true,
+        fullscreen_via_manifest: true,
     };
 
     function follow(arg: unknown) {

--- a/pkg/shell/state.tsx
+++ b/pkg/shell/state.tsx
@@ -589,6 +589,7 @@ export class ShellState extends EventEmitter<ShellStateEvents> {
     current_manifest: Manifest | null = null;
 
     current_frame: ShellFrame | null = null;
+    current_fullscreen: boolean | null = null;
 
     update() {
         if (!this.ready || this.problem) {
@@ -645,6 +646,21 @@ export class ShellState extends EventEmitter<ShellStateEvents> {
         this.current_machine_manifest_items = compiled;
         this.current_manifest_item = item;
         this.current_manifest = compiled.find_path_manifest(location.path);
+
+        this.current_fullscreen = false;
+        if (this.current_manifest._fullscreen) {
+            const fs = this.current_manifest._fullscreen;
+            const path_prefix = location.path.split("/", 1)[0];
+            for (const path_suffix in fs) {
+                if ((path_suffix == "" && path_prefix == location.path) ||
+                    (path_prefix + "/" + path_suffix == location.path)) {
+                    for (const hash_prefix of fs[path_suffix]) {
+                        if (this.current_location.hash.startsWith(hash_prefix))
+                            this.current_fullscreen = true;
+                    }
+                }
+            }
+        }
 
         let frame = null;
         if (location.path && (machine.state == "connected" || machine.state == "connecting"))

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -1130,6 +1130,37 @@ OnCalendar=daily
         assert_mode(filename, "600")
         assert_content(filename, content)
 
+    def testFullscreen(self):
+        b = self.browser
+
+        self.login_and_go("/playground/fullscreen")
+
+        def get_size(sel):
+            clip = b.call_js_func('ph_element_clip', sel)
+            return (clip["width"], clip["height"])
+
+        def wait_size(sel, size):
+            b.wait(lambda: get_size(sel) == size)
+
+        b.switch_to_top()
+        shell_size = get_size('body')
+        content_size = get_size('#content')
+        b.enter_page("/playground/fullscreen")
+
+        self.assertEqual(get_size("#app"), content_size)
+
+        b.click('#app button:contains("Go fullscreen")')
+        wait_size("#app", shell_size)
+
+        b.click('#app button:contains("Go back")')
+        wait_size("#app", content_size)
+
+        b.click('#app button:contains("Go fullscreen")')
+        wait_size("#app", shell_size)
+
+        b.eval_js("window.history.back()")
+        wait_size("#app", content_size)
+
 
 if __name__ == '__main__':
     testlib.test_main()


### PR DESCRIPTION
The Machines application of Cockpit lets people interact with the graphical console of a virtual machine. This is useful for baby sitting a VM through its boot process or doing the occasional rescue work, but it might also be used to do real day-to-day work in a graphical desktop environment that runs in the VM.

The graphical console in Cockpit Machines is fundamentally limited by having to run in a browser. The browser might eat some keys, for example, and serious work might thus require a external viewer application such as GNOME Connections, TigerVNC, or virt-viewer. Nevertheless, we should make Cockpit's own viewer work as well as possible.

One aspect of improving our own viewer is to give more space to the actual console, and less to Cockpit's own UI.  Cockpit Machines can already "expand" the console to fill most of the content iframe.

### Purpose

The purpose of this task is to make it possible to remove as much of the Shell UI elements that normally surround the content iframe as possible when people are interacting with the expanded view of a VM console.

--------------------------------

Demos: https://youtu.be/9kDEZkvI2eo, https://www.youtube.com/watch?v=FsBE4eQo0As

This needs a change to the cockpit-machines manifest to recreate the demo.  There is also a new "fullscreen" playground.

- [x] Inform iframes whether the shell supports the "fullscreen-via-manifest" feature. 
- [x] Don't break in mobile layout
- [x] Fix layout of fullscreen playground, has regressed during PF6 trans, I think.
- [x] Docs for the new "fullscreen" manifest field.
- [x] No docs for the new private experimental unsupported "_fullscreen" field. :-)