### PR TITLE
release: Automatically create flathub PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,6 +133,7 @@ jobs:
           git commit -m "Update to version ${{ github.ref_name }}"
           git show
           git push git@github.com:cockpit-project/org.cockpit_project.CockpitClient HEAD
+          gh pr create --fill-verbose
 
 
   node-cache:


### PR DESCRIPTION
With this we should now automatically get flathub PRs created
automatically without us having to click it manually.

`gh` CLI is available in GitHub workflows in general and can be used
without issues.

Signed-off-by: Freya Gustavsson <freya@venefilyn.se>