### PR TITLE
systemd: show link to podman page for quadlets

### DIFF
--- a/pkg/systemd/service-details.jsx
+++ b/pkg/systemd/service-details.jsx
@@ -419,6 +419,7 @@ export class ServiceDetails extends React.Component {
         const showAction = this.props.permitted || this.props.owner == "user";
         const isCustom = this.props.unit.FragmentPath.startsWith("/etc/systemd/system") && !masked;
         const isTimer = (this.unitType === "timer");
+        const isQuadlet = this.props.unit.SourcePath.includes("/containers/systemd/");
 
         let status = [];
 
@@ -667,6 +668,15 @@ export class ServiceDetails extends React.Component {
                                 <DescriptionListTerm>{ _("Listen") }</DescriptionListTerm>
                                 <DescriptionListDescription id="listen">
                                     {cockpit.format("$0 ($1)", this.props.unit.Listen[0][1], this.props.unit.Listen[0][0])}
+                                </DescriptionListDescription>
+                            </DescriptionListGroup>}
+                            {isQuadlet && cockpit.manifests?.podman?.capabilities?.includes("services") && <DescriptionListGroup>
+                                <DescriptionListTerm>{ _("Container") }</DescriptionListTerm>
+                                <DescriptionListDescription id="container">
+                                    <Button variant="link" isInline onClick={
+                                        () => cockpit.jump(`/podman#/?service=${this.props.unit.Id}`)}>
+                                        {_("View Podman container")}
+                                    </Button>
                                 </DescriptionListDescription>
                             </DescriptionListGroup>}
                             { notMetConditions.length > 0 &&


### PR DESCRIPTION
On a service details page show a link to the podman if the service is a quadlet. Quadlets are detected by checking if the SourcePath contains "containers/systemd", normally it is /etc/containers/systemd or /usr/share/containers/systemd.

Related: https://github.com/cockpit-project/cockpit-podman/issues/2055

---

Blocked on a podman implementation for filtering quadlets.

Currently podman supports filtering on name via a simple url ie. http://127.0.0.2:9091/podman#/?name=systemd this does not yet support quadlets. Which is needed as Cockpit does not know the real container or pod name as this can be configured in the .container or .pod file.

There are two options for podman to fix this: (the filtering is currently based on ContainerName/PodName or ImageName)

* Allowing filtering on the service name so passing `name=jellyfin.service` and setting that in the as textFilter
* Resolving the .service to the ContainerName/PodName, and then setting that as textFilter. Requires looping over all containers/pods at least once.