### PR TITLE
cockpit.user() deprecation

### DIFF
--- a/doc/guide/cockpit-session.xml
+++ b/doc/guide/cockpit-session.xml
@@ -58,6 +58,14 @@ promise.then(user => { ... });
     </variablelist>
 
     <para>Returns a promise that completes once the user information is available.</para>
+    <warning>
+      <para>
+	<code>cockpit.user()</code> is soft-deprecated since Cockpit 336, if
+	your page does not need to maintain compatibility with older Cockpit
+	versions you can use<link linkend="cockpit-info">cockpit.info</link> to
+	obtain the user information.
+      </para>
+    </warning>
   </refsection>
 
   <refsection id="cockpit-permission">

--- a/pkg/lib/cockpit.d.ts
+++ b/pkg/lib/cockpit.d.ts
@@ -335,7 +335,7 @@ declare module 'cockpit' {
         home: string;
         shell: string;
     };
-    export function user(): Promise<Readonly<UserInfo>>;
+    /** @deprecated */ export function user(): Promise<Readonly<UserInfo>>;
 
     /* === String helpers ======================== */
 

--- a/pkg/lib/cockpit.d.ts
+++ b/pkg/lib/cockpit.d.ts
@@ -335,7 +335,7 @@ declare module 'cockpit' {
         home: string;
         shell: string;
     };
-    export function user(): Promise<UserInfo>;
+    export function user(): Promise<Readonly<UserInfo>>;
 
     /* === String helpers ======================== */
 

--- a/pkg/lib/cockpit.js
+++ b/pkg/lib/cockpit.js
@@ -1107,6 +1107,7 @@ function factory() {
                             home: user.Home.v,
                             shell: user.Shell.v
                         };
+                        Object.freeze(the_user);
                         return the_user;
                     })
                     .finally(() => dbus.close());


### PR DESCRIPTION
Let's soft deprecate cockpit.user() and teach our users about the existing alternative with a fallback option. The TypeScript shenanigans sparked this ;-)