### PR TITLE
[r8] cockpit-ci: Move tasks container to 2024-03-18

### DIFF
--- a/.cockpit-ci/container
+++ b/.cockpit-ci/container
@@ -1,1 +1,1 @@
-ghcr.io/cockpit-project/tasks:2024-03-16
+ghcr.io/cockpit-project/tasks:2024-03-18


### PR DESCRIPTION
While the tag still exists, `podman pull` now fails with "manifest unknown". move to 2024-03-18, which seems to work.

[1] https://github.com/cockpit-project/cockpituous/pkgs/container/tasks/191826427?tag=2024-03-16

----

Should fix https://github.com/cockpit-project/bots/pull/7942