### PR TITLE
flathub: Add `GH_TOKEN` for auto-PR creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,8 @@ jobs:
   flathub:
     needs: source
     environment: flathub
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     permissions: {}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This should now work with automatic flathub PR creation. Though we'll
see if it actually has permissions or not to create PRs in different
repos. We might need a different type of token.

Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
