### PR TITLE
github: drop quay secrets in build step

### DIFF
--- a/.github/workflows/build-ws-container.yml
+++ b/.github/workflows/build-ws-container.yml
@@ -20,7 +20,6 @@ jobs:
             runner: ubuntu-24.04-arm
 
     runs-on: ${{ matrix.build.runner }}
-    environment: quay.io
     permissions: {}
     timeout-minutes: 20
     outputs:


### PR DESCRIPTION
Publishing happens in a separate "manifest" step so we won't need quay login credentials there.