### PR TITLE
shell: Change hostname boldness

### DIFF
--- a/pkg/shell/nav.scss
+++ b/pkg/shell/nav.scss
@@ -310,7 +310,7 @@ $desktop: $phone + 1px;
 
   .hostname {
     display: block;
-    font-weight: var(--pf-t--global--font--weight--heading--bold);
+    font-weight: var(--pf-t--global--font--weight--heading--default);
     overflow: hidden;
     text-overflow: ellipsis;
   }


### PR DESCRIPTION
With the new font I accidentally set the boldness to be too bold. We can
default to just normal header bold and it'll look much better.

Before and after
![image](https://github.com/user-attachments/assets/dfce802c-3789-4bda-b68d-6e0a4d18fc59) ![image](https://github.com/user-attachments/assets/8c137583-4edb-4528-8842-e457ee12417a)

Relates-to: #21651
Signed-off-by: Freya Gustavsson <freya@venefilyn.se>