### PR TITLE
lib: Remove PropTypes in TSX files

### DIFF
--- a/pkg/lib/cockpit-components-dropdown.tsx
+++ b/pkg/lib/cockpit-components-dropdown.tsx
@@ -18,12 +18,20 @@
  */
 
 import React, { useState } from 'react';
-import PropTypes from "prop-types";
 
 import { MenuToggle } from "@patternfly/react-core/dist/esm/components/MenuToggle";
 import { Dropdown, DropdownList, DropdownPopperProps } from "@patternfly/react-core/dist/esm/components/Dropdown";
 
 import { EllipsisVIcon } from '@patternfly/react-icons';
+
+interface KebabDropdownProps {
+    dropdownItems: React.ReactNode,
+    position?: DropdownPopperProps['position'],
+    isDisabled?: boolean,
+    toggleButtonId?: string;
+    isOpen?: boolean,
+    setIsOpen?: React.Dispatch<React.SetStateAction<boolean>>,
+}
 
 /*
  * A dropdown with a Kebab button, commonly used in Cockpit pages provided as
@@ -36,13 +44,14 @@ import { EllipsisVIcon } from '@patternfly/react-icons';
  * require a separator between DropdownItem's use PatternFly's Divivder
  * component.
  */
-export const KebabDropdown = ({ dropdownItems, position = "end", isDisabled = false, toggleButtonId, isOpen, setIsOpen } : {
-    dropdownItems: React.ReactNode,
-    position?: DropdownPopperProps['position'],
-    isDisabled?: boolean,
-    toggleButtonId?: string;
-    isOpen?: boolean, setIsOpen?: React.Dispatch<React.SetStateAction<boolean>>,
-}) => {
+export const KebabDropdown = ({
+    dropdownItems,
+    position = "end",
+    isDisabled = false,
+    toggleButtonId,
+    isOpen,
+    setIsOpen
+}: KebabDropdownProps) => {
     const [isKebabOpenInternal, setKebabOpenInternal] = useState(false);
     const isKebabOpen = isOpen ?? isKebabOpenInternal;
     const setKebabOpen = setIsOpen ?? setKebabOpenInternal;
@@ -71,13 +80,4 @@ export const KebabDropdown = ({ dropdownItems, position = "end", isDisabled = fa
             </DropdownList>
         </Dropdown>
     );
-};
-
-KebabDropdown.propTypes = {
-    dropdownItems: PropTypes.array.isRequired,
-    isDisabled: PropTypes.bool,
-    toggleButtonId: PropTypes.string,
-    position: PropTypes.oneOf(['right', 'left', 'center', 'start', 'end']),
-    isOpen: PropTypes.bool,
-    setIsOpen: PropTypes.func,
 };

--- a/pkg/lib/cockpit-components-empty-state.tsx
+++ b/pkg/lib/cockpit-components-empty-state.tsx
@@ -18,7 +18,6 @@
  */
 
 import React from "react";
-import PropTypes from 'prop-types';
 import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
 import type { ButtonProps } from "@patternfly/react-core/dist/esm/components/Button/index.js";
 import {
@@ -27,6 +26,19 @@ import {
 import type { EmptyStateProps } from "@patternfly/react-core/dist/esm/components/EmptyState/index.js";
 import { Spinner } from "@patternfly/react-core/dist/esm/components/Spinner/index.js";
 import "./cockpit-components-empty-state.css";
+
+interface EmptyStatePanelProps {
+    title?: EmptyStateProps["titleText"],
+    paragraph?: React.ReactNode,
+    loading?: boolean,
+    icon?: EmptyStateProps["icon"],
+    action?: React.ReactNode | string,
+    isActionInProgress?: boolean,
+    onAction?: ButtonProps["onClick"],
+    actionVariant?: ButtonProps["variant"],
+    secondary?: React.ReactNode,
+    headingLevel?: EmptyStateProps['headingLevel'],
+}
 
 export const EmptyStatePanel = ({
     title,
@@ -39,18 +51,7 @@ export const EmptyStatePanel = ({
     actionVariant = "primary",
     secondary,
     headingLevel = "h1"
-}: {
-    title?: EmptyStateProps["titleText"],
-    paragraph?: React.ReactNode,
-    loading?: boolean,
-    icon?: EmptyStateProps["icon"],
-    action?: React.ReactNode | string,
-    isActionInProgress?: boolean,
-    onAction?: ButtonProps["onClick"],
-    actionVariant?: ButtonProps["variant"],
-    secondary?: React.ReactNode,
-    headingLevel?: EmptyStateProps['headingLevel'],
-}) => {
+}: EmptyStatePanelProps) => {
     const slimType = title || paragraph ? "" : "slim";
     const emptyStateHeaderIcon = loading ? Spinner : icon;
 
@@ -73,16 +74,4 @@ export const EmptyStatePanel = ({
                 </EmptyStateFooter>}
         </EmptyState>
     );
-};
-
-EmptyStatePanel.propTypes = {
-    loading: PropTypes.bool,
-    icon: PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.func]),
-    title: PropTypes.string,
-    paragraph: PropTypes.node,
-    action: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
-    actionVariant: PropTypes.string,
-    isActionInProgress: PropTypes.bool,
-    onAction: PropTypes.func,
-    secondary: PropTypes.node,
 };

--- a/pkg/lib/cockpit-components-inline-notification.tsx
+++ b/pkg/lib/cockpit-components-inline-notification.tsx
@@ -17,7 +17,6 @@
  * along with Cockpit; If not, see <https://www.gnu.org/licenses/>.
  */
 import React, { useState } from 'react';
-import PropTypes from 'prop-types';
 import cockpit from 'cockpit';
 
 import { Alert, AlertActionCloseButton, AlertProps } from "@patternfly/react-core/dist/esm/components/Alert/index.js";
@@ -26,14 +25,23 @@ import './cockpit-components-inline-notification.css';
 
 const _ = cockpit.gettext;
 
-export const InlineNotification = ({ text, detail, type = "danger", onDismiss, isInline = true, isLiveRegion = false }: {
+interface InlineNotificationProps {
     text: string;
     detail?: string;
     type?: AlertProps["variant"];
     onDismiss?: (ev?: Event) => void;
     isInline?: boolean;
     isLiveRegion?: boolean;
-}) => {
+}
+
+export const InlineNotification = ({
+    text,
+    detail,
+    type = "danger",
+    onDismiss,
+    isInline = true,
+    isLiveRegion = false
+}: InlineNotificationProps) => {
     const [isDetail, setIsDetail] = useState(false);
 
     const detailButton = (detail &&
@@ -58,15 +66,6 @@ export const InlineNotification = ({ text, detail, type = "danger", onDismiss, i
             {isDetail && (<p>{detail}</p>)}
         </Alert>
     );
-};
-
-InlineNotification.propTypes = {
-    onDismiss: PropTypes.func,
-    isInline: PropTypes.bool,
-    text: PropTypes.string.isRequired, // main information to render
-    detail: PropTypes.string, // optional, more detailed information. If empty, the more/less button is not rendered.
-    type: PropTypes.string,
-    isLiveRegion: PropTypes.bool,
 };
 
 export const ModalError = ({ dialogError, dialogErrorDetail, id, isExpandable }: {


### PR DESCRIPTION
This is redundant as interfaces exists, so we can migrate over and
reduce the overall codebase. This also adds props interface to reduce
complexity.

Signed-off-by: Freya Gustavsson <freya@venefilyn.se>