### PR TITLE
tests: skip stratis tests on archlinux

### DIFF
--- a/test/verify/check-storage-anaconda
+++ b/test/verify/check-storage-anaconda
@@ -174,7 +174,7 @@ class TestStorageAnaconda(storagelib.StorageCase):
         b.wait(lambda: b.call_js_func('ph_count', self.card("Storage") + " tbody tr") == 1)
         b.wait_not_present(self.card_row("Storage", location="/var"))
 
-    @testlib.skipImage("No Stratis", "debian-*", "ubuntu-*")
+    @testlib.skipImage("No Stratis", "debian-*", "ubuntu-*", "arch")
     @testlib.skipImage("commit 817c957899a4 removed Statis 2 support", "rhel-8-*")
     def testStratis(self):
         m = self.machine

--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -47,7 +47,7 @@ def create_pool_key(machine, keyname, passphrase):
     machine.execute(f"echo -n '{passphrase}' | stratis key set --keyfile-path /dev/stdin {keyname}")
 
 
-@testlib.skipImage("No Stratis", "debian-*", "ubuntu-*")
+@testlib.skipImage("No Stratis", "debian-*", "ubuntu-*", "arch")
 @testlib.skipImage("commit 817c957899a4 removed Statis 2 support", "rhel-8-*")
 @testlib.nondestructive
 class TestStorageStratis(storagelib.StorageCase):
@@ -540,7 +540,7 @@ systemctl restart stratisd
         b.wait_text(self.card_desc("Stratis filesystem", "Virtual size limit"), "none")
 
 
-@testlib.skipImage("No Stratis", "debian-*", "ubuntu-*")
+@testlib.skipImage("No Stratis", "debian-*", "ubuntu-*", "arch")
 @testlib.skipImage("commit 817c957899a4 removed Statis 2 support", "rhel-8-*")
 class TestStorageStratisReboot(storagelib.StorageCase):
     # LUKS uses memory hard PBKDF, 1 GiB is not enough; see https://bugzilla.redhat.com/show_bug.cgi?id=1881829
@@ -875,7 +875,7 @@ class TestStoragePackagesStratis(packagelib.PackageCase, storagelib.StorageCase)
             b.wait_not_present(stratis_action)
 
 
-@testlib.skipImage("No Stratis", "debian-*", "ubuntu-*")
+@testlib.skipImage("No Stratis", "debian-*", "ubuntu-*", "arch")
 @testlib.skipImage("Stratis too old", "rhel-8-*")
 class TestStorageStratisNBDE(packagelib.PackageCase, storagelib.StorageCase):
     provision = {


### PR DESCRIPTION
Stratis was removed from archlinux, see:
https://github.com/cockpit-project/bots/issues/7624