### PR TITLE
test: Restore subuids to unbreak rootless podman

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -98,6 +98,13 @@ if grep -q platform:el10 /etc/os-release; then
     export NETAVARK_FW=nftables
 fi
 
+# HACK: unbreak subuid assignment for new users; see
+# https://bugzilla.redhat.com/show_bug.cgi?id=2382662
+# https://issues.redhat.com/browse/RHEL-103765
+if [ -e /etc/login.defs ]; then
+    sed -i '/^SUB_.ID_COUNT/ s/\b0/65536/' /etc/login.defs
+fi
+
 # Run tests in the cockpit tasks container, as unprivileged user
 CONTAINER="$(cat .cockpit-ci/container)"
 exec podman \

--- a/test/vm.install
+++ b/test/vm.install
@@ -61,6 +61,17 @@ if [ "$PLATFORM_ID" = "platform:el10" ]; then
     printf  '[network]\nfirewall_driver = "nftables"\n' > /etc/containers/containers.conf
 fi
 
+# HACK: unbreak subuid assignment for current and new users; see
+# https://bugzilla.redhat.com/show_bug.cgi?id=2382662
+# https://issues.redhat.com/browse/RHEL-103765
+if [ -e /etc/login.defs ]; then
+    sed -i '/^SUB_.ID_COUNT/ s/\b0/65536/' /etc/login.defs
+fi
+if ! grep -q admin /etc/subuid; then
+    usermod --add-subuids 100000-165535 admin
+    usermod --add-subgids 100000-165535 admin
+fi
+
 # start cockpit once to ensure it works, and generate the certificate (to avoid re-doing that for each test)
 if [ -n "$HAVE_COCKPIT_SOCKET" ]; then
     systemctl start cockpit


### PR DESCRIPTION
Recent shadow-utils broke rootless containers [1][2]. This is under heavy debate, but until then unbreak our tests by restoring the working configuration and re-adding subuids to our admin user.

Fixes #2203

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2382662
[2] https://issues.redhat.com/browse/RHEL-103765

----

This is the same hack as in https://github.com/cockpit-project/cockpit-podman/pull/2205 and https://github.com/cockpit-project/cockpit-podman/pull/2209 . Cockpit's tests also  use podman, this unbreaks https://github.com/cockpit-project/bots/pull/8042