### PR TITLE
ws: Support globs in configured origins

### DIFF
--- a/doc/man/cockpit.conf.xml
+++ b/doc/man/cockpit.conf.xml
@@ -59,12 +59,12 @@
       <listitem>
         <para>By default cockpit will not accept crossdomain websocket connections. Use this
             setting to allow access from alternate domains. Origins should include scheme, host
-            and port, if necessary.</para>
+            and port, if necessary. Wildcards and glob expressions are permitted.</para>
 
         <informalexample>
 <programlisting language="ini">
 [WebService]
-Origins = https://somedomain1.com https://somedomain2.com:9090
+Origins = https://somedomain1.com https://somedomain2.com:9090 https://*.somedomain3.com
 </programlisting>
         </informalexample>
       </listitem>

--- a/src/websocket/websocketserver.c
+++ b/src/websocket/websocketserver.c
@@ -23,6 +23,7 @@
 #include "websocketprivate.h"
 
 #include <string.h>
+#include <fnmatch.h>
 
 enum {
   PROP_0,
@@ -195,7 +196,7 @@ respond_handshake_rfc6455 (WebSocketServer *self,
         }
       for (i = 0; self->allowed_origins[i] != NULL; i++)
         {
-          if (g_ascii_strcasecmp (origin, self->allowed_origins[i]) == 0)
+          if (fnmatch (self->allowed_origins[i], origin, FNM_CASEFOLD) == 0)
             break;
         }
       if (self->allowed_origins[i] == NULL)

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -576,17 +576,22 @@ class TestConnection(testlib.MachineCase):
     @testlib.nondestructive
     def testConfigOrigins(self):
         m = self.machine
-        m.write("/etc/cockpit/cockpit.conf", "[WebService]\nOrigins = http://other-origin:9090 http://localhost:9090")
+        m.write("/etc/cockpit/cockpit.conf", "[WebService]\nOrigins = http://origin-one:9090 http://localhost:9090 http://*.origin-two:9090")
         m.start_cockpit()
         headers = {
             'Connection': 'Upgrade',
             'Upgrade': 'websocket',
             'Host': 'localhost:9090',
-            'Origin': 'http://other-origin:9090',
+            'Origin': 'http://origin-one:9090',
             'Sec-Websocket-Key': '3sc2c9IzwRUc3BlSIYwtSA==',
             'Sec-Websocket-Version': 13
         }
         output = m.curl('-f', '-N', 'http://localhost:9090/cockpit/socket', headers=headers)
+        self.assertIn('"no-session"', output)
+
+        # Test wildcard functionaity of Origin Matching
+        headers['Origin'] = "http://wildcard.origin-two:9090"
+        output = m.curl('-f', '-N', 'http://localhost:9090/socket', headers=headers)
         self.assertIn('"no-session"', output)
 
         # The socket should also answer at /socket


### PR DESCRIPTION
References #21738 #21727 

Changes the default matching behavior of cockpit `Origin` configuration to use fnmatch instead of string comparison, allowing for the use of wildcards and standard glob matching.