### PR TITLE
cockpit: fsinfo: add missing access types

### DIFF
--- a/pkg/lib/cockpit/fsinfo.ts
+++ b/pkg/lib/cockpit/fsinfo.ts
@@ -57,6 +57,9 @@ export interface FileInfo {
     group?: string | number;
     mtime?: number;
     target?: string;
+    ['r-ok']?: boolean,
+    ['w-ok']?: boolean,
+    ['x-ok']?: boolean,
     entries?: Record<string, FileInfo>;
     targets?: Record<string, FileInfo>;
 }


### PR DESCRIPTION
Follow up from 6ffaa9cdfd4e40d764470cfe570fe4e4bae0d97c

---

Woops :sweat_smile: 