### PR TITLE
test: disable packagekit pre-loading in expensive tests

### DIFF
--- a/test/common/netlib.py
+++ b/test/common/netlib.py
@@ -93,6 +93,9 @@ class NetworkCase(NetworkHelpers):
             self.restore_dir("/etc/netplan")
             self.restore_dir("/run/NetworkManager/system-connections")
             self.addCleanup(cleanupDevs)
+        else:
+            # Disable pre-loading packagekit, dnf needs-restarting (dnf 4) consumes tons of cpu/memory on RHEL-10-1
+            self.disable_preload("packagekit")
 
         m.execute("systemctl start NetworkManager")
 

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1470,6 +1470,9 @@ class TestGrafanaClient(testlib.MachineCase):
         mg = self.machines['services']
         pcp_dialog_selector = "#pcp-settings-modal"
 
+        # Disable pre-loading packagekit, dnf needs-restarting (dnf 4) consumes tons of cpu/memory on RHEL-10-1
+        self.disable_preload("packagekit")
+
         # avoid dynamic host name changes during PCP data collection, and start from clean slate
         m.execute("""systemctl stop pmlogger || true
                      systemctl reset-failed pmlogger || true


### PR DESCRIPTION
On RHEL-10-1 we OOM the machine when running the Grafana client tests bumping the memory requirements showed there was barely enough free memory on 512 MB

```
free -m
               total        used        free      shared  buff/cache   available
Mem:             744         499         105           2         245         245
```

---

This aims to solve [this flake](https://cockpit-logs.us-east-1.linodeobjects.com/pull-22065-1b7ae186-20250603-180251-rhel-10-1-other/log.html).

Draft for now as I assume we need to discuss the memory adjustments a bit :)