### PR TITLE
packit: Enable fedora-42 test

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -30,8 +30,7 @@ jobs:
     trigger: pull_request
     targets:
       - fedora-41
-      # https://pagure.io/fedora-infrastructure/issue/12389
-      # - fedora-42
+      - fedora-42
       - fedora-latest-stable-aarch64
       - fedora-rawhide
       - centos-stream-9-x86_64


### PR DESCRIPTION
This has worked for some time, and is enabled in all our other projects, we just forgot about it here.