### PR TITLE
test: Retry BiDi pointer events on "no such element"

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -546,7 +546,9 @@ class Browser:
         # sidestep the browser
         element = self.call_js_func('ph_find_scroll_into_view' if scrollVisible else 'ph_find', selector)
 
-        actions = [{"type": "pointerMove", "x": 0, "y": 0, "origin": {"type": "element", "element": element}}]
+        actions: list[JsonObject] = [
+            {"type": "pointerMove", "x": 0, "y": 0, "origin": {"type": "element", "element": element}}
+        ]
         down = {"type": "pointerDown", "button": btn}
         up = {"type": "pointerUp", "button": btn}
         if event == "click":
@@ -563,8 +565,8 @@ class Browser:
 
         # modifier keys
         ev_id = f"pointer-{self.driver.last_id}"
-        keys_pre = []
-        keys_post = []
+        keys_pre: list[JsonObject] = []
+        keys_post: list[JsonObject] = []
 
         def key(type_: str, name: str) -> JsonObject:
             return {"type": "key", "id": ev_id + type_, "actions": [{"type": type_, "value": WEBDRIVER_KEYS[name]}]}
@@ -682,7 +684,7 @@ class Browser:
         self.call_js_func('ph_blur', selector)
 
     def input_text(self, text: str) -> None:
-        actions = []
+        actions: list[JsonObject] = []
         for c in text:
             # quality-of-life special case
             if c == '\n':
@@ -701,9 +703,9 @@ class Browser:
         :param repeat: number of times to repeat this key (default 1)
         :param modifiers: "Shift", "Control", "Alt"
         """
-        actions = []
-        actions_pre = []
-        actions_post = []
+        actions: list[JsonObject] = []
+        actions_pre: list[JsonObject] = []
+        actions_post: list[JsonObject] = []
         keycode = WEBDRIVER_KEYS.get(name, name)
 
         for m in (modifiers or []):
@@ -2481,7 +2483,8 @@ class MachineCase(unittest.TestCase):
     def enable_root_login(self) -> None:
         """Enable root login
 
-        By default root login is disabled in cockpit, removing the root entry of /etc/cockpit/disallowed-users allows root to login.
+        By default root login is disabled in cockpit, removing the root entry of
+        /etc/cockpit/disallowed-users allows root to login.
         """
 
         disallowed_conf = '/etc/cockpit/disallowed-users'


### PR DESCRIPTION
It can happen that the clicked element re-renders in between the
`wait_visible()` and the `input.performActions`. This caused random test
failures like

> testlib.Error: no such element: Origin element f.[...] was not found

Prevent this by retrying the `ph_find` + `performActions` up to 3 times
when that error happens.

Also update the obsolete "top frame with Chromium" comment, this was
fixed in commit 1b6a12676fd4.

----

This problem happens [here](https://logs-cockpit.apps.ocp.cloud.ci.centos.org/pull-22212-0f27fd3c-20250715-180244-rhel-10-1-expensive/log.html), [here](https://logs-cockpit.apps.ocp.cloud.ci.centos.org/pull-22209-eed30f1e-20250714-153617-fedora-41-storage/log.html), or [here](https://logs-cockpit.apps.ocp.cloud.ci.centos.org/pull-22201-8eb5e7d6-20250713-075437-rhel-9-7-expensive/log.html). I can reproduce it locally with `TestUpdatesSubscriptions.testNoUpdates` on rhel-9-7 in about 1/5 of runs. When it fails:

```
INFO:bidi.command:→ {'realm': '-5990477385401455293.-3922111857784826156', 'result': None, 'type': 'success'}
INFO:bidi.command:← script.evaluate({'expression': 'ph_wait_cond(() => ph_is_present(".pf-v6-c-empty-state button:not([disabled]):not([aria-disabled=true])"), 15000, null)', 'awaitPromise': True, 'target': {'context': 'B3BDE822F13D4FC8097E2A2667F3B2C2'}}) [id 50]
INFO:bidi.command:→ {'realm': '-5990477385401455293.-3922111857784826156', 'result': None, 'type': 'success'}
INFO:bidi.command:← script.evaluate({'expression': 'ph_wait_cond(() => ph_is_visible(".pf-v6-c-empty-state button:not([disabled]):not([aria-disabled=true])"), 15000, null)', 'awaitPromise': True, 'target': {'context': 'B3BDE822F13D4FC8097E2A2667F3B2C2'}}) [id 51]
INFO:bidi.command:→ {'realm': '-5990477385401455293.-3922111857784826156', 'result': None, 'type': 'success'}
INFO:bidi.command:← script.evaluate({'expression': 'ph_find_scroll_into_view(".pf-v6-c-empty-state button:not([disabled]):not([aria-disabled=true])")', 'awaitPromise': True, 'target': {'context': 'B3BDE822F13D4FC8097E2A2667F3B2C2'}}) [id 52]
INFO:bidi.command:→ {'realm': '-5990477385401455293.-3922111857784826156', 'result': {'sharedId': 'f.B3BDE822F13D4FC8097E2A2667F3B2C2.d.50136F150D5C34F66B26FADB7EF7347C.e.82', 'type': 'node', 'value': {'attributes': {'class': 'pf-v6-c-button pf-m-primary pf-m-progress', 'data-ouia-component-id': 'OUIA-Generated-Button-primary-1', 'data-ouia-component-type': 'PF6/Button', 'data-ouia-safe': 'true', 'type': 'button'}, 'childNodeCount': 1, 'localName': 'button', 'namespaceURI': 'http://www.w3.org/1999/xhtml', 'nodeType': 1, 'shadowRoot': None}}, 'type': 'success'}
INFO:bidi.command:← input.performActions({'context': 'B3BDE822F13D4FC8097E2A2667F3B2C2', 'actions': [{'id': 'pointer-53', 'type': 'pointer', 'parameters': {'pointerType': 'mouse'}, 'actions': [{'type': 'pointerMove', 'x': 0, 'y': 0, 'origin': {'type': 'element', 'element': {'sharedId': 'f.B3BDE822F13D4FC8097E2A2667F3B2C2.d.50136F150D5C34F66B26FADB7EF7347C.e.82', 'type': 'node', 'value': {'attributes': {'class': 'pf-v6-c-button pf-m-primary pf-m-progress', 'data-ouia-component-id': 'OUIA-Generated-Button-primary-1', 'data-ouia-component-type': 'PF6/Button', 'data-ouia-safe': 'true', 'type': 'button'}, 'childNodeCount': 1, 'localName': 'button', 'namespaceURI': 'http://www.w3.org/1999/xhtml', 'nodeType': 1, 'shadowRoot': None}}}}, {'type': 'pointerDown', 'button': 0}, {'type': 'pointerUp', 'button': 0}]}]}) [id 53]
Traceback (most recent call last):
  File "/var/home/martin/upstream/cockpit/main/test/verify/check-packagekit", line 1326, in testNoUpdates
    b.click(".pf-v6-c-empty-state button")
    ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/home/martin/upstream/cockpit/main/test/common/testlib.py", line 600, in click
    self.mouse(selector + ":not([disabled]):not([aria-disabled=true])", "click")
    ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/home/martin/upstream/cockpit/main/test/common/testlib.py", line 593, in mouse
    self.bidi("input.performActions", context=self.driver.context, actions=keys_pre + actions + keys_post)
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/home/martin/upstream/cockpit/main/test/common/testlib.py", line 349, in bidi
    raise Error(str(e)) from None
testlib.Error: no such element: Origin element f.B3BDE822F13D4FC8097E2A2667F3B2C2.d.50136F150D5C34F66B26FADB7EF7347C.e.82 was not found
```

Now when this happens it retries successfully:

```
INFO:bidi.command:← script.evaluate({'expression': 'ph_wait_cond(() => ph_is_present(".pf-v6-c-empty-state button:not([disabled]):not([aria-disabled=true])"), 15000, null)', 'awaitPromise': True, 'target': {'context': '2BADBB9F1E6EF7DC3AD70F9F0B257A73'}}) [id 50]
INFO:bidi.command:→ {'realm': '1452837056462728827.7760228435499806768', 'result': None, 'type': 'success'}
INFO:bidi.command:← script.evaluate({'expression': 'ph_wait_cond(() => ph_is_visible(".pf-v6-c-empty-state button:not([disabled]):not([aria-disabled=true])"), 15000, null)', 'awaitPromise': True, 'target': {'context': '2BADBB9F1E6EF7DC3AD70F9F0B257A73'}}) [id 51]
INFO:bidi.command:→ {'realm': '1452837056462728827.7760228435499806768', 'result': None, 'type': 'success'}
INFO:bidi.command:← script.evaluate({'expression': 'ph_find_scroll_into_view(".pf-v6-c-empty-state button:not([disabled]):not([aria-disabled=true])")', 'awaitPromise': True, 'target': {'context': '2BADBB9F1E6EF7DC3AD70F9F0B257A73'}}) [id 52]
INFO:bidi.command:→ {'realm': '1452837056462728827.7760228435499806768', 'result': {'sharedId': 'f.2BADBB9F1E6EF7DC3AD70F9F0B257A73.d.055702E1208162725D19FE179D89EDDC.e.82', 'type': 'node', 'value': {'attributes': {'class': 'pf-v6-c-button pf-m-primary pf-m-progress', 'data-ouia-component-id': 'OUIA-Generated-Button-primary-1', 'data-ouia-component-type': 'PF6/Button', 'data-ouia-safe': 'true', 'type': 'button'}, 'childNodeCount': 1, 'localName': 'button', 'namespaceURI': 'http://www.w3.org/1999/xhtml', 'nodeType': 1, 'shadowRoot': None}}, 'type': 'success'}
INFO:bidi.command:← input.performActions({'context': '2BADBB9F1E6EF7DC3AD70F9F0B257A73', 'actions': [{'id': 'pointer-53', 'type': 'pointer', 'parameters': {'pointerType': 'mouse'}, 'actions': [{'type': 'pointerMove', 'x': 0, 'y': 0, 'origin': {'type': 'element', 'element': {'sharedId': 'f.2BADBB9F1E6EF7DC3AD70F9F0B257A73.d.055702E1208162725D19FE179D89EDDC.e.82', 'type': 'node', 'value': {'attributes': {'class': 'pf-v6-c-button pf-m-primary pf-m-progress', 'data-ouia-component-id': 'OUIA-Generated-Button-primary-1', 'data-ouia-component-type': 'PF6/Button', 'data-ouia-safe': 'true', 'type': 'button'}, 'childNodeCount': 1, 'localName': 'button', 'namespaceURI': 'http://www.w3.org/1999/xhtml', 'nodeType': 1, 'shadowRoot': None}}}}, {'type': 'pointerDown', 'button': 0}, {'type': 'pointerUp', 'button': 0}]}]}) [id 53]
WARNING:bidi.command:Browser.mouse('.pf-v6-c-empty-state button:not([disabled]):not([aria-disabled=true])', 'click'): retrying after no such element: Origin element f.2BADBB9F1E6EF7DC3AD70F9F0B257A73.d.055702E1208162725D19FE179D89EDDC.e.82 was not found
INFO:bidi.command:← script.evaluate({'expression': 'ph_find(".pf-v6-c-empty-state button:not([disabled]):not([aria-disabled=true])")', 'awaitPromise': True, 'target': {'context': '2BADBB9F1E6EF7DC3AD70F9F0B257A73'}}) [id 54]
INFO:bidi.command:→ {'realm': '1452837056462728827.7760228435499806768', 'result': {'sharedId': 'f.2BADBB9F1E6EF7DC3AD70F9F0B257A73.d.055702E1208162725D19FE179D89EDDC.e.85', 'type': 'node', 'value': {'attributes': {'class': 'pf-v6-c-button pf-m-primary pf-m-progress', 'data-ouia-component-id': 'OUIA-Generated-Button-primary-2', 'data-ouia-component-type': 'PF6/Button', 'data-ouia-safe': 'true', 'type': 'button'}, 'childNodeCount': 1, 'localName': 'button', 'namespaceURI': 'http://www.w3.org/1999/xhtml', 'nodeType': 1, 'shadowRoot': None}}, 'type': 'success'}
INFO:bidi.command:← input.performActions({'context': '2BADBB9F1E6EF7DC3AD70F9F0B257A73', 'actions': [{'id': 'pointer-55', 'type': 'pointer', 'parameters': {'pointerType': 'mouse'}, 'actions': [{'type': 'pointerMove', 'x': 0, 'y': 0, 'origin': {'type': 'element', 'element': {'sharedId': 'f.2BADBB9F1E6EF7DC3AD70F9F0B257A73.d.055702E1208162725D19FE179D89EDDC.e.85', 'type': 'node', 'value': {'attributes': {'class': 'pf-v6-c-button pf-m-primary pf-m-progress', 'data-ouia-component-id': 'OUIA-Generated-Button-primary-2', 'data-ouia-component-type': 'PF6/Button', 'data-ouia-safe': 'true', 'type': 'button'}, 'childNodeCount': 1, 'localName': 'button', 'namespaceURI': 'http://www.w3.org/1999/xhtml', 'nodeType': 1, 'shadowRoot': None}}}}, {'type': 'pointerDown', 'button': 0}, {'type': 'pointerUp', 'button': 0}]}]}) [id 55]
INFO:bidi.command:→ {}
```