### PR TITLE
test: mock-insights should have /host_exists endpoint

### DIFF
--- a/test/verify/files/mock-insights
+++ b/test/verify/files/mock-insights
@@ -86,6 +86,19 @@ class handler(BaseHTTPRequestHandler):
             self.wfile.write(json.dumps(res).encode("utf-8") + b"\n")
             return
 
+        m = self.match("/r/insights/platform/inventory/v1/host_exists\\?insights_id=(.*)")
+        if m:
+            insights_id = m[1]
+            self.send_response(200)
+            self.end_headers()
+            res = {}
+            for system in systems.values():
+                if system["insights_id"] == insights_id:
+                    res["id"] = system["id"]
+                    break
+            self.wfile.write(json.dumps(res).encode("utf-8") + b"\n")
+            return
+
         m = self.match("/r/insights/platform/insights/v1/system/([^/]+)/reports/")
         if m:
             inventory_id = m[1]


### PR DESCRIPTION
* Card ID: CCT-722

Added a test with /host_exists API endpoint. This change ensures compatibility with the updated insights-client which uses the new /host_exists endpoint for checking whether the host is registered.

(cherry picked from commit [3a1b3f9](https://github.com/candlepin/subscription-manager-cockpit/commit/3a1b3f9416942679c506e0a835627f1e37ab16b6))