### PR TITLE
topnav: Call `read_os_release()` when mounted

### DIFF
--- a/pkg/shell/topnav.tsx
+++ b/pkg/shell/topnav.tsx
@@ -77,12 +77,11 @@ export class TopNav extends React.Component {
             theme: localStorage.getItem('shell:style') || 'auto',
         };
 
-        read_os_release().then(os => this.setState({ osRelease: os || {} }));
-
         this.handleClickOutside = () => this.setState({ menuOpened: false, docsOpened: false });
     }
 
     componentDidMount() {
+        read_os_release().then(os => this.setState({ osRelease: os || {} }));
         /* This is a HACK for catching lost clicks on the pages which live in iframes so as to close dropdown menus on the shell.
          * Note: Clicks on an <iframe> element won't trigger document.documentElement listeners, because it's literally different page with different security domain.
          * However, when clicking on an iframe moves focus to its content's window that triggers the main window.blur event.


### PR DESCRIPTION
This changes the setState to be called when component is mounted instead
as it is otherwise not advisable from React's side.