### PR TITLE
workflows: adjust stamp checking for dnf 5

### DIFF
--- a/.github/workflows/trigger-anaconda.yml
+++ b/.github/workflows/trigger-anaconda.yml
@@ -44,8 +44,8 @@ jobs:
           for _ in $(seq 60); do
               sleep 60;
               if dnf copr enable -y packit/$COPR_NAME &&
-                 out=$(dnf info --refresh --repo='copr:*cockpit*' cockpit-bridge) &&
-                 stamp=$(echo "$out" | awk '/^Release/ { split($3, v, "."); print substr(v[2], 0, 14)}') &&
+                 out=$(dnf repoquery --refresh --repo='copr:*cockpit*' --queryformat '%{release}\n' --recent cockpit-bridge) &&
+                 stamp=$(echo $out | tail -n 1 | awk '{ split($0, v, "."); print substr(v[2], 0, 14)}') &&
                  [ "$stamp" -gt "$PUSH_TIME" ]; then
                   exit 0
               fi


### PR DESCRIPTION
Upgrading the container from Fedora 40 -> 41 seems to have changed `dnf info` output. If multiple copr builds are available the `dnf info` query now returns:

```
[jelle@toolbx main]$ dnf info --refresh --repo='copr:*cockpit*' cockpit-bridge | awk '/^Release/ { split($3, v, "."); print substr(v[2], 0, 14)}' 2>/dev/null
Updating and loading repositories:
 Copr repo for cockpit-project-cockpit- 100% |  12.5 KiB/s |   1.5 KiB |  00m00s
Repositories loaded.
20250307123226
20250310153201
```

This breaks as previously it expected on stamp and one stamp only. Switching to `repoquery` gives us the benefit that we don't need awk to match on `Release` but still doesn't help us with the limiting issues so a `tail` is still required.

---

Example where it is broken atm: https://github.com/cockpit-project/cockpit/actions/runs/13768512737/job/38500948853