### PR TITLE
Dependabot changes and Sass bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,10 +36,6 @@ updates:
         patterns:
           - "@xterm/*"
     ignore:
-      # https://github.com/cockpit-project/cockpit/issues/21151
-      - dependency-name: "sass"
-        versions: ["1.x", "2.x"]
-
       # lots of work, do this explicitly
       - dependency-name: "@patternfly/*"
         versions: ["6.x"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,11 +36,14 @@ updates:
         patterns:
           - "@xterm/*"
     ignore:
-      # lots of work, do this explicitly
+      # When Patternfly gets a major version we don't want to get PRs for it
+      # Would require a lot of work and not something we wanna do in a dependabot PR.
       - dependency-name: "@patternfly/*"
-        versions: ["6.x"]
+        update-types: ["version-update:semver-major"]
 
-      # PF5 requires fixed major React version
+      # PF6 doesn't support React 19 yet and often doesn't support new major versions
+      # right away in general.
+      # https://github.com/patternfly/pf-roadmap/issues/201
       - dependency-name: "*react*"
         update-types: ["version-update:semver-major"]
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "jed": "1.1.1",
     "qunit": "2.24.1",
     "qunit-tap": "1.5.1",
-    "sass": "1.79.6",
+    "sass": "1.86.3",
     "sizzle": "2.3.10",
     "stylelint": "16.17.0",
     "stylelint-config-recommended-scss": "14.0.0",


### PR DESCRIPTION
We ignored PF6 before as we didn't want to update it through dependabot.
Now with us using PF6 this is no longer necessary so we can instead just
change this to major version changes not being of interest to us for
dependabot stuff.

I also improved the reason for why we lock React major version updates.

Previously Sass was locked to a specific version and dependabot was
given instructions to ignore any updates to Sass. As we now support both
`@use` and `@forward` with no more `@import`s present in our own
codebase as well as the Patternfly codebase we can safely bump this.