### PR TITLE
storage: Stratis 3.8 emergency fixes

### DIFF
--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -1468,6 +1468,12 @@ function stratis3_start() {
                                                                                    "/org/storage/stratis3",
                                                                                    { watch: false });
 
+                // HACK - give us a sneak preview of the "r8"
+                // manager. It is used to start V2 pools.
+                client.stratis_manager_r8 = stratis.proxy(
+                    "org.storage.stratis3.Manager.r8",
+                    "/org/storage/stratis3");
+
                 return stratis.watch({ path_namespace: "/org/storage/stratis3" }).then(() => {
                     client.stratis_manager.client.addEventListener('notify', (event, data) => {
                         client.update();

--- a/pkg/storaged/stratis/stratis3-start-pool.py
+++ b/pkg/storaged/stratis/stratis3-start-pool.py
@@ -1,0 +1,11 @@
+import sys
+
+import dbus
+
+reply = dbus.SystemBus().call_blocking('org.storage.stratis3', '/org/storage/stratis3',
+                                       'org.storage.stratis3.Manager.r8', 'StartPool',
+                                       'ss(b(bu))(bh)',
+                                       [sys.argv[1], 'uuid', [True, [False, 0]], [sys.argv[2] == "passphrase", 0]])
+if reply[1] != 0:
+    sys.stderr.write(reply[2] + '\n')
+    sys.exit(1)

--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -18,6 +18,7 @@
 # along with Cockpit; If not, see <https://www.gnu.org/licenses/>.
 
 import subprocess
+import time
 
 import packagelib
 import storagelib
@@ -639,6 +640,9 @@ class TestStorageStratisReboot(storagelib.StorageCase):
         self.dialog_apply()
         self.dialog_wait_close()
         b.wait_in_text(self.card_row("Encrypted Stratis pool", name=dev_3), "cache")
+
+        # HACK - https://github.com/stratis-storage/stratisd/issues/3810
+        time.sleep(60)
 
         self.reboot()
         m.start_cockpit()

--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -886,6 +886,8 @@ class TestStorageStratisNBDE(packagelib.PackageCase, storagelib.StorageCase):
 
         self.stop_type_opt = get_stratis_stop_type_opt(self.machine.execute)
 
+        self.stratis_version = list(map(int, self.machine.execute("stratis daemon version").split(".")))
+
     def testBasic(self):
         m = self.machine
         b = self.browser
@@ -941,10 +943,16 @@ class TestStorageStratisNBDE(packagelib.PackageCase, storagelib.StorageCase):
         tang_m.execute("systemctl stop tangd.socket")
         b.click(self.card_button("Stratis pool", "Start"))
         self.dialog_wait_open()
-        # stratis' error message for unreachable tang server is very poor:
-        # https://bugzilla.redhat.com/show_bug.cgi?id=2246920 Version < 3.6.0 said
-        # "Error communicating with server 10.111.112.5", check this again after fixing
-        b.wait_in_text("#dialog", "Error")
+        if self.stratis_version >= [3, 8, 0]:
+            # For V2 pools (created by Stratis 3.8.0 and later),
+            # Cockpit doesn't know whether they have a passphrase or
+            # not. So it asks always.
+            self.dialog_wait_val("passphrase", "")
+        else:
+            # stratis' error message for unreachable tang server is very poor:
+            # https://bugzilla.redhat.com/show_bug.cgi?id=2246920 Version < 3.6.0 said
+            # "Error communicating with server 10.111.112.5", check this again after fixing
+            b.wait_in_text("#dialog", "Error")
         self.dialog_cancel()
         self.dialog_wait_close()
 


### PR DESCRIPTION
Stratis 3.8 has introduced V2 metadata for pools, and those pools need to be started with the R8 StartPool method. Let's hack our way to success.

 - We need to use the "r8" revision of the D-Bus API to identify stopped V2 pools, but we can't unconditionally switch over to it since we still need to support older Stratises.
 - Conditionally using r8 when available and falling back to r6 makes sense, but might turn into a bit of work.
 - So the plan is to look into the r8 StoppedPools property to figure out whether a given pool needs the r8 StartPool method, and then use it.
 - The r8 StartPool method takes a filehandle for delivering the passphrase (just like the r6 SetKey method), so we need a little Python helper to invoke it.

Also, StoppedPools has a "name" attribute now, which we should use in preference of the UUID for stopped pools.

Also also, there is a mapper device visible now in Cockpit that needs to be hidden, `/dev/mapper/stratis-1-private-69ab132dacda40f698db089ed79cd94d-crypt`.

The non-hacky, permanent solution is to use the r8 API for everything when it is available, and fall back to r6 otherwise.