### PR TITLE
lib: Fix memory leak in DBus client

### DIFF
--- a/pkg/lib/cockpit.js
+++ b/pkg/lib/cockpit.js
@@ -1781,6 +1781,16 @@ function factory() {
                 options = { problem: options };
             if (!options)
                 options = { };
+
+            // Clean up all subscribers when closing
+            for (const id in subscribers) {
+                const subscription = subscribers[id];
+                if (subscription.callback) {
+                    send(JSON.stringify({ "remove-match": subscription.match }));
+                    delete subscribers[id];
+                }
+            }
+            
             if (channel)
                 channel.close(options);
             else

--- a/pkg/lib/cockpit.js
+++ b/pkg/lib/cockpit.js
@@ -1783,7 +1783,8 @@ function factory() {
                 options = { };
 
             // Clean up all subscribers when closing
-            for (const id in subscribers) {
+            const subscriberKeys = Object.keys(subscribers);
+            for (const id of subscriberKeys) {
                 const subscription = subscribers[id];
                 if (subscription.callback) {
                     send(JSON.stringify({ "remove-match": subscription.match }));


### PR DESCRIPTION
This commit ensures all DBus signal subscriptions are properly cleaned up when a DBusClient is closed. Previously, subscriptions could remain active after client closure, causing memory leaks and potentially unwanted signal handling. The fix properly iterates through all subscribers and sends remove-match messages to the server before removing them from the subscribers collection.