### PR TITLE
patternfly: override font-weight table header in mobile layout

### DIFF
--- a/pkg/lib/page.scss
+++ b/pkg/lib/page.scss
@@ -218,3 +218,14 @@ body {
     shape-rendering: crispedges;
   }
 }
+
+// Set patternfly-6 native font-weight for bold elements
+b,
+strong {
+  font-weight: var(--pf-t--global--font--weight--body--bold);
+}
+
+b.ct-heading-font-weight,
+strong.ct-heading-font-weight {
+  font-weight: var(--pf-t--global--font--weight--heading--bold);
+}

--- a/pkg/lib/patternfly/patternfly-6-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-6-overrides.scss
@@ -404,3 +404,9 @@ $phone: 767px;
     flex-wrap: wrap;
   }
 }
+
+// NOTE: PF6 workaround, when table is in the small screen layout PF sets too big font-weight
+// https://github.com/patternfly/patternfly/issues/7526
+.pf-v6-c-table .pf-v6-c-table__tbody :where(.pf-v6-c-table__th, .pf-v6-c-table__td)[data-label]::before {
+    font-weight: var(--pf-t--global--font--weight--body--bold);
+}

--- a/pkg/networkmanager/networking.scss
+++ b/pkg/networkmanager/networking.scss
@@ -217,7 +217,7 @@ th {
   block-size: 100%;
 
   .ct-table tbody tr:first-of-type td:nth-child(2) {
-    font-weight: var(--pf-t--global--font--weight--heading--bold);
+    font-weight: var(--pf-t--global--font--weight--body--bold);
   }
 }
 

--- a/pkg/shell/hosts_dialog.jsx
+++ b/pkg/shell/hosts_dialog.jsx
@@ -261,7 +261,7 @@ class Connect extends React.Component {
             <Modal id="hosts_connect_server_dialog" isOpen
                    position="top" variant="small"
                    onClose={this.props.onClose}
-                   title={fmt_to_fragments(_("Connect to $0?"), <b>{this.props.host}</b>)}
+                   title={fmt_to_fragments(_("Connect to $0?"), <b className="ct-heading-font-weight">{this.props.host}</b>)}
                    titleIconVariant="warning"
                    footer={<>
                        <HelperText>


### PR DESCRIPTION
Verified that this works on tables located on accounts page, account detail, metrics and hw info page. Also crosschecked with fedora-coreos where this issue was discovered.

The `@media screen ...` condition in css is not required and wouldn't work correctly on the metrics page in network interfaces card. To work around this the css selector specifically targets `::before` pseudo element which is only present once the table switches to the mobile layout.