### PR TITLE
shell: Improve PF6 styling

### DIFF
--- a/pkg/lib/page.scss
+++ b/pkg/lib/page.scss
@@ -173,6 +173,10 @@ html:not(.index-page) body {
   // Ensure UI fills the entire page (and does not run over)
   .ct-page-fill {
     block-size: 100% !important;
+
+    .pf-v6-c-page__main-container {
+      block-size: 100%;
+    }
   }
 }
 

--- a/pkg/lib/patternfly/patternfly-6-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-6-overrides.scss
@@ -447,6 +447,8 @@ to wrap around when there isn't enough space.
 .pf-v6-l-stack__item + .pf-v6-l-stack__item > .pf-v6-c-card.pf-m-plain {
   border-block-start: var(--pf-t--global--border--width--100) solid var(--pf-t--global--border--color--default);
   border-radius: var(--pf-t--global--border--radius--0);
+  margin-block: var(--pf-t--global--spacer--md);
+  padding-block-start: var(--pf-t--global--spacer--md);
 }
 
 

--- a/pkg/shell/nav.scss
+++ b/pkg/shell/nav.scss
@@ -119,6 +119,10 @@ $desktop: $phone + 1px;
     display: none !important;
   }
 
+  .desktop_v .pf-v6-c-toolbar__item {
+    align-items: center;
+  }
+
   .view-hosts .sidebar-hosts {
     animation: navHostsSlide 300ms ease-out;
     transform-origin: top;
@@ -139,8 +143,6 @@ $desktop: $phone + 1px;
   }
 
   .header {
-    background-color: var(--pf-t--global--background--color--tertiary--default);
-
     .credential-unlocked {
       /* AAA contrast: simulate #a1a1a1 on #151515 */
       opacity: 0.6;
@@ -148,8 +150,6 @@ $desktop: $phone + 1px;
   }
 
   .ct-switcher {
-    background-color: var(--pf-t--global--background--color--secondary--default);
-
     .pf-v6-c-select__toggle-wrapper {
       display: flex;
     }
@@ -448,6 +448,7 @@ $desktop: $phone + 1px;
     gap: var(--pf-t--global--spacer--xs);
     padding-block: var(--pf-t--global--spacer--xs);
     padding-inline: var(--pf-t--global--spacer--sm);
+
     // Pull the background color over
 
     @media (min-width: $desktop) {
@@ -463,6 +464,11 @@ $desktop: $phone + 1px;
   }
 }
 
+.nav-item-actions:empty {
+  /* Nav item actions are part of the grid, whether they have content or not. If they do not have content, don't add extra spacing. */
+  display: none;
+}
+
 .ct-topnav-content {
   margin-inline-start: auto;
 }
@@ -470,7 +476,6 @@ $desktop: $phone + 1px;
 // Rework navigation toggles in desktop and (especially) mobile modes
 .super-user-indicator > button,
 .ct-nav-toggle:not(.pf-v6-c-menu) {
-  background: transparent !important;
   // The normal margin to the right of the select dropdown makes them look uncentered in the masthead.
   // https://github.com/patternfly/patternfly/issues/6632
   .pf-v6-c-menu-toggle__toggle-icon {
@@ -478,11 +483,23 @@ $desktop: $phone + 1px;
   }
 }
 
+.navbar {
+  margin: var(--pf-t--global--spacer--xs);
+
+  .ct-nav-toggle {
+  }
+}
+
 .ct-nav-toggle:not(.pf-v6-c-menu) {
+  border-radius: var(--pf-t--global--border--radius--small);
+  background: transparent;
+
+  &:hover {
+    background: var(--pf-t--global--background--color--action--plain--alt--hover);
+  }
+
   &:hover, &:active, &.active, &.interact, &[aria-expanded="true"] {
     text-decoration: none;
-    // add in opacity so the navigation colored line doesn't hide on hover
-    background: color-mix(in srgb, var(--pf-t--global--background--color--secondary--hover) 32%, transparent) !important;
 
     .hostname {
       text-decoration: underline;

--- a/pkg/shell/nav.scss
+++ b/pkg/shell/nav.scss
@@ -486,6 +486,11 @@ $desktop: $phone + 1px;
   .pf-m-current + .nav-item-actions {
     background-color: var(--pf-v6-c-nav__link--m-current--BackgroundColor);
   }
+
+  // Use hover background for the whole nav item correctly
+  .nav-item:hover {
+    background-color: var(--pf-v6-c-nav__link--hover--BackgroundColor);
+  }
 }
 
 .nav-item-actions:empty {

--- a/pkg/shell/nav.scss
+++ b/pkg/shell/nav.scss
@@ -119,10 +119,6 @@ $desktop: $phone + 1px;
     display: none !important;
   }
 
-  .desktop_v .pf-v6-c-toolbar__item {
-    align-items: center;
-  }
-
   .view-hosts .sidebar-hosts {
     animation: navHostsSlide 300ms ease-out;
     transform-origin: top;

--- a/pkg/shell/nav.scss
+++ b/pkg/shell/nav.scss
@@ -138,6 +138,11 @@ $desktop: $phone + 1px;
     }
   }
 
+  /* Move host switcher away from the host line and page edges */
+  .navbar {
+    margin: var(--pf-t--global--spacer--xs);
+  }
+
   .header {
     .credential-unlocked {
       /* AAA contrast: simulate #a1a1a1 on #151515 */
@@ -177,7 +182,30 @@ $desktop: $phone + 1px;
   .clicked {
     transform: rotate(180deg);
   }
+
+  .ct-nav-toggle:not(.pf-v6-c-menu) {
+    border-radius: var(--pf-t--global--border--radius--small);
+    background: transparent;
+
+    &:hover {
+      background: var(--pf-t--global--background--color--action--plain--alt--hover);
+    }
+
+    &:hover, &:active, &.active, &.interact, &[aria-expanded="true"] {
+      text-decoration: none;
+
+      .hostname {
+        text-decoration: underline;
+      }
+    }
+
+    &:focus {
+      text-decoration: none;
+    }
+
+  }
 }
+
 
 /* Mobile navigation */
 @media (max-width: $phone) {
@@ -476,34 +504,6 @@ $desktop: $phone + 1px;
   // https://github.com/patternfly/patternfly/issues/6632
   .pf-v6-c-menu-toggle__toggle-icon {
       margin-inline-end: 0;
-  }
-}
-
-.navbar {
-  margin: var(--pf-t--global--spacer--xs);
-
-  .ct-nav-toggle {
-  }
-}
-
-.ct-nav-toggle:not(.pf-v6-c-menu) {
-  border-radius: var(--pf-t--global--border--radius--small);
-  background: transparent;
-
-  &:hover {
-    background: var(--pf-t--global--background--color--action--plain--alt--hover);
-  }
-
-  &:hover, &:active, &.active, &.interact, &[aria-expanded="true"] {
-    text-decoration: none;
-
-    .hostname {
-      text-decoration: underline;
-    }
-  }
-
-  &:focus {
-    text-decoration: none;
   }
 
   // The way the event is handled, it checks for the button, but not the icon. It should bubble, but doesn't. We can work around this by passing mouse events through.

--- a/pkg/shell/shell.scss
+++ b/pkg/shell/shell.scss
@@ -151,13 +151,8 @@ $desktop: $phone + 1px;
       background: linear-gradient(
         to top,
         var(--ct-color-host-accent),
-        var(--ct-color-host-accent) 0.1875rem,
-        transparent 0.1875rem
-      ),
-        linear-gradient(
-        to top,
-        var(--ct-color-host-accent) -1.5rem,
-        var(--ct-topnav-background) 0.75rem
+        var(--ct-color-host-accent) 3px,
+        transparent 3px
       );
     }
 
@@ -171,12 +166,21 @@ $desktop: $phone + 1px;
   }
 
   @media (min-width: $desktop) {
-    grid-template-areas: "switcher header" "sidebar main";
+    // Shadow to the left, Line on top, Base color (with subtle glow)
+    background: linear-gradient(
+      to bottom,
+      var(--ct-color-host-accent),
+      var(--ct-color-host-accent) 3px,
+      transparent 3px
+    );
+
+    grid-template-areas: "switcher switcher header" "sidebar main main";
     grid-template-rows: max-content 1fr;
-    grid-template-columns: minmax(min-content, var(--nav-width)) 1fr;
+    grid-template-columns: minmax(min-content, var(--nav-width)) auto 1fr;
 
     > .navbar {
-      max-inline-size: var(--nav-width);
+      grid-area: switcher;
+      margin-inline-end: calc(-1 * var(--pf-t--global--spacer--sm));
     }
 
     .sidebar {
@@ -188,19 +192,10 @@ $desktop: $phone + 1px;
       display: none;
     }
 
-    > .header {
-      // Shadow to the left, Line on top, Base color (with subtle glow)
-      background: linear-gradient(
-        to bottom,
-        var(--ct-color-host-accent),
-        var(--ct-color-host-accent) 0.1875rem,
-        transparent 0.1875rem
-      ),
-        linear-gradient(
-        to bottom,
-        var(--ct-color-host-accent) -1.5rem,
-        var(--ct-topnav-background) 0.75rem
-      );
+    .view-hosts .sidebar-hosts,
+    .nav-system-menu {
+      /* Top of the navbar should start when the curve of the content area ends. This means the search entry should be bumped down a bit. */
+      padding-block-start: var(--pf-t--global--spacer--md);
     }
   }
 


### PR DESCRIPTION
Fixes include:

- Host switcher
- Navbar
- Stripe across the top
- Expand content area (when content area is set to ct page fill)
- Adjusts spacing between multiple plain cards (to add a little more space)