### PR TITLE
storage: Fix section spacing

### DIFF
--- a/pkg/lib/patternfly/patternfly-6-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-6-overrides.scss
@@ -356,13 +356,10 @@ $phone: 767px;
   }
 }
 
-/* FIXME: Temporary rework plain cards to make it look like how PF6 is designed, adding borders between sections */
-.pf-v6-c-card.pf-m-plain + .pf-v6-c-card.pf-m-plain,
-.pf-v6-l-stack__item + .pf-v6-l-stack__item > .pf-v6-c-card.pf-m-plain {
+// FIXME: Temporary rework table cards in mobile/small view to have row dividers between each row.
+.pf-v6-c-card.ct-small-table-card {
   border-block-start: var(--pf-t--global--border--width--100) solid var(--pf-t--global--border--color--default);
   border-radius: var(--pf-t--global--border--radius--0);
-  margin-block: var(--pf-t--global--spacer--md);
-  padding-block-start: var(--pf-t--global--spacer--md);
 }
 
 


### PR DESCRIPTION
We had a bit too much spacing between cards that caused issues with
storage mobile-view. Reverting this to how we had it before.

This also removes the border between cards for the storage page
and instead only keeps them for the table-style of cards we have between
storage types.

Future improvements would be to
- Remove usage of Card for Storage page sections or embrace it fully
- Remove usage of Card for mobile-view rows and instead use Table or
  Data list component

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2366666
Signed-off-by: Freya Gustavsson <freya@venefilyn.se>