### PR TITLE
doc: Add version introduced to `conditions`

### DIFF
--- a/doc/guide/packages.xml
+++ b/doc/guide/packages.xml
@@ -113,7 +113,7 @@ $ cockpit-bridge --packages
         <listitem><para>An optional list of <code>{"predicate": "value"}</code> objects. Cockpit will only
           consider the package if <emphasis>all</emphasis> conditions are met. Currently supported predicates
           are <code>path-exists</code> and <code>path-not-exists</code>. Unknown predicates are ignored.
-          This is preferable to using <code>priority</code>, but only available since Cockpit FIXME-RELEASE.</para>
+          This is preferable to using <code>priority</code>, but only available since Cockpit 286.</para>
         </listitem>
       </varlistentry>
       <varlistentry>


### PR DESCRIPTION
This was previously merged and released without a note indicating which
version it was added in (286).

Related-to: #18291
Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
