### PR TITLE
fonts: Load in the older fonts as a backup

### DIFF
--- a/pkg/lib/patternfly/_fonts.scss
+++ b/pkg/lib/patternfly/_fonts.scss
@@ -1,0 +1,44 @@
+// NOTE @Venefilyn: This is here for backwards compatibility. The file should be removed at some point.
+// There are scenarios such as running tests for a plugin with a stable cockpit-shell/ws
+// Since those may be older, for now we should include the old fonts to make sure that the plugins
+// This allows plugins to still utilize the Red Hat fonts when testing plugins on or before Cockpit v336
+
+@mixin printRedHatFont(
+  $weightValue: 400,
+  $weightName: "Regular",
+  $familyName: "RedHatText",
+  $style: "normal",
+  $relative: true
+) {
+  $filePath: "../../static/fonts" + "/" + $familyName + "-" + $weightName;
+
+  @font-face {
+    font-family: $familyName;
+    src: url("#{$filePath}.woff2") format("woff2");
+    font-style: #{$style};
+    font-weight: $weightValue;
+    text-rendering: optimizelegibility;
+    font-display: fallback;
+  }
+}
+
+@include printRedHatFont(700, "Bold", $familyName: "RedHatDisplay");
+@include printRedHatFont(700, "BoldItalic", $style: "italic", $familyName: "RedHatDisplay");
+@include printRedHatFont(900, "Black", $familyName: "RedHatDisplay");
+@include printRedHatFont(900, "BlackItalic", $style: "italic", $familyName: "RedHatDisplay");
+@include printRedHatFont(300, "Italic", $style: "italic", $familyName: "RedHatDisplay");
+@include printRedHatFont(400, "Medium", $familyName: "RedHatDisplay");
+@include printRedHatFont(400, "MediumItalic", $style: "italic", $familyName: "RedHatDisplay");
+@include printRedHatFont(300, "Regular", $familyName: "RedHatDisplay");
+@include printRedHatFont(700, "Bold");
+@include printRedHatFont(700, "BoldItalic", $style: "italic");
+@include printRedHatFont(400, "Italic", $style: "italic");
+@include printRedHatFont(700, "Medium");
+@include printRedHatFont(700, "MediumItalic", $style: "italic");
+@include printRedHatFont(400, "Regular");
+@include printRedHatFont(700, "Bold", $familyName: "RedHatMono");
+@include printRedHatFont(700, "BoldItalic", $style: "italic", $familyName: "RedHatMono");
+@include printRedHatFont(400, "Italic", $style: "italic", $familyName: "RedHatMono");
+@include printRedHatFont(500, "Medium", $familyName: "RedHatMono");
+@include printRedHatFont(500, "MediumItalic", $style: "italic", $familyName: "RedHatMono");
+@include printRedHatFont(400, "Regular", $familyName: "RedHatMono");

--- a/pkg/lib/patternfly/patternfly-6-cockpit.scss
+++ b/pkg/lib/patternfly/patternfly-6-cockpit.scss
@@ -8,3 +8,10 @@ $pf-v6-global--disable-fontawesome: true !default; // Disable Font Awesome 5 Fre
   $pf-v6-global--fonticon-path: "patternfly-icons-fake-path"
 );
 @forward "@patternfly/patternfly/base";
+
+// NOTE @Venefilyn: This is here for backwards compatibility. Should be removed at some point
+// There are scenarios such as running tests for a plugin with a stable cockpit-shell/ws
+// Since those may be older, for now we should include the old fonts to make sure that the plugins
+// This allows plugins to still utilize the Red Hat fonts when testing plugins on or before Cockpit v336
+// Is related to distributions and their Cockpit versions.
+@forward "./fonts";


### PR DESCRIPTION
There are scenarios such as running tests for a plugin with a stable cockpit-shell/ws.
Since those may be older, for now we should include the old fonts to make sure that the plugins.
This allows plugins to still utilize the Red Hat fonts when testing plugins on or before Cockpit v336.

Within cockpit-podman the tests are run for the plugin on a stable host cockpit host. But if you load in the latest changes from cockpit for your plugin you wouldn't otherwise be able to load the fonts correctly as the latest changes didn't provide our older way of loading Red Hat fonts but only included our new ones - which has a different directory structure.

This should help develop plugins at least until our next release containing PF6 is published.

