### PR TITLE
mark host switching as deprecated in docs

### DIFF
--- a/doc/guide/feature-machines.xml
+++ b/doc/guide/feature-machines.xml
@@ -3,7 +3,7 @@
 	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
 <chapter id="feature-machines">
   <title>Multiple Machines</title>
-
+  <warning> This feature is deprecated as of version 322. </warning> 
   <para>Cockpit can connect to multiple machines from a single Cockpit session.
     These are listed in the host switcher.</para>
 

--- a/doc/guide/multi-host.xml
+++ b/doc/guide/multi-host.xml
@@ -5,7 +5,7 @@
   <title>
     Managing multiple hosts at the same time
   </title>
-
+  <warning> This feature is deprecated as of version 322. </warning> 
   <para>
     Cockpit allows you to access multiple hosts in a single session,
     by establishing SSH connections to other hosts. This is quite


### PR DESCRIPTION
Should resolve #22092 