### PR TITLE
Test accounts cleanup

### DIFF
--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -112,6 +112,10 @@ class TestAccounts(testlib.MachineCase):
         b = self.browser
         m = self.machine
 
+        # Clean out the relevant logfiles
+        m.execute("truncate -s0 /var/log/{[bw]tmp,lastlog} /run/utmp")
+        m.execute("rm -f /var/lib/lastlog/lastlog2.db /var/lib/wtmpdb/wtmp.db")
+
         self.login_and_go("/users")
 
         # Add a user externally

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -137,9 +137,10 @@ class TestAccounts(testlib.MachineCase):
         # Set a real name
         b.go("#/anton")
         b.wait_visible("#account-locked:not([disabled])")
-        b.assert_pixels("#users-page", "user-detail-page")
         b.wait_text("#account-user-name", "anton")
         b.wait_text("#account-title", "anton")
+        b.wait_text("#account-last-login", "Never")
+        b.assert_pixels("#users-page", "user-detail-page")
         b.wait_not_attr("#account-delete", "disabled", "disabled")
         b.set_input_text('#account-real-name', "")  # Check that we can delete the name before setting it up
         b.set_input_text('#account-real-name', "Anton Arbitrary")


### PR DESCRIPTION
This test flaked in the Fedora 42 reference image pull request, cleanup up the lastlog resolved it but also lets assert that we show "Never" before taking the screenshot so it is stable and easier to debug in the future.