### PR TITLE
flatpak: Extra GH arguments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,7 +135,10 @@ jobs:
           git commit -m "Update to version ${{ github.ref_name }}"
           git show
           git push git@github.com:cockpit-project/org.cockpit_project.CockpitClient HEAD
-          gh pr create --fill-verbose
+          gh pr create \
+            --fill \
+            -H cockpit-project:${{ github.ref_name }} \
+            -R flathub/org.cockpit_project.CockpitClient
 
 
   node-cache:


### PR DESCRIPTION
Adds extra arguments to the `gh pr create` so it selects from which
project's fork's branch to which remote to create the PR for.

Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
