### PR TITLE
test: support testing against systemd's main repository

### DIFF
--- a/test/run
+++ b/test/run
@@ -38,6 +38,11 @@ case "${TEST_SCENARIO:=}" in
         RUN_OPTS="$RUN_OPTS "
         PREPARE_OPTS="$PREPARE_OPTS --overlay"
         ;;&
+   *systemd-main*)
+        bots/image-customize --fresh -v --script test/vm.systemd-main "$TEST_OS"
+        RUN_OPTS="$RUN_OPTS "
+        PREPARE_OPTS="$PREPARE_OPTS --overlay"
+        ;;&
    *updates-testing*)
         bots/image-customize --fresh -v --script test/vm.updates-testing "$TEST_OS"
         RUN_OPTS="$RUN_OPTS "

--- a/test/vm.systemd-main
+++ b/test/vm.systemd-main
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+
+grep -q 'ID=.*fedora' /etc/os-release 
+
+. /etc/os-release
+
+fedora_release="Fedora_${VERSION_ID}"
+
+echo "https://download.opensuse.org/repositories/system:systemd/${fedora_release}/system:systemd.repo"
+dnf config-manager addrepo --from-repofile="https://download.opensuse.org/repositories/system:systemd/${fedora_release}/system:systemd.repo"
+dnf -y update --repo=system_systemd --setopt=install_weak_deps=False


### PR DESCRIPTION
The systemd project maintains its own repository of `main` builds on OBS (Open Build Service). Testing against this repository allows us to catch regressions before a major systemd release or test out new features included in `main`.

---

### Found issues so far:

* `b.reload()` now logs out our logged in user on the hardware details page.
* > warn: failed to connect to session bus: [Errno 123] sd_bus_default_user: No medium found
* Stopping 'systemd-logind.service', but its triggering units are still active:
systemd-logind-varlink.socket
* Failed to set time: Requested to set the clock to time before build time, refusing.