### PR TITLE
users: Fix double-rendering of user fields

### DIFF
--- a/pkg/lib/hooks.ts
+++ b/pkg/lib/hooks.ts
@@ -192,6 +192,9 @@ export function useFileWithError(path: string, options: cockpit.JsonObject, hook
     const memo_hook_options = useDeepEqualMemo(hook_options);
 
     useEffect(() => {
+        if (path === "/etc/passwd") {
+            console.log("file with error", path, memo_options, memo_hook_options);
+        }
         const handle = cockpit.file(path, memo_options);
         handle.watch((data, _tag, error) => {
             setContentAndError([data || false, error || false]);
@@ -200,7 +203,9 @@ export function useFileWithError(path: string, options: cockpit.JsonObject, hook
         });
         return handle.close;
     }, [path, memo_options, memo_hook_options]);
-
+    if (path === "/etc/passwd") {
+        console.log("content_and_error /etc/passwd", content_and_error);
+    }
     return content_and_error;
 }
 

--- a/pkg/users/account-details.js
+++ b/pkg/users/account-details.js
@@ -96,40 +96,40 @@ function get_expire(name) {
             .then(parse_expire);
 }
 
-export function AccountDetails({ accounts, groups, current_user, user, shells }) {
+export function AccountDetails({ account, details, groups, isLoading, current_user, user, shells }) {
     const [expiration, setExpiration] = useState(null);
 
     useEffect(() => {
         get_expire(user).then(setExpiration);
-    }, [user, accounts]);
+    }, [user, account]);
 
-    const [edited_real_name, set_edited_real_name] = useState(null);
-    const [committing_real_name, set_committing_real_name] = useState(false);
+    const [editedRealName, setEditedRealName] = useState(null);
+    const [comittingRealName, setCommittingRealName] = useState(false);
 
-    const [edited_locked, set_edited_locked] = useState(null);
+    const [editedLocked, setEditedLocked] = useState(null);
 
     function change_real_name() {
-        if (!edited_real_name)
+        if (!editedRealName)
             return;
 
-        set_committing_real_name(true);
+        setCommittingRealName(true);
 
         // TODO: unwanted chars check
-        cockpit.spawn(["/usr/sbin/usermod", user, "--comment", edited_real_name],
+        cockpit.spawn(["/usr/sbin/usermod", user, "--comment", editedRealName],
                       { superuser: "try", err: "message" })
                 .then(() => {
-                    set_edited_real_name(null);
-                    set_committing_real_name(false);
+                    setEditedRealName(null);
+                    setCommittingRealName(false);
                 })
                 .catch(error => {
-                    set_edited_real_name(null);
-                    set_committing_real_name(false);
+                    setEditedRealName(null);
+                    setCommittingRealName(false);
                     show_unexpected_error(error);
                 });
     }
 
     function change_locked(value, dont_retry_if_stuck) {
-        set_edited_locked(value);
+        setEditedLocked(value);
 
         cockpit.spawn(["/usr/sbin/usermod", user, value ? "--lock" : "--unlock"],
                       { superuser: "require", err: "message" })
@@ -145,12 +145,11 @@ export function AccountDetails({ accounts, groups, current_user, user, shells })
                                     console.log("Account locked state doesn't match desired value, trying again.");
                                     // only retry once to avoid uncontrolled recursion
                                     change_locked(value, true);
-                                } else
-                                    set_edited_locked(null);
+                                }
                             });
                 })
                 .catch(error => {
-                    set_edited_locked(null);
+                    setEditedLocked(null);
                     show_unexpected_error(error);
                 });
     }
@@ -164,15 +163,21 @@ export function AccountDetails({ accounts, groups, current_user, user, shells })
                 .catch(show_unexpected_error);
     }
 
-    if (!accounts.length) {
+    useEffect(
+        () => {
+            setEditedLocked(null);
+            console.log("edited locked being changed to null");
+        },
+        [details],
+    );
+
+    if (isLoading) {
         return (
             <EmptyState headingLevel="h1" titleText={_("Loading...")} variant={EmptyStateVariant.sm}>
                 <EmptyStateFooter><Spinner size="xl" /></EmptyStateFooter>
             </EmptyState>
         );
     }
-
-    const account = accounts.find(acc => acc.name == user);
 
     if (!account) {
         return (
@@ -200,17 +205,17 @@ export function AccountDetails({ accounts, groups, current_user, user, shells })
         title_name = account.name;
 
     let last_login;
-    if (account.loggedIn)
+    if (details.loggedIn)
         last_login = _("Logged in");
-    else if (!account.lastLogin)
+    else if (!details.lastLogin)
         last_login = _("Never");
     else
-        last_login = timeformat.dateTime(new Date(account.lastLogin));
+        last_login = timeformat.dateTime(new Date(details.lastLogin));
 
     const actions = superuser.allowed && (
         <>
             <Button variant="secondary" onClick={() => logout_account()} id="account-logout"
-              isDisabled={!account.loggedIn || account.uid == 0 || user === current_user}>
+              isDisabled={!details.loggedIn || account.uid == 0 || user === current_user}>
                 {_("Terminate session")}
             </Button>
             { "\n" }
@@ -240,21 +245,21 @@ export function AccountDetails({ accounts, groups, current_user, user, shells })
                                 <FormGroup fieldId="account-real-name" hasNoPaddingTop={!superuser.allowed} label={_("Full name")}>
                                     { superuser.allowed
                                         ? <TextInput id="account-real-name"
-                                                     isDisabled={committing_real_name || account.uid == 0}
-                                                     value={edited_real_name !== null ? edited_real_name : account.gecos}
+                                                     isDisabled={comittingRealName || account.uid == 0}
+                                                     value={editedRealName !== null ? editedRealName : account.gecos}
                                                      onKeyDown={event => {
                                                          if (event.key == "Enter") {
                                                              event.target.blur();
                                                          }
                                                      }}
-                                                     onChange={(_event, value) => set_edited_real_name(value)}
+                                                     onChange={(_event, value) => setEditedRealName(value)}
                                                      onBlur={() => change_real_name()} />
                                         : <output id="account-real-name">{account.gecos}</output>}
                                 </FormGroup>
                                 <FormGroup fieldId="account-user-name" hasNoPaddingTop label={_("User name")}>
                                     <output id="account-user-name">{account.name}</output>
                                 </FormGroup>
-                                <AccountGroupsSelect key={account.name} loggedIn={account.loggedIn} name={account.name} groups={groups} />
+                                <AccountGroupsSelect key={account.name} loggedIn={details.loggedIn} name={account.name} groups={groups} />
                                 <FormGroup fieldId="account-last-login" hasNoPaddingTop label={_("Last login")}>
                                     <output id="account-last-login">{last_login}</output>
                                 </FormGroup>
@@ -262,8 +267,9 @@ export function AccountDetails({ accounts, groups, current_user, user, shells })
                                     <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
                                         <FlexItem spacer={{ default: 'spacerNone' }}>
                                             <Checkbox id="account-locked"
-                                                        isDisabled={!superuser.allowed || edited_locked != null || user == current_user || account.isLocked == null}
-                                                        isChecked={edited_locked != null ? edited_locked : account.isLocked}
+                                                        ouiaSafe={editedLocked === null}
+                                                        isDisabled={!superuser.allowed || editedLocked != null || user == current_user || details.isLocked == null}
+                                                        isChecked={editedLocked != null ? editedLocked : details.isLocked}
                                                         onChange={(_event, checked) => change_locked(checked)}
                                                         label={_("Disallow interactive password")} />
                                         </FlexItem>

--- a/pkg/users/users.js
+++ b/pkg/users/users.js
@@ -20,7 +20,7 @@ import '../lib/patternfly/patternfly-6-cockpit.scss';
 import 'polyfills'; // once per application
 import 'cockpit-dark-theme'; // once per page
 
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 
 import { debounce } from 'throttle-debounce';
@@ -123,13 +123,22 @@ function AccountsPage() {
     }, [], null, handles => handles.forEach(handle => handle.close()));
 
     const accountsInfo = useMemo(() => {
+        console.log("accounts && details", accounts, details);
         if (accounts && details)
             return accounts.map(account => {
                 return Object.assign({}, account, details[account.name]);
             });
         else
             return [];
-    }, [accounts, details]);
+    }, [accounts, details]); // FIXME: We want to update this when details is updated
+
+    useEffect(() => {
+        console.log("accounts updated");
+    }, [accounts]);
+
+    useEffect(() => {
+        console.log("details updated");
+    }, [details]);
 
     const groupsExtraInfo = useMemo(() => sortGroups(
         (groups || []).map(group => {
@@ -164,8 +173,10 @@ function AccountsPage() {
             />
         );
     } else if (path.length === 1) {
+        const account = accounts?.find(account => account.name === path[0]);
+        const accountDetails = details?.[path[0]];
         return (
-            <AccountDetails accounts={accountsInfo} groups={groupsExtraInfo}
+            <AccountDetails account={account} details={accountDetails} isLoading={accountsInfo.length === 0} groups={groupsExtraInfo}
                 current_user={current_user_info?.name} user={path[0]} shells={shells} />
         );
     } else return null;


### PR DESCRIPTION
Within user details there was an issue where if you modify something
like "Disallow interactive password" you would get two renders following
the information from cockpit. First render didn't change the state at
all whereas the second render did. However, if the second render is a
bit slower enough this would cause visual rendering changes that look
very jarring.

With this an OUIA Ready flag has been added to the checkbox as well to
signify that the checkbox is not waiting for anything.

Signed-off-by: Freya Gustavsson <freya@venefilyn.se>