### PR TITLE
lib: Help TS infer a better type for "superuser"

### DIFF
--- a/pkg/lib/superuser.js
+++ b/pkg/lib/superuser.js
@@ -90,13 +90,11 @@ function Superuser() {
         return (proxy.Bridges?.length ?? 0) > 0;
     };
 
-    const self = {
+    const self = cockpit.event_target({
         allowed: compute_allowed(),
         configured: null,
         reload_page_on_change
-    };
-
-    cockpit.event_target(self);
+    });
 
     function changed(allowed) {
         if (self.allowed != allowed) {


### PR DESCRIPTION
Now "superuser" is a proper EventSource and we can use it with our "useEvent" hook in TypeScript.