### PR TITLE
tools: Fix Debian --build={all,any} FTBFS

### DIFF
--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -76,8 +76,7 @@ execute_after_dh_install-indep:
 	# avoid dh_missing failure
 	rm -r debian/tmp/usr/lib/python*
 
-# run pytests *after* installation, so that we can make sure that we installed the right files
-execute_after_dh_install-arch:
+	# run pytests *after* installation, so that we can make sure that we installed the right files
 ifeq (, $(findstring nocheck, $(DEB_BUILD_OPTIONS)))
 ifeq ($(shell . /etc/os-release; echo $${VERSION_ID:-unstable}),22.04)
 	NO_QUNIT=1 PYTHONPATH=$$(ls -d debian/cockpit-bridge/usr/lib/python3*/dist-packages) python3 -m pytest -vv -k 'not linter and not test_descriptions'


### PR DESCRIPTION
Commit 5d70a2ae53b4ab moved cockpit-bridge to "Architecture: all", so we cannot run the package pytest in `dh_install-arch` any more as the package isn't build there. Move it to `-indep` instead.

Taken from downstream:
https://salsa.debian.org/utopia-team/cockpit/-/commit/6587a3326

---

This broke the Debian release: https://buildd.debian.org/status/logs.php?pkg=cockpit&ver=335-1 We don't cover that in our CI as we build all binary packages together, not separately per arch as the buildds do.