### PR TITLE
Add SMART status to overview page

### DIFF
--- a/pkg/systemd/overview-cards/healthCard.tsx
+++ b/pkg/systemd/overview-cards/healthCard.tsx
@@ -28,6 +28,7 @@ import LastLogin from "./lastLogin.jsx";
 import { CryptoPolicyStatus } from "./cryptoPolicies.jsx";
 
 import "./healthCard.scss";
+import { SmartOverviewStatus } from './smart-status.jsx';
 
 const _ = cockpit.gettext;
 
@@ -40,6 +41,7 @@ export const HealthCard = () =>
                 <InsightsStatus />
                 <CryptoPolicyStatus />
                 <ShutDownStatus />
+                <SmartOverviewStatus />
                 <LastLogin />
             </ul>
         </CardBody>

--- a/pkg/systemd/overview-cards/smart-status.jsx
+++ b/pkg/systemd/overview-cards/smart-status.jsx
@@ -1,0 +1,101 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import React, { useState } from 'react';
+
+import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
+import { ExclamationCircleIcon } from "@patternfly/react-icons";
+import { Flex } from "@patternfly/react-core/dist/esm/layouts/Flex/index.js";
+import { Icon } from '@patternfly/react-core/dist/esm/components/Icon/index.js';
+
+import cockpit from "cockpit";
+import { useEvent, useInit } from 'hooks';
+
+function countFailingDisks(proxies) {
+    const sataFail = Object.keys(proxies.drives_ata).reduce((acc, drive) => {
+        const smart = proxies.drives_ata[drive];
+        if (smart.SmartFailing) {
+            return acc + 1;
+        } else {
+            return acc;
+        }
+    }, 0);
+
+    const nvmeFail = Object.keys(proxies.nvme_controller).reduce((acc, drive) => {
+        const smart = proxies.nvme_controller[drive];
+        if (smart.SmartCriticalWarning.length > 0) {
+            return acc + 1;
+        } else {
+            return acc;
+        }
+    }, 0);
+
+    return sataFail + nvmeFail;
+}
+
+const proxies = {
+    drives_ata: null,
+    nvme_controller: null,
+};
+
+export const SmartOverviewStatus = () => {
+    useEvent(proxies.drives_ata, "changed");
+    useEvent(proxies.nvme_controller, "changed");
+    const [initDone, setInitDone] = useState(false);
+
+    useInit(async () => {
+        const udisksdbus = cockpit.dbus("org.freedesktop.UDisks2");
+
+        const addProxy = (iface) => {
+            return udisksdbus.proxies("org.freedesktop.UDisks2." + iface, "/org/freedesktop/UDisks2");
+        };
+
+        proxies.drives_ata = addProxy("Drive.Ata");
+        proxies.nvme_controller = addProxy("NVMe.Controller");
+        await Promise.all(Object.keys(proxies).map(proxy => proxies[proxy].wait()));
+
+        setInitDone(true);
+    });
+
+    if (initDone === false || proxies.drives_ata === null || proxies.nvme_controller === null) {
+        return;
+    }
+
+    const failingDisks = countFailingDisks(proxies);
+    if (failingDisks === 0) {
+        return;
+    }
+
+    return (
+        <li id="smart-status">
+            <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+                <Icon status="danger">
+                    <ExclamationCircleIcon />
+                </Icon>
+                <Button variant="link" component="a" isInline
+                    onClick={() => cockpit.jump("/storage")}
+                >
+                    {cockpit.format(cockpit.ngettext("$0 disk is failing",
+                                                     "$0 disks are failing", failingDisks),
+                                    failingDisks)}
+                </Button>
+            </Flex>
+        </li>
+    );
+};

--- a/test/verify/check-storage-smart
+++ b/test/verify/check-storage-smart
@@ -66,10 +66,10 @@ class TestStorageSmart(storagelib.StorageSmartCase):
         else:
             return False
 
-    def testSmart(self):
-        def set_smart_dump(name: str, block: str):
-            self.machine.execute(f"udisksctl smart-simulate -f /tmp/smart-dumps/{name} -b {block}")
+    def set_smart_dump(self, name: str, block: str):
+        self.machine.execute(f"udisksctl smart-simulate -f /tmp/smart-dumps/{name} -b {block}")
 
+    def testSmart(self):
         def check_smart_info(assessment: str, hours: str, status: str, bad_sectors: str | None = None,
                              failing_attrs: str | None = None):
             self.assertIn(assessment, b.text(self.card_desc("Device health (SMART)", "Assessment")))
@@ -91,42 +91,58 @@ class TestStorageSmart(storagelib.StorageSmartCase):
             return
 
         m.upload(["verify/files/smart-dumps"], "/tmp")
-        # new disk, no failing sectors
-        set_smart_dump("MCCOE64GEMPP--2.9.09", "/dev/sda")
+        # Failing disk, storage page is not loaded
+        self.set_smart_dump("Maxtor_96147H8--BAC51KJ0--2", "/dev/sda")
+        self.login_and_go("/system")
+        b.wait_in_text("#smart-status", "1 disk is failing")
 
-        self.login_and_go("/storage")
+        self.set_smart_dump("MCCOE64GEMPP--2.9.09", "/dev/sda")
+        b.wait_not_present("#smart-status")
+
+        # Clicking the link navigates to storage page, failing disk has red icon
+        self.set_smart_dump("Maxtor_96147H8--BAC51KJ0--2", "/dev/sda")
+        b.wait_in_text("#smart-status", "1 disk is failing")
+        b.click("#smart-status a")
+        b.enter_page("/storage")
+        b.wait_visible(self.card("Storage"))
+        b.wait_visible(self.card_row("Storage", name="sda"))
+        b.wait_visible(self.card_row("Storage", name="sda") + " .ct-icon-times-circle")
+
+        # new disk, no failing sectors
+        self.set_smart_dump("MCCOE64GEMPP--2.9.09", "/dev/sda")
+
         b.wait_visible(self.card("Storage"))
         self.click_card_row("Storage", name="sda")
         b.wait_visible(self.card("Device health (SMART)"))
         check_smart_info("Disk is OK", "1 hours", "Successful")
 
         # Disk with running self test
-        set_smart_dump("SAMSUNG_MMCQE28G8MUP--0VA_VAM08L1Q", "/dev/sda")
+        self.set_smart_dump("SAMSUNG_MMCQE28G8MUP--0VA_VAM08L1Q", "/dev/sda")
         check_smart_info("Disk is OK", "2417 hours", "In progress, 30%")
 
         # Interrupted self test, disk is OK
-        set_smart_dump("INTEL_SSDSA2MH080G1GC--045C8820", "/dev/sda")
+        self.set_smart_dump("INTEL_SSDSA2MH080G1GC--045C8820", "/dev/sda")
         check_smart_info("Disk is OK", "2309 hours", "Interrupted")
 
         # latest libblockdev builds (since 3.3.0-99) from copr have different behavior when assessing disk as failed
         has_new_libblockdev = self.has_new_libblockdev()
 
         # Aborted self test and has known bad sector (overall assessment is still OK)
-        set_smart_dump("ST9160821AS--3.CLH", "/dev/sda")
+        self.set_smart_dump("ST9160821AS--3.CLH", "/dev/sda")
         if has_new_libblockdev:
             check_smart_info("Disk is OK", "556 hours", "Aborted", bad_sectors="1")
         else:
             check_smart_info("Disk is failing", "556 hours", "Aborted", bad_sectors="1")
 
         # Multiple bad sectors
-        set_smart_dump("Maxtor_96147H8--BAC51KJ0", "/dev/sda")
+        self.set_smart_dump("Maxtor_96147H8--BAC51KJ0", "/dev/sda")
         if has_new_libblockdev:
             check_smart_info("Disk is OK", "2016 hours", "Successful", bad_sectors="71")
         else:
             check_smart_info("Disk is failing", "2016 hours", "Successful", bad_sectors="71")
 
         # Multiple bad sectors with failing attribute
-        set_smart_dump("Maxtor_96147H8--BAC51KJ0--2", "/dev/sda")
+        self.set_smart_dump("Maxtor_96147H8--BAC51KJ0--2", "/dev/sda")
         check_smart_info("Disk is failing", "2262 hours", "Successful", bad_sectors="71", failing_attrs="1")
         b.wait_visible(self.card_desc("Device health (SMART)", "Assessment") + " .pf-m-danger")
 


### PR DESCRIPTION
Shows entry in Health card on the overview page about failing disks. Clicking on the warning redirects to the storage page where failing disk is highlighted with the same danger icon.

![image](https://github.com/user-attachments/assets/479acb8e-4fb1-4ea3-b8f8-b4a36b8d982e)
![image](https://github.com/user-attachments/assets/9be03468-7bba-4de8-815c-525e07dabb37)
