### PR TITLE
lib: Fix `FileAutoComplete` setState calls

### DIFF
--- a/pkg/lib/cockpit-components-file-autocomplete.jsx
+++ b/pkg/lib/cockpit-components-file-autocomplete.jsx
@@ -74,6 +74,9 @@ export class FileAutoComplete extends React.Component {
             }
         };
         this.debouncedChange = debounce(300, this.onPathChange);
+    }
+
+    componentDidMount() {
         this.onPathChange(this.state.value);
     }
 


### PR DESCRIPTION
Within the constructor for `FileAutoComplete` it was calling
`this.onPathChange`, but as the component wasn't running this was
never executed. Instead React complained in console about it being a
no-operation call.

In short, you cannot call `this.setState` in the constructor as the
component isn't mounted. So to fix this I just moved the call to the
`componentDidMount()`