### PR TITLE
login: Improve error message for unsupported shells

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -1355,6 +1355,7 @@ doubt use `internal-error`.
 
  * `internal-error`
  * `no-cockpit`
+ * `unsupported-shell`
  * `no-session`
  * `access-denied`
  * `authentication-failed`

--- a/pkg/static/login.js
+++ b/pkg/static/login.js
@@ -1050,6 +1050,9 @@ function debug(...args) {
                     login_machine || "localhost");
 
                 login_failure(_("Packageless session unavailable"), message);
+            } else if (xhr.status == 500 && xhr.statusText.indexOf("unsupported-shell") > -1) {
+                login_failure(_("Authentication failed"),
+                              _("Unsupported shell. Check the journal for details."));
             } else if (xhr.statusText) {
                 fatal(decodeURIComponent(xhr.statusText));
             } else {

--- a/src/common/Makefile-common.am
+++ b/src/common/Makefile-common.am
@@ -94,6 +94,7 @@ libcockpit_common_a_SOURCES = \
 # libcockpit-common.a static-links an HTML template to use on failures
 nodist_libcockpit_common_a_SOURCES = src/common/fail-html.c
 src/common/fail-html.c: src/common/fail.html
+	@mkdir -p '$(dir $@)'
 	$(AM_V_GEN) $(top_srcdir)/tools/escape-to-c cockpit_webresponse_fail_html_text < $< > $@.tmp && mv $@.tmp $@
 CLEANFILES += src/common/fail-html.c
 EXTRA_DIST += src/common/fail.html

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -119,13 +119,15 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         # Try to login with disabled shell; this does not work on OSTree where
         # we log in through ssh
         if not m.ws_container:
-            m.execute("usermod --shell /bin/false admin; sync")
-            b.reload()
-            b.try_login("admin", "foobar")
-            b.wait_text_not("#login-error-title", "")
-            self.assertIn(b.text("#login-error-title"),
-                          ["Permission denied", "Authentication failed"])
-            m.execute("usermod --shell /bin/bash admin; sync")
+            try:
+                m.execute("usermod --shell /bin/false admin; sync")
+                b.reload()
+                b.try_login("admin", "foobar")
+                b.wait_text_not("#login-error-title", "")
+                self.assertIn(b.text("#login-error-title"),
+                              ["Permission denied", "Authentication failed"])
+            finally:
+                m.execute("usermod --shell /bin/bash admin; sync")
 
         # Login as admin
         b.open("/system")

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -121,11 +121,20 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         if not m.ws_container:
             try:
                 m.execute("usermod --shell /bin/false admin; sync")
+                journal_cursor = self.machine.journal_cursor()
                 b.reload()
                 b.try_login("admin", "foobar")
-                b.wait_text_not("#login-error-title", "")
-                self.assertIn(b.text("#login-error-title"),
-                              ["Permission denied", "Authentication failed"])
+                b.wait_text("#login-error-title", "Authentication failed")
+                # arch enforces pam_shells, so it fails already in PAM auth
+                if m.image != "arch":
+                    b.wait_in_text("#login-error-message", "Unsupported shell")
+
+                    testlib.wait(
+                        lambda: re.search(
+                            r'User admin shell.*/bin/false.*exit 71.*unsupported',
+                            m.execute(f"journalctl -ocat --cursor '{journal_cursor}' SYSLOG_IDENTIFIER=cockpit-session")
+                        ),
+                        tries=10)
             finally:
                 m.execute("usermod --shell /bin/bash admin; sync")
 


### PR DESCRIPTION
When trying to log in with a shell that does not understand `exit 71`
(our litmus test for "reasonable shell"), this was previously really
hard to understand/debug: The journal did not show anything bad other
than that the session only lasted a blink of an eye, and the login page
just said "permission denied".

Log a proper warning to the journal that explains what happens.

Let the login page show "Unsupported shell. Check the journal for
details." We are past authentication at this point, so we can afford
giving away that piece of information.

Fixes #20741

----

Looks like this now:

<img width="608" height="551" alt="shell-fail" src="https://github.com/user-attachments/assets/205ae9cc-b7fd-4a4b-b563-53990d2f267d" />

That screenshot reveals that we broke the background in the alert. I'll check if I can fix that quickly.

And the journal says

```
cockpit-session[18957]: cockpit-session: User admin shell (/bin/false) does not understand 'exit 71', unsupported with Cockpit
```

I also piggy-back the trivial fix for #21918 here.