### PR TITLE
debug c9s aarch64 raid regression with mixing scsi_debug and loop devices

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -29,13 +29,8 @@ jobs:
     identifier: self
     trigger: pull_request
     targets: &test_targets
-      - fedora-41
-      - fedora-42
-      - fedora-latest-stable-aarch64
-      - fedora-rawhide
       - centos-stream-9-x86_64
       - centos-stream-9-aarch64
-      - centos-stream-10
 
   # current Fedora runs reverse dependency testing against https://copr.fedorainfracloud.org/coprs/g/cockpit/main-builds/
   - job: tests

--- a/packit.yaml
+++ b/packit.yaml
@@ -31,6 +31,8 @@ jobs:
     targets: &test_targets
       - centos-stream-9-x86_64
       - centos-stream-9-aarch64
+      - fedora-latest-aarch64
+      - fedora-42
 
   # current Fedora runs reverse dependency testing against https://copr.fedorainfracloud.org/coprs/g/cockpit/main-builds/
   - job: tests

--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -502,6 +502,8 @@ function update_indices() {
     for (path in client.mdraids_members) {
         client.mdraids_members[path].sort(utils.block_cmp);
     }
+    console.log("mdraids_members", JSON.stringify(client.mdraids_members));
+    console.log("mdraids", JSON.stringify(client.mdraids));
 
     client.slashdevs_block = { };
     function enter_slashdev(block, enc) {

--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -1066,7 +1066,10 @@ function init_model(callback) {
                 query_fsys_info().then((fsys_info) => {
                     client.fsys_info = fsys_info;
 
-                    client.storaged_client.addEventListener('notify', () => client.update());
+                    client.storaged_client.addEventListener('notify', data => {
+                        console.log("XXX udisks client notify", JSON.stringify(data));
+                        client.update();
+                    });
 
                     update_indices();
                     cockpit.addEventListener("visibilitychange", () => update_lvm2_polling(true));

--- a/plans/all.fmf
+++ b/plans/all.fmf
@@ -11,17 +11,7 @@ execute:
 environment:
     TEST_AUDIT_NO_SELINUX: 1
 
-/main:
-    summary: Non-storage tests
-    discover+:
-        test: /test/browser/main
-
 /storage-basic:
     summary: Basic storage tests
     discover+:
         test: /test/browser/storage-basic
-
-/storage-extra:
-    summary: More expensive storage tests (LVM, LUKS, Anaconda)
-    discover+:
-        test: /test/browser/storage-extra

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -149,19 +149,7 @@ if [ "$PLAN" = "main" ]; then
 fi
 
 if [ "$PLAN" = "storage-basic" ]; then
-    TESTS="TestStorageBasic
-           TestStorageBtrfs
-           TestStorageMdRaid
-           TestStorageMounting
-           TestStorageMountingLUKS
-           TestStorageMsDOS
-           TestStorageNfs
-           TestStoragePartitions
-           TestStorageRaid
-           TestStorageStratis
-           TestStorageUnrecognized
-           TestStorageUsed
-           TestStorageswap
+    TESTS="TestStorageMdRaid
            "
 
     # These don't test more external APIs

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -207,6 +207,7 @@ done
 GATEWAY="$(python3 -c 'import socket; print(socket.gethostbyname("_gateway"))')"
 RC=0
 ./test/common/run-tests \
+    -vt \
     --test-dir test/verify \
     --nondestructive \
     --machine "${GATEWAY}":22 \

--- a/test/verify/check-storage-mdraid
+++ b/test/verify/check-storage-mdraid
@@ -123,7 +123,7 @@ class TestStorageMdRaid(storagelib.StorageCase):
 
         self.click_card_row("Storage", name="/dev/md/raid0")
         print(m.execute("cat /proc/mdstat"))
-        print(m.execute("udiskctl dump"))
+        print(m.execute("udisksctl dump"))
         self.wait_states({disk1: "In sync",
                           disk2: "In sync",
                           disk3: "In sync"})

--- a/test/verify/check-storage-mdraid
+++ b/test/verify/check-storage-mdraid
@@ -81,7 +81,7 @@ class TestStorageMdRaid(storagelib.StorageCase):
         self.login_and_go("/storage")
 
         # Add four disks and make a RAID out of three of them
-        disk1 = self.add_loopback_disk(name="loop4")
+        disk1 = self.add_ram_disk()
         b.wait_visible(self.card_row("Storage", name=disk1))
         disk2 = self.add_loopback_disk(name="loop5")
         b.wait_visible(self.card_row("Storage", name=disk2))

--- a/test/verify/check-storage-mdraid
+++ b/test/verify/check-storage-mdraid
@@ -122,6 +122,7 @@ class TestStorageMdRaid(storagelib.StorageCase):
         self.dialog_wait_close()
 
         self.click_card_row("Storage", name="/dev/md/raid0")
+        m.execute("until grep 'recovery' /proc/mdstat; do sleep 1; done")
         print(m.execute("cat /proc/mdstat"))
         print(m.execute("udisksctl dump"))
         self.wait_states({disk1: "In sync",

--- a/test/verify/check-storage-mdraid
+++ b/test/verify/check-storage-mdraid
@@ -81,7 +81,7 @@ class TestStorageMdRaid(storagelib.StorageCase):
         self.login_and_go("/storage")
 
         # Add four disks and make a RAID out of three of them
-        disk1 = self.add_ram_disk()
+        disk1 = self.add_loopback_disk(name="loop4")
         b.wait_visible(self.card_row("Storage", name=disk1))
         disk2 = self.add_loopback_disk(name="loop5")
         b.wait_visible(self.card_row("Storage", name=disk2))

--- a/test/verify/check-storage-mdraid
+++ b/test/verify/check-storage-mdraid
@@ -130,6 +130,10 @@ class TestStorageMdRaid(storagelib.StorageCase):
         print(m.execute("cat /proc/mdstat"))
         print("XXXX udisks")
         print(m.execute("udisksctl dump"))
+
+        b.reload()
+        b.enter_page("/storage")
+
         self.wait_states({disk1: "In sync",
                           disk2: "In sync",
                           disk3: "In sync"})

--- a/test/verify/check-storage-mdraid
+++ b/test/verify/check-storage-mdraid
@@ -122,9 +122,13 @@ class TestStorageMdRaid(storagelib.StorageCase):
         self.dialog_wait_close()
 
         self.click_card_row("Storage", name="/dev/md/raid0")
+        print("XXXX mdstat")
         print(m.execute("cat /proc/mdstat"))
-        m.execute("until grep -v 'recovery' /proc/mdstat; do sleep 1; done")
+        print("XXXX waiting for recovery")
+        m.execute("set -ex; while grep 'recovery' /proc/mdstat; do sleep 1; done")
+        print("XXXX mdstat")
         print(m.execute("cat /proc/mdstat"))
+        print("XXXX udisks")
         print(m.execute("udisksctl dump"))
         self.wait_states({disk1: "In sync",
                           disk2: "In sync",

--- a/test/verify/check-storage-mdraid
+++ b/test/verify/check-storage-mdraid
@@ -123,7 +123,7 @@ class TestStorageMdRaid(storagelib.StorageCase):
 
         self.click_card_row("Storage", name="/dev/md/raid0")
         print(m.execute("cat /proc/mdstat"))
-        m.execute("until grep 'recovery' /proc/mdstat; do sleep 1; done")
+        m.execute("until grep -v 'recovery' /proc/mdstat; do sleep 1; done")
         print(m.execute("cat /proc/mdstat"))
         print(m.execute("udisksctl dump"))
         self.wait_states({disk1: "In sync",

--- a/test/verify/check-storage-mdraid
+++ b/test/verify/check-storage-mdraid
@@ -130,10 +130,6 @@ class TestStorageMdRaid(storagelib.StorageCase):
         print(m.execute("cat /proc/mdstat"))
         print("XXXX udisks")
         print(m.execute("udisksctl dump"))
-
-        b.reload()
-        b.enter_page("/storage")
-
         self.wait_states({disk1: "In sync",
                           disk2: "In sync",
                           disk3: "In sync"})

--- a/test/verify/check-storage-mdraid
+++ b/test/verify/check-storage-mdraid
@@ -28,7 +28,7 @@ class TestStorageMdRaid(storagelib.StorageCase):
 
     def wait_states(self, states):
         for s in states.keys():
-            with self.browser.wait_timeout(30):
+            with self.browser.wait_timeout(45):
                 self.browser.wait_in_text(self.card_row("MDRAID device", name=s), states[s])
 
     def raid_add_disk(self, name):

--- a/test/verify/check-storage-mdraid
+++ b/test/verify/check-storage-mdraid
@@ -26,27 +26,27 @@ import testlib
 @testlib.nondestructive
 class TestStorageMdRaid(storagelib.StorageCase):
 
-    def wait_states(self, states):
+    def wait_states(self, states: dict[str, str]):
         for s in states.keys():
             with self.browser.wait_timeout(45):
                 self.browser.wait_in_text(self.card_row("MDRAID device", name=s), states[s])
 
-    def raid_add_disk(self, name):
+    def raid_add_disk(self, name: str):
         self.dialog_open_with_retry(trigger=lambda: self.browser.click(self.card_button("MDRAID device", "Add disk")),
                                     expect=lambda: self.dialog_is_present('disks', name))
         self.dialog_set_val("disks", {name: True})
         self.dialog_apply_with_retry()
 
-    def raid_remove_disk(self, name):
+    def raid_remove_disk(self, name: str):
         self.click_dropdown(self.card_row("MDRAID device", name=name), "Remove")
 
-    def raid_action(self, action):
+    def raid_action(self, action: str):
         self.browser.click(self.card_button("MDRAID device", action))
 
-    def raid_default_action_start(self, action):
+    def raid_default_action_start(self, action: str):
         self.raid_action(action)
 
-    def raid_default_action_finish(self, action):
+    def raid_default_action_finish(self, action: str):
         if action == "Stop":
             # Right after assembling an array the device might be busy
             # from udev rules probing or the mdadm monitor; retry a
@@ -70,7 +70,7 @@ class TestStorageMdRaid(storagelib.StorageCase):
             else:
                 self.fail("Timed out waiting for array to get stopped")
 
-    def raid_default_action(self, action):
+    def raid_default_action(self, action: str):
         self.raid_default_action_start(action)
         self.raid_default_action_finish(action)
 
@@ -134,7 +134,7 @@ class TestStorageMdRaid(storagelib.StorageCase):
                           disk2: "In sync",
                           disk3: "In sync"})
 
-        def wait_degraded_state(is_degraded):
+        def wait_degraded_state(is_degraded: bool):
             degraded_selector = ".pf-v6-c-alert h4"
             if is_degraded:
                 b.wait_in_text(degraded_selector, 'The MDRAID device is in a degraded state')

--- a/test/verify/check-storage-mdraid
+++ b/test/verify/check-storage-mdraid
@@ -122,7 +122,8 @@ class TestStorageMdRaid(storagelib.StorageCase):
         self.dialog_wait_close()
 
         self.click_card_row("Storage", name="/dev/md/raid0")
-
+        print(m.execute("cat /proc/mdstat"))
+        print(m.execute("udiskctl dump"))
         self.wait_states({disk1: "In sync",
                           disk2: "In sync",
                           disk3: "In sync"})

--- a/test/verify/check-storage-mdraid
+++ b/test/verify/check-storage-mdraid
@@ -122,6 +122,7 @@ class TestStorageMdRaid(storagelib.StorageCase):
         self.dialog_wait_close()
 
         self.click_card_row("Storage", name="/dev/md/raid0")
+        print(m.execute("cat /proc/mdstat"))
         m.execute("until grep 'recovery' /proc/mdstat; do sleep 1; done")
         print(m.execute("cat /proc/mdstat"))
         print(m.execute("udisksctl dump"))


### PR DESCRIPTION
testing-farm:centos-stream-9-aarch64:self has failed in our CI for a while, examples:

- https://artifacts.dev.testing-farm.io/e2ac09f2-29ea-4032-90ef-3e7c74d31fce/
- https://artifacts.dev.testing-farm.io/841542b2-fceb-47c4-ad74-4a0ac8a83e5c/
- https://artifacts.dev.testing-farm.io/73138f56-3114-4d15-84b0-9d446cdef41d/
- https://artifacts.dev.testing-farm.io/56bd7133-0688-4a25-bb34-b7e2a0a2a1e1/

So some conclusions from looking at the logs, first failure:

```
Traceback (most recent call last):
  File "/source/test/verify/check-storage-mdraid", line 126, in testRaid
    self.wait_states({disk1: "In sync",
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
                      disk2: "In sync",
                      ^^^^^^^^^^^^^^^^^
                      disk3: "In sync"})
                      ^^^^^^^^^^^^^^^^^^
  File "/source/test/verify/check-storage-mdraid", line 32, in wait_states
    self.browser.wait_in_text(self.card_row("MDRAID device", name=s), states[s])
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/source/test/common/testlib.py", line 865, in wait_in_text
    self.wait_visible(selector)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/source/test/common/testlib.py", line 834, in wait_visible
    self._wait_present(selector)
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/source/test/common/testlib.py", line 825, in _wait_present
    self.wait_js_func('ph_is_present', selector)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/source/test/common/testlib.py", line 819, in wait_js_func
    self.wait_js_cond("%s(%s)" % (func, ','.join(map(jsquote, args))))
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/source/test/common/testlib.py", line 816, in wait_js_cond
    raise Error(f"timeout\nwait_js_cond({cond}): {last_error.msg}") from None
testlib.Error: timeout
wait_js_cond(ph_is_present("[data-test-card-title='MDRAID device'] table:nth-of-type(1) tbody [data-test-row-name='sda']")): Error: condition did not become true
```

Only shows 2 disks:

![image](https://github.com/user-attachments/assets/899b2928-a3ac-4e17-9172-783d2217a5e0)


We are missing `disk1` which is the iscsi_debug disk. Is there something special about scsi_debug on ARM which breaks this test?


TestStorageMdRaid.testNotRemovingDisks

Shows only loop0, again disk1 is missing which is iscsi_debug.

![image](https://github.com/user-attachments/assets/a02bc5cd-03f5-4f01-9478-4d820c210310)
