### PR TITLE
storaged: Show correct usage for unmounted btrfs filesystems

### DIFF
--- a/pkg/storaged/btrfs/btrfs-tool.py
+++ b/pkg/storaged/btrfs/btrfs-tool.py
@@ -139,15 +139,24 @@ def poll(opt_mount):
     info = {}
     for fs in filesystems.values():
         mp = get_mount_point(fs, opt_mount)
-        if mp:
-            try:
-                info[fs['uuid']] = {
-                    'subvolumes': get_subvolume_info(mp),
-                    'default_subvolume': get_default_subvolume(mp),
-                    'usages': get_usages(fs['uuid']),
-                }
-            except Exception as err:
-                info[fs['uuid']] = {'error': str(err)}
+        try:
+            usages = get_usages(fs['uuid'])
+
+            if mp:
+                subvolumes = get_subvolume_info(mp)
+                default_subvolume = get_default_subvolume(mp)
+            else:
+                subvolumes = None
+                default_subvolume = None
+
+            info[fs['uuid']] = {
+                'subvolumes': subvolumes,
+                'default_subvolume': default_subvolume,
+                'usages': usages,
+            }
+        except Exception as err:
+            info[fs['uuid']] = {'error': str(err)}
+
     return info
 
 

--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -308,9 +308,15 @@ function btrfs_update(data) {
         if (data[uuid].error) {
             console.warn("Error polling btrfs", uuid, data[uuid].error);
         } else {
-            uuids_subvols[uuid] = [{ pathname: "/", id: 5, parent: null }].concat(data[uuid].subvolumes);
-            uuids_usage[uuid] = data[uuid].usages;
-            default_subvol[uuid] = data[uuid].default_subvolume;
+            if (data[uuid].subvolumes) {
+                uuids_subvols[uuid] = [{ pathname: "/", id: 5, parent: null }].concat(data[uuid].subvolumes);
+            }
+            if (data[uuid].usages) {
+                uuids_usage[uuid] = data[uuid].usages;
+            }
+            if (data[uuid].default_subvolume) {
+                default_subvol[uuid] = data[uuid].default_subvolume;
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #20852

The 'btrfs filesystem show' command works even for unmounted filesystems, but btrfs-tool.py skips the filesystem if it's not mounted. Therefore, we can run the command whether the filesystem is mounted or not to find its usage.