### PR TITLE
test: disable preloading of packagekit for TestShutdownRestart

### DIFF
--- a/test/verify/check-system-shutdown-restart
+++ b/test/verify/check-system-shutdown-restart
@@ -38,6 +38,10 @@ class TestShutdownRestart(testlib.MachineCase):
         m2 = self.machines['machine2']
         b2 = self.new_browser(m2)
 
+        # Disable pre-loading packagekit, dnf needs-restarting (dnf 4) consumes tons of cpu/memory on RHEL-10-1
+        self.disable_preload("packagekit")
+        self.disable_preload("packagekit", machine=m2)
+
         self.enable_multihost(m2)
 
         m.start_cockpit()


### PR DESCRIPTION
Starting this test with limited memory runs into dnf-restart memory issues causing flakes.

---

Fixes our 68% top flake https://cockpit-logs.us-east-1.linodeobjects.com/pull-22101-d19795ee-20250616-083915-rhel-10-1-other/log.html