### PR TITLE
test: Refactor mount directories in storage tests

### DIFF
--- a/test/common/storagelib.py
+++ b/test/common/storagelib.py
@@ -694,6 +694,10 @@ class StorageCase(StorageHelpers):
         else:
             self.default_crypto_type = "luks1"
 
+        # OSTree friendly, automatically unmounted and cleaned up
+        self.mnt_dir = os.path.join(self.vm_tmpdir, "mnt")
+        self.machine.execute(f"mkdir -p {self.mnt_dir}")
+
         if self.image.startswith("rhel-8"):
             # HACK: missing /etc/crypttab file upsets udisks: https://github.com/storaged-project/udisks/pull/835
             self.machine.write("/etc/crypttab", "")

--- a/test/image-prepare
+++ b/test/image-prepare
@@ -175,7 +175,7 @@ def build_install_bootc(dist_tar, image, verbose, quick):
         rpms = build_rpms(dist_tar, machine, verbose, quick)
     args = ["--run-command", "mkdir -p /var/tmp/rpms"]
     for rpm in rpms:
-        if not any(r in rpm for r in [".src", "debug", "packagekit", "storaged"]):
+        if not any(r in rpm for r in [".src", "debug", "packagekit"]):
             args += ["--upload", f"{rpm}:/var/tmp/rpms/"]
     args += [
         "--upload", os.path.join(BASE_DIR, "dist/playground") + ":/var/tmp/",

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -518,7 +518,8 @@ OnCalendar=daily
         b.wait_not_present("#host-apps li a:contains('Logs')")
         b.key("ArrowDown", 2)
         b.key("Enter")
-        if m.ostree_image:
+        # CoreOS images don't have cockpit-storaged; all others including bootc do
+        if "coreos" in m.image:
             b.enter_page("/users")
         else:
             b.enter_page("/storage")

--- a/test/verify/check-storage-anaconda
+++ b/test/verify/check-storage-anaconda
@@ -285,7 +285,7 @@ class TestStorageAnaconda(storagelib.StorageCase):
         b.wait_not_present(self.dialog_field("mount_options"))
         self.dialog_set_val("name", "butter")
         self.dialog_set_val("type", "btrfs")
-        self.dialog_set_val("mount_point", "/mnt/butter")
+        self.dialog_set_val("mount_point", f"{self.mnt_dir}/butter")
         self.dialog_set_val("crypto", self.default_crypto_type)
         self.dialog_set_val("passphrase", "vainu-reku-toma-rolle-kaja")
         self.dialog_set_val("passphrase2", "vainu-reku-toma-rolle-kaja")
@@ -293,7 +293,7 @@ class TestStorageAnaconda(storagelib.StorageCase):
         self.dialog_wait_close()
 
         # Create two subvolumes
-        self.click_dropdown(self.card_row("Storage", location="/mnt/butter"), "Create subvolume")
+        self.click_dropdown(self.card_row("Storage", location=f"{self.mnt_dir}/butter"), "Create subvolume")
         self.dialog_wait_open()
         b.wait_not_present(self.dialog_field("at_boot"))
         b.wait_not_present(self.dialog_field("mount_options"))
@@ -303,7 +303,7 @@ class TestStorageAnaconda(storagelib.StorageCase):
         self.dialog_apply()
         self.dialog_wait_close()
 
-        self.click_dropdown(self.card_row("Storage", location="/mnt/butter"), "Create subvolume")
+        self.click_dropdown(self.card_row("Storage", location=f"{self.mnt_dir}/butter"), "Create subvolume")
         self.dialog_wait_open()
         self.dialog_set_val("name", "home")
         self.dialog_set_val("mount_point", "/home")
@@ -323,7 +323,7 @@ class TestStorageAnaconda(storagelib.StorageCase):
                                           "type": "filesystem",
                                           "subvolumes": {
                                               "/": {
-                                                  "dir": "/mnt/butter"
+                                                  "dir": f"{self.mnt_dir}/butter"
                                               },
                                               "root": {
                                                   "dir": "/"
@@ -587,7 +587,7 @@ class TestStorageAnaconda(storagelib.StorageCase):
         # Create some content on the disk
         m.execute(f"echo einszweidrei | cryptsetup luksFormat --pbkdf-memory 32768 {disk}")
         m.execute(f"echo einszweidrei | cryptsetup luksOpen {disk} dm-test")
-        m.execute("mkfs.ext4 /dev/mapper/dm-test; mount /dev/mapper/dm-test /mnt; echo Hi >/mnt/hello; umount /mnt")
+        m.execute(f"mkfs.ext4 /dev/mapper/dm-test; mount /dev/mapper/dm-test {self.mnt_dir}; echo Hi >{self.mnt_dir}/hello; umount {self.mnt_dir}")
         m.execute("cryptsetup close dm-test")
 
         self.login_and_go("/storage")
@@ -656,8 +656,8 @@ AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
         # A filesystem with just directories should not show the
         # warning.
 
-        m.execute(f"mkfs.ext4 {disk}; mount {disk} /mnt; mkdir -p /mnt/dir/ect/ory")
-        m.execute("while mountpoint -q /mnt && ! umount /mnt; do sleep 0.2; done;")
+        m.execute(f"mkfs.ext4 {disk}; mount {disk} {self.mnt_dir}; mkdir -p {self.mnt_dir}/dir/ect/ory")
+        m.execute(f"while mountpoint -q {self.mnt_dir} && ! umount {self.mnt_dir}; do sleep 0.2; done;")
         b.wait_text(self.card_row_col("Storage", 1, 3), "ext4 filesystem")
 
         self.dialog_open_with_retry(lambda: self.click_dropdown(self.card_row("Storage", 1), "Create partition table"),

--- a/test/verify/check-storage-btrfs
+++ b/test/verify/check-storage-btrfs
@@ -637,8 +637,8 @@ class TestStorageBtrfs(storagelib.StorageCase):
 
         disk = self.add_ram_disk(size=128)
 
-        m.execute(f"mkfs.btrfs -L butter {disk}; mount {disk} /mnt; btrfs subvolume create /mnt/home; btrfs subvolume create /mnt/home/backups")
-        m.execute("while mountpoint -q /mnt && ! umount /mnt; do sleep 0.2; done;")
+        m.execute(f"mkfs.btrfs -L butter {disk}; mount {disk} {self.mnt_dir}; btrfs subvolume create {self.mnt_dir}/home; btrfs subvolume create {self.mnt_dir}/home/backups")
+        m.execute(f"while mountpoint -q {self.mnt_dir} && ! umount {self.mnt_dir}; do sleep 0.2; done;")
 
         self.login_and_go("/storage")
 
@@ -649,11 +649,11 @@ class TestStorageBtrfs(storagelib.StorageCase):
         # Add some fstab entries. Cockpit should pick up the
         # subvolumes mentioned in them and show them.
 
-        m.execute(f"echo >>/etc/fstab '{disk} /mnt/home auto noauto,subvol=home 0 0'")
-        m.execute(f"echo >>/etc/fstab '{disk} /mnt/backups auto noauto,subvol=home/backups 0 0'")
+        m.execute(f"echo >>/etc/fstab '{disk} {self.mnt_dir}/home auto noauto,subvol=home 0 0'")
+        m.execute(f"echo >>/etc/fstab '{disk} {self.mnt_dir}/backups auto noauto,subvol=home/backups 0 0'")
 
-        b.wait_text(self.card_row_col("btrfs filesystem", row_name="home", col_index=3), "/mnt/home (not mounted)")
-        b.wait_text(self.card_row_col("btrfs filesystem", row_name="backups", col_index=3), "/mnt/backups (not mounted)")
+        b.wait_text(self.card_row_col("btrfs filesystem", row_name="home", col_index=3), f"{self.mnt_dir}/home (not mounted)")
+        b.wait_text(self.card_row_col("btrfs filesystem", row_name="backups", col_index=3), f"{self.mnt_dir}/backups (not mounted)")
 
     def testSnapshot(self):
         m = self.machine

--- a/test/verify/check-storage-format
+++ b/test/verify/check-storage-format
@@ -37,7 +37,7 @@ class TestStorageFormat(storagelib.StorageCase):
         self.click_card_dropdown("Unformatted data", "Format")
         self.dialog_wait_open()
         self.dialog_set_val("type", "xfs")
-        self.dialog_set_val("mount_point", "/foo")
+        self.dialog_set_val("mount_point", f"{self.mnt_dir}/foo")
         self.dialog_apply_secondary()
 
         b.wait_in_text("#dialog", "Error creating")
@@ -56,7 +56,7 @@ class TestStorageFormat(storagelib.StorageCase):
             self.click_card_dropdown("Unformatted data", "Format")
             self.dialog_wait_open()
             self.dialog_set_val("type", fstype)
-            self.dialog_set_val("mount_point", "/foo")
+            self.dialog_set_val("mount_point", f"{self.mnt_dir}/foo")
             self.dialog_set_val("name", "X" * (label_limit + 1))
             self.dialog_apply_secondary()
             self.dialog_wait_error("name", "Name cannot be longer than %d characters" % label_limit)
@@ -119,7 +119,7 @@ class TestStorageFormat(storagelib.StorageCase):
         self.click_card_dropdown("Unformatted data", "Format")
         self.dialog_wait_open()
         self.dialog_set_val("erase.on", val=True)
-        self.dialog_set_val("mount_point", "/foo")
+        self.dialog_set_val("mount_point", f"{self.mnt_dir}/foo")
         self.dialog_apply()
         with b.wait_timeout(60):
             b.wait_in_text("footer", "Erasing /dev/mapper/superslow")
@@ -144,7 +144,7 @@ class TestStorageFormat(storagelib.StorageCase):
             self.dialog_wait_open()
             self.dialog_wait_val("at_boot", expected_at_boot)
             self.dialog_set_val("type", "ext4")
-            self.dialog_set_val("mount_point", "/foo")
+            self.dialog_set_val("mount_point", f"{self.mnt_dir}/foo")
             self.dialog_set_val("at_boot", at_boot)
             if keep:
                 self.dialog_set_val("crypto", " keep")
@@ -157,36 +157,36 @@ class TestStorageFormat(storagelib.StorageCase):
 
         format_partition("nofail", "local", keep=False, first=True)
         b.wait_in_text(self.card_desc("ext4 filesystem", "Mount point"), "stop boot on failure")
-        self.assertNotIn("noauto", m.execute("findmnt --fstab -n -o OPTIONS /foo"))
+        self.assertNotIn("noauto", m.execute(f"findmnt --fstab -n -o OPTIONS {self.mnt_dir}/foo"))
 
         format_partition("local", "nofail", keep=True)
         b.wait_in_text(self.card_desc("ext4 filesystem", "Mount point"), "ignore failure")
-        self.assertIn("nofail", m.execute("findmnt --fstab -n -o OPTIONS /foo"))
+        self.assertIn("nofail", m.execute(f"findmnt --fstab -n -o OPTIONS {self.mnt_dir}/foo"))
         self.assert_in_configuration(disk, "crypttab", "options", "nofail")
 
         format_partition("nofail", "netdev", keep=True)
         b.wait_in_text(self.card_desc("ext4 filesystem", "Mount point"), "after network")
-        self.assertIn("_netdev", m.execute("findmnt --fstab -n -o OPTIONS /foo"))
+        self.assertIn("_netdev", m.execute(f"findmnt --fstab -n -o OPTIONS {self.mnt_dir}/foo"))
         self.assert_in_configuration(disk, "crypttab", "options", "_netdev")
 
         format_partition("netdev", "never", keep=True)
         b.wait_in_text(self.card_desc("ext4 filesystem", "Mount point"), "never mount")
-        self.assertIn("x-cockpit-never-auto", m.execute("findmnt --fstab -n -o OPTIONS /foo"))
+        self.assertIn("x-cockpit-never-auto", m.execute(f"findmnt --fstab -n -o OPTIONS {self.mnt_dir}/foo"))
         self.assert_in_configuration(disk, "crypttab", "options", "noauto")
 
         format_partition("never", "nofail", keep=False)
         b.wait_in_text(self.card_desc("ext4 filesystem", "Mount point"), "ignore failure")
-        self.assertIn("nofail", m.execute("findmnt --fstab -n -o OPTIONS /foo"))
+        self.assertIn("nofail", m.execute(f"findmnt --fstab -n -o OPTIONS {self.mnt_dir}/foo"))
         self.assert_in_configuration(disk, "crypttab", "options", "nofail")
 
         format_partition("nofail", "netdev", keep=False)
         b.wait_in_text(self.card_desc("ext4 filesystem", "Mount point"), "after network")
-        self.assertIn("_netdev", m.execute("findmnt --fstab -n -o OPTIONS /foo"))
+        self.assertIn("_netdev", m.execute(f"findmnt --fstab -n -o OPTIONS {self.mnt_dir}/foo"))
         self.assert_in_configuration(disk, "crypttab", "options", "_netdev")
 
         format_partition("netdev", "never", keep=False)
         b.wait_in_text(self.card_desc("ext4 filesystem", "Mount point"), "never mount")
-        self.assertIn("x-cockpit-never-auto", m.execute("findmnt --fstab -n -o OPTIONS /foo"))
+        self.assertIn("x-cockpit-never-auto", m.execute(f"findmnt --fstab -n -o OPTIONS {self.mnt_dir}/foo"))
         self.assert_in_configuration(disk, "crypttab", "options", "noauto")
 
 

--- a/test/verify/check-storage-hidden
+++ b/test/verify/check-storage-hidden
@@ -27,7 +27,7 @@ class TestStorageHiddenLuks(storagelib.StorageCase):
         m = self.machine
         b = self.browser
 
-        mount_point_1 = "/run/mount1"
+        mount_point_1 = f"{self.mnt_dir}/mount1"
 
         self.login_and_go("/storage")
 
@@ -89,7 +89,7 @@ class TestStorageHidden(storagelib.StorageCase):
         m = self.machine
         b = self.browser
 
-        mount_point_2 = "/run/mount2"
+        mount_point_2 = f"{self.mnt_dir}/mount2"
 
         self.login_and_go("/storage")
 

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -216,7 +216,7 @@ class TestStorageLuks(storagelib.StorageCase):
 
         self.click_card_dropdown("Unformatted data", "Format")
         self.dialog({"type": "ext4",
-                     "mount_point": "/run/foo",
+                     "mount_point": f"{self.mnt_dir}/foo",
                      "mount_options.ro": True,
                      "crypto": "luks1",
                      "passphrase": "vainu-reku-toma-rolle-kaja",
@@ -237,7 +237,7 @@ class TestStorageLuks(storagelib.StorageCase):
 
         self.click_card_dropdown("ext4 filesystem", "Format")
         self.dialog_wait_open()
-        self.dialog_wait_val("mount_point", "/run/foo")
+        self.dialog_wait_val("mount_point", f"{self.mnt_dir}/foo")
         self.dialog_wait_val("type", "ext4")
         self.dialog_wait_val("crypto", " keep")
         self.dialog_wait_val("crypto_options", "")
@@ -319,7 +319,7 @@ class TestStorageLuks(storagelib.StorageCase):
                      "crypto": self.default_crypto_type,
                      "passphrase": "vainu-reku-toma-rolle-kaja",
                      "passphrase2": "vainu-reku-toma-rolle-kaja",
-                     "mount_point": "/run/foo"})
+                     "mount_point": f"{self.mnt_dir}/foo"})
         b.wait_visible(self.card("ext4 filesystem"))
 
         # Format it again but keep the keys
@@ -327,7 +327,7 @@ class TestStorageLuks(storagelib.StorageCase):
         self.click_card_dropdown("ext4 filesystem", "Format")
         self.dialog({"type": "ext4",
                      "crypto": " keep",
-                     "mount_point": "/run/foo"})
+                     "mount_point": f"{self.mnt_dir}/foo"})
         b.wait_visible(self.card("ext4 filesystem"))
 
         # Unmount (and lock) it
@@ -343,7 +343,7 @@ class TestStorageLuks(storagelib.StorageCase):
         self.dialog({"type": "ext4",
                      "crypto": " keep",
                      "old_passphrase": "vainu-reku-toma-rolle-kaja",
-                     "mount_point": "/run/foo"})
+                     "mount_point": f"{self.mnt_dir}/foo"})
         self.wait_mounted("ext4 filesystem")
 
 
@@ -518,7 +518,7 @@ class TestStorageLuksDestructive(storagelib.StorageCase):
                      "crypto": self.default_crypto_type,
                      "passphrase": "vainu-reku-toma-rolle-kaja",
                      "passphrase2": "vainu-reku-toma-rolle-kaja",
-                     "mount_point": "/run/foo"})
+                     "mount_point": f"{self.mnt_dir}/foo"})
         self.wait_mounted("ext4 filesystem")
 
         self.setup_systemd_password_agent("vainu-reku-toma-rolle-kaja")

--- a/test/verify/check-storage-mdraid
+++ b/test/verify/check-storage-mdraid
@@ -187,7 +187,7 @@ class TestStorageMdRaid(storagelib.StorageCase):
         self.click_dropdown(self.card_row("GPT partitions", 1), "Create partition")
         self.dialog({"size": 20,
                      "type": "ext4",
-                     "mount_point": "/foo1",
+                     "mount_point": f"{self.mnt_dir}/foo1",
                      "name": "One"},
                     secondary=True)
         b.wait_text(self.card_row_col("GPT partitions", 1, 2), "ext4 filesystem")
@@ -196,13 +196,13 @@ class TestStorageMdRaid(storagelib.StorageCase):
         # Create second partition
         self.click_dropdown(self.card_row("GPT partitions", 2), "Create partition")
         self.dialog({"type": "ext4",
-                     "mount_point": "/foo2",
+                     "mount_point": f"{self.mnt_dir}/foo2",
                      "name": "Two"})
         b.wait_text(self.card_row_col("GPT partitions", 2, 2), "ext4 filesystem")
         b.wait_text(self.card_row_col("GPT partitions", 2, 1), part_prefix + "2")
         b.wait_not_present(self.card_row("GPT partitions", name="Free space"))
 
-        b.wait_visible(self.card_row("GPT partitions", location="/foo2") + " .usage-bar[role=progressbar]")
+        b.wait_visible(self.card_row("GPT partitions", location=f"{self.mnt_dir}/foo2") + " .usage-bar[role=progressbar]")
         b.assert_pixels('body', "page",
                         ignore=[self.card_desc("MDRAID device", "UUID")])
 

--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -42,8 +42,8 @@ class TestStorageMounting(storagelib.StorageCase):
         m = self.machine
         b = self.browser
 
-        mount_point_foo = "/run/foo"
-        mount_point_bar = "/run/bar"
+        mount_point_foo = f"{self.mnt_dir}/foo"
+        mount_point_bar = f"{self.mnt_dir}/bar"
 
         self.login_and_go("/storage")
 
@@ -188,61 +188,61 @@ ExecStart=/usr/bin/sleep infinity
         self.dialog_wait_open()
         self.dialog_set_val("type", fstype)
         self.dialog_set_val("name", "FILESYSTEM")
-        self.dialog_set_val("mount_point", "/run/foo")
+        self.dialog_set_val("mount_point", f"{self.mnt_dir}/foo")
         self.dialog_apply()
         self.dialog_wait_close()
         if fstype == "btrfs":
             self._navigate_root_subvolume()
-            b.wait_in_text(self.card_desc("btrfs subvolume", "Mount point"), "/run/foo")
-            self.addCleanupMount("/run/foo")
+            b.wait_in_text(self.card_desc("btrfs subvolume", "Mount point"), f"{self.mnt_dir}/foo")
+            self.addCleanupMount(f"{self.mnt_dir}/foo")
         else:
             b.wait_text(self.card_desc(filesystem, "Name"), "FILESYSTEM")
-            b.wait_in_text(self.card_desc(filesystem, "Mount point"), "/run/foo")
+            b.wait_in_text(self.card_desc(filesystem, "Mount point"), f"{self.mnt_dir}/foo")
 
         # Unmount externally, remount with Cockpit
 
-        m.execute("while mountpoint -q /run/foo && ! umount /run/foo; do sleep 0.2; done;")
+        m.execute(f"while mountpoint -q {self.mnt_dir}/foo && ! umount {self.mnt_dir}/foo; do sleep 0.2; done;")
         b.click(self.card_button(filesystem, "Mount now"))
         b.wait_not_present(self.card_button(filesystem, "Mount now"))
         b.wait_not_in_text(self.card_desc(filesystem, "Mount point"), "The filesystem is not mounted")
 
         # Unmount externally, adjust fstab with Cockpit
 
-        m.execute("while mountpoint -q /run/foo && ! umount /run/foo; do sleep 0.2; done;")
+        m.execute(f"while mountpoint -q {self.mnt_dir}/foo && ! umount {self.mnt_dir}/foo; do sleep 0.2; done;")
         b.click(self.card_button(filesystem, "Do not mount automatically on boot"))
         b.wait_not_present(self.card_button(filesystem, "Do not mount automatically on boot"))
 
         # Mount somewhere else externally while "noauto", unmount with Cockpit
 
-        m.execute(f"mkdir -p /run/bar; mount {disk} /run/bar")
+        m.execute(f"mkdir -p {self.mnt_dir}/bar; mount {disk} {self.mnt_dir}/bar")
         b.click(self.card_button(filesystem, "Unmount now"))
         b.wait_not_present(self.card_button(filesystem, "Unmount now"))
 
         # Mount externally, unmount with Cockpit
 
-        m.execute("mount /run/foo")
+        m.execute(f"mount {self.mnt_dir}/foo")
         b.click(self.card_button(filesystem, "Unmount now"))
         b.wait_not_present(self.card_button(filesystem, "Unmount now"))
 
         # Mount externally, adjust fstab with Cockpit
 
-        m.execute("mount /run/foo")
+        m.execute(f"mount {self.mnt_dir}/foo")
         b.click(self.card_button(filesystem, "Mount also automatically on boot"))
         b.wait_not_present(self.card_button(filesystem, "Mount also automatically on boot"))
 
         # Move mount point externally, move back with Cockpit
 
-        m.execute("while mountpoint -q /run/foo && ! umount /run/foo; do sleep 0.2; done;")
-        m.execute(f"mkdir -p /run/bar; mount {disk} /run/bar")
-        b.click(self.card_button(filesystem, "Mount on /run/foo now"))
-        b.wait_not_present(self.card_button(filesystem, "Mount on /run/foo now"))
+        m.execute(f"while mountpoint -q {self.mnt_dir}/foo && ! umount {self.mnt_dir}/foo; do sleep 0.2; done;")
+        m.execute(f"mkdir -p {self.mnt_dir}/bar; mount {disk} {self.mnt_dir}/bar")
+        b.click(self.card_button(filesystem, f"Mount on {self.mnt_dir}/foo now"))
+        b.wait_not_present(self.card_button(filesystem, f"Mount on {self.mnt_dir}/foo now"))
 
         # Move mount point externally, adjust fstab with Cockpit
 
-        m.execute("while mountpoint -q /run/foo && ! umount /run/foo; do sleep 0.2; done;")
-        m.execute(f"mkdir -p /run/bar; mount {disk} /run/bar")
-        b.click(self.card_button(filesystem, "Mount automatically on /run/bar on boot"))
-        b.wait_not_present(self.card_button(filesystem, "Mount automatically on /run/bar on boot"))
+        m.execute(f"while mountpoint -q {self.mnt_dir}/foo && ! umount {self.mnt_dir}/foo; do sleep 0.2; done;")
+        m.execute(f"mkdir -p {self.mnt_dir}/bar; mount {disk} {self.mnt_dir}/bar")
+        b.click(self.card_button(filesystem, f"Mount automatically on {self.mnt_dir}/bar on boot"))
+        b.wait_not_present(self.card_button(filesystem, f"Mount automatically on {self.mnt_dir}/bar on boot"))
 
         # Using noauto,x-systemd.automount should not show a warning
         m.execute("sed -i -e 's/auto nofail/auto nofail,noauto/' /etc/fstab")
@@ -251,10 +251,10 @@ ExecStart=/usr/bin/sleep infinity
         b.wait_not_present(self.card_button(filesystem, "Mount also automatically on boot"))
 
         # Without fstab entry, mount and try to unmount
-        m.execute("sed -i '/run\\/bar/d' /etc/fstab")
-        b.wait_visible(self.card_button(filesystem, "Mount automatically on /run/bar on boot"))
+        m.execute(f"sed -i '{self.mnt_dir.replace('/', '\\/')}\\/bar/d' /etc/fstab")
+        b.wait_visible(self.card_button(filesystem, f"Mount automatically on {self.mnt_dir}/bar on boot"))
         b.click(self.card_button(filesystem, "Unmount now"))
-        b.wait_not_present(self.card_button(filesystem, "Mount automatically on /run/bar on boot"))
+        b.wait_not_present(self.card_button(filesystem, f"Mount automatically on {self.mnt_dir}/bar on boot"))
 
     def testFstabOptions(self):
         self._testFstabOptions()
@@ -306,10 +306,10 @@ ExecStart=/usr/bin/sleep infinity
 
         self.click_card_dropdown("Unformatted data", "Format")
         self.dialog({"type": "ext4",
-                     "mount_point": "/run/foo"},
+                     "mount_point": f"{self.mnt_dir}/foo"},
                     secondary=True)
         b.wait_in_text(self.card_desc("ext4 filesystem", "Mount point"), "The filesystem is not mounted")
-        self.assertIn("noauto", m.execute("findmnt --fstab -n -o OPTIONS /run/foo"))
+        self.assertIn("noauto", m.execute(f"findmnt --fstab -n -o OPTIONS {self.mnt_dir}/foo"))
 
         b.click(self.card_button("ext4 filesystem", "Mount"))
         self.dialog_wait_open()
@@ -321,8 +321,8 @@ ExecStart=/usr/bin/sleep infinity
 
         # No changes should have been done to fstab, and the
         # filesystem should not be mounted.
-        self.assertIn("noauto", m.execute("findmnt --fstab -n -o OPTIONS /run/foo"))
-        self.assertNotIn("hurr", m.execute("findmnt --fstab -n -o OPTIONS /run/foo"))
+        self.assertIn("noauto", m.execute(f"findmnt --fstab -n -o OPTIONS {self.mnt_dir}/foo"))
+        self.assertNotIn("hurr", m.execute(f"findmnt --fstab -n -o OPTIONS {self.mnt_dir}/foo"))
         b.wait_in_text(self.card_desc("ext4 filesystem", "Mount point"), "The filesystem is not mounted")
 
         # Mount
@@ -347,7 +347,7 @@ ExecStart=/usr/bin/sleep infinity
         self.dialog_cancel()
         self.dialog_wait_close()
 
-        self.assertNotIn("hurr", m.execute("findmnt --fstab -n -o OPTIONS /run/foo"))
+        self.assertNotIn("hurr", m.execute(f"findmnt --fstab -n -o OPTIONS {self.mnt_dir}/foo"))
         b.wait_not_in_text(self.card_desc("ext4 filesystem", "Mount point"), "The filesystem is not mounted")
 
     def testAtBoot(self):
@@ -361,14 +361,14 @@ ExecStart=/usr/bin/sleep infinity
 
         self.click_card_dropdown("Unformatted data", "Format")
         self.dialog({"type": "ext4",
-                     "mount_point": "/foo",
+                     "mount_point": f"{self.mnt_dir}/foo",
                      "at_boot": "local",
                      "crypto": "luks1",
                      "passphrase": "foobarfoo",
                      "passphrase2": "foobarfoo"},
                     secondary=True)
         b.wait_in_text(self.card_desc("Filesystem", "Mount point"), "The filesystem is not mounted")
-        self.assertIn("noauto", m.execute("findmnt --fstab -n -o OPTIONS /foo"))
+        self.assertIn("noauto", m.execute(f"findmnt --fstab -n -o OPTIONS {self.mnt_dir}/foo"))
         self.assert_in_configuration(disk, "crypttab", "options", "noauto")
 
         def mount(expected_at_boot, at_boot):
@@ -389,19 +389,19 @@ ExecStart=/usr/bin/sleep infinity
 
         mount("local", "nofail")
         b.wait_in_text(self.card_desc("ext4 filesystem", "Mount point"), "ignore failure")
-        self.assertIn("nofail", m.execute("findmnt --fstab -n -o OPTIONS /foo"))
+        self.assertIn("nofail", m.execute(f"findmnt --fstab -n -o OPTIONS {self.mnt_dir}/foo"))
         self.assert_in_configuration(disk, "crypttab", "options", "nofail")
         unmount()
 
         mount("nofail", "netdev")
         b.wait_in_text(self.card_desc("ext4 filesystem", "Mount point"), "after network")
-        self.assertIn("_netdev", m.execute("findmnt --fstab -n -o OPTIONS /foo"))
+        self.assertIn("_netdev", m.execute(f"findmnt --fstab -n -o OPTIONS {self.mnt_dir}/foo"))
         self.assert_in_configuration(disk, "crypttab", "options", "_netdev")
         unmount()
 
         mount("netdev", "never")
         b.wait_in_text(self.card_desc("ext4 filesystem", "Mount point"), "never mount")
-        self.assertIn("x-cockpit-never-auto", m.execute("findmnt --fstab -n -o OPTIONS /foo"))
+        self.assertIn("x-cockpit-never-auto", m.execute(f"findmnt --fstab -n -o OPTIONS {self.mnt_dir}/foo"))
         self.assert_in_configuration(disk, "crypttab", "options", "noauto")
         unmount()
 
@@ -429,16 +429,16 @@ class TestStorageMountingLUKS(storagelib.StorageCase):
         self.dialog_set_val("crypto_options", "xxx")
         self.dialog_set_val("passphrase", "vainu-reku-toma-rolle-kaja")
         self.dialog_set_val("passphrase2", "vainu-reku-toma-rolle-kaja")
-        self.dialog_set_val("mount_point", "/run/foo")
+        self.dialog_set_val("mount_point", f"{self.mnt_dir}/foo")
         self.dialog_set_val("at_boot", "netdev")
         self.dialog_apply()
         self.dialog_wait_close()
         b.wait_text(self.card_desc("ext4 filesystem", "Name"), "FILESYSTEM")
-        b.wait_in_text(self.card_desc("ext4 filesystem", "Mount point"), "/run/foo")
+        b.wait_in_text(self.card_desc("ext4 filesystem", "Mount point"), f"{self.mnt_dir}/foo")
 
         # Unmount and lock externally, unlock and remount with Cockpit
 
-        m.execute("while mountpoint -q /run/foo && ! umount /run/foo; do sleep 0.2; done;")
+        m.execute(f"while mountpoint -q {self.mnt_dir}/foo && ! umount {self.mnt_dir}/foo; do sleep 0.2; done;")
         m.execute(f"udisksctl lock -b {disk}")
         # wait until the UI updated to the locking
         b.wait_text(self.card_desc("Encryption", "Cleartext device"), "-")
@@ -450,7 +450,7 @@ class TestStorageMountingLUKS(storagelib.StorageCase):
 
         # Unmount and lock externally, adjust fstab with Cockpit
 
-        m.execute("while mountpoint -q /run/foo && ! umount /run/foo; do sleep 0.2; done;")
+        m.execute(f"while mountpoint -q {self.mnt_dir}/foo && ! umount {self.mnt_dir}/foo; do sleep 0.2; done;")
         m.execute(f"udisksctl lock -b {disk}")
         # wait until the UI updated to the locking
         b.wait_text(self.card_desc("Encryption", "Cleartext device"), "-")
@@ -460,7 +460,7 @@ class TestStorageMountingLUKS(storagelib.StorageCase):
         # Unlock and mount externally, unmount and lock with Cockpit
 
         m.execute(f"echo -n vainu-reku-toma-rolle-kaja | udisksctl unlock --key-file /dev/stdin -b {disk}")
-        m.execute("mount /run/foo")
+        m.execute(f"mount {self.mnt_dir}/foo")
         b.click(self.card_button("ext4 filesystem", "Unmount now"))
         b.wait_visible(self.card("Filesystem"))
         b.wait_not_present(self.card_button("Filesystem", "Unmount now"))
@@ -468,7 +468,7 @@ class TestStorageMountingLUKS(storagelib.StorageCase):
         # Unlock and mount externally, adjust fstab with Cockpit
 
         m.execute(f"echo -n vainu-reku-toma-rolle-kaja | udisksctl unlock --key-file /dev/stdin -b {disk}")
-        m.execute("mount /run/foo")
+        m.execute(f"mount {self.mnt_dir}/foo")
         b.click(self.card_button("ext4 filesystem", "Mount also automatically on boot"))
         b.wait_not_present(self.card_button("ext4 filesystem", "Mount also automatically on boot"))
         b.wait_visible(self.card("ext4 filesystem"))
@@ -558,20 +558,20 @@ class TestStorageMountingLUKS(storagelib.StorageCase):
                      "passphrase": "vainu-reku-toma-rolle-kaja",
                      "passphrase2": "vainu-reku-toma-rolle-kaja",
                      "at_boot": "never",
-                     "mount_point": "/run/foo"})
+                     "mount_point": f"{self.mnt_dir}/foo"})
         b.wait_in_text(self.card_desc("ext4 filesystem", "Mount point"), "never mount at boot")
 
         # The filesystem should be mounted but have the "noauto"
         # option in both fstab and crypttab
         self.wait_mounted("ext4 filesystem")
-        self.assertIn("noauto", m.execute("grep /run/foo /etc/fstab || true"))
+        self.assertIn("noauto", m.execute(f"grep {self.mnt_dir}/foo /etc/fstab || true"))
         self.assertNotEqual(m.execute("grep noauto /etc/crypttab"), "")
 
         # Unmounting should keep the noauto option, as always
         b.click(self.card_button("ext4 filesystem", "Unmount"))
         self.confirm()
         self.wait_not_mounted("Filesystem")
-        self.assertIn("noauto", m.execute("grep /run/foo /etc/fstab || true"))
+        self.assertIn("noauto", m.execute(f"grep {self.mnt_dir}/foo /etc/fstab || true"))
         self.assertNotEqual(m.execute("grep noauto /etc/crypttab"), "")
 
         # Mounting should also keep the "noauto", but it should not show up in the extra options
@@ -581,7 +581,7 @@ class TestStorageMountingLUKS(storagelib.StorageCase):
         self.dialog_apply()
         self.dialog_wait_close()
         self.wait_mounted("ext4 filesystem")
-        self.assertIn("noauto", m.execute("grep /run/foo /etc/fstab || true"))
+        self.assertIn("noauto", m.execute(f"grep {self.mnt_dir}/foo /etc/fstab || true"))
         self.assertNotEqual(m.execute("grep noauto /etc/crypttab"), "")
 
         # As should updating the mount information
@@ -589,7 +589,7 @@ class TestStorageMountingLUKS(storagelib.StorageCase):
         self.dialog_check({"mount_options.extra": False})
         self.dialog_apply()
         self.dialog_wait_close()
-        self.assertIn("noauto", m.execute("grep /run/foo /etc/fstab || true"))
+        self.assertIn("noauto", m.execute(f"grep {self.mnt_dir}/foo /etc/fstab || true"))
         self.assertNotEqual(m.execute("grep noauto /etc/crypttab"), "")
 
         # Removing "noauto" from fstab but not from crypttab externally should show a warning
@@ -605,8 +605,8 @@ class TestStorageMountingLUKS(storagelib.StorageCase):
 
         self.login_and_go("/storage")
 
-        # Add a disk and make two partitions on it, one on /run/foo
-        # and one on /run/foo/bar
+        # Add a disk and make two partitions on it, one on self.mnt_dir/foo
+        # and one on self.mnt_dir/foo/bar
 
         disk = self.add_ram_disk(100)
         self.click_card_row("Storage", name=disk)
@@ -621,25 +621,25 @@ class TestStorageMountingLUKS(storagelib.StorageCase):
                      "crypto": self.default_crypto_type,
                      "passphrase": "vainu-reku-toma-rolle-kaja",
                      "passphrase2": "vainu-reku-toma-rolle-kaja",
-                     "mount_point": "/run/foo"},
+                     "mount_point": f"{self.mnt_dir}/foo"},
                     secondary=True)
-        b.wait_text(self.card_row_col("GPT partitions", 1, 3), "/run/foo (not mounted)")
+        b.wait_text(self.card_row_col("GPT partitions", 1, 3), f"{self.mnt_dir}/foo (not mounted)")
 
         self.click_dropdown(self.card_row("GPT partitions", 2), "Create partition")
         self.dialog({"type": "ext4",
                      "crypto": self.default_crypto_type,
                      "passphrase": "vainu-reku-toma-rolle-kaja",
                      "passphrase2": "vainu-reku-toma-rolle-kaja",
-                     "mount_point": "/run/foo/bar"},
+                     "mount_point": f"{self.mnt_dir}/foo/bar"},
                     secondary=True)
-        b.wait_text(self.card_row_col("GPT partitions", 2, 3), "/run/foo/bar (not mounted)")
+        b.wait_text(self.card_row_col("GPT partitions", 2, 3), f"{self.mnt_dir}/foo/bar (not mounted)")
 
-        # Mount /run/foo/bar first and check that mounting /run/foo is
+        # Mount self.mnt_dir/foo/bar first and check that mounting self.mnt_dir/foo is
         # rejected
 
         self.click_dropdown(self.card_row("GPT partitions", 2), "Mount")
         self.dialog({"passphrase": "vainu-reku-toma-rolle-kaja"})
-        b.wait_text(self.card_row_col("GPT partitions", 2, 3), "/run/foo/bar")
+        b.wait_text(self.card_row_col("GPT partitions", 2, 3), f"{self.mnt_dir}/foo/bar")
 
         self.click_dropdown(self.card_row("GPT partitions", 1), "Mount")
         self.dialog_wait_open()
@@ -650,41 +650,41 @@ class TestStorageMountingLUKS(storagelib.StorageCase):
         self.dialog_cancel()
         self.dialog_wait_close()
 
-        # Unmount /run/foo/bar, mount /run/foo, mount /run/foo/bar
-        # again and then check that unmounting /run/foo will also
-        # unmount /run/foo/bar.
+        # Unmount self.mnt_dir/foo/bar, mount self.mnt_dir/foo, mount self.mnt_dir/foo/bar
+        # again and then check that unmounting self.mnt_dir/foo will also
+        # unmount self.mnt_dir/foo/bar.
 
         self.click_dropdown(self.card_row("GPT partitions", 2), "Unmount")
         self.confirm()
 
         self.click_dropdown(self.card_row("GPT partitions", 1), "Mount")
         self.dialog({"passphrase": "vainu-reku-toma-rolle-kaja"})
-        b.wait_text(self.card_row_col("GPT partitions", 1, 3), "/run/foo")
+        b.wait_text(self.card_row_col("GPT partitions", 1, 3), f"{self.mnt_dir}/foo")
 
         self.click_dropdown(self.card_row("GPT partitions", 2), "Mount")
         self.dialog({"passphrase": "vainu-reku-toma-rolle-kaja"})
-        b.wait_text(self.card_row_col("GPT partitions", 2, 3), "/run/foo/bar")
+        b.wait_text(self.card_row_col("GPT partitions", 2, 3), f"{self.mnt_dir}/foo/bar")
 
         self.click_dropdown(self.card_row("GPT partitions", 1), "Unmount")
         self.dialog_wait_open()
-        b.wait_in_text("#dialog tr:contains('/run/foo/bar')", "unmount")
+        b.wait_in_text(f"#dialog tr:contains('{self.mnt_dir}/foo/bar')", "unmount")
         self.dialog_apply()
         self.dialog_wait_close()
 
-        # Now /run/foo/bar should be noauto.
+        # Now self.mnt_dir/foo/bar should be noauto.
         self.assert_in_configuration(disk + "2", "crypttab", "options", "noauto")
-        self.assertIn("noauto", m.execute("findmnt --fstab -n -o OPTIONS /run/foo/bar"))
+        self.assertIn("noauto", m.execute(f"findmnt --fstab -n -o OPTIONS {self.mnt_dir}/foo/bar"))
 
         # Mount them again and check that initializing the disk will
-        # unmount /run/foo/bar first.
+        # unmount self.mnt_dir/foo/bar first.
 
         self.click_dropdown(self.card_row("GPT partitions", 1), "Mount")
         self.dialog({"passphrase": "vainu-reku-toma-rolle-kaja"})
-        b.wait_text(self.card_row_col("GPT partitions", 1, 3), "/run/foo")
+        b.wait_text(self.card_row_col("GPT partitions", 1, 3), f"{self.mnt_dir}/foo")
 
         self.click_dropdown(self.card_row("GPT partitions", 2), "Mount")
         self.dialog({"passphrase": "vainu-reku-toma-rolle-kaja"})
-        b.wait_text(self.card_row_col("GPT partitions", 2, 3), "/run/foo/bar")
+        b.wait_text(self.card_row_col("GPT partitions", 2, 3), f"{self.mnt_dir}/foo/bar")
 
         # Sometimes a block device is still held open by
         # something immediately after locking it. This
@@ -692,8 +692,8 @@ class TestStorageMountingLUKS(storagelib.StorageCase):
         # table. Let's just retry in that case.
 
         def first_setup():
-            b.wait_text("#dialog tbody:nth-of-type(1) td[data-label=Location]", "/run/foo/bar")
-            b.wait_text("#dialog tbody:nth-of-type(2) td[data-label=Location]", "/run/foo")
+            b.wait_text("#dialog tbody:nth-of-type(1) td[data-label=Location]", f"{self.mnt_dir}/foo/bar")
+            b.wait_text("#dialog tbody:nth-of-type(2) td[data-label=Location]", f"{self.mnt_dir}/foo")
 
         self.dialog_with_error_retry(trigger=lambda: self.click_card_dropdown("Solid State Drive",
                                                                               "Create partition table"),

--- a/test/verify/check-storage-msdos
+++ b/test/verify/check-storage-msdos
@@ -42,7 +42,7 @@ class TestStorageMsDOS(storagelib.StorageCase):
         self.click_dropdown(self.card_row("DOS partitions", 1), "Create partition")
         self.dialog({"size": 10,
                      "type": "ext4",
-                     "mount_point": "/foo",
+                     "mount_point": f"{self.mnt_dir}/foo",
                      "name": "FIRST"},
                     secondary=True)
         b.wait_text(self.card_row_col("DOS partitions", 1, 2), "ext4 filesystem")

--- a/test/verify/check-storage-nfs
+++ b/test/verify/check-storage-nfs
@@ -31,15 +31,15 @@ class TestStorageNfs(storagelib.StorageCase):
 
         self.login_and_go("/storage")
 
-        m.execute("mkdir /home/foo /home/bar /mnt/test")
+        m.execute(f"mkdir /home/foo /home/bar {self.mnt_dir}/test")
         self.write_file("/etc/exports", "/home/foo 127.0.0.0/24(rw)\n/home/bar 127.0.0.0/24(rw)\n",
                         post_restore_action="systemctl restart nfs-server")
         m.execute("systemctl restart nfs-server")
         # Removing the nfs mount removes the target dir, if the test fails it
         # won't. It's important to umount before restoring /etc/exports as
         # otherwise nfs is confused and we can't umount the share.
-        self.addCleanup(m.execute, "if [ -e /mnt/test ]; then rm -r /mnt/test; fi")
-        self.addCleanupMount("/mnt/test")
+        self.addCleanup(m.execute, f"if [ -e {self.mnt_dir}/test ]; then rm -r {self.mnt_dir}/test; fi")
+        self.addCleanupMount(f"{self.mnt_dir}/test")
 
         orig_fstab = m.execute("cat /etc/fstab")
 
@@ -48,17 +48,17 @@ class TestStorageNfs(storagelib.StorageCase):
         self.dialog_wait_open()
         self.dialog_set_val("server", "127.0.0.1")
         self.dialog_set_val("remote", "/home/foo")
-        self.dialog_set_val("dir", "/mnt/test")
+        self.dialog_set_val("dir", f"{self.mnt_dir}/test")
         self.dialog_apply()
         self.dialog_wait_close()
 
         b.wait_visible(self.card_row("Storage", name="127.0.0.1:/home/foo"))
-        b.wait_visible(self.card_row("Storage", location="/mnt/test"))
-        b.wait_visible(self.card_row("Storage", location="/mnt/test") + " .usage-bar[role=progressbar]")
+        b.wait_visible(self.card_row("Storage", location=f"{self.mnt_dir}/test"))
+        b.wait_visible(self.card_row("Storage", location=f"{self.mnt_dir}/test") + " .usage-bar[role=progressbar]")
 
         # Should be saved to fstab
         self.assertEqual(m.execute("cat /etc/fstab"), orig_fstab +
-                         "127.0.0.1:/home/foo /mnt/test nfs defaults\n")
+                         f"127.0.0.1:/home/foo {self.mnt_dir}/test nfs defaults\n")
 
         # Try to add some non-exported directory
         self.click_dropdown(self.card_header("Storage"), "New NFS mount")
@@ -77,32 +77,32 @@ class TestStorageNfs(storagelib.StorageCase):
         self.dialog_wait_open()
         self.dialog_set_val("server", "127.0.0.1")
         self.dialog_set_val("remote", "/home/bar")
-        self.dialog_set_val("dir", "/mounts/bar")
+        self.dialog_set_val("dir", f"{self.mnt_dir}s/bar")
         self.dialog_apply()
         self.dialog_wait_close()
 
         b.wait_visible(self.card_row("Storage", name="127.0.0.1:/home/bar"))
-        b.wait_visible(self.card_row("Storage", location="/mounts/bar"))
-        b.wait_visible(self.card_row("Storage", location="/mounts/bar") + " .usage-bar[role=progressbar]")
-        m.execute("test -d /mounts/bar")
+        b.wait_visible(self.card_row("Storage", location=f"{self.mnt_dir}s/bar"))
+        b.wait_visible(self.card_row("Storage", location=f"{self.mnt_dir}s/bar") + " .usage-bar[role=progressbar]")
+        m.execute(f"test -d {self.mnt_dir}s/bar")
 
         # Go to details of /home/bar
         self.click_card_row("Storage", name="127.0.0.1:/home/bar")
         b.wait_text(self.card_desc("NFS mount", "Server"), "127.0.0.1:/home/bar")
-        b.wait_text(self.card_desc("NFS mount", "Mount point"), "/mounts/bar")
+        b.wait_text(self.card_desc("NFS mount", "Mount point"), f"{self.mnt_dir}s/bar")
 
         # Change mount point of /home/bar
         b.click(self.card_button("NFS mount", "Edit"))
         self.dialog_wait_open()
-        self.dialog_set_val("dir", "/mounts/barbar")
+        self.dialog_set_val("dir", f"{self.mnt_dir}s/barbar")
         self.dialog_apply()
         self.dialog_wait_close()
-        self.addCleanup(m.execute, "umount /mounts/barbar; rmdir /mounts/barbar")
+        self.addCleanup(m.execute, f"umount {self.mnt_dir}s/barbar; rmdir {self.mnt_dir}s/barbar")
 
-        b.wait_text(self.card_desc("NFS mount", "Mount point"), "/mounts/barbar")
-        m.execute("! test -e /mounts/bar")
-        m.execute("test -d /mounts/barbar")
-        self.assertEqual(m.execute("findmnt -s -n -o OPTIONS /mounts/barbar").strip(), "defaults")
+        b.wait_text(self.card_desc("NFS mount", "Mount point"), f"{self.mnt_dir}s/barbar")
+        m.execute(f"! test -e {self.mnt_dir}s/bar")
+        m.execute(f"test -d {self.mnt_dir}s/barbar")
+        self.assertEqual(m.execute(f"findmnt -s -n -o OPTIONS {self.mnt_dir}s/barbar").strip(), "defaults")
 
         # Set options for /home/bar
         b.click(self.card_button("NFS mount", "Edit"))
@@ -122,18 +122,18 @@ class TestStorageNfs(storagelib.StorageCase):
         self.dialog_apply()
         self.dialog_wait_close()
 
-        self.assertEqual(m.execute("findmnt -s -n -o OPTIONS /mounts/barbar").strip(), "noauto,ro,ac")
+        self.assertEqual(m.execute(f"findmnt -s -n -o OPTIONS {self.mnt_dir}s/barbar").strip(), "noauto,ro,ac")
 
         # Should be saved to fstab
         self.assertEqual(m.execute("cat /etc/fstab"), orig_fstab +
-                         "127.0.0.1:/home/foo /mnt/test nfs defaults\n" +
-                         "127.0.0.1:/home/bar /mounts/barbar nfs noauto,ro,ac\n")
+                         f"127.0.0.1:/home/foo {self.mnt_dir}/test nfs defaults\n" +
+                         f"127.0.0.1:/home/bar {self.mnt_dir}s/barbar nfs noauto,ro,ac\n")
 
         # Go to details of /home/foo
         b.go("#/")
         self.click_card_row("Storage", name="127.0.0.1:/home/foo")
         b.wait_text(self.card_desc("NFS mount", "Server"), "127.0.0.1:/home/foo")
-        b.wait_text(self.card_desc("NFS mount", "Mount point"), "/mnt/test")
+        b.wait_text(self.card_desc("NFS mount", "Mount point"), f"{self.mnt_dir}/test")
 
         # Unmount and remount /home/foo
         b.click(self.card_button("NFS mount", "Unmount"))
@@ -144,10 +144,10 @@ class TestStorageNfs(storagelib.StorageCase):
         self.click_card_dropdown("NFS mount", "Remove")
         b.wait_visible(self.card("Storage"))
         b.wait_not_present(self.card_row("Storage", name="127.0.0.1:/home/foo"))
-        m.execute("! test -e /mnt/test")
+        m.execute(f"! test -e {self.mnt_dir}/test")
         # Should be removed from fstab, too
         self.assertEqual(m.execute("cat /etc/fstab"), orig_fstab +
-                         "127.0.0.1:/home/bar /mounts/barbar nfs noauto,ro,ac\n")
+                         f"127.0.0.1:/home/bar {self.mnt_dir}s/barbar nfs noauto,ro,ac\n")
 
         # Picks up mounts in fstab
         m.execute("echo '1.2.3.4:/something /somewhere nfs defaults 0 0' >> /etc/fstab")
@@ -211,14 +211,14 @@ class TestStorageNfs(storagelib.StorageCase):
         # Manually add a remote location to the select
         b.set_input_text("[data-field=remote] input", "/home/foo")
         b.click(".pf-v6-c-menu button.pf-v6-c-menu__item")
-        self.dialog_set_val("dir", "/mnt")
+        self.dialog_set_val("dir", self.mnt_dir)
         self.dialog_apply()
         self.dialog_wait_close()
-        self.addCleanup(m.execute, "umount /mnt")
+        self.addCleanup(m.execute, f"umount {self.mnt_dir}")
 
         b.wait_visible(self.card_row("Storage", name="127.0.0.1:/home/foo"))
-        b.wait_visible(self.card_row("Storage", location="/mnt"))
-        b.wait_visible(self.card_row("Storage", location="/mnt") + " .usage-bar[role=progressbar]")
+        b.wait_visible(self.card_row("Storage", location=self.mnt_dir))
+        b.wait_visible(self.card_row("Storage", location=self.mnt_dir) + " .usage-bar[role=progressbar]")
 
     def testNfsBusy(self):
         m = self.machine
@@ -237,20 +237,20 @@ class TestStorageNfs(storagelib.StorageCase):
         self.dialog_wait_open()
         self.dialog_set_val("server", "127.0.0.1")
         self.dialog_set_val("remote", "/home/foo")
-        self.dialog_set_val("dir", "/mounts/foo")
+        self.dialog_set_val("dir", f"{self.mnt_dir}s/foo")
         self.dialog_apply()
         self.dialog_wait_close()
 
         b.wait_visible(self.card_row("Storage", name="127.0.0.1:/home/foo"))
-        b.wait_visible(self.card_row("Storage", location="/mounts/foo"))
-        b.wait_visible(self.card_row("Storage", location="/mounts/foo") + " .usage-bar[role=progressbar]")
+        b.wait_visible(self.card_row("Storage", location=f"{self.mnt_dir}s/foo"))
+        b.wait_visible(self.card_row("Storage", location=f"{self.mnt_dir}s/foo") + " .usage-bar[role=progressbar]")
 
         # Go to details of /home/foo
         self.click_card_row("Storage", name="127.0.0.1:/home/foo")
         b.wait_text(self.card_desc("NFS mount", "Server"), "127.0.0.1:/home/foo")
-        b.wait_text(self.card_desc("NFS mount", "Mount point"), "/mounts/foo")
+        b.wait_text(self.card_desc("NFS mount", "Mount point"), f"{self.mnt_dir}s/foo")
 
-        sleep_pid = m.spawn("cd /mounts/foo; sleep infinity", "busy")
+        sleep_pid = m.spawn(f"cd {self.mnt_dir}s/foo; sleep infinity", "busy")
         b.click(self.card_button("NFS mount", "Edit"))
 
         self.dialog_wait_open()
@@ -272,7 +272,7 @@ class TestStorageNfs(storagelib.StorageCase):
         b.click(self.card_button("NFS mount", "Mount"))
         b.wait_visible(self.card_button("NFS mount", "Unmount"))
 
-        sleep_pid = m.spawn("cd /mounts/foo; sleep infinity", "busy")
+        sleep_pid = m.spawn(f"cd {self.mnt_dir}s/foo; sleep infinity", "busy")
         self.click_card_dropdown("NFS mount", "Remove")
         b.wait_in_text("#dialog", str(sleep_pid))
         b.wait_in_text("#dialog", "sleep infinity")
@@ -284,7 +284,7 @@ class TestStorageNfs(storagelib.StorageCase):
         # We are back on the Overview with nothing there
         b.wait_visible(self.card("Storage"))
         b.wait_not_present(self.card_row("Storage", name="127.0.0.1:/home/foo"))
-        b.wait_not_present(self.card_row("Storage", location="/mounts/foo"))
+        b.wait_not_present(self.card_row("Storage", location=f"{self.mnt_dir}s/foo"))
 
 
 # Re-use allowed journal messages from StorageCase

--- a/test/verify/check-storage-partitions
+++ b/test/verify/check-storage-partitions
@@ -48,8 +48,8 @@ class TestStoragePartitions(storagelib.StorageCase):
 
         self.click_dropdown(self.card_row("GPT partitions", 1), "Create partition")
         self.dialog({"type": "ext4",
-                     "mount_point": "/foo"})
-        b.wait_text(self.card_row_col("GPT partitions", 1, 3), "/foo")
+                     "mount_point": f"{self.mnt_dir}/foo"})
+        b.wait_text(self.card_row_col("GPT partitions", 1, 3), f"{self.mnt_dir}/foo")
 
         self.click_card_row("GPT partitions", 1)
         self.click_card_dropdown("Partition", "Delete")
@@ -131,12 +131,12 @@ class TestStoragePartitions(storagelib.StorageCase):
 
         self.click_dropdown(self.card_row("GPT partitions", 1), "Create partition")
         self.dialog({"type": "ext4",
-                     "mount_point": "/foo1",
+                     "mount_point": f"{self.mnt_dir}/foo1",
                      "size": 80},
                     secondary=True)
         self.click_dropdown(self.card_row("GPT partitions", 2), "Create partition")
         self.dialog({"type": "ext4",
-                     "mount_point": "/foo2",
+                     "mount_point": f"{self.mnt_dir}/foo2",
                      "size": 23},
                     secondary=True)
 
@@ -168,7 +168,7 @@ class TestStoragePartitions(storagelib.StorageCase):
         self.click_card_row("GPT partitions", 2)
         self.click_card_dropdown("Partition", "Delete")
         self.confirm()
-        self.click_card_row("GPT partitions", location="/foo1 (not mounted)")
+        self.click_card_row("GPT partitions", location=f"{self.mnt_dir}/foo1 (not mounted)")
         b.click(self.card_button("Partition", "Grow"))
         self.dialog({"size": 103})
         b.wait_visible(self.card_button("Partition", "Grow") + ":disabled")

--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -59,7 +59,7 @@ class TestStorageResize(storagelib.StorageCase):
         self.dialog_wait_apply_enabled()
         self.dialog_set_val("name", "FSYS")
         self.dialog_set_val("type", fsys)
-        self.dialog_set_val("mount_point", "/run/foo")
+        self.dialog_set_val("mount_point", f"{self.mnt_dir}/foo")
         if crypto:
             self.dialog_set_val("crypto", self.default_crypto_type)
             self.dialog_set_val("passphrase", "vainu-reku-toma-rolle-kaja")
@@ -69,7 +69,7 @@ class TestStorageResize(storagelib.StorageCase):
             self.dialog_wait_close()
 
         b.wait_text(self.card_row_col("LVM2 logical volumes", 1, 2), filesystem_desc_enc)
-        b.wait_text(self.card_row_col("LVM2 logical volumes", 1, 3), "/run/foo")
+        b.wait_text(self.card_row_col("LVM2 logical volumes", 1, 3), f"{self.mnt_dir}/foo")
 
         if can_grow:
             self.click_card_row("LVM2 logical volumes", 1)
@@ -86,7 +86,7 @@ class TestStorageResize(storagelib.StorageCase):
             b.wait_in_text(self.card_desc("LVM2 logical volume", "Size"), "398 MB")
             with b.wait_timeout(30):
                 self.wait_mounted(filesystem_desc)
-            size = int(m.execute("df -k --output=size /run/foo | tail -1").strip())
+            size = int(m.execute(f"df -k --output=size {self.mnt_dir}/foo | tail -1").strip())
             self.assertGreater(size, 300000)
         else:
             self.wait_card_button_disabled("LVM2 logical volume", "Grow")
@@ -104,7 +104,7 @@ class TestStorageResize(storagelib.StorageCase):
             self.dialog_wait_close()
             b.wait_in_text(self.card_desc("LVM2 logical volume", "Size"), "201 MB")
             self.wait_mounted(filesystem_desc)
-            size = int(m.execute("df -k --output=size /run/foo | tail -1").strip())
+            size = int(m.execute(f"df -k --output=size {self.mnt_dir}/foo | tail -1").strip())
             self.assertLess(size, 300000)
         else:
             self.wait_card_button_disabled("LVM2 logical volume", "Shrink")
@@ -164,7 +164,7 @@ class TestStorageResize(storagelib.StorageCase):
         b.wait_visible(self.card("LVM2 volume group"))
         b.wait_text(self.card_row_col("LVM2 logical volumes", 1, 1), "vol")
 
-        mountpoint = "/run/foo"
+        mountpoint = f"{self.mnt_dir}/foo"
         self.click_dropdown(self.card_row("LVM2 logical volumes", 1), "Format")
         self.dialog_wait_open()
         self.dialog_set_val("name", "FSYS")
@@ -221,7 +221,7 @@ class TestStorageResize(storagelib.StorageCase):
         b.wait_visible(self.card("LVM2 volume group"))
         b.wait_text(self.card_row_col("LVM2 logical volumes", 1, 1), "vol")
 
-        mountpoint = "/run/foo"
+        mountpoint = f"{self.mnt_dir}/foo"
         self.click_dropdown(self.card_row("LVM2 logical volumes", 1), "Format")
         self.dialog_wait_open()
         self.dialog_set_val("name", "FSYS")

--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -803,10 +803,10 @@ class TestStorageStratisReboot(storagelib.StorageCase):
         def create(at_boot):
             b.click(self.card_button("Stratis filesystems", "Create new filesystem"))
             self.dialog({'name': 'fsys1',
-                         'mount_point': '/foo',
+                         'mount_point': f'{self.mnt_dir}/foo',
                          'at_boot': at_boot})
             b.wait_text(self.card_row_col("Stratis filesystems", 1, 1), "fsys1")
-            b.wait_text(self.card_row_col("Stratis filesystems", 1, 3), "/foo")
+            b.wait_text(self.card_row_col("Stratis filesystems", 1, 3), f"{self.mnt_dir}/foo")
 
         def destroy():
             self.click_card_row("Stratis filesystems", 1)
@@ -817,20 +817,20 @@ class TestStorageStratisReboot(storagelib.StorageCase):
             b.wait_not_present(self.card_row("Stratis filesystems", name="fsys1"))
 
         create("local")
-        self.assertNotIn("noauto", m.execute("findmnt --fstab -n -o OPTIONS /foo"))
+        self.assertNotIn("noauto", m.execute(f"findmnt --fstab -n -o OPTIONS {self.mnt_dir}/foo"))
         destroy()
 
         create("nofail")
-        self.assertIn("nofail", m.execute("findmnt --fstab -n -o OPTIONS /foo"))
+        self.assertIn("nofail", m.execute(f"findmnt --fstab -n -o OPTIONS {self.mnt_dir}/foo"))
         destroy()
 
         create("netdev")
-        self.assertIn("_netdev", m.execute("findmnt --fstab -n -o OPTIONS /foo"))
+        self.assertIn("_netdev", m.execute(f"findmnt --fstab -n -o OPTIONS {self.mnt_dir}/foo"))
         destroy()
 
         create("never")
-        self.assertIn("x-cockpit-never-auto", m.execute("findmnt --fstab -n -o OPTIONS /foo"))
-        self.assertIn("noauto", m.execute("findmnt --fstab -n -o OPTIONS /foo"))
+        self.assertIn("x-cockpit-never-auto", m.execute(f"findmnt --fstab -n -o OPTIONS {self.mnt_dir}/foo"))
+        self.assertIn("noauto", m.execute(f"findmnt --fstab -n -o OPTIONS {self.mnt_dir}/foo"))
         destroy()
 
     @testlib.skipImage("Stratis too old", "rhel-8-*")

--- a/test/verify/check-storage-used
+++ b/test/verify/check-storage-used
@@ -39,19 +39,19 @@ class TestStorageUsed(storagelib.StorageCase):
         m.execute(f"echo einszweidrei | cryptsetup luksOpen {disk}1 dm-test")
         m.execute("udevadm settle")
         m.execute("mke2fs -q -L TEST /dev/mapper/dm-test")
-        m.execute("mount /dev/mapper/dm-test /mnt")
+        m.execute(f"mount /dev/mapper/dm-test {self.mnt_dir}")
 
         # Keep the mount point busy.  The extra "true" is here to
         # prevent bash from applying tail call optimization to the
         # "sleep" invocation.
-        sleep_pid = m.spawn("cd /mnt; sleep infinity; true", "sleep")
+        sleep_pid = m.spawn(f"cd {self.mnt_dir}; sleep infinity; true", "sleep")
         self.write_file("/etc/systemd/system/keep-mnt-busy.service",
-                        """
+                        f"""
 [Unit]
 Description=Test Service
 
 [Service]
-WorkingDirectory=/mnt
+WorkingDirectory={self.mnt_dir}
 ExecStart=/usr/bin/sleep infinity
 """)
         m.execute("systemctl start keep-mnt-busy")
@@ -158,10 +158,10 @@ ExecStart=/usr/bin/sleep infinity
         disk = self.add_ram_disk()
         b.wait_visible(self.card_row("Storage", name=disk))
         m.execute(f"mke2fs -q -L TEST {disk}")
-        m.execute(f"mount {disk} /mnt")
+        m.execute(f"mount {disk} {self.mnt_dir}")
 
         self.click_card_row("Storage", name=disk)
-        b.wait_in_text(self.card("ext2 filesystem"), "The filesystem is currently mounted on /mnt")
+        b.wait_in_text(self.card("ext2 filesystem"), f"The filesystem is currently mounted on {self.mnt_dir}")
 
         # Start formatting, and while the dialog is open, make the
         # filesystem unmountable.
@@ -171,15 +171,15 @@ ExecStart=/usr/bin/sleep infinity
         # is not. The first is only used to figure out when the dialog
         # is done initializing.
 
-        m.spawn("cd /mnt; sleep infinity; true", "sleep")
+        m.spawn(f"cd {self.mnt_dir}; sleep infinity; true", "sleep")
 
         self.click_card_dropdown("Solid State Drive", "Create partition table")
         self.dialog_wait_open()
         b.wait_visible("#dialog tbody:first-of-type button:contains(Currently in use)")
         self.dialog_wait_apply_enabled()
-        m.spawn("cd /mnt; sleep infinity; true", "sleep")
+        m.spawn(f"cd {self.mnt_dir}; sleep infinity; true", "sleep")
         self.dialog_apply()
-        b.wait_in_text("#dialog", "umount: /mnt: target is busy")
+        b.wait_in_text("#dialog", f"umount: {self.mnt_dir}: target is busy")
         self.dialog_wait_apply_disabled()
         self.dialog_cancel()
         self.dialog_wait_close()


### PR DESCRIPTION
We previously had a wild organically grown mix of test mount directories like `/mnt/`, `/foo1`, `/run/foo`, `/mounts` etc., which are problematic:

 * Using top-level directories does not work on a read-only root file system (ostree, bootc)
 * /mnt (and /home) is a symlink to /var/... on OSTree, which breaks test expectations.
 * Tests leave these directories behind, breaking re-runs and reproducibility.

Replace all of these with a consistent `self.mnt_dir`, which gets cleaned up for nondestructive tests.

The heavy lifting of this patch was done by Cursor and Claude AI.

---

This is a prerequisite for enabling storage tests on our centos-9-bootc image as well as in TF (see PR #22256)

This changes pixels, so let's land after #22252