### PR TITLE
test: Fix RHEL 8 race in TestSelinux.testTroubleshootAlerts

### DIFF
--- a/test/verify/check-selinux
+++ b/test/verify/check-selinux
@@ -141,6 +141,11 @@ class TestSelinux(testlib.MachineCase):
         b.wait_not_present(row_selector)
         # unbreak sebool, and trigger the error again
         m.execute(f"chmod a+x {sebool_path}; rm -r ~admin/public_html")
+        if m.image.startswith("rhel-8"):
+            # HACK: RHEL 8's setroubleshootd sometimes misses the second alert
+            m.execute("systemctl restart setroubleshootd")
+            b.reload()
+            b.enter_page("/selinux")
         self.machine.execute(SELINUX_SEBOOL_ALERT_SCRIPT)
         with b.wait_timeout(60):
             b.wait_visible(row_selector)


### PR DESCRIPTION
On RHEL 8, setroubleshootd sometimes misses the second `ls` violation. Restart setroubleshootd.service and reload the page in between to avoid that.

Don't report that -- RHEL 8 is frozen, it does not happen on newer OSes, and there is no useful reproducer.

---

This is currently one of our top flakes:

![image](https://github.com/user-attachments/assets/f53872f3-263a-4bd0-9df4-97aac0a8a737)

This commit addresses [this variant](https://cockpit-logs.us-east-1.linodeobjects.com/pull-22177-a74f8bae-20250707-024352-rhel-8-10-ws-container-other/log.html). There are others, but they are really "stupid" from our PoV:

 * [this failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-22171-b0a73073-20250704-125310-rhel-8-10-ws-container-other/log.html) is about [a crash while calling the fixer](https://cockpit-logs.us-east-1.linodeobjects.com/pull-22171-b0a73073-20250704-125310-rhel-8-10-ws-container-other/TestSelinux-testTroubleshootAlerts-rhel-8-10-127.0.0.2-2901-FAIL.png), but without a really useful error message.
 * [this failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-22175-41722d54-20250706-031934-fedora-42-devel/log.html) is about an [error while deleting the alert](https://cockpit-logs.us-east-1.linodeobjects.com/pull-22175-41722d54-20250706-031934-fedora-42-devel/TestSelinux-testTroubleshootAlerts-fedora-42-127.0.0.2-2501-FAIL.png), the test log has that as well:
> warn: Unable to delete alert with id d8532f6c-c8ba-48fc-b454-b0f0defe2728 : {"problem":null,"name":"org.freedesktop.DBus.Error.NoReply","message":"Remote peer disconnected"}

These can at most become naughties. But these tests are hard to fail locally, and there is no reliable reproducer for a downstream bug report.

 - [x] https://github.com/cockpit-project/bots/pull/7968