### PR TITLE
workflows: Fix latest tag checkout in build-ws-container

### DIFF
--- a/.github/workflows/build-ws-container.yml
+++ b/.github/workflows/build-ws-container.yml
@@ -38,10 +38,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: debug
+        uses: mxschmitt/action-tmate@v4
+
       # Dockerfile  must correspond to latest release, not main
       - name: Check out latest tag
         run: |
-          git checkout $(git rev-list --tags --max-count=1)
+          set -ex
+          git checkout $(git describe --tags --abbrev=0 main)
           git describe
 
       - name: Build ws container


### PR DESCRIPTION
The previous command checked out the latest tag across *all* branches, but that's wrong -- it currently catches 310.5 from the rhel-8 branch. We want to get the latest tag on main.

---

This is what broke the workflow a few days ago: https://github.com/cockpit-project/cockpit/actions/workflows/build-ws-container.yml