### PR TITLE
workflows: obtain the last field and not line of dnf output

### DIFF
--- a/.github/workflows/trigger-anaconda.yml
+++ b/.github/workflows/trigger-anaconda.yml
@@ -45,7 +45,7 @@ jobs:
               sleep 60;
               if dnf copr enable -y packit/$COPR_NAME &&
                  out=$(dnf repoquery --refresh --repo='copr:*cockpit*' --queryformat '%{release}\n' --recent cockpit-bridge) &&
-                 stamp=$(echo $out | tail -n 1 | awk '{ split($0, v, "."); print substr(v[2], 0, 14)}') &&
+                 stamp=$(echo "$out" | tail -n 1 | awk '{ split($0, v, "."); print substr(v[2], 0, 14)}') &&
                  [ "$stamp" -gt "$PUSH_TIME" ]; then
                   exit 0
               fi


### PR DESCRIPTION
The shell echo does not emit newlines making `tail` return the whole line while we want the last field.

```
[jelle@toolbx cockpit]$ echo $out  | awk '{ split($NF, v, "."); print substr(v[2], 0, 14)}'
+ awk '{ split($NF, v, "."); print substr(v[2], 0, 14)}'
+ echo cockpit-bridge 1.20250317122026634830.pr21719.9.g24dcebd11.fc41 cockpit-bridge 1.20250317131220797557.pr21719.9.g3a52e099d.fc41
20250317131220
```