### PR TITLE
testlib: remove support for setUp(restrict=) kwarg

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1737,7 +1737,7 @@ class MachineCase(unittest.TestCase):
 
         return int(v[0]) < version
 
-    def setUp(self, restrict: bool = True) -> None:
+    def setUp(self) -> None:
         self.allowed_messages = self.default_allowed_messages
         self.allowed_console_errors = self.default_allowed_console_errors
         self.allow_core_dumps = False
@@ -1780,8 +1780,6 @@ class MachineCase(unittest.TestCase):
                 options.pop('address', None)
                 options.pop('dns', None)
                 options.pop('dhcp', None)
-                if 'restrict' not in options:
-                    options['restrict'] = restrict
                 machine = self.new_machine(**options)
                 self.machines[key] = machine
                 if first_machine:


### PR DESCRIPTION
In general, per Liskov, it's not permitted to modify the signature of a function when overriding it.  Our MachineCase.setUp() override does this by adding a restrict= parameter.  That's strictly OK, since it adds a default value for that argument so there's no situation where a call to .setUp() on the base class would not also work with the overridden method.

Unfortunately, it does create a problem further down the line.  Since we add this parameter, it means (again, per Liskov) that all of our many subclasses (packagelib, netlib, storagelib, plus individual test cases) need to add it to, and none of them do that.  That's hindering our attempt to make this code strictly type-checked with mypy.

It looks like this was only ever used from the previous version of cockpit-composer, so let's drop it.  If someone else is using this then they can provide the same option via the provision.