### PR TITLE
ci: Add quay.io environment to build ws container

### DIFF
--- a/.github/workflows/build-ws-container.yml
+++ b/.github/workflows/build-ws-container.yml
@@ -55,6 +55,7 @@ jobs:
 
   manifest:
     needs: build
+    environment: quay.io
 
     runs-on: ubuntu-latest
     timeout-minutes: 20


### PR DESCRIPTION
After #21969 was merged we started getting build failures. This relates
to the login not getting any environment variables due to the
environment for the job not being set. So since we have no context, no
variables are provided.

To fix this we just repeat the environment to this step as well.

Github-action: https://github.com/cockpit-project/cockpit/actions/runs/15167058371/job/42647647203
Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
