### PR TITLE
test: type packagelib in strict mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ module = [
 
     # test/common
     'testlib',
+    'packagelib',
     'js_coverage',
     'webdriver_bidi',
 ]


### PR DESCRIPTION
Useful when working on integration tests and wanting to quickly see the required types for `createPackage`.