### PR TITLE
test: Use loop devices in TestStorageMdRaid on C9S/aarch64

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -31,7 +31,7 @@ jobs:
     targets: &test_targets
       - fedora-41
       - fedora-42
-      - fedora-latest-stable-aarch64
+      - fedora-latest-aarch64
       - fedora-rawhide
       - centos-stream-9-x86_64
       - centos-stream-9-aarch64

--- a/test/verify/check-storage-mdraid
+++ b/test/verify/check-storage-mdraid
@@ -81,7 +81,12 @@ class TestStorageMdRaid(storagelib.StorageCase):
         self.login_and_go("/storage")
 
         # Add four disks and make a RAID out of three of them
-        disk1 = self.add_ram_disk()
+        # HACK: on CentOS 9 aarch64 (only!), scsi_debug doesn't like being part of a RAID
+        # see https://github.com/cockpit-project/cockpit/pull/22143
+        if m.image.startswith('centos-9') and m.execute("uname -m").strip() == "aarch64":
+            disk1 = self.add_loopback_disk(name="loop4")
+        else:
+            disk1 = self.add_ram_disk()
         b.wait_visible(self.card_row("Storage", name=disk1))
         disk2 = self.add_loopback_disk(name="loop5")
         b.wait_visible(self.card_row("Storage", name=disk2))
@@ -274,7 +279,12 @@ class TestStorageMdRaid(storagelib.StorageCase):
 
         self.login_and_go("/storage")
 
-        disk1 = self.add_ram_disk()
+        # HACK: on CentOS 9 aarch64 (only!), scsi_debug doesn't like being part of a RAID
+        # see https://github.com/cockpit-project/cockpit/pull/22143
+        if m.image.startswith('centos-9') and m.execute("uname -m").strip() == "aarch64":
+            disk1 = self.add_loopback_disk()
+        else:
+            disk1 = self.add_ram_disk()
         b.wait_visible(self.card_row("Storage", name=disk1))
         disk2 = self.add_loopback_disk()
         b.wait_visible(self.card_row("Storage", name=disk2))

--- a/test/verify/check-storage-mdraid
+++ b/test/verify/check-storage-mdraid
@@ -26,27 +26,27 @@ import testlib
 @testlib.nondestructive
 class TestStorageMdRaid(storagelib.StorageCase):
 
-    def wait_states(self, states):
+    def wait_states(self, states: dict[str, str]):
         for s in states.keys():
             with self.browser.wait_timeout(30):
                 self.browser.wait_in_text(self.card_row("MDRAID device", name=s), states[s])
 
-    def raid_add_disk(self, name):
+    def raid_add_disk(self, name: str):
         self.dialog_open_with_retry(trigger=lambda: self.browser.click(self.card_button("MDRAID device", "Add disk")),
                                     expect=lambda: self.dialog_is_present('disks', name))
         self.dialog_set_val("disks", {name: True})
         self.dialog_apply_with_retry()
 
-    def raid_remove_disk(self, name):
+    def raid_remove_disk(self, name: str):
         self.click_dropdown(self.card_row("MDRAID device", name=name), "Remove")
 
-    def raid_action(self, action):
+    def raid_action(self, action: str):
         self.browser.click(self.card_button("MDRAID device", action))
 
-    def raid_default_action_start(self, action):
+    def raid_default_action_start(self, action: str):
         self.raid_action(action)
 
-    def raid_default_action_finish(self, action):
+    def raid_default_action_finish(self, action: str):
         if action == "Stop":
             # Right after assembling an array the device might be busy
             # from udev rules probing or the mdadm monitor; retry a
@@ -70,7 +70,7 @@ class TestStorageMdRaid(storagelib.StorageCase):
             else:
                 self.fail("Timed out waiting for array to get stopped")
 
-    def raid_default_action(self, action):
+    def raid_default_action(self, action: str):
         self.raid_default_action_start(action)
         self.raid_default_action_finish(action)
 
@@ -127,7 +127,7 @@ class TestStorageMdRaid(storagelib.StorageCase):
                           disk2: "In sync",
                           disk3: "In sync"})
 
-        def wait_degraded_state(is_degraded):
+        def wait_degraded_state(is_degraded: bool):
             degraded_selector = ".pf-v6-c-alert h4"
             if is_degraded:
                 b.wait_in_text(degraded_selector, 'The MDRAID device is in a degraded state')

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -850,6 +850,9 @@ ipa-advise enable-admins-sudo | sh -ex
         m.execute("while ls /run/user/$(id -u alice)/*.ccache; do sleep 1; done")
         m.execute(f"! su -c '{ccache_env} klist' alice")
 
+        # FIXME: Something above triggers this error message
+        self.allow_journal_messages("Received unexpected TLS connection and no certificate was configured")
+
 
 @testlib.skipImage("adcli not on test images", "debian-*", "ubuntu-*")
 @testlib.no_retry_when_changed


### PR DESCRIPTION
Mixing scsi_debug and loop does strange things on CentOS 9 aarch64
Testing Farm instances, and the SCSI disk doesn't get detected properly
as part of the array.

This papers over a bug, but we are testing the Cockpit logic here, not
weird low-level kernel bugs. See #22143 for debug information.


---

Fixes the C9S aarch64 failures, see #22143 for debugging details.