### PR TITLE
test: Allow KbdInteractiveAuthentication in sshd_config as well

### DIFF
--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -275,10 +275,17 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         m = self.machine
         b = self.browser
 
-        # with the ws container this happens over ssh
+        # With the ws container this happens over ssh and we need
+        # ChallengeResponseAuthentication (or
+        # KbdInteractiveAuthentication, it's new name) to be allowed.
+        # Without that, OpenSSH will do the required password change
+        # without PAM and by running "/bin/passwd" instead.
+        #
         if m.ws_container:
             self.restore_dir("/etc/ssh", restart_unit=self.sshd_service)
             m.execute("sed -i 's/.*ChallengeResponseAuthentication.*/ChallengeResponseAuthentication yes/' "
+                      "/etc/ssh/sshd_config $(ls /etc/ssh/sshd_config.d/* 2>/dev/null || true)")
+            m.execute("sed -i 's/.*KbdInteractiveAuthentication.*/KbdInteractiveAuthentication yes/' "
                       "/etc/ssh/sshd_config $(ls /etc/ssh/sshd_config.d/* 2>/dev/null || true)")
             m.execute(self.restart_sshd)
 

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -704,10 +704,18 @@ class TestAccounts(testlib.MachineCase):
             b2.login_and_go("/users")
             b2.wait_in_text("#accounts-list tbody tr:contains(robert) td[data-label='Last active']", "Never logged in")
 
-        # with container this happens over ssh
+        # With the ws container this happens over ssh and we need
+        # ChallengeResponseAuthentication (or
+        # KbdInteractiveAuthentication, it's new name) to be allowed.
+        # Without that, OpenSSH will do the required password change
+        # without PAM and by running "/bin/passwd" instead.
+        #
         if m.ws_container:
             self.restore_dir("/etc/ssh", restart_unit=self.sshd_service)
-            m.execute("sed -i 's/.*ChallengeResponseAuthentication.*/ChallengeResponseAuthentication yes/' /etc/ssh/sshd_config $(ls /etc/ssh/sshd_config.d/* 2>/dev/null) || true")
+            m.execute("sed -i 's/.*ChallengeResponseAuthentication.*/ChallengeResponseAuthentication yes/' "
+                      "/etc/ssh/sshd_config $(ls /etc/ssh/sshd_config.d/* 2>/dev/null || true)")
+            m.execute("sed -i 's/.*KbdInteractiveAuthentication.*/KbdInteractiveAuthentication yes/' "
+                      "/etc/ssh/sshd_config $(ls /etc/ssh/sshd_config.d/* 2>/dev/null || true)")
             m.execute(self.restart_sshd)
 
         b.wait_visible("#login")


### PR DESCRIPTION
It's the new name for ChallengeResponseAuthentication and the 50-redhat.conf file in Fedora 42 uses that spelling. This matters when fedora-coreos moves to F42 in https://github.com/cockpit-project/bots/pull/7636