### PR TITLE
test: always restart/refresh packagekit on Arch Linux

### DIFF
--- a/test/common/packagelib.py
+++ b/test/common/packagelib.py
@@ -462,6 +462,8 @@ Server = file://{self.repo_dir}
             """
             if 'testrepo' not in self.machine.execute('grep testrepo /etc/pacman.conf || true'):
                 self.machine.write("/etc/pacman.conf", config, append=True)
+                # packagekit does not detect new repositories without a restart and refresh
+                self.machine.execute("systemctl restart packagekit; pkcon refresh force")
 
         else:
             self.machine.execute(f"""printf '[updates]\nname=cockpittest\nbaseurl=file://{self.repo_dir}\nenabled=1\ngpgcheck=0\n' > /etc/yum.repos.d/cockpittest.repo


### PR DESCRIPTION
The alpm PackageKit backend does not automatically detect new configured repositories when they are added.