### PR TITLE
test: disable preloading of packagekit for Wireguard test

### DIFF
--- a/test/verify/check-networkmanager-wireguard
+++ b/test/verify/check-networkmanager-wireguard
@@ -19,6 +19,9 @@ class TestWireGuard(packagelib.PackageCase, netlib.NetworkCase):
         m2 = self.machines["machine2"]
         b = self.browser
 
+        # Disable pre-loading packagekit, dnf needs-restarting (dnf 4) consumes tons of cpu/memory on RHEL-10-1
+        self.disable_preload("packagekit", machine=m2)
+
         self.login_and_go("/network")
 
         # Peer 1 (client)


### PR DESCRIPTION
Starting this test with limited memory runs into dnf-restart memory issues on RHEL-10-1 which flakes around ~ 20% of the time.

---


See also 7da43690498ded402dcc0928d5c6aafeac21d949