### PR TITLE
Revert "storage: Use mdraid metadata version 1.0 when in Anaconda mode"

### DIFF
--- a/pkg/storaged/mdraid/create-dialog.jsx
+++ b/pkg/storaged/mdraid/create-dialog.jsx
@@ -20,44 +20,10 @@
 import cockpit from "cockpit";
 import client from "../client";
 
-import {
-    mdraid_name, validate_mdraid_name, get_available_spaces, prepare_available_spaces,
-    encode_filename, decode_filename
-} from "../utils.js";
+import { mdraid_name, validate_mdraid_name, get_available_spaces, prepare_available_spaces } from "../utils.js";
 import { dialog_open, TextInput, SelectOne, SelectSpaces } from "../dialog.jsx";
 
 const _ = cockpit.gettext;
-
-async function mdraid_create(members, level, name, chunk, metadata_version) {
-    if (!metadata_version || client.at_least("2.11")) {
-        const opts = { };
-        if (metadata_version)
-            opts.version = { t: "ay", v: encode_filename(metadata_version) };
-        await client.manager.MDRaidCreate(members, level, name, chunk, opts);
-    } else {
-        // Let's call mdadm explicitly if we need to set the metadata
-        // version and UDisks2 is older than 2.11.
-
-        // The member block devices are all empty already and we don't
-        // need to wipe them.  We need to wait for their D-Bus proxies
-        // since they might have just been created by
-        // prepare_available_spaces.
-
-        const devs = [];
-        for (const path of members) {
-            devs.push(decode_filename((await client.wait_for(() => client.blocks[path])).PreferredDevice));
-        }
-
-        await cockpit.spawn([
-            "mdadm", "--create", name, "--run",
-            "--level=" + level,
-            ...(chunk ? ["--chunk=" + String(chunk / 1024)] : []),
-            "--metadata=" + metadata_version,
-            "--raid-devices=" + String(devs.length),
-            ...devs
-        ], { superuser: "require", err: "message" });
-    }
-}
 
 export function create_mdraid() {
     function mdraid_exists(name) {
@@ -145,14 +111,10 @@ export function create_mdraid() {
         Action: {
             Title: _("Create"),
             action: function (vals) {
-                // When in Anaconda mode, we explicitly use metadata
-                // version 1.0 since the default doesn't work for
-                // things that the bootloaders need to access.
-                //
-                const metadata_version = client.in_anaconda_mode() ? "1.0" : null;
-
                 return prepare_available_spaces(client, vals.disks).then(paths => {
-                    return mdraid_create(paths, vals.level, vals.name, (vals.chunk || 0) * 1024, metadata_version);
+                    return client.manager.MDRaidCreate(paths, vals.level,
+                                                       vals.name, (vals.chunk || 0) * 1024,
+                                                       { });
                 });
             }
         }

--- a/test/verify/check-storage-anaconda
+++ b/test/verify/check-storage-anaconda
@@ -487,7 +487,6 @@ class TestStorageAnaconda(storagelib.StorageCase):
 
     def testMDRaid(self):
         b = self.browser
-        m = self.machine
 
         disk1 = self.add_loopback_disk(name="loop10")
         disk2 = self.add_loopback_disk(name="loop11")
@@ -511,9 +510,6 @@ class TestStorageAnaconda(storagelib.StorageCase):
         self.dialog_wait_close()
         # Stop the raid array in case the test fails otherwise losetup can't release the devices
         self.addCleanup(self.machine.execute, "if [ -b /dev/md/raid0 ]; then mdadm --stop /dev/md/raid0; fi;")
-
-        # Check that metadata version is "1.0"
-        self.assertIn("Version : 1.0", m.execute("mdadm --detail /dev/md/raid0"))
 
         # Create a partition with a filesystem on it
         self.click_dropdown(self.card_row("Storage", name="md/raid0"), "Create partition table")

--- a/test/verify/check-storage-mdraid
+++ b/test/verify/check-storage-mdraid
@@ -111,9 +111,6 @@ class TestStorageMdRaid(storagelib.StorageCase):
         self.dialog_wait_close()
         b.wait_visible(self.card_row("Storage", name="/dev/md/raid0"))
 
-        # Check that metadata version is "1.2"
-        self.assertIn("Version : 1.2", m.execute("mdadm --detail /dev/md/raid0"))
-
         self.addCleanup(m.execute, "if [ -e /dev/md/raid0 ]; then mdadm --stop /dev/md/raid0; fi")
         self.addCleanup(m.execute, "mount | grep ^/dev/md | cut -f1 -d' ' | xargs -r umount")
 


### PR DESCRIPTION
parted does not recognize mdraid format 1.0 on GPT tables,
so the cure was worse than the fix. Instead, anaconda will forbit
putting /boot on mdraid for the time being.
See https://bugzilla.redhat.com/show_bug.cgi?id=2355346

This reverts commit 5e0a4e48a0df9c46bf70a900d5951630eefa340f.
