### PR TITLE
apps: Fix alignment of application list

### DIFF
--- a/pkg/apps/application-list.jsx
+++ b/pkg/apps/application-list.jsx
@@ -21,7 +21,6 @@ import cockpit from "cockpit";
 import React, { useState } from "react";
 import { Alert, AlertActionCloseButton, AlertActionLink } from "@patternfly/react-core/dist/esm/components/Alert/index.js";
 import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
-import { Card } from "@patternfly/react-core/dist/esm/components/Card/index.js";
 import { DataList, DataListAction, DataListCell, DataListItem, DataListItemCells, DataListItemRow } from "@patternfly/react-core/dist/esm/components/DataList/index.js";
 import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex/index.js";
 import { Page, PageSection } from "@patternfly/react-core/dist/esm/components/Page/index.js";
@@ -199,11 +198,9 @@ export const ApplicationList = ({ metainfo_db, appProgress, appProgressTitle, ac
                             </StackItem>
                         }
                         <StackItem>
-                            <Card isPlain>
-                                <DataList aria-label={_("Applications list")}>
-                                    { tbody }
-                                </DataList>
-                            </Card>
+                            <DataList aria-label={_("Applications list")}>
+                                { tbody }
+                            </DataList>
                         </StackItem>
                     </Stack>
                 </PageSection>

--- a/pkg/apps/application.scss
+++ b/pkg/apps/application.scss
@@ -7,6 +7,7 @@
   inline-size: 32px;
   block-size: 32px;
   max-inline-size: unset;
+  margin-block: -4px;
 }
 
 .app-list .progress-title {
@@ -15,11 +16,6 @@
 
 .app-list .pf-v6-c-data-list__item-action button {
   min-inline-size: 6rem;
-}
-
-.app-list .pf-v6-c-data-list__item-content {
-  /* Vertically align application info to the center */
-  align-items: center;
 }
 
 .progress-bar {

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -129,6 +129,9 @@ class TestApps(packagelib.PackageCase):
         b.wait_visible("#list-page")
         b.wait_not_present("#app-page")
 
+        if urlroot == "":
+            b.assert_pixels("#list-page", "list-page")
+
         b.click(".app-list .pf-v6-c-data-list__item-row:contains('app-1') button:contains('Install')")
         b.wait_visible(".app-list .pf-v6-c-data-list__item-row:contains('app-1') button:contains('Remove')")
         b.wait_visible(f".app-list .pf-v6-c-data-list__item-row:contains('app-1') img[src^='{urlroot}/cockpit/channel/']")


### PR DESCRIPTION
With this we fix the alignment of applications to remove the centering
and instead change the alignment of the app icons themselves. This will
improve the mobile layout as well and ensure that the text, icon, and
button for installing/removing is all aligned correctly.

Fixes: #21878
Signed-off-by: Freya Gustavsson <freya@venefilyn.se>

Before:

![image](https://github.com/user-attachments/assets/bed9439a-29db-469c-8518-15a3a17db9bb)

After:

![image](https://github.com/user-attachments/assets/6cb38b7e-8b20-4331-9933-8e5fe81ff9e7)


