### PR TITLE
test: Fix TestWsBastionContainer for current passt version

### DIFF
--- a/test/verify/check-ws-bastion
+++ b/test/verify/check-ws-bastion
@@ -270,11 +270,15 @@ class TestWsBastionContainer(testlib.MachineCase):
         self.addCleanup(m.execute, "ip route del default")
 
         self.restore_dir("/home/admin")
+
+        # podman needs logind session (https://bugzilla.redhat.com/show_bug.cgi?id=2375715)
+        m.execute("loginctl enable-linger admin")
+        self.addCleanup(m.execute, "loginctl disable-linger admin")
+
         m.execute("runuser -u admin -- sh -ex", input=f"""
         # we don't start a real login session here, fake it
         cd $HOME
-        export XDG_RUNTIME_DIR=$HOME/run
-        mkdir -p "$XDG_RUNTIME_DIR"
+        export XDG_RUNTIME_DIR=/run/user/$(id -u)
 
         # create new key, set it up for logging into host
         ssh-keygen -q -f ~/.ssh/id_bastion -N {KEY_PASSWORD}


### PR DESCRIPTION
passt 0^20250507.geea8a76-1.fc42 → 0^20250611.g0293c6f-1.fc42 has a regression: Starting containers without a running logind session fails.

Avoid that by enabling lingering. Then we also get a proper XDG_RUNTIME_DIR, which is cleaner anyway.

---

Blocks/fixes https://github.com/cockpit-project/bots/pull/7938. no-test, as TestWsBastionContainer only runs on fcos anyway.

Not naughtying, I have a gut feeling that this bugzilla will become a wontfix..

I [triggered a run against the refresh](https://cockpit-logs.us-east-1.linodeobjects.com/pull-22156-ca805d7a-20250701-075658-fedora-coreos-other-bots%237938/log.html) and it passed.