### PR TITLE
Bootc current metrics memory

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1051,7 +1051,7 @@ BEGIN {{
 
             # use even more memory to trigger swap
             m.execute("systemd-run --collect --slice cockpittest --unit mem-hog2 awk "
-                      """'BEGIN { x = sprintf("%700000000s",""); system("touch /tmp/hogged2; sleep infinity") }'""")
+                      """'BEGIN { x = sprintf("%750000000s",""); system("touch /tmp/hogged2; sleep infinity") }'""")
             m.execute("while [ ! -e /tmp/hogged2 ]; do sleep 1; done")
             b.wait(lambda: b.get_pf_progress_value("#current-swap-usage") > 0)
 


### PR DESCRIPTION
Some debugging notes:

- swapiness is lower then for example Fedora-41/Ubuntu virtual machines 30 versus 60. But this is the same as other RHEL virtual machines so a lower swapiness does not seem to be the root cause.
- Can't reproduce this locally reliably


* [ ] Swap information comes from PCP or cockpit itself?
* [ ] Where does cockpit-bridge run?


swap-total comes from machine_info.js
memory.swap-used comes from the cockpit internal sampler


There is no container involved in running cockpit-ws nor can I reproduce this issue locally.