### PR TITLE
examples/long-running-process: Add reset

### DIFF
--- a/examples/long-running-process/index.js
+++ b/examples/long-running-process/index.js
@@ -40,8 +40,8 @@ function update(process) {
         showJournal(process.serviceName, "--since=@" + Math.floor(process.startTimestamp / 1000000));
         break;
     case ProcessState.FAILED:
-        run_button.setAttribute("disabled", "");
-        run_button.textContent = "Start";
+        run_button.removeAttribute("disabled");
+        run_button.textContent = "Reset";
         // Show the whole journal of this boot
         showJournal(process.serviceName, "--boot");
         break;
@@ -74,6 +74,8 @@ cockpit.transport.wait(() => {
     run_button.addEventListener("click", () => {
         if (process.state === ProcessState.RUNNING)
             process.terminate();
+        else if (process.state === ProcessState.FAILED)
+            process.reset();
         else
             process.run(["/bin/sh", "-ec", command.value])
                     .catch(ex => {

--- a/pkg/lib/long-running-process.js
+++ b/pkg/lib/long-running-process.js
@@ -91,6 +91,12 @@ export class LongRunningProcess {
         return this.systemdClient.call(O_SD_OBJ, I_SD_MGR, "StopUnit", [this.serviceName, "replace"], { type: "ss" });
     }
 
+    reset() {
+        if (this.state === ProcessState.FAILED)
+            this.systemdClient.call(O_SD_OBJ, I_SD_MGR, "ResetFailedUnit", [this.serviceName], { type: "s" });
+        else
+            throw new Error(`cannot reset LongRuningProcess in state ${this.state}`);
+    }
     /*
      * below are internal private methods
      */

--- a/test/verify/check-examples
+++ b/test/verify/check-examples
@@ -150,7 +150,7 @@ class TestLongRunning(testlib.MachineCase):
         self.assertNotIn("\nNOTME", out)
         # does not contain previous logs
         self.assertNotIn("STEP_B", out)
-        b.wait_text("button#run", "Start")
+        b.wait_text("button#run", "Reset")
 
         # failing state gets picked up on page reconnect
         b.logout()
@@ -160,11 +160,10 @@ class TestLongRunning(testlib.MachineCase):
         out = b.text("#output")
         self.assertIn("\nBREAK_A\n", out)
         self.assertNotIn("\nNOTME", out)
-        b.wait_visible("button#run:disabled")
-        b.wait_text("button#run", "Start")
+        b.wait_text("button#run", "Reset")
 
         # reset
-        m.execute("systemctl reset-failed cockpit-longrunning.service")
+        b.click("button#run")
         b.wait_text("#state", "cockpit-longrunning.service stopped")
 
         # cancel long-running command


### PR DESCRIPTION
When I was creating a module for cockpit that used the LongRunningProcess Example I found that while debugging the module I made there wasn't a way to reset the process without going to the terminal (with the proper command) to reset the process if it failed.

So, I created a way and thought I would share it.