### PR TITLE
pkg/user: Retrieve login def from /usr/etc/login.defs if exists

### DIFF
--- a/pkg/users/users.js
+++ b/pkg/users/users.js
@@ -36,6 +36,7 @@ import { AccountsMain } from "./accounts-list.js";
 import { AccountDetails } from "./account-details.js";
 
 import "./users.scss";
+import { fsinfo } from 'cockpit/fsinfo';
 
 superuser.reload_page_on_change();
 
@@ -91,7 +92,14 @@ function AccountsPage() {
         const handleShadow = cockpit.file("/etc/shadow", { superuser: "try" });
         handleShadow.watch(() => debouncedGetLoginDetails(), { read: false });
 
-        const handleLogindef = cockpit.file("/etc/login.defs");
+        let handleLogindef;
+        try {
+            await fsinfo("/etc/login.defs", []);
+            handleLogindef = cockpit.file("/etc/login.defs");
+        } catch (ex) {
+            handleLogindef = cockpit.file("/usr/etc/login.defs");
+        }
+
         handleLogindef.watch((logindef) => {
             if (logindef === null)
                 return;


### PR DESCRIPTION
Morning! Just a small one, in cases where only root exists (otherwise it runs off the last uid it finds) the system will only grab login definitions from /etc/login.defs, this updates the behavior to also check against /usr/etc/login.defs if it's not overwritten