### PR TITLE
packagekit: move watchRedHatSubscription to packagekit page

### DIFF
--- a/pkg/lib/packagekit.js
+++ b/pkg/lib/packagekit.js
@@ -284,53 +284,6 @@ export function cancellableTransaction(method, arglist, progress_cb, signalHandl
     });
 }
 
-/**
- * Check Red Hat subscription-manager if if this is an unregistered RHEL
- * system. If subscription-manager is not installed or required (not a
- * Red Hat product), nothing happens.
- *
- * callback: Called with a boolean (true: registered, false: not registered)
- *           after querying subscription-manager once, and whenever the value
- *           changes.
- */
-export function watchRedHatSubscription(callback) {
-    const sm = cockpit.dbus("com.redhat.RHSM1");
-
-    function check() {
-        sm.call(
-            "/com/redhat/RHSM1/Entitlement", "com.redhat.RHSM1.Entitlement", "GetStatus", ["", ""])
-                .then(result => {
-                    const status = JSON.parse(result[0]);
-                    callback(status.valid);
-                })
-                .catch(ex => console.warn("Failed to query RHEL subscription status:", JSON.stringify(ex)));
-    }
-
-    // check if subscription is required on this system, i.e. whether there are any installed products
-    sm.call("/com/redhat/RHSM1/Products", "com.redhat.RHSM1.Products", "ListInstalledProducts", ["", {}, ""])
-            .then(result => {
-                const products = JSON.parse(result[0]);
-                if (products.length === 0)
-                    return;
-
-                // check if this is an unregistered RHEL system
-                sm.subscribe(
-                    {
-                        path: "/com/redhat/RHSM1/Entitlement",
-                        interface: "com.redhat.RHSM1.Entitlement",
-                        member: "EntitlementChanged"
-                    },
-                    () => check()
-                );
-
-                check();
-            })
-            .catch(ex => {
-                if (ex.problem != "not-found")
-                    console.warn("Failed to query RHSM products:", JSON.stringify(ex));
-            });
-}
-
 /* Support for installing missing packages.
  *
  * First call check_missing_packages to determine whether something

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -76,7 +76,7 @@ import * as PK from "packagekit.js";
 import * as python from "python.js";
 import * as timeformat from "timeformat";
 
-import { debug } from './utils';
+import { debug, watchRedHatSubscription } from './utils';
 import callTracerScript from './callTracer.py';
 
 import "./updates.scss";
@@ -1319,7 +1319,7 @@ class OsUpdates extends React.Component {
     }
 
     initialLoadOrRefresh() {
-        PK.watchRedHatSubscription(registered => this.setState({ unregistered: !registered }));
+        watchRedHatSubscription(registered => this.setState({ unregistered: !registered }));
 
         cockpit.addEventListener("visibilitychange", () => {
             if (!cockpit.hidden)

--- a/pkg/packagekit/utils.tsx
+++ b/pkg/packagekit/utils.tsx
@@ -1,4 +1,55 @@
+import cockpit from "cockpit";
+
 export function debug(...args: unknown[]) {
     if (window.debugging == 'all' || window.debugging?.includes('packagekit'))
         console.debug('packagekit:', ...args);
+}
+
+/**
+ * Check Red Hat subscription-manager if if this is an unregistered RHEL
+ * system. If subscription-manager is not installed or required (not a
+ * Red Hat product), nothing happens.
+ *
+ * callback: Called with a boolean (true: registered, false: not registered)
+ *           after querying subscription-manager once, and whenever the value
+ *           changes.
+ */
+export function watchRedHatSubscription(callback: (registered: boolean) => void) {
+    const sm = cockpit.dbus("com.redhat.RHSM1");
+
+    function check() {
+        sm.call(
+            "/com/redhat/RHSM1/Entitlement", "com.redhat.RHSM1.Entitlement", "GetStatus", ["", ""])
+                .then(([reply]) => {
+                    const result = reply as string;
+                    const status = JSON.parse(result);
+                    callback(status.valid);
+                })
+                .catch(ex => console.warn("Failed to query RHEL subscription status:", JSON.stringify(ex)));
+    }
+
+    // check if subscription is required on this system, i.e. whether there are any installed products
+    sm.call("/com/redhat/RHSM1/Products", "com.redhat.RHSM1.Products", "ListInstalledProducts", ["", {}, ""])
+            .then(([reply]) => {
+                const result = reply as string;
+                const products = JSON.parse(result);
+                if (products.length === 0)
+                    return;
+
+                // check if this is an unregistered RHEL system
+                sm.subscribe(
+                    {
+                        path: "/com/redhat/RHSM1/Entitlement",
+                        interface: "com.redhat.RHSM1.Entitlement",
+                        member: "EntitlementChanged"
+                    },
+                    () => check()
+                );
+
+                check();
+            })
+            .catch(ex => {
+                if (ex.problem != "not-found")
+                    console.warn("Failed to query RHSM products:", JSON.stringify(ex));
+            });
 }


### PR DESCRIPTION
This is only used in the packagekit page and doesn't make sense to be part of a shared "packagekit" API as it uses a different dbus interface.

---

Note that it technically is used on the "overview page" but via page_status (notifications).