### PR TITLE
systemd: ensure update() is called at least once for tuned-dialog

### DIFF
--- a/pkg/systemd/overview-cards/tuned-dialog.jsx
+++ b/pkg/systemd/overview-cards/tuned-dialog.jsx
@@ -99,7 +99,7 @@ export const TunedPerformanceProfile = () => {
     useEvent(tunedService, "changed", () => {
         // We get a flood of "changed" events sometimes without the
         // state actually changing. So let's protect against that.
-        if (oldServiceState.current != tunedService.state) {
+        if (oldServiceState.current !== tunedService.state) {
             oldServiceState.current = tunedService.state;
             update();
         }


### PR DESCRIPTION
Currently if tuned isn't installed there is no message under `Performance Profile`

<img width="750" height="458" alt="image" src="https://github.com/user-attachments/assets/8e5ec6ef-7fa8-47de-8db4-64f479da6b7f" />

This is due to the type juggling of `oldServiceState.current != tunedService.state` juggling `null` and `undefined`

Instead we should be strictly checking the typing so we can be sure `update()` has been called at least once so we can show "Tuned is not available" to the user

<img width="750" height="458" alt="image" src="https://github.com/user-attachments/assets/39ac9544-26a2-4b91-969e-e879e982002b" />
