### PR TITLE
test: type some test helper functions

### DIFF
--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -27,12 +27,12 @@ import testlib
 @testlib.nondestructive
 class TestApps(packagelib.PackageCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
-        self.appstream_collection = set()
+        self.appstream_collection: 'set[str]' = set()
         self.machine.upload(["verify/files/test.png"], "/var/tmp/")
 
-    def createAppStreamPackage(self, name, version, revision, install=False):
+    def createAppStreamPackage(self, name: str, version: str, revision: str, install: bool = False) -> None:
         self.createPackage(name, version, revision, content={
             f"/usr/share/metainfo/org.cockpit_project.{name}.metainfo.xml": f"""
 <component type="addon">
@@ -47,7 +47,7 @@ class TestApps(packagelib.PackageCase):
             f"/usr/share/icons/hicolor/64x64/apps/{name}.png": {"path": "/var/tmp/test.png"}}, install=install)
         self.appstream_collection.add(name)
 
-    def createAppStreamRepoPackage(self, subdir=None):
+    def createAppStreamRepoPackage(self, subdir: str | None = None) -> None:
         if subdir is None:
             subdir = "swcatalog/xml"
         body = ""
@@ -80,7 +80,7 @@ class TestApps(packagelib.PackageCase):
         # ignore the corresponding journal entry
         self.allow_journal_messages("org.freedesktop.PackageKit.*org.freedesktop.DBus.Error.NoReply.*")
 
-    def testBasic(self, urlroot=""):
+    def testBasic(self, urlroot: str = ""):
         b = self.browser
         m = self.machine
 
@@ -243,7 +243,7 @@ class TestApps(packagelib.PackageCase):
 
         b.wait_visible(".app-description:contains('DESCRIPTION:none')")
 
-        def set_lang(lang):
+        def set_lang(lang: str) -> None:
             b.switch_to_top()
             b.open_session_menu()
             b.click("button.display-language-menu")

--- a/test/verify/check-client
+++ b/test/verify/check-client
@@ -66,7 +66,7 @@ done
 exec "$@"
 """, perm="0755")
 
-    def check_login(self, expected_user):
+    def check_login(self, expected_user: str) -> None:
         b = self.browser
         b.wait_visible('#content')
         b.wait_in_text("#hosts-sel", expected_user)
@@ -78,7 +78,7 @@ exec "$@"
             b.wait_visible("#page_status_notification_updates")
         b.switch_to_top()
 
-    def logout(self, check_last_host=None):
+    def logout(self, check_last_host: str | None = None) -> None:
         b = self.browser
 
         b.logout()

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -21,6 +21,7 @@ import time
 
 import testlib
 from lib.constants import TEST_OS_DEFAULT
+from machine import testvm
 
 
 class KdumpHelpers(testlib.MachineCase):
@@ -28,14 +29,14 @@ class KdumpHelpers(testlib.MachineCase):
         super().setUp()
         self.allow_restart_journal_messages()
 
-    def enableLocalSsh(self, machine=None):
+    def enableLocalSsh(self, machine: testvm.Machine | None = None) -> None:
         machine = machine or self.machine
         machine.execute("[ -f /root/.ssh/id_rsa ] || ssh-keygen -t rsa -N '' -f /root/.ssh/id_rsa")
         machine.execute("cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys")
         machine.execute("ssh-keyscan -H localhost >> /root/.ssh/known_hosts")
         machine.execute("cat /root/.ssh/id_rsa.pub >> /home/admin/.ssh/authorized_keys; chown admin: /home/admin/.ssh/authorized_keys")
 
-    def assertActive(self, active, browser=None):
+    def assertActive(self, active: bool, browser: testlib.Browser | None = None) -> None:
         browser = browser or self.browser
         browser.wait_visible(".pf-v6-c-switch__input" + (":checked" if active else ":not(:checked)"))
 
@@ -44,7 +45,8 @@ class KdumpHelpers(testlib.MachineCase):
             self.machine.execute("systemctl enable kdump; kdumpctl reset-crashkernel")
             self.machine.reboot()
 
-    def crashKernel(self, message, cancel=False, machine=None, browser=None):
+    def crashKernel(self, message: str, cancel: bool = False, machine: testvm.Machine | None = None,
+                    browser: testlib.Browser | None = None) -> None:
         browser = browser or self.browser
         machine = machine or self.machine
 
@@ -65,7 +67,7 @@ class KdumpHelpers(testlib.MachineCase):
             machine.disconnect()
             machine.wait_boot(timeout_sec=300)
 
-    def enableNFSServer(self, machine=None):
+    def enableNFSServer(self, machine: testvm.Machine | None = None) -> None:
         machine = machine or self.machine
         # set up NFS server
         self.machines["nfs"].write("/etc/exports", "/srv/kdump 10.111.113.0/24(rw,no_root_squash)\n")
@@ -74,7 +76,8 @@ class KdumpHelpers(testlib.MachineCase):
         # there shouldn't be any crash reports in the target directory
         self.assertEqual(machine.execute("find /var/crash -maxdepth 1 -mindepth 1 -type d"), "")
 
-    def run_ansible_playbook(self, browser, machine, allow_failure=False):
+    def run_ansible_playbook(self, browser: testlib.Browser, machine: testvm.Machine,
+                             allow_failure: bool = False) -> None:
         browser.click("#kdump-automation-script")
         ansible_script_sel = ".automation-script-modal .pf-v6-c-modal-box__body section:nth-child(2) textarea"
         machine.execute("mkdir -p roles/kdump/tasks")


### PR DESCRIPTION
A bit of procrastination with the main benefit that I see less "red squiggly lines" in tests :)

Note that we don't run any type checking here so locally:

```
[jelle@carbon][~/projects/cockpit/testlib-typing-extending]%mypy test/verify/check-apps
test/verify/check-apps:33: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
Success: no issues found in 1 source file
[jelle@carbon][~/projects/cockpit/testlib-typing-extending]%mypy test/verify/check-kdump
Success: no issues found in 1 source file
[jelle@carbon][~/projects/cockpit/testlib-typing-extending]%mypy test/verify/check-client
Success: no issues found in 1 source file
```