### PR TITLE
lib: type cockpit-components-password

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@types/qunit": "^2.19.10",
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1",
+    "@types/throttle-debounce": "5.0.2",
     "@typescript-eslint/eslint-plugin": "8.33.1",
     "argparse": "2.0.1",
     "esbuild": "0.25.5",


### PR DESCRIPTION
This is used in Cockpit machines so is useful to have typed. The only notable change is converting `passwordStrength` from `undefined | number`, or as the code claims possibly a string to a number with a default value of -1. When `passwordStrength` is -1 the strength meter is not shown.