### PR TITLE
test: drop NetworkManager version check for 1.4.0

### DIFF
--- a/test/verify/check-networkmanager-mac
+++ b/test/verify/check-networkmanager-mac
@@ -43,20 +43,16 @@ class TestNetworkingMAC(netlib.NetworkCase):
         self.select_iface(iface)
         b.wait_text("#network-interface-mac", mac.upper())
 
-        if self.networkmanager_version >= [1, 4, 0]:
-            new_mac = self.network.interface()["mac"]
-            b.click("#network-interface-mac button")
-            b.wait_visible("#network-mac-settings-dialog")
-            b.set_input_text('#network-mac-settings-mac-input input', new_mac)
-            b.click(".pf-v6-c-menu ul > li > button")
-            b.click("#network-mac-settings-save")
-            b.wait_not_present("#network-mac-settings-dialog")
+        new_mac = self.network.interface()["mac"]
+        b.click("#network-interface-mac button")
+        b.wait_visible("#network-mac-settings-dialog")
+        b.set_input_text('#network-mac-settings-mac-input input', new_mac)
+        b.click(".pf-v6-c-menu ul > li > button")
+        b.click("#network-mac-settings-save")
+        b.wait_not_present("#network-mac-settings-dialog")
 
-            b.wait_text("#network-interface-mac", new_mac.upper())
-            self.assertIn(new_mac.lower(), m.execute(f"ip link show '{iface}'"))
-
-        else:
-            b.wait_not_present("#network-interface-mac button")
+        b.wait_text("#network-interface-mac", new_mac.upper())
+        self.assertIn(new_mac.lower(), m.execute(f"ip link show '{iface}'"))
 
     def testBondMac(self):
         b = self.browser


### PR DESCRIPTION
RHEL-8-10 has NetworkManager 1.4.0 so this check can now be dropped.