### PR TITLE
storage: Fix passphrase remembering with "Reuse encryption"

### DIFF
--- a/pkg/storaged/block/format-dialog.jsx
+++ b/pkg/storaged/block/format-dialog.jsx
@@ -596,7 +596,7 @@ function format_dialog_internal(client, path, start, size, enable_dos_extended, 
                     const path = new_path || block.path;
                     const new_block = await client.wait_for(() => client.blocks[path]);
 
-                    if (is_encrypted(vals))
+                    if (is_encrypted(vals) && vals.passphrase)
                         remember_passphrase(new_block, vals.passphrase);
 
                     if (is_encrypted(vals) && is_filesystem(vals) && vals.mount_options?.ro) {

--- a/test/verify/check-storage-anaconda
+++ b/test/verify/check-storage-anaconda
@@ -146,13 +146,21 @@ class TestStorageAnaconda(storagelib.StorageCase):
                                       }
                                   })
 
-        # Activate and mount again, to check location in tear down information
+        # Activate
         b.click(self.card_button("Inactive logical volume", "Activate"))
-        b.click(self.card_button("Filesystem", "Mount"))
+
+        # Crypto is locked.  Unlock and mount via the "Reuse existing
+        # encryption" mode of the Format dialog
+        self.click_card_dropdown("Filesystem", "Format")
         self.dialog_wait_open()
-        self.dialog_set_val("passphrase", "vainu-reku-toma-rolle-kaja")
+        self.dialog_wait_val("crypto", " keep")
+        self.dialog_set_val("old_passphrase", "vainu-reku-toma-rolle-kaja")
+        b.set_checked("#dialog-confirm", val=True)
         self.dialog_apply()
         self.dialog_wait_close()
+
+        # Passphrase should still be remembered
+        self.expectExportedDevicePassphrase("/dev/vgroup0/lvol0", "vainu-reku-toma-rolle-kaja")
 
         # Check and delete volume group
         b.click(self.card_parent_link())


### PR DESCRIPTION
The Format dialog does remember the passphrase used to unlock a device in the "Reuse existing encryption" scenario, via the call to unlock_with_type.

However, later on it would erroneously call "remember_passphrase" with "undefined" during "maybe_mount", which would delete the previously remembered passphrase.  We avoid that now.