### PR TITLE
Deprecate more cockpit object functions

### DIFF
--- a/doc/guide/cockpit-dbus.xml
+++ b/doc/guide/cockpit-dbus.xml
@@ -896,14 +896,4 @@ variant = cockpit.variant(type, value)
 
     <para>This is a helper function for creating such a variant object.</para>
   </refsection>
-
-  <refsection id="cockpit-dbus-byte-array">
-    <title>cockpit.byte_array()</title>
-<programlisting>
-byte_array = cockpit.byte_array(value)
-</programlisting>
-
-    <para>A DBus byte array is represented as base64 data encoded in a string. This
-      is a helper function for creating such a byte array.</para>
-  </refsection>
 </refentry>

--- a/pkg/lib/cockpit.js
+++ b/pkg/lib/cockpit.js
@@ -1971,6 +1971,7 @@ function factory() {
     };
 
     cockpit.byte_array = function byte_array(string) {
+        console.warn("cockpit.byte_array() is deprecated, use window.btoa");
         return window.btoa(string);
     };
 

--- a/pkg/lib/cockpit.js
+++ b/pkg/lib/cockpit.js
@@ -1066,6 +1066,7 @@ function factory() {
 
     /* Not public API ... yet? */
     cockpit.drop_privileges = function drop_privileges() {
+        console.warn("cockpit.drop_privileges() is deprecated");
         ensure_transport(function(transport) {
             transport.send_control({ command: "logout", disconnect: false });
         });


### PR DESCRIPTION
In the long run our plan is to change how users consume cocpit's API probably like fsinfo

```
import { fsinfo } from 'cockpit/fsinfo'
```

So everything we have on our global cockpit object isn't helping and these two methods aren't used or useful.