### PR TITLE
test: Add temporary flag for running Chromium tests with fake mouse clicks

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -246,6 +246,12 @@ class Browser:
         self.coverage_label = coverage_label
         self.machine = machine
 
+        # HACK: Tests which don't yet get along with real mouse clicks in Chromium
+        # can opt into falling back to the old MouseEvent emulation; this is cheating, but fixing
+        # all the tests at once is too much work. Remove this once all tests in all our projects
+        # got fixed.
+        self.chromium_fake_mouse = False
+
         headless = os.environ.get("TEST_SHOW_BROWSER", '0') == '0'
         self.browser = os.environ.get("TEST_BROWSER", "chromium")
         if self.browser == "chromium":
@@ -530,7 +536,7 @@ class Browser:
         self.wait_visible(selector)
 
         # TODO: x and y are not currently implemented: webdriver (0, 0) is the element's center, not top left corner
-        if x is not None or y is not None:
+        if x is not None or y is not None or (self.browser == "chromium" and self.chromium_fake_mouse):
             self.call_js_func('ph_mouse', selector, event, x or 0, y or 0, btn, ctrlKey, shiftKey, altKey, metaKey)
             return
 


### PR DESCRIPTION
While real mouse clicks work fine in cockpit, they cause all kinds of trouble and unstable tests in machines and podman. Fixing all the tests at once is too much work. To unblock infra updates, allow tests to use the old fake MouseEvent synthesis on Chromium by setting `b.chromium_fake_mouse = True` at the top of the test, or just before a problematic test section.

Remove this once all tests in all our projects get fixed.

-----

I tested this locally with c-podman and verified that by default it uses BiDi clicks, and with 

```diff
--- test/check-application
+++ test/check-application
@@ -1873,6 +1873,8 @@ PodName={podName}
             self.execute("podman rmi --all", system=False)
 
         self.login(system=auth)
+        b.chromium_fake_mouse = True
+
         showImages(b)
 
         b.wait_in_text("#containers-images", IMG_BUSYBOX)
```

it calls `ph_mouse()`.