### PR TITLE
failures: Update grid of early failure page

### DIFF
--- a/pkg/shell/failures.tsx
+++ b/pkg/shell/failures.tsx
@@ -81,7 +81,7 @@ const EarlyFailureReady = ({
 }) => {
     return (
         <div id="early-failure-ready" className="curtains-ct">
-            <Page>
+            <Page className="no-masthead-sidebar">
                 <PageSection hasBodyWrapper={false}>
                     <EmptyStatePanel {... !loading ? { icon: ExclamationCircleIcon } : {} }
                                      loading={loading}


### PR DESCRIPTION
Update early failure page to match new grid layout for iframes.

Relates-to: #21651