### PR TITLE
cockpit: Port to Python 3.14, fix SubprocessTransport

### DIFF
--- a/src/cockpit/transports.py
+++ b/src/cockpit/transports.py
@@ -323,6 +323,10 @@ class SubprocessTransport(_Transport, asyncio.SubprocessTransport):
 
     @staticmethod
     def _get_watcher(loop: asyncio.AbstractEventLoop) -> asyncio.AbstractChildWatcher:
+        if hasattr(loop, '_watcher'):
+            # Python 3.14 event loop always has a child process watcher
+            return loop._watcher
+
         quark = '_cockpit_transports_child_watcher'
         watcher = getattr(loop, quark, None)
 


### PR DESCRIPTION
Python 3.14 removed asyncio.SafeChildWatcher and other classes and functions related to "child process watcher". Instead of creating our own watcher, just reuse the event loop watcher which always exists on Python 3.14.

https://bugzilla.redhat.com/show_bug.cgi?id=2350287