### PR TITLE
shell: Load favicon explicitly from static

### DIFF
--- a/pkg/shell/index.html
+++ b/pkg/shell/index.html
@@ -4,6 +4,7 @@
     <title>Cockpit</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="../../static/favicon.ico" />
     <link href="shell.css" rel="stylesheet" />
     <link href="../../static/branding.css" rel="stylesheet" />
     <script src="../base1/cockpit.js"></script>


### PR DESCRIPTION
When using a reverse proxy with an UrlRoot browsers load the favicon from the root which would be a 404 or load the wrong favicon. We can work around this by explicitly loading the favicon from the static directory similar to how we load branding.css

Closes: #20580