### PR TITLE
Provide cockpit/ws image for arm64

### DIFF
--- a/.github/workflows/build-ws-container.yml
+++ b/.github/workflows/build-ws-container.yml
@@ -6,14 +6,25 @@ on:
   # can be run manually on https://github.com/cockpit-project/cockpit/actions
   workflow_dispatch:
 
+env:
+  registry_repo: ${{ vars.REGISTRY_REPO || 'quay.io/cockpit/ws' }}
+
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        build:
+          - label: amd64
+            runner: ubuntu-24.04
+          - label: arm64
+            runner: ubuntu-24.04-arm
+
+    runs-on: ${{ matrix.build.runner }}
     environment: quay.io
     permissions: {}
     timeout-minutes: 20
-    env:
-      RUNC: docker
+    outputs:
+      VERSION: ${{ steps.build.outputs.VERSION }}
 
     steps:
       - name: Clone repository
@@ -27,8 +38,46 @@ jobs:
           git checkout $(git rev-list --tags --max-count=1)
           git describe
 
-      - name: Log into container registry
-        run: $RUNC login -u ${{ secrets.QUAY_BOTUSER }} -p ${{ secrets.QUAY_TOKEN }} quay.io
+      - name: Build ws container
+        id: build
+        env:
+          IMAGE_TAG: localhost/cockpit-ws:release-${{ matrix.build.label }}
+          RUNC: podman
+        run: |
+          containers/ws/release.sh
+          $RUNC save --format=oci-archive $IMAGE_TAG > cockpit-ws-${{ matrix.build.label }}.tar
 
-      - name: Build and push ws container
-        run: containers/ws/release.sh
+      - name: Save image to artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: cockpit-ws-${{ matrix.build.label }}
+          path: cockpit-ws-${{ matrix.build.label }}.tar
+
+  manifest:
+    needs: build
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Login in to container registry
+        run: podman login -u ${{ secrets.QUAY_BOTUSER }} -p ${{ secrets.QUAY_TOKEN }} $(echo ${{ env.registry_repo }} | cut -d/ -f1)
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+
+      - name: Load images into Podman
+        run: |
+          for artifact in cockpit-ws-*; do
+            podman load < $artifact/$artifact.tar
+          done
+
+      - name: Create manifest
+        # containers-storage:localhost/ is a workaround for https://github.com/containers/common/issues/1896, will probably be fixed in Ubuntu 26.04
+        run: podman manifest create ws containers-storage:localhost/cockpit-ws:release-{amd64,arm64}
+
+      - name: Push with versioned tag
+        run: podman manifest push ws "${{ env.registry_repo }}:${{ needs.build.outputs.VERSION }}"
+
+      - name: Push :latest tag
+        run: podman manifest push ws "${{ env.registry_repo }}:latest"

--- a/containers/ws/release.sh
+++ b/containers/ws/release.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -eux
 
 if [ -z "${RUNC:-}" ]; then
@@ -8,24 +8,23 @@ if [ -z "${RUNC:-}" ]; then
     }
 fi
 
-$RUNC build -t quay.io/cockpit/ws:release containers/ws
+if [ -z "${IMAGE_TAG:-}" ]; then
+    IMAGE_TAG=quay.io/cockpit/ws:release-$(date +%s)
+fi
+
+$RUNC build -t $IMAGE_TAG containers/ws
 
 # smoke test
 name=ws-release
-$RUNC run --name $name -p 19999:9090 -d quay.io/cockpit/ws:release
+$RUNC run --name $name -p 19999:9090 -d $IMAGE_TAG
 until curl --fail --show-error -k --head https://localhost:19999; do
     sleep 1
 done
 
 # determine cockpit version
-TAG=$($RUNC exec $name cockpit-bridge --version | sed -n '/^Version:/ { s/^.*: //p }')
+VERSION=$($RUNC exec $name bash -c "cockpit-bridge --version | sed -n '/^Version:/ { s/^.*: //p }'")
+echo VERSION=$VERSION >> ${GITHUB_OUTPUT:-/dev/null}
+
+$RUNC exec $name bash -c "echo Successfully tested cockpit-ws container version $VERSION on \$(uname -m) architecture"
 
 $RUNC rm -f $name
-
-$RUNC tag quay.io/cockpit/ws:release quay.io/cockpit/ws:$TAG
-$RUNC tag quay.io/cockpit/ws:release quay.io/cockpit/ws:latest
-$RUNC rmi quay.io/cockpit/ws:release
-
-# push both tags
-$RUNC push quay.io/cockpit/ws:$TAG
-$RUNC push quay.io/cockpit/ws:latest


### PR DESCRIPTION
This PR implements multi-platform images for the `ws` container as requested in #17569. It is inspired by both the implementation and review comments of #17935, but excludes changes in the documentation or unrelated scripts (I do support those changes, but assume it is better to handle those in a separate PR).

I wish to highlight the following changes:

> [!WARNING]  
> The section below is outdated.

<details>

- Multi-platform images are build by Docker Buildx for `linux/amd64` and `linux/arm64` by default
- ~Due to the differences of syntax of commands required to build multi-platform images between Podman and Docker, the script is no longer compatible with Podman. If support for Podman is required, I will have to rewrite some commands and this will likely result in a more complex script (also I never worked with Podman before and have no idea to what extent it supports multi-platform images). If support for Podman is no longer required, perhaps the `$RUNC` variable should also be removed.~ I went ahead and implemented support for both Podman and Docker in https://github.com/cockpit-project/cockpit/pull/21969/commits/202d22b415f3689495393a80e02f7a669e21f8f7.
- The interpreter has been changed to `bash` to support iterating through a comma-separated list of platforms
- Smoke tests run on every platform image and let the container print its own architecture to ensure that everything went as expected
- Docker must use the `containerd` image store in order to support storing multi-arch images locally, which is required for running them before pushing. When building locally, ensure that your Docker service uses the `containerd` image store. Also, QEMU must be installed for building and running images for different platforms
- The GitHub actions machine type is now `ubuntu-24.04-arm`. This is not strictly necessary, since the setup can create the intended result on every architecture, but aarch64 runners appear to be more performant at emulating x86 (~ 7 minutes) than x86 runners are at emulating aarch64 (timeout after 20 minutes)

</details>

Fixes #17569 