### PR TITLE
test: Stop assuming user systemd-exit.service never runs

### DIFF
--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -210,6 +210,16 @@ ExecStart=/usr/bin/false
 [Install]
 WantedBy=default.target
 """)
+
+        # this can't be in /etc, as we want to test masking
+        self.write_file(f"{path.replace('/etc', '/usr/local/lib')}/test-static.service",
+                        """
+[Unit]
+Description=Static Test Service
+[Service]
+ExecStart=/usr/bin/true
+""")
+
         self.write_file(f"{path}/special@:-characters.service",
                         """
 [Unit]
@@ -314,7 +324,7 @@ WantedBy=default.target
         self.wait_service_state("test-fail.service", "failed")
 
         # Check static service
-        self.goto_service("systemd-exit.service")
+        self.goto_service("test-static.service")
         self.check_service_details(["Static", "Not running"],
                                    ["Start", "Disallow running (mask)", "Pin unit"],
                                    enabled=True, onoff=False)


### PR DESCRIPTION
It does at least on Ubuntu 22.04. This was lazy. Fix this by introducing our own static test service.

Fixes #22158

---

[example log](https://cockpit-logs.us-east-1.linodeobjects.com/pull-22113-ba3257c4-20250701-072009-ubuntu-2204-other/log.html), also high on the weather report.