### PR TITLE
tmt: Don't fail if /dev/nvme* does not exist

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -27,8 +27,8 @@ fi
 # our tests, and only causes trouble; https://github.com/amazonlinux/amazon-ec2-utils/issues/37
 if rpm -q amazon-ec2-utils; then
     rpm -e --verbose amazon-ec2-utils
-    # clean up the symlinks
-    udevadm trigger /dev/nvme*
+    # clean up the symlinks, if they exist
+    udevadm trigger /dev/nvme* || true
 fi
 
 if grep -q 'ID=.*fedora' /etc/os-release && [ "$PLAN" = "main" ]; then


### PR DESCRIPTION
Robustify the amazon-ec2-utils workaround: Fedora 42 images don't seem to have /dev/nvme* any more, so don't fail on

> Failed to open the device '/dev/nvme*': No such device

Same fix as https://github.com/cockpit-project/cockpit-machines/commit/dcdf4988e4beb7

---

This broke https://github.com/fedora-selinux/selinux-policy/pull/2594 recently.