### PR TITLE
pyproject.toml: workaround asyncio 1.0 compatibility issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,7 +220,7 @@ deps =
   lint: ruff
   lint: vulture
   pytest
-  pytest-asyncio
+  pytest-asyncio < 1.0
   pytest: pytest-cov
   pytest: pytest-timeout
   pytest: pytest-xdist


### PR DESCRIPTION
Works test issues on Python > 3.8 with asyncio version 1.0

Related: #22049