### PR TITLE
test: Robustify memory hog check in TestSystemInfo.testOverview

### DIFF
--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -675,8 +675,9 @@ fi
         # replacing it's own process with the sleep (as a "tail call
         # optimization") and thereby dropping the memory blob too early.
         #
-        mem_hog = m.spawn("MEMBLOB=$(yes | dd bs=1M count=200 iflag=fullblock); touch /tmp/hogged; sleep infinity; true",
-                          "mem_hog.log")
+        mem_hog = m.spawn("""
+            awk 'BEGIN { x = sprintf("%200000000s",""); system("touch /tmp/hogged; sleep infinity") }'
+            """, "mem_hog.log")
         try:
             m.execute("while [ ! -e /tmp/hogged ]; do sleep 1; done")
             # bars update every 5s
@@ -687,7 +688,12 @@ fi
             m.execute("kill %d" % mem_hog)
         # Should go back to initial_usage, but it doesn't always, for example on fedora.
         # So let's be happy if the usage drops significantly
-        testlib.wait(lambda: progressValue(2) <= hog_usage - 15)
+        try:
+            testlib.wait(lambda: progressValue(2) <= hog_usage - 10)
+        except testlib.Error:
+            print(f"Memory before hogging: {initial_usage}, after hogging: {hog_usage}, now: {progressValue(2)}")
+            raise
+
         self.assertGreater(progressValue(2), 10)
 
     @testlib.nondestructive


### PR DESCRIPTION
Replace the shell memory hog with awk, like we did in the metrics tests in commit e16e81c9f6cde.

Also fix the exit condition: It previously waited for the memory usage to increase at least by 10% from running the hog, but then to drop by 15% afterwards, which is unreasonable. We can at most expect it to drop by the same amount as it previously climbed.

Show the actual numbers on failures, so that this becomes easier to debug.

----

Fixes our current top flake, [example 1](https://cockpit-logs.us-east-1.linodeobjects.com/pull-22177-a74f8bae-20250707-050124-ubuntu-2204-other/log.html), [example 2](https://cockpit-logs.us-east-1.linodeobjects.com/pull-22177-a74f8bae-20250707-024344-ubuntu-2204-other/log.html)