### PR TITLE
storage: Allow btrfs mounts to fail while monitoring

### DIFF
--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -857,6 +857,8 @@ function update_indices() {
         const bfs = client.blocks_fsys_btrfs[p];
         const uuid = bfs.data.uuid;
         const block_fsys = client.blocks_fsys[p];
+        if (!uuid)
+            continue;
         if ((block_fsys && block_fsys.MountPoints.length > 0) || !client.uuids_btrfs_volume[uuid]) {
             client.uuids_btrfs_volume[uuid] = bfs;
             if (!old_uuids || !old_uuids[uuid])

--- a/test/verify/check-storage-anaconda
+++ b/test/verify/check-storage-anaconda
@@ -335,6 +335,30 @@ class TestStorageAnaconda(storagelib.StorageCase):
                                       }
                                   })
 
+    @testlib.skipImage('no btrfs support', 'rhel-*', 'centos-*')
+    def testDegradedBtrfs(self):
+        b = self.browser
+        m = self.machine
+
+        disk1 = self.add_ram_disk(size=140)
+        disk2 = self.add_loopback_disk(size=140)
+
+        anaconda_config = {
+            "mount_point_prefix": "/sysroot",
+            "available_devices": [disk1, disk2],
+        }
+
+        # Create a two-device btrfs and then degrade it by wiping the second device.
+        # Cockpit used to crash when such a filesystem is present in Anaconda mode.
+
+        m.execute(f"mkfs.btrfs -L butter {disk1} {disk2}")
+        m.execute(f"wipefs -a {disk2}")
+
+        self.login_and_go("/storage")
+        self.enterAnacondaMode(anaconda_config)
+
+        b.wait_visible(self.card_row("Storage", name="butter"))
+
     def testBiosboot(self):
         b = self.browser
 


### PR DESCRIPTION
Previously, if btrfs-tool would encounter a btrfs device that fails to mount that would kill the monitor and the whole storage page would fail to initialize.

Now, a failure to mount is expected and returned in the results of monitoring.  The error will be permanently recorded and no further mount attempts are made until Cockpit is reloaded.

An example for a failed mount is a multi-device btrfs filesystem that has too many devices missing at the time of mounting.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2358267