### PR TITLE
storage: Fix gap in Anaconda mode

### DIFF
--- a/pkg/storaged/storage-anaconda.scss
+++ b/pkg/storaged/storage-anaconda.scss
@@ -4,6 +4,7 @@
     border-radius: 0;
     margin: 0;
     border: 0;
+    max-block-size: 100%;
   }
 
   .pf-v6-c-page__main {


### PR DESCRIPTION
Without this fix, the content area has a grey gap at the bottom. With this fix, the height works as intended.

Before:

![image](https://github.com/user-attachments/assets/24c5c2a8-fb9b-4a4f-a816-ae324c93b3f1)

After:

![image](https://github.com/user-attachments/assets/55736ed0-d574-427a-a5ce-1a3fb23f8df4)
