### PR TITLE
packagekit: Move dnf5-plugin-automatic config to canonical location

### DIFF
--- a/pkg/packagekit/autoupdates.jsx
+++ b/pkg/packagekit/autoupdates.jsx
@@ -221,7 +221,7 @@ class Dnf4Impl extends ImplBase {
 class Dnf5Impl extends ImplBase {
     async getConfig() {
         this.packageName = "dnf5-plugin-automatic";
-        this.configFile = "/etc/dnf/dnf5-plugins/automatic.conf";
+        this.configFile = "/etc/dnf/automatic.conf";
 
         try {
             await cockpit.spawn(["rpm", "-q", this.packageName], { err: "ignore" });
@@ -234,6 +234,8 @@ class Dnf5Impl extends ImplBase {
 
         // - dnf 5 only has a single timer dnf5-automatic.timer and a config file with
         //   "apply_updates" (yes/no) and "upgrade_type" (default/security)
+        //   defaults are in /usr/share/dnf5/dnf5-plugins/automatic.conf and admin overrides are in /etc
+        //   (this.configFile)
         // - by default this runs every day (OnCalendar)
         try {
             const output = await cockpit.script(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ module = [
     'packagelib',
     'netlib',
     'storagelib',
+    'submanlib',
     'js_coverage',
     'webdriver_bidi',
 ]

--- a/test/common/packagelib.py
+++ b/test/common/packagelib.py
@@ -134,7 +134,7 @@ class PackageCase(MachineCase):
             self.machine.execute("rm -r /etc/systemd/system/dnf-automatic* && systemctl daemon-reload || true")
 
         if self.backend == 'dnf5':
-            self.restore_file("/etc/dnf/dnf5-plugins/automatic.conf")
+            self.restore_file("/etc/dnf/automatic.conf")
             self.addCleanup(self.machine.execute, "systemctl disable --now dnf5-automatic.timer 2>/dev/null || true")
             self.addCleanup(self.machine.execute,
                             "rm -r /etc/systemd/system/dnf5-automatic*.d && systemctl daemon-reload || true")

--- a/test/common/submanlib.py
+++ b/test/common/submanlib.py
@@ -18,11 +18,12 @@
 import os
 
 import testlib
+from machine import testvm
 
 
 class SubscriptionCase(testlib.MachineCase):
 
-    def setup_candlepin_service(self, candlepin_machine):
+    def setup_candlepin_service(self, candlepin_machine: testvm.Machine) -> None:
         m = self.machine
 
         # wait for candlepin to be active and verify
@@ -57,6 +58,6 @@ class SubscriptionCase(testlib.MachineCase):
         m.execute(
             "subscription-manager config --server.hostname services.cockpit.lan --server.port 8443 --server.prefix /candlepin")
 
-    def register_with_candlepin(self):
+    def register_with_candlepin(self) -> None:
         self.machine.execute(
             "LC_ALL=C.UTF-8 subscription-manager register --org=donaldduck --activationkey=awesome_os_pool")

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -65,14 +65,14 @@ class TestUpdates(NoSubManCase):
         self.update_text = "#page_status_notification_updates"
         self.update_text_action = "#page_status_notification_updates a"
 
-    def assertHistory(self, path, updates):
+    def assertHistory(self, path: str, updates: list[str]) -> None:
         selector = path + " li:nth-child({0})"
         for index, pkg in enumerate(updates, start=1):
             self.browser.wait_in_text(selector.format(index), pkg)
         # make sure we don't have any extra ones
         self.assertFalse(self.browser.is_present(selector.format(len(updates) + 1)))
 
-    def check_nth_update(self, index: int, pkgname: str, version: str, severity: str = "bug",
+    def check_nth_update(self, index: int, pkgname: list[str] | str, version: str, severity: str = "bug",
                          num_issues: 'int | None' = None, desc_matches: Collection[str] = (),
                          cves: Collection[str] = (), bugs: Collection[str] = (), arch: 'str | None' = None) -> str:
         """Check the contents of the package update table row at index
@@ -86,7 +86,8 @@ class TestUpdates(NoSubManCase):
 
         if isinstance(pkgname, list):
             for idx, pkg in enumerate(pkgname, 1):
-                self.assertEqual(b.text(row + "tr:first-child [data-label=Name] > div:nth-of-type(%i) span" % idx).split(', ', 1)[0], pkg)
+                sel = row + "tr:first-child [data-label=Name] > div:nth-of-type(%i) span" % idx
+                self.assertEqual(b.text(sel).split(', ', 1)[0], pkg)
         else:
             self.assertEqual(b.text(row + " tr:first-child [data-label=Name]"), pkgname)
             b.mouse(row + "tr:first-child [data-label=Name] span", "mouseenter")
@@ -143,8 +144,8 @@ class TestUpdates(NoSubManCase):
         kpp_kernel_release = "_".join(release)
 
         sanitized_kernel_ver = "_".join(kernel_ver_arch.split(".")[:-2])
-        self.createPackage("-".join(["kpatch-patch", kpp_kernel_version, kpp_kernel_release]), "0", "0", arch=self.secondary_arch,
-                           provides=f"kpatch-patch = {kernel_ver_arch}")
+        self.createPackage("-".join(["kpatch-patch", kpp_kernel_version, kpp_kernel_release]), "0", "0",
+                           arch=self.secondary_arch, provides=f"kpatch-patch = {kernel_ver_arch}")
         self.enableRepo()
 
         self.restore_file("/etc/dnf/plugins/kpatch.conf")
@@ -457,7 +458,11 @@ ExecStart=/usr/local/bin/{package} infinity
         m = self.machine
 
         class Tracer(object):
-            def __init__(self, testObj, rebootRequired=False, testStatusCard=False, packageName="vanilla"):
+            def __init__(self,
+                         testObj: TestUpdates,
+                         rebootRequired: bool = False,
+                         testStatusCard: bool = False,
+                         packageName: str = "vanilla"):
                 self.testObj = testObj
                 self.rebootRequired = rebootRequired
                 self.testStatusCard = testStatusCard
@@ -569,7 +574,8 @@ ExecStart=/usr/local/bin/{package} infinity
             def verify_backend(self):
                 if not self.rebootRequired:
                     # Check the service was actually restarted
-                    newServiceStartTime = m.execute(f"systemctl show {self.packageName}.service --property=ExecMainStartTimestamp")
+                    newServiceStartTime = m.execute(
+                        f"systemctl show {self.packageName}.service --property=ExecMainStartTimestamp")
                     self.testObj.assertGreater(newServiceStartTime, self.serviceStartTime)
 
                 # check no services/processes need reboot or service restart
@@ -696,7 +702,8 @@ Type=simple
 ExecStart=/usr/local/bin/{packageName}
 """
         self.createPackage(packageName, "1", "1", install=True, changes="initial package with service and run script",
-                           content={f"/usr/local/bin/{packageName}": scriptContent, f"/etc/systemd/system/{packageName}.service": unitContent},
+                           content={f"/usr/local/bin/{packageName}": scriptContent,
+                                    f"/etc/systemd/system/{packageName}.service": unitContent},
                            postinst=f"chmod a+x /usr/local/bin/{packageName}; systemctl daemon-reload; systemctl start {packageName}.service")
 
         scriptContent = "#!/bin/sh\nfalse"
@@ -707,7 +714,8 @@ RemainAfterExit=yes
 ExecStart=/usr/local/bin/{packageName}
 """
         self.createPackage(packageName, "1", "2",
-                           content={f"/usr/local/bin/{packageName}": scriptContent, f"/etc/systemd/system/{packageName}.service": unitContent})
+                           content={f"/usr/local/bin/{packageName}": scriptContent,
+                                    f"/etc/systemd/system/{packageName}.service": unitContent})
 
         self.enableRepo()
 
@@ -758,7 +766,7 @@ ExecStart=/usr/local/bin/{packageName}
                            changes="Now 10% *more* [unicorns](http://unicorn.example.com)")
         # bug fixes
         self.createPackage("buggy", "2", "1", install=True)
-        self.createPackage("buggy", "2", "2", changes="* Fixit", bugs=[123, 456])
+        self.createPackage("buggy", "2", "2", changes="* Fixit", bugs=["123", "456"])
         # security fix with proper CVE list and severity
         self.createPackage("secdeclare", "3", "4.a1", install=True)
         self.createPackage("secdeclare", "3", "4.b1", severity="security",
@@ -1420,7 +1428,7 @@ class TestAutoUpdates(NoSubManCase):
             self.timer_unit = "dnf-automatic-install"
             self.config = "/etc/dnf/automatic.conf"
 
-    def closeSettings(self, browser):
+    def closeSettings(self, browser: testlib.Browser) -> None:
         browser.click("#automatic-updates-dialog button:contains('Save changes')")
         with browser.wait_timeout(30):
             browser.wait_not_present("#automatic-updates-dialog")
@@ -1438,7 +1446,7 @@ class TestAutoUpdates(NoSubManCase):
             self.assertFalse(b.is_present("#auto-update-type"))
             return
 
-        def assertTimerDnf(hour, dow):
+        def assertTimerDnf(hour: str | None, dow: str | None) -> None:
             out = m.execute(f"systemctl --no-legend list-timers {self.timer_unit}.timer")
             if hour:
                 # don't test the minutes, due to RandomizedDelaySec=60m
@@ -1469,13 +1477,13 @@ class TestAutoUpdates(NoSubManCase):
             else:
                 self.assertNotIn("ExecStartPost", out)
 
-        def assertTimer(hour, dow=None):
+        def assertTimer(hour: str | None, dow: str | None = None) -> None:
             if "dnf" in self.backend:
                 assertTimerDnf(hour, dow)
             else:
                 raise NotImplementedError(self.backend)
 
-        def assertTypeDnf(type_):
+        def assertTypeDnf(type_: str) -> None:
             if type_ == "all":
                 match = '= default'
             elif type_ == "security":
@@ -1485,7 +1493,7 @@ class TestAutoUpdates(NoSubManCase):
 
             self.assertIn(match, m.execute(f"grep upgrade_type {self.config}"))
 
-        def assertType(type_):
+        def assertType(type_: str) -> None:
             if "dnf" in self.backend:
                 assertTypeDnf(type_)
             else:

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1423,7 +1423,7 @@ class TestAutoUpdates(NoSubManCase):
         self.supported_backend = "dnf" in self.backend
         if self.backend == "dnf5":
             self.timer_unit = "dnf5-automatic"
-            self.config = "/etc/dnf/dnf5-plugins/automatic.conf"
+            self.config = "/etc/dnf/automatic.conf"
         elif self.backend == "dnf4":
             self.timer_unit = "dnf-automatic-install"
             self.config = "/etc/dnf/automatic.conf"

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -615,5 +615,18 @@ via PackageKit.
 %files -n cockpit-packagekit -f packagekit.list
 %license COPYING
 
+%post -n cockpit-packagekit
+
+# on upgrades, move old dnf5 automatic config file to current location
+# see https://github.com/cockpit-project/cockpit/issues/22184
+if [ "$1" = 2 ]; then
+    old=/etc/dnf/dnf5-plugins/automatic.conf
+    new=/etc/dnf/automatic.conf
+   if [ -e $old ] && ! [ -e $new ]; then
+       echo "Moving deprecated dnf-automatic config $old to $new" >&2
+       mv $old $new
+   fi
+fi
+
 # The changelog is automatically generated and merged
 %changelog


### PR DESCRIPTION
Recent dnf5 deprecated /etc/dnf/dnf5-plugins/automatic.conf and moved to the dnf4-compatible /etc/dnf/automatic.conf location. Follow suit. Move the file on upgrades.

Fixes #22184

----

I tested the upgrade manually:
```
# ls -l /etc/dnf/automatic.conf /etc/dnf/dnf5-plugins/automatic.conf
ls: cannot access '/etc/dnf/automatic.conf': No such file or directory
-rw-r--r--. 1 root root 96 Jul 17 05:56 /etc/dnf/dnf5-plugins/automatic.conf

# rpm -Uvp /tmp/cockpit-packagekit-342.dev31+gfab992f35-1.fc42.noarch.rpm 
Verifying packages...
Preparing packages...
cockpit-packagekit-342.dev31+gfab992f35-1.fc42.noarch
Moving deprecated dnf-automatic config /etc/dnf/dnf5-plugins/automatic.conf to /etc/dnf/automatic.conf
cockpit-packagekit-342.dev30+gdecde81f1.dirty-1.fc42.noarch

# ls -l /etc/dnf/automatic.conf /etc/dnf/dnf5-plugins/automatic.conf
ls: cannot access '/etc/dnf/dnf5-plugins/automatic.conf': No such file or directory
-rw-r--r--. 1 root root 96 Jul 17 05:56 /etc/dnf/automatic.conf
```