### PR TITLE
workflows: Fix latest tag checkout in build-ws-container

### DIFF
--- a/.github/workflows/build-ws-container.yml
+++ b/.github/workflows/build-ws-container.yml
@@ -37,11 +37,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: main
 
       # Dockerfile  must correspond to latest release, not main
       - name: Check out latest tag
         run: |
-          git checkout $(git rev-list --tags --max-count=1)
+          set -ex
+          git checkout $(git describe --tags --abbrev=0 main)
           git describe
 
       - name: Build ws container


### PR DESCRIPTION
The previous command checked out the latest tag across *all* branches, but that's wrong -- it currently catches 310.5 from the rhel-8 branch. We want to get the latest tag on main.

---


This is what broke the workflow a few days ago: https://github.com/cockpit-project/cockpit/actions/workflows/build-ws-container.yml

I [ran the workflow manually on this branch](https://github.com/cockpit-project/cockpit/actions/runs/16108853626/job/45448896749), it correctly checked out 341.1 and succeeded.