### PR TITLE
lib: use `never` for incompatible options

### DIFF
--- a/pkg/lib/cockpit.d.ts
+++ b/pkg/lib/cockpit.d.ts
@@ -309,11 +309,11 @@ declare module 'cockpit' {
 
     function file(
         path: string,
-        options?: FileOpenOptions & { binary?: false; syntax?: undefined; }
+        options?: FileOpenOptions & { binary?: false; syntax?: never; }
     ): FileHandle<string>;
     function file(
         path: string,
-        options: FileOpenOptions & { binary: true; syntax?: undefined; }
+        options: FileOpenOptions & { binary: true; syntax?: never; }
     ): FileHandle<Uint8Array>;
     function file<T>(
         path: string,


### PR DESCRIPTION
We provide four overloads for the file() function, two are for when syntax should be not be set and thus should use `never` and not `undefined`.