### PR TITLE
shell: Update about modal to PF6

### DIFF
--- a/files.js
+++ b/files.js
@@ -124,6 +124,7 @@ const info = {
         "shell/images/server-large.png",
         "shell/images/server-small.png",
         "shell/images/cockpit-icon.svg",
+        "shell/images/cockpit-icon-gray.svg",
         "shell/images/bg-plain.jpg",
         "shell/index.html",
         "shell/shell.html",

--- a/pkg/shell/images/cockpit-icon-gray.svg
+++ b/pkg/shell/images/cockpit-icon-gray.svg
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 32 32"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="cockpit-icon-gray.svg"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview2"
+     pagecolor="#ffffff"
+     bordercolor="#999999"
+     borderopacity="1"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="23.84375"
+     inkscape:cx="16.02097"
+     inkscape:cy="16"
+     inkscape:window-width="1920"
+     inkscape:window-height="981"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g2" />
+  <defs
+     id="defs1" />
+  <g
+     fill="#fff"
+     class="ct-icon"
+     id="g2">
+    <path
+       class="ct-icon-circle"
+       d="M16 0A16 16 0 000 16a16 16 0 0016 16 16 16 0 0016-16A16 16 0 0016 0zm0 2.5A13.5 13.5 0 0129.5 16 13.5 13.5 0 0116 29.5 13.5 13.5 0 012.5 16 13.5 13.5 0 0116 2.5z"
+       id="path1"
+       style="fill:#a3a3a3;fill-opacity:1" />
+    <path
+       class="ct-icon-plane"
+       d="M21.26 10c-.664-.024-1.67.498-2.575 1.398l-1.951 1.94-5.846-1.963-1.14 1.177 4.408 3.35-.986.98c-.349.346-.64.71-.87 1.066l-2.652-.197-.648.656 2.641 1.956L13.571 23l.652-.653-.196-2.679c.334-.22.677-.494 1.005-.822l1.038-1.031 3.382 4.442 1.177-1.14-1.973-5.875 1.89-1.879c1.207-1.2 1.763-2.603 1.248-3.149-.13-.136-.313-.205-.534-.213z"
+       id="path2"
+       style="fill:#a3a3a3;fill-opacity:1" />
+  </g>
+</svg>

--- a/pkg/shell/shell-modals.tsx
+++ b/pkg/shell/shell-modals.tsx
@@ -64,9 +64,10 @@ export const AboutCockpitModal = ({ dialogResult }) => {
             isOpen
             onClose={() => dialogResult.resolve()}
             id="about-cockpit-modal"
+            aria-label="About Cockpit and its versions"
             trademark={_("Licensed under GNU LGPL version 2.1")}
             productName={_("Web Console")}
-            brandImageSrc="../shell/images/cockpit-icon.svg"
+            brandImageSrc="../shell/images/cockpit-icon-gray.svg"
             brandImageAlt={_("Web console logo")}
         >
             <Content component={ContentVariants.p}>

--- a/pkg/shell/shell.scss
+++ b/pkg/shell/shell.scss
@@ -238,11 +238,23 @@ $desktop: $phone + 1px;
 
 // Customize the about screen with the Cockpit logo
 .pf-v6-c-about-modal-box {
-  --pf-v5-c-about-modal-box--BackgroundImage: linear-gradient(#000d, #000d), url(../shell/images/cockpit-icon.svg);
-  --pf-v5-c-about-modal-box--BackgroundPosition: max(25rem, 143%) 10rem;
-  --pf-v5-c-about-modal-box--BackgroundSize--min-width: 786px;
+  // Gray is best as it works in both light and dark mode
+  // Ideally About modal should allow setting this through DOM instead of CSS
+  // so we can color it easier.
+  //
+  // Or we can see about modifying it inline in scss and changing color there somehow
+  --pf-v6-c-about-modal-box--BackgroundImage: url(../shell/images/cockpit-icon-gray.svg);
+  --pf-v6-c-about-modal-box--BackgroundPosition: max(25rem, 143%) 10rem;
+  --pf-v6-c-about-modal-box--BackgroundSize--min-width: 786px;
+
+  .pf-v6-c-content {
+    /* Don't wrap package names */
+    --pf-v6-c-content--dl--GridTemplateColumns--dt: auto;
+    /* Tidy up the vertical space usage between packages */
+    --pf-v6-c-content--dl--RowGap: var(--pf-t--global--spacer--sm);
+  }
 
   [dir="rtl"] {
-    --pf-v5-c-about-modal-box--BackgroundPosition: calc(100% - 30rem) 10rem;
+    --pf-v6-c-about-modal-box--BackgroundPosition: calc(100% - 30rem) 10rem;
   }
 }

--- a/test/verify/check-shell-menu
+++ b/test/verify/check-shell-menu
@@ -79,6 +79,8 @@ class TestMenu(testlib.MachineCase):
         if not m.ostree_image:
             pkgname = "cockpit" if m.image == "arch" else "cockpit-bridge"
             b.wait_visible(f'#about-cockpit-modal:contains("{pkgname}")')
+            b.assert_pixels('.pf-v6-c-modal-box:has(#about-cockpit-modal)', "about-cockpit-modal",
+                            mock={".pf-v6-c-content--dd": "v1234"})
         b.click('.pf-v6-c-about-modal-box__close button')
         b.wait_not_present('#about-cockpit-modal')
 


### PR DESCRIPTION
Should take care of the last few pf-v5 items inside of shell.scss while also giving us the about modal back to how it was before.

To make the svg work in both dark and light mode I've introduced a gray svg variant that uses `#A3A3A3`.

Ideally, if we could modify this during build-time that would be best, but that involves figuring out image manipulation with scss and I have no experience with that. So instead this introduces a new file for the purpose instead.

Light mode
![image](https://github.com/user-attachments/assets/5458736c-0e97-4e79-9251-0b1e6f52aeee)

Dark mode
![image](https://github.com/user-attachments/assets/2ca04b16-4fa6-4ab1-85fd-7bb29fa59b1b)

Relates-to: #21651