### PR TITLE
test: workaround testPrivateKeys pixel test flake

### DIFF
--- a/test/verify/check-shell-keys
+++ b/test/verify/check-shell-keys
@@ -274,7 +274,7 @@ session    optional     pam_ssh_add.so
         b.set_input_text("#id_ed25519-old-password", "locked")
         b.set_input_text("#id_ed25519-new-password", "foobar")
         b.set_input_text("#id_ed25519-confirm-password", "foobar")
-        b.assert_pixels("#credentials-modal", "ssh-keys-dialog")
+        b.assert_pixels("#credentials-modal", "ssh-keys-dialog", chrome_hack_double_shots=True)
 
         b.click("#id_ed25519-change-password")
         b.wait_visible('#credentials-modal .pf-v6-c-helper-text__item.pf-m-success')


### PR DESCRIPTION
For some layouts the dialog is not fully rendered when taking a screenshot. This occurred before in files and cockpit so we apply the same double screenshot workaround.

Example: https://cockpit-logs.us-east-1.linodeobjects.com/pull-0-827553b6-20250415-013220-fedora-41-daily/pixeldiff.html#TestKeys-testPrivateKeys-ssh-keys-dialog-medium