### PR TITLE
test: mock stratis usage numbers

### DIFF
--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -145,7 +145,10 @@ class TestStorageStratis(storagelib.StorageCase):
         self.addCleanupMount("/run/fsys2")
         b.wait_text(self.card_row_col("Stratis filesystems", 2, 1), "fsys2")
         b.wait_text(self.card_row_col("Stratis filesystems", 2, 3), "/run/fsys2")
-        b.assert_pixels(self.card("Stratis filesystems"), "fsys-rows")
+        # different stratis versions report different usage numbers.
+        b.assert_pixels(self.card("Stratis filesystems"), "fsys-rows",
+                        mock={".usage-text": "0.57 / 7.4 GB"},
+                        ignore=[".usage-bar"])
         self.assertEqual(self.inode(m.execute("findmnt -n -o SOURCE /run/fsys2").strip()),
                          self.inode("/dev/stratis/pool0/fsys2"))
         m.write("/run/fsys2/FILE", "Hello Stratis!")
@@ -925,8 +928,10 @@ class TestStorageStratisNBDE(packagelib.PackageCase, storagelib.StorageCase):
         b.wait_visible(self.card_desc("Encrypted Stratis pool", "Passphrase"))
         b.wait_in_text(self.card_desc("Encrypted Stratis pool", "Keyserver"), "10.111.112.5")
 
+        # different stratis versions report different usage numbers.
         b.assert_pixels(self.card("Encrypted Stratis pool"), "header",
-                        ignore=['.pf-v6-c-description-list__group:contains(UUID)'])
+                        mock={".usage-text": "0.55 / 4.3 GB"},
+                        ignore=['.usage-bar', '.pf-v6-c-description-list__group:contains(UUID)'])
 
         # Remove passphrase
         b.click(self.card_desc("Encrypted Stratis pool", "Passphrase") + " button:contains(Remove)")


### PR DESCRIPTION
Between the stratis version in Fedora 41 and the one in updates-testing (3.8.0) the usage numbers aren't stable so mock them instead as we aren't interested in asserting stratis FS usage sizes.

---

This addresses https://github.com/cockpit-project/cockpit/issues/21782