### PR TITLE
pf6: use switch label instead of helper text

### DIFF
--- a/pkg/kdump/kdump-view.jsx
+++ b/pkg/kdump/kdump-view.jsx
@@ -551,8 +551,8 @@ ${enableCrashKernel}
             kdumpSwitch = (<Switch isChecked={!!serviceRunning}
                 onChange={this.props.onSetServiceState}
                 aria-label={_("kdump status")}
+                label={serviceRunning ? _("Enabled") : _("Disabled")}
                 isDisabled={this.props.stateChanging} />);
-            kdumpSwitchHelper = serviceRunning ? _("Enabled") : _("Disabled");
         }
 
         let alertMessage;
@@ -595,9 +595,10 @@ ${enableCrashKernel}
                             {_("Kernel crash dump")}
                         </Title>
                         {kdumpSwitch}
-                        <HelperText>
-                            <HelperTextItem variant="indeterminate">{kdumpSwitchHelper}</HelperTextItem>
-                        </HelperText>
+                        {kdumpSwitchHelper &&
+                            <HelperText className="subtle-helper-text">
+                                <HelperTextItem>{kdumpSwitchHelper}</HelperTextItem>
+                            </HelperText>}
                         {automationButton}
                     </Flex>
                 </PageSection>

--- a/pkg/kdump/kdump.scss
+++ b/pkg/kdump/kdump.scss
@@ -32,3 +32,12 @@
   max-block-size: 200px;
   overflow-y: auto;
 }
+
+// use same spacing as spacing between card title and switch
+.pf-v6-c-switch {
+  --pf-v6-c-switch--ColumnGap: var(--pf-t--global--spacer--md);
+}
+
+.subtle-helper-text .pf-v6-c-helper-text__item-text {
+  color: var(--pf-t--global--text--color--subtle);
+}

--- a/pkg/networkmanager/firewall-switch.jsx
+++ b/pkg/networkmanager/firewall-switch.jsx
@@ -18,7 +18,6 @@
  */
 import cockpit from "cockpit";
 import React from "react";
-import { HelperText, HelperTextItem } from "@patternfly/react-core/dist/esm/components/HelperText/index.js";
 import { Switch } from "@patternfly/react-core/dist/esm/components/Switch/index.js";
 import { Tooltip } from "@patternfly/react-core/dist/esm/components/Tooltip/index.js";
 
@@ -62,6 +61,7 @@ export class FirewallSwitch extends React.Component {
                         id='networking-firewall-switch'
                         className='networking-firewall-switch'
                         onChange={this.onSwitchChanged}
+                        label={enabled ? _("Enabled") : _("Disabled")}
                         aria-label={enabled ? _("Not authorized to disable the firewall") : _("Not authorized to enable the firewall")}
                         isDisabled />
             </Tooltip>;
@@ -71,15 +71,9 @@ export class FirewallSwitch extends React.Component {
                                     className='networking-firewall-switch'
                                     isDisabled={!!this.state.pendingTarget}
                                     onChange={this.onSwitchChanged}
+                                    label={enabled ? _("Enabled") : _("Disabled")}
                                     aria-label={enabled ? _("Disable the firewall") : _("Enable the firewall")} />;
         }
-        return (
-            <>
-                {firewallOnOff}
-                <HelperText>
-                    <HelperTextItem variant="indeterminate">{enabled ? _("Enabled") : _("Disabled")}</HelperTextItem>
-                </HelperText>
-            </>
-        );
+        return firewallOnOff;
     }
 }

--- a/pkg/networkmanager/networking.scss
+++ b/pkg/networkmanager/networking.scss
@@ -163,6 +163,11 @@ th {
   }
 }
 
+// use same spacing as spacing between card title and switch
+#networking-firewall-summary .pf-v6-c-switch {
+  --pf-v6-c-switch--ColumnGap: var(--pf-t--global--spacer--md);
+}
+
 /********** Firewall section **********/
 
 #add-services-dialog {


### PR DESCRIPTION
Fixes helper texts from this:
![image](https://github.com/user-attachments/assets/4cca2a5f-4182-42bd-a767-73f4a96edb08)

to this:
![image](https://github.com/user-attachments/assets/eaedca5b-76a6-4954-bdce-f792ca0b1e18)
![image](https://github.com/user-attachments/assets/486b5f54-d94f-4c42-82e3-a9fe4556d52a)

Similarly for the kdump switch and I kept the behavior where switch isn't present when kdump is unavailable on the system.