### PR TITLE
workflows: Run tox in current fedora

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -6,11 +6,26 @@ jobs:
     permissions: {}
 
     runs-on: ubuntu-latest
-    container: ghcr.io/allisonkarlitskaya/toxbox
+    container: registry.fedoraproject.org/fedora:latest
 
     timeout-minutes: 20
 
+    env:
+      TOX_WORK_DIR: /tmp/.tox
+      COVERAGE_FILE: /tmp/.coverage
+      RUFF_CACHE_DIR: /tmp/.ruff_cache
+      MYPY_CACHE_DIR: /tmp/.mypy_cache
+
     steps:
+      - name: Install tox dependencies
+        run: |
+          dnf install -y git-core tox util-linux
+          useradd tox
+
+      # https://github.blog/2022-04-12-git-security-vulnerability-announced/
+      - name: Pacify git's permission check
+        run: git config --global --add safe.directory /__w/cockpit/cockpit
+
       - name: Clone repository
         uses: actions/checkout@v4
 


### PR DESCRIPTION
Lis'es toxbox image was an one-off build over a year ago, with no automatic or manual refreshes. It now failed to run the Python 3.13 tox tests, and also does not have 3.14 and future versions.

We may want to pull this image into cockpituous or bots and refresh/gate it regularly. Until then, run this in the current Fedora base image and manually install tox.

----

Fixes the [tox failure](https://github.com/cockpit-project/cockpit/actions/runs/15699657632/job/44231520599?pr=22055) that started to break main a few days ago.