### PR TITLE
test: Use a V1 pool in TestStorageStratis.testAlert

### DIFF
--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -320,16 +320,22 @@ class TestStorageStratis(storagelib.StorageCase):
         b.wait_visible(self.card_row("Storage", name=dev_1))
         b.wait_visible(self.card_row("Storage", name=dev_2))
 
-        # Create an encrypted pool with two block devices
-        self.click_devices_dropdown("Create Stratis pool")
-        self.dialog_wait_open()
-        self.dialog_set_val("encrypt_pass.on", val=True)
-        self.dialog_set_val("passphrase", "foodeeboodeebar")
-        self.dialog_set_val("passphrase2", "foodeeboodeebar")
-        self.dialog_set_val("disks", {dev_1: True})
-        self.dialog_set_val("disks", {dev_2: True})
-        self.dialog_apply()
-        self.dialog_wait_close()
+        # Create an encrypted V1 pool with two block devices
+
+        if m.image not in V1_POOL_IMAGES:
+            create_pool_key(m, "pool0", "foodeeboodeebar")
+            m.execute(f"yes | stratisd-tools stratis-legacy-pool --key-desc pool0 pool0 {dev_1} {dev_2}")
+            m.execute("stratis key unset pool0")
+        else:
+            self.click_devices_dropdown("Create Stratis pool")
+            self.dialog_wait_open()
+            self.dialog_set_val("encrypt_pass.on", val=True)
+            self.dialog_set_val("passphrase", "foodeeboodeebar")
+            self.dialog_set_val("passphrase2", "foodeeboodeebar")
+            self.dialog_set_val("disks", {dev_1: True})
+            self.dialog_set_val("disks", {dev_2: True})
+            self.dialog_apply()
+            self.dialog_wait_close()
 
         b.wait_visible(self.card_row("Storage", name="pool0"))
         b.wait_not_present(self.card_row("Storage", name="pool0") + " .ct-icon-exclamation-triangle")

--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -26,6 +26,12 @@ import testlib
 
 PV_SIZE = 4000  # 4 GB in MB
 
+# List of images that support Stratis and create V1 pools by
+# default. When this gets empty, Cockpit itself can be cleaned up to
+# drop support for Stratis API revisions before "r8".
+#
+V1_POOL_IMAGES = ["rhel-9-7", "rhel-10-1", "centos-9-bootc", "centos-10"]
+
 
 def get_stratis_stop_type_opt(execute):
     """Get `stratis stop pool` required option for a pool name
@@ -893,8 +899,6 @@ class TestStorageStratisNBDE(packagelib.PackageCase, storagelib.StorageCase):
 
         self.stop_type_opt = get_stratis_stop_type_opt(self.machine.execute)
 
-        self.stratis_version = list(map(int, self.machine.execute("stratis daemon version").split(".")))
-
     def testBasic(self):
         m = self.machine
         b = self.browser
@@ -952,7 +956,7 @@ class TestStorageStratisNBDE(packagelib.PackageCase, storagelib.StorageCase):
         tang_m.execute("systemctl stop tangd.socket")
         b.click(self.card_button("Stratis pool", "Start"))
         self.dialog_wait_open()
-        if self.stratis_version >= [3, 8, 0]:
+        if m.image not in V1_POOL_IMAGES:
             # For V2 pools (created by Stratis 3.8.0 and later),
             # Cockpit doesn't know whether they have a passphrase or
             # not. So it asks always.


### PR DESCRIPTION
[COCKPIT-1267](https://issues.redhat.com/browse/COCKPIT-1267)

The alert can not happen with V2 pools.

