### PR TITLE
test: Enable most PackageKit tests on arch

### DIFF
--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -22,7 +22,6 @@ import packagelib
 import testlib
 
 
-@testlib.skipImage("TODO: bug in refreshing removed/installed state on Arch Linux", "arch")
 @testlib.skipWsContainer("Not supported")
 @testlib.nondestructive
 class TestApps(packagelib.PackageCase):
@@ -80,6 +79,7 @@ class TestApps(packagelib.PackageCase):
         # ignore the corresponding journal entry
         self.allow_journal_messages("org.freedesktop.PackageKit.*org.freedesktop.DBus.Error.NoReply.*")
 
+    @testlib.skipImage("TODO: works locally, unstable in CI", "arch")
     def testBasic(self, urlroot: str = ""):
         b = self.browser
         m = self.machine

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -45,7 +45,6 @@ class NoSubManCase(packagelib.PackageCase):
         self.allow_journal_messages("(Created symlink|Removed).*dnf-automatic-install.timer.*")
 
 
-@testlib.skipImage("TODO: Fails with 401 on our test runners", "arch")
 @testlib.skipOstree("Image uses OSTree")
 class TestUpdates(NoSubManCase):
 
@@ -267,6 +266,7 @@ echo -e "Loaded patch modules:\nkpatch_3_10_0_1062_1_1 [enabled]\n\nInstalled pa
         m.execute("rpm -q kpatch-patch-" + sanitized_kernel_ver)
 
     @testlib.nondestructive
+    @testlib.skipImage("alpm PackageKit backend does not support cancelling", "arch")
     def testBasic(self):
         # no security updates, no changelogs
         b = self.browser
@@ -451,7 +451,6 @@ ExecStart=/usr/local/bin/{package} infinity
 
         return startTime
 
-    @testlib.skipImage("TODO: Packagekit on Arch does not detect the pear update", "arch")
     @testlib.skipImage("tracer not available", *OSesWithoutTracer)
     def testTracer(self):
         b = self.browser


### PR DESCRIPTION
The generalized hack in commit 2c299e56f2d0 fixed most PackageKit tests on arch. The only exception is TestUpdates.testBasic, which fails because apparently the alpm PackageKit backend does not support cancelling. We may refine that test in the future.

`TestApps.testBasic()` also works in principle (locally and in some CI runs), but is very unstable in CI. Keep this skipped for now.