### PR TITLE
test: re-enable kdump tests on rhel-10

### DIFF
--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -92,7 +92,6 @@ class KdumpHelpers(testlib.MachineCase):
 
 @testlib.skipOstree("kexec-tools not installed")
 @testlib.skipImage("kexec-tools not installed", "debian-*", "ubuntu-*", "arch")
-@testlib.skipImage("https://issues.redhat.com/browse/RHEL-35567", "centos-10", "rhel-10*")
 @testlib.timeout(900)
 class TestKdump(KdumpHelpers):
 
@@ -464,7 +463,6 @@ class TestKdump(KdumpHelpers):
 
 @testlib.skipOstree("kexec-tools not installed")
 @testlib.skipImage("kexec-tools not installed", "debian-*", "ubuntu-*", "arch")
-@testlib.skipImage("https://issues.redhat.com/browse/RHEL-35567", "centos-10", "rhel-10*")
 @testlib.timeout(900)
 class TestKdumpNFS(KdumpHelpers):
     provision = {


### PR DESCRIPTION
kdump tools are now available.