### PR TITLE
kdump: Remove nfs directory when using sysconfig configuration style

### DIFF
--- a/pkg/kdump/config-client-suse.js
+++ b/pkg/kdump/config-client-suse.js
@@ -61,6 +61,7 @@ export class ConfigFileSUSE extends ConfigFile {
             _internal: {},
             targets: {},
             compression: { enabled: false, allowed: true },
+            nfs_supports_directory: false,
         };
 
         this._lines = rawContent.split(/\r?\n/);

--- a/pkg/kdump/config-client.js
+++ b/pkg/kdump/config-client.js
@@ -95,6 +95,7 @@ export class ConfigFile {
             _internal: {},
             targets: {},
             compression: { enabled: false, allowed: false, },
+            nfs_supports_directory: true,
         };
         this._lines.forEach((line, index) => {
             const trimmed = line.trim();

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -414,20 +414,10 @@ class TestKdumpConfiguration(KdumpHelpers):
         b.set_input_text("#kdump-settings-nfs-export", "/srv")
         b.click("button:contains('Save')")
         b.wait_not_present("#kdump-settings-dialog")
-        b.wait_text("#kdump-target-info", "Remote over NFS, someserver:/srv/var/crash")
+        b.wait_text("#kdump-target-info", "Remote over NFS, someserver:/srv/")
         conf = m.execute("cat /etc/sysconfig/kdump")
         self.assertIn('KDUMP_SAVEDIR=nfs://someserver/srv', conf)
         self.assertNotIn("ssh://", conf)
-
-        # NFS with custom path
-        b.click("#kdump-change-target")
-        b.wait_visible("#kdump-settings-dialog")
-        b.set_input_text("#kdump-settings-nfs-directory", "dumps")
-        b.click("button:contains('Save')")
-        b.wait_not_present("#kdump-settings-dialog")
-        b.wait_text("#kdump-target-info", "Remote over NFS, someserver:/srv/dumps/var/crash")
-        conf = m.execute("cat /etc/sysconfig/kdump")
-        self.assertIn('KDUMP_SAVEDIR=nfs://someserver/srv/dumps', conf)
 
         # Check local location
         b.click("#kdump-change-target")


### PR DESCRIPTION
Because of sysconfig/kdump only having a flat `KDUMP_SAVEDIR` field, we can't pull back out the `Directory` field since it's concatenated to one path, so instead we should just let it run off only the `Export` field