### PR TITLE
lib: patternfly: make the select dark theme override more specific

### DIFF
--- a/pkg/lib/patternfly/patternfly-6-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-6-overrides.scss
@@ -264,7 +264,7 @@ $phone: 767px;
   // FIXME: Force FormSelect's to get a readable background.
   // https://github.com/patternfly/patternfly/issues/7593
   // https://issues.redhat.com/browse/RHEL-97180
-  select {
+  .pf-v6-c-form-control select:not(:disabled) {
       background-color: var(--pf-t--global--background--color--floating--default);
   }
 }


### PR DESCRIPTION
In cockpit-podman there is fallout from overriding the select background color. A disabled FormSelect would also change color when it is disabled and we apply it to all select's while this is specifically for a FormSelect.

Follow up from 7fec09ed0e4569b02336f5d5da15cd86b011a648

---

For https://github.com/cockpit-project/cockpit-podman/pull/2177