### PR TITLE
WIP: Collect PCP logs through a quadlet container

### DIFF
--- a/tools/cockpit-pcp.container
+++ b/tools/cockpit-pcp.container
@@ -1,0 +1,17 @@
+# This gets installed to /usr/share/containers/systemd/cockpit-pcp.container
+[Unit]
+Description=Cockpit PCP Container
+
+[Service]
+ExecStartPre=mkdir -p /var/log/pcp/pmlogger
+
+[Container]
+Image=registry.suse.com/suse/pcp
+Environment=HOST_MOUNT=/host
+Environment=PROC_STATSPATH=/host
+Environment=PCP_PODMAN_DATADIR=/host/var/lib/containers/storage/overlay-containers
+Environment=PCP_PODMAN_RUNDIR=/host/run/containers/storage/overlay-containers
+Volume=/:/host:ro,rslave
+Volume=/var/log/pcp/pmlogger:/var/log/pcp/pmlogger:Z
+Network=host
+PodmanArgs=--privileged


### PR DESCRIPTION
Hey! So I wanted to pitch something I've been working on lately to see if there's any interest in it. Obviously it would need changes, but it's a draft for that reason so take the diffs with a pinch of salt

This looks to add an alternative way of running pcp for Cockpit, instead of running it directly on the host system, we can run it through a container quite easily, the metrics backend as far as I've tested doesn't really require pcp to be on the host

Meaning we can run pcp through a quadlet container, proxy the created service and essentially have everything working only relying on python3-pcp as a dependency

My use case for this is that Micro doesn't and won't provide full pcp in it's repos, it will however provide python3-pcp, meaning with the use of a container we can have pcp logs

![image](https://github.com/user-attachments/assets/51a207a7-4541-49e6-b9e6-6c16d71fc05f)

Some of the catches are:

- the container should run with host network, otherwise we might enter issues where the hostname is different to what the container thinks and cockpit operates on the hostname for pcp logs
- it should be run as privileged otherwise we get issues properly collecting metrics
- to enable it for boot we have to write:
  ```
  [Install]
  WantedBy=default.target
  ```
  to /etc/containers/systemd/cockpit-pcp.container.d/10-enable.conf which doesn't feel nice

Let me know what you think and if there's any interest in this for upstreaming