### PR TITLE
storage: Round size slider value in one more case

### DIFF
--- a/pkg/storaged/dialog.jsx
+++ b/pkg/storaged/dialog.jsx
@@ -1052,7 +1052,7 @@ class SizeSliderElement extends React.Component {
             if (val.unit)
                 onChange({ text: val.text, unit: Number(u) });
             else
-                onChange(val / unit * Number(u));
+                onChange(size_slider_round(val / unit * Number(u), round));
             this.setState({ unit: Number(u) });
         };
 


### PR DESCRIPTION
The value should always be rounded, except when it is split into text and unit.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2352526