### PR TITLE
patternfly: Override expand and select for tables

### DIFF
--- a/pkg/lib/patternfly/patternfly-6-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-6-overrides.scss
@@ -455,3 +455,17 @@ to wrap around when there isn't enough space.
 :root[dir="rtl"] {
   --pf-v6-global--inverse--multiplier: -1;
 }
+
+// NOTEs @Venefilyn: Expandable table has an alignment issue with the expand button and the text
+// Tracked upstream here https://github.com/patternfly/patternfly/issues/7423
+.pf-v6-c-table.pf-m-compact .pf-v6-c-table__toggle {
+  --pf-v6-c-table--m-compact__action--PaddingBlockStart: 0
+}
+
+// NOTE @Venefilyn: Selectable table has an alignment issue with the expand button and the text
+// Tracked upstream here https://github.com/patternfly/patternfly/issues/7424
+.pf-v6-c-table__td.pf-v6-c-table__check {
+  // We add 0.125 rem which isn't on PF's spacers variable list, that aligns nicely with
+  // the correct sizing (becomes 10px on compact table, 18px on normal table)
+  padding-block-start: calc(var(--pf-v6-c-table--cell--PaddingBlockStart) + 0.125rem)
+}


### PR DESCRIPTION
With our migration to PF6 we noticed that there is an alignment issue
within PF Tables when it comes to expand button and the select checkbox
itself. They were aligned with the text in the bottom rather than in the
middle.

This fix changes the padding so that it all aligns as good as possible.

Two upstream issues created:
- https://github.com/patternfly/patternfly/issues/7423
- https://github.com/patternfly/patternfly/issues/7424

With the fixes:
![image](https://github.com/user-attachments/assets/347cf709-d791-4bdb-84ea-295876210d4f)

Without the fixes:
![image](https://github.com/user-attachments/assets/494771b3-2ab4-4b7c-a722-b0b9bbe28376)

--- 

As well as for normal (not compacted) table
With the fixes:
![image](https://github.com/user-attachments/assets/a7b374ad-d29d-4d3a-824f-aa87458bfc8e)

Without the fixes:
![image](https://github.com/user-attachments/assets/35c572f0-f9a7-4223-b434-8e22f2c8fa6e)

Relates-to: #21651