### PR TITLE
Load additional configuration files .conf from directory /etc/cockpit/cockpit.conf.d/ 

### DIFF
--- a/src/common/cockpitconf.c
+++ b/src/common/cockpitconf.c
@@ -236,9 +236,11 @@ load_conf_d_files (void)
       if (!g_str_has_suffix (entry->d_name, ".conf"))
         continue;
 
-      snprintf (filepath, sizeof (filepath), "%s/%s", conf_d_dir, entry->d_name);
-      if (stat (filepath, &st) == 0 && S_ISREG (st.st_mode))
-        load_key_file (filepath);
+      int len = snprintf(filepath, sizeof(filepath), "%s/%s", conf_d_dir, entry->d_name);
+      if (len < 0 || (size_t)len >= sizeof(filepath))
+        continue;
+      if (stat(filepath, &st) == 0 && S_ISREG (st.st_mode))
+        load_key_file(filepath);
     }
 
   closedir (dir);


### PR DESCRIPTION
There is only /etc/cockpit/cockpit.conf file used as configuration file. As per RHEL-13021 RFE adding section to load configuration files from /etc/cockpit/cockpit.conf.d/ directory as well. 

Entries added in src/common/cockpitconf.c file under comment /* Logic to load all additional .conf files from cockpit.conf.d directory */. 

https://issues.redhat.com/browse/RHEL-13021