### PR TITLE
pf: Don't clip modal content when content would otherwise overflow

### DIFF
--- a/pkg/lib/patternfly/patternfly-6-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-6-overrides.scss
@@ -77,6 +77,12 @@ $phone: 767px;
   white-space: normal;
 }
 
+// Modals should accomodate content width, as languages can make elements (especially buttons) too long
+// https://github.com/patternfly/patternfly/issues/7440
+.pf-v6-c-modal-box {
+  min-width: min-content;
+}
+
 .pf-v6-c-card {
   // https://github.com/patternfly/patternfly/issues/3959
   // TODO @Venefilyn: Change so we use .pf-m-no-offset, then remove this

--- a/pkg/lib/patternfly/patternfly-6-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-6-overrides.scss
@@ -80,7 +80,7 @@ $phone: 767px;
 // Modals should accomodate content width, as languages can make elements (especially buttons) too long
 // https://github.com/patternfly/patternfly/issues/7440
 .pf-v6-c-modal-box {
-  min-width: min-content;
+  min-inline-size: min-content;
 }
 
 .pf-v6-c-card {


### PR DESCRIPTION
Upstream issue filed @ https://github.com/patternfly/patternfly/issues/7440

Affects Anaconda too; PR for a local Anaconda workaround @ https://github.com/rhinstaller/anaconda-webui/pull/765 (merged already)

Bugzilla issue (filed against Anaconda): https://bugzilla.redhat.com/show_bug.cgi?id=2357172

This affects all PatternFly projects, especially when there are several actions in a modal and the buttons have long text (which may be caused by languages), and especially on smaller-width modals.