### PR TITLE
test: adjust libblockdev version comparison for smart

### DIFF
--- a/test/verify/check-storage-smart
+++ b/test/verify/check-storage-smart
@@ -59,9 +59,9 @@ class TestStorageSmart(storagelib.StorageSmartCase):
         # split on `dot` to remove extra info from rpm
         sub_ver = int(sub_ver.split('.')[0])
 
-        if base_ver > (3, 3, 0):
+        if base_ver > (3, 3, 1):
             return True
-        elif base_ver == (3, 3, 0) and sub_ver >= 3:
+        elif base_ver == (3, 3, 0) and sub_ver >= 3:  # @storage/udisks-daily and Fedora-42
             return True
         else:
             return False


### PR DESCRIPTION
libblockdev 3.3.1 was released with only security fixes no changes in smart behaviour. The copr builds use the latest release tag as version and a release version of 99 so assert on that instead.