### PR TITLE
.github: give flathub release workflow pull-requests permission

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,8 @@ jobs:
     environment: flathub
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    permissions: {}
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source repository


### PR DESCRIPTION
This is what we normally do for, for example cockpit-lib-update I am not :100: sure if it works across different projects but not my issue :)