### PR TITLE
storage: Navigate via explicit links in tables

### DIFF
--- a/pkg/storaged/btrfs/device.jsx
+++ b/pkg/storaged/btrfs/device.jsx
@@ -40,7 +40,10 @@ export function make_btrfs_device_card(next, backing_block, content_block, block
 
     const btrfs_card = new_card({
         title: _("btrfs device"),
-        location: label || uuid,
+        location: {
+            label: label || uuid,
+            to: ["btrfs-volume", uuid],
+        },
         next,
         component: BtrfsDeviceCard,
         props: { backing_block, content_block },

--- a/pkg/storaged/lvm2/physical-volume.jsx
+++ b/pkg/storaged/lvm2/physical-volume.jsx
@@ -38,7 +38,10 @@ export function make_lvm2_physical_volume_card(next, backing_block, content_bloc
 
     const pv_card = new_card({
         title: _("LVM2 physical volume"),
-        location: vgroup ? vgroup.Name : null,
+        location: {
+            label: vgroup ? vgroup.Name : null,
+            to: vgroup ? ["vg", vgroup.Name] : null,
+        },
         next,
         page_size: (block_pvol
             ? <StorageUsageBar stats={[block_pvol.Size - block_pvol.FreeSize, block_pvol.Size]} short />

--- a/pkg/storaged/mdraid/mdraid-disk.jsx
+++ b/pkg/storaged/mdraid/mdraid-disk.jsx
@@ -39,7 +39,10 @@ export function make_mdraid_disk_card(next, backing_block, content_block) {
     const disk_card = new_card({
         title: _("MDRAID disk"),
         next,
-        location: mdraid_block ? block_short_name(mdraid_block) : (mdraid ? mdraid_name(mdraid) : null),
+        location: {
+            label: mdraid_block ? block_short_name(mdraid_block) : (mdraid ? mdraid_name(mdraid) : null),
+            to: mdraid ? ["mdraid", mdraid.UUID] : null,
+        },
         component: MDRaidDiskCard,
         props: { backing_block, content_block, mdraid },
         actions: [

--- a/pkg/storaged/pages.jsx
+++ b/pkg/storaged/pages.jsx
@@ -569,7 +569,7 @@ export const PageTable = ({ emptyCaption, aria_label, pages, crossrefs, sorted, 
                 step("TD", "previousElementSibling");
         }
 
-        function location_link(location) {
+        function location_link(id, location) {
             if (!location)
                 return null;
             if (typeof location == "string")
@@ -578,7 +578,7 @@ export const PageTable = ({ emptyCaption, aria_label, pages, crossrefs, sorted, 
                 return location.label;
 
             return (
-                <Button isInline variant="link" onClick={() => cockpit.location.go(location.to)}>
+                <Button ouiaId={id} isInline variant="link" onClick={() => cockpit.location.go(location.to)}>
                     <Truncate content={location.label} />
                 </Button>
             );
@@ -598,14 +598,14 @@ export const PageTable = ({ emptyCaption, aria_label, pages, crossrefs, sorted, 
                         <Split hasGutter>
                             { icon && <SplitItem>{icon}</SplitItem> }
                             <SplitItem isFilled>
-                                {location_link({ to: page.location, label: <strong>{name}</strong> })}
+                                {location_link("id-link", { to: page.location, label: <strong>{name}</strong> })}
                                 {info}
                             </SplitItem>
                             <SplitItem>{actions}</SplitItem>
                         </Split>
                         <Split hasGutter isWrappable>
                             <SplitItem>{type}</SplitItem>
-                            <SplitItem isFilled>{location_link(location)}</SplitItem>
+                            <SplitItem isFilled>{location_link("location-link", location)}</SplitItem>
                             <SplitItem isFilled className="pf-v6-u-text-align-end">{size}</SplitItem>
                         </Split>
                     </CardBody>
@@ -614,12 +614,12 @@ export const PageTable = ({ emptyCaption, aria_label, pages, crossrefs, sorted, 
             const cols = [
                 <Td key="1">
                     <div className="indent" style={ { "--level": level } }>
-                        {location_link({ to: page.location, label: name })}
+                        {location_link("id-link", { to: page.location, label: name })}
                         {info}
                     </div>
                 </Td>,
                 <Td key="2" modifier="nowrap">{type}</Td>,
-                <Td key="3" modifier="nowrap">{location_link(location)}</Td>,
+                <Td key="3" modifier="nowrap">{location_link("location-link", location)}</Td>,
                 <Td key="4" className="storage-size-column">{size}</Td>,
                 <Td key="5" className="pf-v6-c-table__action">{actions || <div /> }</Td>,
             ];

--- a/pkg/storaged/storage.scss
+++ b/pkg/storaged/storage.scss
@@ -266,11 +266,6 @@ td.job-action {
   border-block-end: 0 !important;
 }
 
-.ct-clickable-card:hover {
-    background: var(--pf-t--global--background--color--primary--hover);
-    cursor: pointer;
-}
-
 .storage-menu-title {
     text-align: start;
     white-space: nowrap !important;

--- a/pkg/storaged/storage.scss
+++ b/pkg/storaged/storage.scss
@@ -308,3 +308,10 @@ td.job-action {
     // 1rem: margin between text and progress bar
     padding-inline-end: calc(var(--pf-v6-c-table--cell--PaddingInlineEnd) + 3.5rem + 1rem) !important;
 }
+
+// HACK - https://github.com/patternfly/patternfly/issues/7255
+//        Bug - Truncate - removes underline from link
+
+.pf-v6-c-button .pf-v6-c-truncate span {
+    text-decoration: var(--pf-v6-c-button--TextDecorationLine) var(--pf-v6-c-button--TextDecorationStyle);
+}

--- a/pkg/storaged/stratis/blockdev.jsx
+++ b/pkg/storaged/stratis/blockdev.jsx
@@ -39,7 +39,10 @@ export function make_stratis_blockdev_card(next, backing_block, content_block) {
 
     const blockdev_card = new_card({
         title: _("Stratis block device"),
-        location: pool ? pool.Name : client.stratis_manager.StoppedPools[uuid]?.name?.v || uuid,
+        location: {
+            label: pool ? pool.Name : client.stratis_manager.StoppedPools[uuid]?.name?.v || uuid,
+            to: ["pool", pool ? pool.Uuid : uuid],
+        },
         next,
         component: StratisBlockdevCard,
         props: { backing_block, content_block, pool, stopped_pool: uuid },

--- a/test/common/storagelib.py
+++ b/test/common/storagelib.py
@@ -610,8 +610,7 @@ grubby --update-kernel=ALL --args="root=UUID=$uuid rootflags=defaults rd.luks.uu
             return pfx + f" tbody [data-test-row-location='{location}']"
 
     def click_card_row(self, title: str, index: int | None = None, name: str | None = None, location: str | None = None, table_index: int = 1) -> None:
-        # We need to click on a <td> element since that's where the handlers are...
-        self.browser.click(self.card_row(title, index, name, location, table_index) + " td:nth-child(1)")
+        self.browser.click(self.card_row(title, index, name, location, table_index) + " .indent button")
 
     def card_row_col(self, title: str, row_index: int | None = None, col_index: int | None = None,
                      row_name: str | None = None, row_location: str | None = None, table_index: int = 1) -> str:

--- a/test/common/storagelib.py
+++ b/test/common/storagelib.py
@@ -610,7 +610,7 @@ grubby --update-kernel=ALL --args="root=UUID=$uuid rootflags=defaults rd.luks.uu
             return pfx + f" tbody [data-test-row-location='{location}']"
 
     def click_card_row(self, title: str, index: int | None = None, name: str | None = None, location: str | None = None, table_index: int = 1) -> None:
-        self.browser.click(self.card_row(title, index, name, location, table_index) + " .indent button")
+        self.browser.click_button("id-link", self.card_row(title, index, name, location, table_index))
 
     def card_row_col(self, title: str, row_index: int | None = None, col_index: int | None = None,
                      row_name: str | None = None, row_location: str | None = None, table_index: int = 1) -> str:

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -735,6 +735,10 @@ class Browser:
         self.click(f"{menu_class} button:contains('{value}')")
         self.wait_not_present(menu_class)
 
+    def click_button(self, compid: str, prefix: str = "", component: str = "PF6/Button") -> None:
+        """Click on a button identified by its OUIA component id."""
+        self.click(f'{prefix} [data-ouia-component-type="{component}"][data-ouia-component-id="{compid}"]')
+
     def set_input_text(
         self, selector: str, val: str, append: bool = False, value_check: bool = True, blur: bool = True
     ) -> None:

--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -72,7 +72,7 @@ class TestStorageResize(storagelib.StorageCase):
         b.wait_text(self.card_row_col("LVM2 logical volumes", 1, 3), "/run/foo")
 
         if can_grow:
-            b.click(self.card_row_col("LVM2 logical volumes", 1, 1))
+            self.click_card_row("LVM2 logical volumes", 1)
             b.click(self.card_button("LVM2 logical volume", "Grow"))
             self.dialog_wait_open()
             self.dialog_wait_apply_enabled()
@@ -176,7 +176,7 @@ class TestStorageResize(storagelib.StorageCase):
         b.wait_text(self.card_row_col("LVM2 logical volumes", 1, 3), mountpoint)
 
         # Click on the card to check the label
-        b.click(self.card_row_col("LVM2 logical volumes", 1, 1))
+        self.click_card_row("LVM2 logical volumes", 1)
         b.wait_text(self.card_desc("ext4 filesystem", "Name"), "FSYS")
 
         # Grow the logical volume and let Cockpit grow the filesystem
@@ -247,7 +247,7 @@ class TestStorageResize(storagelib.StorageCase):
             self.dialog_apply()
             self.dialog_wait_close()
 
-        b.click(self.card_row_col("LVM2 logical volumes", 1, 1))
+        self.click_card_row("LVM2 logical volumes", 1)
         b.click(self.card_button("LVM2 logical volume", "Grow content"))
         confirm_with_passphrase()
         b.wait_not_present(self.card_button("LVM2 logical volume", "Grow content"))
@@ -330,14 +330,14 @@ class TestStorageResize(storagelib.StorageCase):
 
         fake_fstype("udf")  # UDF is a real filesystem type that UDisks knows about. It can definitely not be resized.
         b.wait_text(self.card_row_col("LVM2 logical volumes", 1, 2), "udf filesystem")
-        b.click(self.card_row_col("LVM2 logical volumes", 1, 1))
+        self.click_card_row("LVM2 logical volumes", 1)
         check_btn("Shrink", "udf can not be resized")
         check_btn("Grow", "udf can not be resized")
         b.click(".pf-v6-c-breadcrumb__link:contains('TEST')")
 
         fake_fstype("fake")  # This is not a real filesystem and UDisks2 knows nothing about it.
         b.wait_text(self.card_row_col("LVM2 logical volumes", 1, 2), "fake filesystem")
-        b.click(self.card_row_col("LVM2 logical volumes", 1, 1))
+        self.click_card_row("LVM2 logical volumes", 1)
         check_btn("Shrink", "fake can not be resized here")
         check_btn("Grow", "fake can not be resized here")
         b.click(".pf-v6-c-breadcrumb__link:contains('TEST')")


### PR DESCRIPTION
The Storage application of Cockpit is driven by a big tree of "storage objects" and the user navigates this tree mainly by selecting representations of these objects in lists.

The page for a storage object contains links back to its direct and indirect parents (in a breadcrumb trail), and a table that lists its children with a short description. There are also tables that list storage objects that are related to the current object in other ad-hoc ways, like the physical volumes of a volume groups, or the snapshots of a btrfs subvolume.

Currently, selecting a child from such a list in a table is done by clicking anywhere on the whole row. The row has a hover animation to indicate this.

However, a row also has a kebab dropdown with actions related to the storage object represented by that row.

This leads to an awkward implementation since we need to distinguish clicks on the row from clicks on the dropdown. It's also a slightly awkward and non-standard UX. I don't think any other table in Cockpit has clickable rows.

### Purpose

The purpose of this task is to replace clickable-rows with the more standard(?) pattern of links in the first column.  This removes the need for all trickiness and frees up the potential for other actions in other columns, such as turning the "Location" column into links to the volume groups, mdraids, etc that are already named there but couldn't be links.

Demo: https://youtu.be/NRxgyhK1ZX0

Pixel changes: https://github.com/cockpit-project/pixel-test-reference/compare/18d6709b0f2c7631c6f83530d85f86bf4c444f2a..6953b88420349a39a1b4965392f33e73fb7f4970

### TODO

- [x] #21726 
- [x] #21935 
- [x] figure out how to style something inside `<Truncate />` like a link
- [x] tests, coverage
- [x] Design review