### PR TITLE
lib: Improve http channel debug messages

### DIFF
--- a/pkg/lib/cockpit.js
+++ b/pkg/lib/cockpit.js
@@ -2547,7 +2547,7 @@ function factory() {
                         channel.send(data);
                     });
                 }
-                http_debug("http done");
+                http_debug("http", req.method, req.path, "request sent, channel done");
                 channel.control({ command: "done" });
             }
 
@@ -2594,10 +2594,10 @@ function factory() {
                             if (type.indexOf("text/plain") === 0)
                                 message = body;
                         }
-                        http_debug("http status: ", resp.status);
+                        http_debug("http", req.method, req.path, "failed:", resp.status, resp.reason);
                         dfd.reject(new HttpError(resp.status, resp.reason, message), body);
                     } else {
-                        http_debug("http done");
+                        http_debug("http", req.method, req.path, "succeeded:", resp.status);
                         dfd.resolve(body);
                     }
                 }


### PR DESCRIPTION
Disambiguate the "http done" message: It was previously shown once for "client finished sending the request" (`done` channel message), and again for "request arrived and was successful". Show a more detailed message in both cases, and also include teh request method and path to disambiguate multiple parallel queries.

---

I noticed that while debugging podman in https://github.com/cockpit-project/cockpit-podman/pull/2024.