### PR TITLE
workflows: Disable man-db trigger for apt installs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,6 +36,10 @@ jobs:
 
       - name: Install build dependencies
         run: |
+          # disable man-db to speed up package install
+          echo "set man-db/auto-update false" | sudo debconf-communicate
+          sudo dpkg-reconfigure man-db
+
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends gettext zlib1g-dev libkrb5-dev libxslt1-dev libglib2.0-dev libgnutls28-dev libsystemd-dev libpolkit-agent-1-dev libpcp3-dev libjson-glib-dev libpam0g-dev libpcp-import1-dev libpcp-pmda3-dev systemd xsltproc xmlto docbook-xsl
         if: ${{ matrix.language == 'cpp' }}

--- a/.github/workflows/flatpak-test.yml
+++ b/.github/workflows/flatpak-test.yml
@@ -10,6 +10,10 @@ jobs:
     steps:
       - name: Install required build and test dependencies
         run: |
+          # disable man-db to speed up package install
+          echo "set man-db/auto-update false" | sudo debconf-communicate
+          sudo dpkg-reconfigure man-db
+
           sudo apt update
           sudo apt install -y --no-install-recommends autoconf automake elfutils libglib2.0-dev libsystemd-dev xsltproc xmlto gettext flatpak xvfb cockpit-system appstream
 

--- a/.github/workflows/weblate-sync-po.yml
+++ b/.github/workflows/weblate-sync-po.yml
@@ -17,6 +17,10 @@ jobs:
     steps:
       - name: Set up dependencies
         run: |
+          # disable man-db to speed up package install
+          echo "set man-db/auto-update false" | sudo debconf-communicate
+          sudo dpkg-reconfigure man-db
+
           sudo apt update
           sudo apt install -y --no-install-recommends gettext
 


### PR DESCRIPTION
We don't need manpages in workflows. Rebuilding the man-db database can take up to a minute, so let's shave that off.

It's not actually hurting our workflows much *at the moment*, but this is a good pattern to follow/copy around.

---

I introduced this in system-roles, where this actually did save about a minute. 