### PR TITLE
lib: Fix http debug message crash

### DIFF
--- a/pkg/lib/cockpit.js
+++ b/pkg/lib/cockpit.js
@@ -2597,7 +2597,10 @@ function factory() {
                         http_debug("http", req.method, req.path, "failed:", resp.status, resp.reason);
                         dfd.reject(new HttpError(resp.status, resp.reason, message), body);
                     } else {
-                        http_debug("http", req.method, req.path, "succeeded:", resp.status);
+                        if (resp)
+                            http_debug("http", req.method, req.path, "succeeded:", resp.status);
+                        else
+                            http_debug("http", req.method, req.path, "failed without response");
                         dfd.resolve(body);
                     }
                 }


### PR DESCRIPTION
Commit cdcef6bd2e259 improved debug messagse of `cockpit.http`. However, the `else` code path runs not only on success, but also if `resp` is false-y (i.e. the initial `null`), which can happen when the request fails before any response is received. Fix the crash on trying to read `null.status`.

---

See https://github.com/cockpit-project/cockpit-podman/pull/2047, it broke [like this](https://cockpit-logs.us-east-1.linodeobjects.com/pull-2047-59010a46-20250312-092659-arch/log.html). no-test here as we don't use the http channel anywhere in cockpit. But I applied this to c-podman and it fixes the crash.