### PR TITLE
[rhel8] Only hand out the saved password to authorize messages once

### DIFF
--- a/src/bridge/askpass.c
+++ b/src/bridge/askpass.c
@@ -197,8 +197,9 @@ main (int argc,
             {
               if (g_str_equal (field, cookie) && g_str_equal (command, "authorize"))
                 {
+                  /* If we don't have a password, the response is an empty string; abort askpass with non-zero exit */
                   /* The password is written back on stdout */
-                  if (write_all (STDOUT_FILENO, response, -1) && write_all (STDOUT_FILENO, "\n", 1))
+                  if (*response && write_all (STDOUT_FILENO, response, -1) && write_all (STDOUT_FILENO, "\n", 1))
                     ret = 0;
                 }
               else

--- a/src/bridge/cockpitrouter.c
+++ b/src/bridge/cockpitrouter.c
@@ -81,6 +81,7 @@ struct _CockpitRouter {
   GDBusMethodInvocation *superuser_stop_invocation;
 
   gboolean superuser_init_in_progress;
+  gboolean superuser_init_authorize_attempted;
   gboolean superuser_legacy_init;
 
   CockpitRouterPromptAnswerFunction *superuser_answer_function;
@@ -1702,6 +1703,13 @@ cockpit_router_prompt (CockpitRouter *self,
     }
   else if (self->superuser_init_in_progress)
     {
+      if (self->superuser_init_authorize_attempted)
+        {
+          g_info ("noninteractive authorize during init already attempted, rejecting");
+          answer (NULL, data);
+          return;
+        }
+      self->superuser_init_authorize_attempted = TRUE;
       self->superuser_answer_function = answer;
       self->superuser_answer_data = data;
 

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -735,6 +735,46 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         self.allow_journal_messages(".*[aA]ccount .*locked due to .* failed logins.*")
         self.allow_journal_messages(".*minutes left to unlock.*")
 
+    @testlib.skipOstree("no local config with cockpit/ws container")
+    def testAutomaticSudoFaillock(self):
+        m = self.machine
+        b = self.browser
+
+        # only tolerate one failure; unfortunately sending no password (the second time) counts as second failure
+        self.enable_faillock(3)
+        self.addCleanup(m.execute, "faillock --user admin --reset")
+        # configure the account to force a password change
+        m.execute("chage -d 0 admin")
+        self.allow_journal_messages('.*You are required to change your password immediately.*',
+                                    '.*user account or password has expired.*')
+        m.start_cockpit()
+        b.open("/")
+        b.try_login()
+
+        # set new password
+        new_pass = "fooBetterBar1@#"
+        if m.ws_container:
+            b.wait_in_text("#conversation-prompt", "You are required to change your password")
+        else:
+            b.wait_in_text("#conversation-message", "You are required to change your password")
+        b.set_val('#conversation-input', 'foobar')
+        b.click('#login-button')
+        b.wait_in_text("#conversation-prompt", "New password")
+        b.set_val('#conversation-input', new_pass)
+        b.click('#login-button')
+        b.wait_in_text("#conversation-prompt", "Retype")
+        b.set_val('#conversation-input', new_pass)
+        b.click('#login-button')
+        b.wait_visible('#content')
+        # automatic sudo will still try the old password
+        b.check_superuser_indicator("Limited access")
+        b.logout()
+
+        # can now login with new password and sudo, account isn't locked
+        b.login_and_go(password=new_pass)
+        b.check_superuser_indicator("Administrative access")
+        b.logout()
+
     @testlib.skipOstree("root logins disabled by default with ssh")
     def testPamAccess(self):
         b = self.browser

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -633,11 +633,13 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
             self.sed_file(f"s/# deny = 3/deny = {count}/", "/etc/security/faillock.conf")
         else:
             # see https://access.redhat.com/solutions/62949
-            self.sed_file("/pam_unix/ {"
-                          "s/sufficient/[success=1 default=ignore]/\n"
-                          f"aauth [default=die] pam_faillock.so authfail audit deny={count} unlock_time=600\n"
-                          f"aauth sufficient pam_faillock.so authsucc audit deny={count} unlock_time=600\n"
-                          "}", "/etc/pam.d/password-auth")
+            sed = ("/^auth.*pam_unix/ {"
+                   "s/sufficient/[success=1 default=ignore]/\n"
+                   f"aauth [default=die] pam_faillock.so authfail audit deny={count} unlock_time=600\n"
+                   f"aauth sufficient pam_faillock.so authsucc audit deny={count} unlock_time=600\n"
+                   "}")
+            self.sed_file(sed, "/etc/pam.d/password-auth")
+            self.sed_file(sed, "/etc/pam.d/system-auth")
 
         m.execute("grep -r faillock /etc/pam.d")
 

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -615,6 +615,32 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
     def testFailingWebsocketSafariNoCA(self):
         self.testFailingWebsocket(safari=True, cacert=False)
 
+    def enable_faillock(self, count: int):
+        m = self.machine
+        # ensure we have no faillock in our pam config already
+        # arch has faillock enabled by default
+        if m.image != "arch":
+            m.execute("! grep -r faillock /etc/pam.d")
+
+        # add it to the pam config
+        if m.image.startswith('debian-') or m.image.startswith('ubuntu'):
+            # enable pam_faillock.  see example in pam_faillock(8)
+            self.sed_file(r"/fallback if no module succeeds/ s/^/"
+                          f"auth [default=die] pam_faillock.so authfail deny={count}\\n"
+                          f"auth sufficient pam_faillock.so authsucc deny={count}\\n/",
+                          "/etc/pam.d/common-auth")
+        elif m.image == "arch":
+            self.sed_file(f"s/# deny = 3/deny = {count}/", "/etc/security/faillock.conf")
+        else:
+            # see https://access.redhat.com/solutions/62949
+            self.sed_file("/pam_unix/ {"
+                          "s/sufficient/[success=1 default=ignore]/\n"
+                          f"aauth [default=die] pam_faillock.so authfail audit deny={count} unlock_time=600\n"
+                          f"aauth sufficient pam_faillock.so authsucc audit deny={count} unlock_time=600\n"
+                          "}", "/etc/pam.d/password-auth")
+
+        m.execute("grep -r faillock /etc/pam.d")
+
     def testFaillock(self):
         m = self.machine
         b = self.browser
@@ -651,30 +677,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
             b.logout()
 
         self.enable_root_login()
-
-        # ensure we have no module in our pam config already
-        # arch has faillock enabled by default
-        if m.image != "arch":
-            m.execute(f"! grep -r '{module}' /etc/pam.d")
-
-        # add it to the pam config
-        if m.image.startswith('debian-') or m.image.startswith('ubuntu'):
-            # enable pam_faillock.  see example in pam_faillock(8)
-            self.sed_file(r"/fallback if no module succeeds/ s/^/"
-                          r"auth [default=die] pam_faillock.so authfail deny=4\n"
-                          r"auth sufficient pam_faillock.so authsucc deny=4\n/",
-                          "/etc/pam.d/common-auth")
-        elif m.image == "arch":
-            self.sed_file("s/# deny = 3/deny = 4/", "/etc/security/faillock.conf")
-        else:
-            # see https://access.redhat.com/solutions/62949
-            self.sed_file("""/pam_unix/ {
-                      s/sufficient/[success=1 default=ignore]/\n
-                      aauth [default=die] pam_faillock.so authfail audit deny=4 unlock_time=600\n
-                      aauth sufficient pam_faillock.so authsucc audit deny=4 unlock_time=600\n
-                      }""", "/etc/pam.d/password-auth")
-
-        m.execute(f"grep -r '{module}' /etc/pam.d")
+        self.enable_faillock(4)
 
         m.start_cockpit()
 


### PR DESCRIPTION
This backports PR #21617 to RHEL 8, with translating the conceptual Python changes to the C bridge.

https://issues.redhat.com/browse/RHEL-96193