### PR TITLE
test: Re-enable FreeIPA, sssd, and pcp tests on debian-testing

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -80,7 +80,6 @@ def applySettings(browser, dialog_selector):
 
 
 @testlib.skipOstree("no PCP support")
-@testlib.skipImage("pcp not currently in testing", "debian-testing")
 class TestHistoryMetrics(testlib.MachineCase):
     def setUp(self):
         super().setUp()
@@ -1412,7 +1411,6 @@ class TestMetricsPackages(packagelib.PackageCase):
 
 
 @testlib.skipOstree("no PCP support")
-@testlib.skipImage("pcp not currently in testing", "debian-testing")
 class TestMultiCPU(testlib.MachineCase):
 
     provision = {
@@ -1458,7 +1456,6 @@ class TestMultiCPU(testlib.MachineCase):
 
 
 @testlib.skipOstree("no PCP support")
-@testlib.skipImage("pcp not currently in testing", "debian-testing")
 class TestGrafanaClient(testlib.MachineCase):
 
     provision = {

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -670,7 +670,6 @@ OnCalendar=daily
             b.wait_in_text(f".pf-v6-c-menu li:nth-of-type({i + 1}) button", paths[i])
 
     @testlib.skipOstree("No PCP available")
-    @testlib.skipImage("pcp not currently in testing", "debian-testing")
     def testPlots(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -841,7 +841,6 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         self.allow_journal_messages(r"cockpit-session: user account access failed.*root.*")
 
     @testlib.skipWsContainer("sssd/cockpit-session not available with ws container")
-    @testlib.skipImage("sssd not currently in testing", "debian-testing")
     def testClientCertAuthentication(self):
         m = self.machine
 

--- a/test/verify/check-storage-swap
+++ b/test/verify/check-storage-swap
@@ -28,7 +28,7 @@ class TestStorageswap(storagelib.StorageCase):
 
     def checkSwapUsed(self):
         # this relies on PCP, which is missing on some images
-        if self.machine.image in ["debian-testing", "rhel-8-10"]:
+        if self.machine.image in ["rhel-8-10"]:
             return
 
         self.browser.wait_text(self.card_desc("Swap", "Used"), "0 B")

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -512,7 +512,6 @@ class TestRealms(testlib.MachineCase):
 
 
 @testlib.no_retry_when_changed
-@testlib.skipImage("freeipa not currently available", "debian-testing")
 class TestIPA(TestRealms, CommonTests):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
https://github.com/cockpit-project/bots/pull/7732 brought back the packages.

 - [x] Land the above image refresh