### PR TITLE
test: install stratisd-tools for CentOS 10

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -46,6 +46,11 @@ if grep -q 'ID=.*fedora' /etc/os-release && [ "$PLAN" = "storage-basic" ]; then
     dnf install -y stratisd-tools
 fi
 
+if grep -q 'ID=.*centos' /etc/os-release && grep -q 'VERSION_ID=.*10' /etc/os-release && [ "$PLAN" = "storage-basic" ]; then
+    # required by TestStorageStratis
+    dnf install -y stratisd-tools
+fi
+
 # dnf installs "missing" weak dependencies, but we don't want them for plans other than "main"
 if [ "$PLAN" != "main" ] && rpm -q cockpit-packagekit; then
     dnf remove -y cockpit-packagekit


### PR DESCRIPTION
CentOS 10 has a newer Stratis version now which creates V2 pools by default, to create V1 pools in tests we need stratisd-tools.