### PR TITLE
lib: Wrap journal log lines

### DIFF
--- a/pkg/lib/journal.css
+++ b/pkg/lib/journal.css
@@ -126,9 +126,6 @@
 .cockpit-log-message,
 .cockpit-log-service,
 .cockpit-log-service-reduced {
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
   flex: auto;
 }
 


### PR DESCRIPTION
Truncating long log lines at the end for æsthetical reasons is detrimental: The most interesting information is often at the end, and there is no way to see the full log.

This was already introduced in the initial commit 87325b96bc3.

Fixes #21892

----

No wraps and looks like this:

<img width="831" height="366" alt="image" src="https://github.com/user-attachments/assets/f9103ec5-4228-4e88-ba68-b8cc4a98329f" />
