### PR TITLE
test: prefer .values() over .items()

### DIFF
--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -359,7 +359,7 @@ def detect_tests(test_files, image, opts):
                 todo = testlib.get_decorator(test_method, test, "todo")
                 if getattr(test.__class__, "provision", None):
                     # each additionally provisioned VM memory costs destructive test capacity
-                    total_memory = sum(config.get('memory_mb', DEFAULT_MACHINE_MEMORY_MB) for _, config in test.__class__.provision.items())
+                    total_memory = sum(config.get('memory_mb', DEFAULT_MACHINE_MEMORY_MB) for config in test.__class__.provision.values())
                     cost = math.ceil(total_memory / DEFAULT_MACHINE_MEMORY_MB)
                 else:
                     cost = 1


### PR DESCRIPTION
Removes the need for ignoring the key when iterating.