### PR TITLE
tls: Fix inconsistent spaces in self-signed SSL certificate

### DIFF
--- a/src/tls/cockpit-certificate-helper.in
+++ b/src/tls/cockpit-certificate-helper.in
@@ -50,8 +50,8 @@ selfsign_openssl() {
         -outform PEM \
         -subj "${MACHINE_ID:+/O=${MACHINE_ID}}/CN=${HOSTNAME}" \
         -addext "subjectAltName=IP:127.0.0.1,DNS:localhost" \
-        -addext "basicConstraints = critical, CA:TRUE" \
-        -addext "keyUsage = critical, digitalSignature,cRLSign,keyCertSign,keyEncipherment,keyAgreement" \
+        -addext "basicConstraints = critical,CA:TRUE" \
+        -addext "keyUsage = critical,digitalSignature,cRLSign,keyCertSign,keyEncipherment,keyAgreement" \
         -addext "extendedKeyUsage = serverAuth"
 }
 


### PR DESCRIPTION
This had no deeper reason -- c-c-helper was introduced in commit 1cd8af0f5fdf copying it from the old cockpitcertificate.c. There it was introduced in commit eb1fc2028c as a mere typo/copy pasta due to the already inconsistent spacing in the existing CA parameters.

---

Leftover from https://github.com/cockpit-project/cockpit/pull/21773#pullrequestreview-2716855351