### PR TITLE
test: Relax "cat" executable assumption for current Ubuntu

### DIFF
--- a/test/pytest/test_bridge.py
+++ b/test/pytest/test_bridge.py
@@ -962,7 +962,7 @@ async def test_channel(bridge: Bridge, transport: MockTransport, channeltype, tm
             if command == 'ready':
                 if 'spawn' in args:
                     assert isinstance(control['pid'], int)
-                    assert os.readlink(f"/proc/{control['pid']}/exe").endswith("/cat")
+                    assert os.readlink(f"/proc/{control['pid']}/exe").endswith("cat")
                 # If we get ready, it's our turn to send data first.
                 # Hopefully we didn't receive any before.
                 assert not saw_data


### PR DESCRIPTION
Latest Ubuntu is moving to Rust coreutils [1] and as intermediate step renamed the original coreutils to gnu-coreutils [2] and thus /usr/bin/cat is now an alternatives link to "gnucat". This broke our `test_channel[SubprocessStreamChannel]` test which assumes that running `cat` will actually be an executable which is named "cat".

Relax this by accepting a "cat" suffix.

[1] https://discourse.ubuntu.com/t/carefully-but-purposefully-oxidising-ubuntu/56995
[2] https://launchpad.net/ubuntu/+source/coreutils/9.5-1ubuntu2

----

This should fix the [Ubuntu questing build failure](https://launchpad.net/ubuntu/+source/cockpit/338-1/+build/30716158), see the [detailed log](https://launchpadlibrarian.net/793929803/buildlog_ubuntu-questing-amd64.cockpit_338-1_BUILDING.txt.gz).