### PR TITLE
infra: test/common/make-bots: override GITHUB_BASE

### DIFF
--- a/test/common/make-bots
+++ b/test/common/make-bots
@@ -5,6 +5,8 @@
 
 GITHUB_REPO='bots'
 SUBDIR='bots'
+# Cockpit plugins from different organizations are expected to share the same bots repository
+GITHUB_BASE="cockpit-project"
 
 V="${V-0}" # default to friendly messages
 


### PR DESCRIPTION
External projects like anaconda-webui, which maintain their own node-cache repository, need to set GITHUB_BASE to their project for git-utils to work as expected.
However, for shared repositories like 'bots', GITHUB_BASE should not be allowed to get overriden.