### PR TITLE
bridge: Support packageless session on Debian 13 "trixie"

### DIFF
--- a/src/cockpit/osinfo.py
+++ b/src/cockpit/osinfo.py
@@ -12,6 +12,7 @@ supported_oses: 'list[dict[str, str | None]]' = [
     {"PLATFORM_ID": "platform:el10"},
 
     {"ID": "debian", "VERSION_ID": "12"},
+    {"ID": "debian", "VERSION_ID": "13"},
     # rolling release
     {"ID": "debian", "VERSION_ID": None},
 


### PR DESCRIPTION
Debian 13 goes into release freeze, and its os-release now has a proper VERSION_ID.

---

This should fix https://github.com/cockpit-project/bots/pull/7795