### PR TITLE
test: wait for cpu hog to start in metrics overview test

### DIFF
--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -656,9 +656,10 @@ fi
         # CPU
         # first wait until system settles down
         testlib.wait(lambda: progressValue(1) < 20)
-        m.spawn("for i in $(seq $(nproc)); do cat /dev/urandom > /dev/null & done", "cpu_hog.log")
+        m.spawn("for i in $(seq $(nproc)); do cat /dev/urandom > /dev/null & done; touch /tmp/cpu-hogged", "cpu_hog.log")
+        m.execute("while [ ! -e /tmp/cpu-hogged ]; do sleep 1; done")
         testlib.wait(lambda: progressValue(1) > 75)
-        m.execute("pkill -e -f [c]at.*urandom")
+        m.execute("pkill -e -f [c]at.*urandom; rm /tmp/cpu-hogged")
         # should go back to idle usage
         # HACK: work around pmie CPU usage https://bugzilla.redhat.com/show_bug.cgi?id=2140572
         testlib.wait(lambda: progressValue(1) < 20, tries=200)


### PR DESCRIPTION
In CI this flakes and shows a graph of the CPU usage not having increased yet, so wait till the script actually executed before checking the CPU usage.

---

Popped up in [rhel-10-1](https://cockpit-logs.us-east-1.linodeobjects.com/pull-22126-b6b264b9-20250623-125217-rhel-10-1-other/log.html) claims to flake 50% of the time.