### PR TITLE
test: Relax "cat" executable assumption further

### DIFF
--- a/test/pytest/test_bridge.py
+++ b/test/pytest/test_bridge.py
@@ -963,7 +963,8 @@ async def test_channel(bridge: Bridge, transport: MockTransport, channeltype, tm
             if command == 'ready':
                 if 'spawn' in args:
                     assert isinstance(control['pid'], int)
-                    assert os.readlink(f"/proc/{control['pid']}/exe").endswith("cat")
+                    with open(f"/proc/{control['pid']}/cmdline") as f:
+                        assert f.read() == 'cat\0'
                 # If we get ready, it's our turn to send data first.
                 # Hopefully we didn't receive any before.
                 assert not saw_data


### PR DESCRIPTION
Ubuntu 25.04 is moving to Rust coreutils. This was already addressed in commit c2a96d076f9d285718 where `cat` resolved to `gnucat`, but now it moved further to actual Rust coreutils by default. So give up on /proc/pid/exe, and instead read and assert the command line.

This fixes the build failure:
https://launchpad.net/ubuntu/+source/cockpit/341.1-1/+build/30965169

---

See the [build log](https://launchpadlibrarian.net/801954259/buildlog_ubuntu-questing-amd64.cockpit_341.1-1_BUILDING.txt.gz). I could reproduce this in a Ubuntu questing toolbox, and it works now.