### PR TITLE
tmt: Enable extra storage tests on image mode, and storage scenario in our CI

### DIFF
--- a/plans/all.fmf
+++ b/plans/all.fmf
@@ -23,9 +23,5 @@ environment:
 
 /storage-extra:
     summary: More expensive storage tests (LVM, LUKS, Anaconda)
-    # FIXME: tests need a lot of work to pass in image mode
-    adjust+:
-        when: distro ~ .*image-mode
-        enabled: false
     discover+:
         test: /test/browser/storage-extra

--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -100,6 +100,7 @@
     - firewalld
     - lvm2
     - nfs-utils
+    - parted
     - rpm-build
     - stratis-cli
     - stratisd

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -190,8 +190,9 @@ if [ "$PLAN" = "storage-basic" ]; then
             "
     fi
 
-    if [ "${TEST_OS%bootc}" != "$TEST_OS" ]; then
-        # no swap on TF bootc
+    if [ "$TEST_OS" = "centos-9-bootc" ]; then
+        # FIXME: pcp is installed, but not working on CentOS 9 (10 is fine)
+        # warn: PM_ERR_NOPMNS PMNS not accessible <pcp.pmapi.c_uint_Array_1 object at 0x...>
         EXCLUDES="$EXCLUDES
                   TestStorageswap.testBasic
                   TestStorageswap.testEncrypted

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -215,6 +215,13 @@ if [ "$PLAN" = "storage-extra" ]; then
               TestStorageMountingLUKS.testDuplicateMountPoints
               TestStorageMountingLUKS.testNeverAuto
               "
+
+    if [ "$TEST_OS" = "centos-10-bootc" ]; then
+        # FIXME: targetcli fails with code 255 and no error message; needs investigation
+        EXCLUDES="$EXCLUDES
+                  TestStorageLvm2.testDegradation
+                  "
+    fi
 fi
 
 exclude_options=""

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1923,14 +1923,13 @@ class MachineCase(unittest.TestCase):
         # cockpit configuration
         self.restore_dir("/etc/cockpit")
 
-        if not m.ostree_image:
-            # for storage tests
-            self.restore_file("/etc/fstab")
-            self.restore_file("/etc/crypttab")
+        # for storage tests
+        self.restore_file("/etc/fstab")
+        self.restore_file("/etc/crypttab")
 
-            if not m.ws_container:
-                # tests expect cockpit.service to not run at start; also, avoid log leakage into the next test
-                self.addCleanup(m.execute, "systemctl stop --quiet cockpit")
+        if not m.ws_container:
+            # tests expect cockpit.service to not run at start; also, avoid log leakage into the next test
+            self.addCleanup(m.execute, "systemctl stop --quiet cockpit")
 
         # The sssd daemon seems to get confused when we restore
         # backups of /etc/group etc and stops following updates to it.

--- a/test/verify/check-storage-anaconda
+++ b/test/verify/check-storage-anaconda
@@ -25,6 +25,7 @@ import testlib
 
 
 @testlib.nondestructive
+@testlib.skipOstree("No /sysroot and directory cannot be created on read-only filesystem")
 class TestStorageAnaconda(storagelib.StorageCase):
 
     def enterAnacondaMode(self, config):

--- a/test/verify/check-storage-iscsi
+++ b/test/verify/check-storage-iscsi
@@ -22,6 +22,7 @@ import testlib
 
 
 @testlib.skipImage("UDisks doesn't have support for iSCSI", "debian-*", "ubuntu-*", "arch")
+@testlib.skipImage("udisks2-iscsi not on image", "*-bootc")
 @testlib.nondestructive
 class TestStorageISCSI(storagelib.StorageCase):
 

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -530,6 +530,7 @@ class TestStorageLuksDestructive(storagelib.StorageCase):
         self.wait_mounted("ext4 filesystem")
 
 
+@testlib.skipImage("clevis/tang not installed", "*-bootc")
 class TestStorageNBDE(storagelib.StorageCase, packagelib.PackageCase):
     provision = {
         "0": {"address": "10.111.112.1/20", "memory_mb": 2048},

--- a/test/verify/check-storage-multipath
+++ b/test/verify/check-storage-multipath
@@ -22,6 +22,7 @@ import testlib
 
 
 @testlib.skipImage("No support for multipath", "debian-*", "ubuntu-*", "arch")
+@testlib.skipImage("multipath support not installed", "*-bootc")
 class TestStorageMultipath(storagelib.StorageCase):
 
     def testBasic(self):

--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -59,6 +59,7 @@ def create_legacy_pool(machine, disks, name="pool0", keydesc=None, tang=None):
 
 
 @testlib.skipImage("No Stratis", "debian-*", "ubuntu-*", "arch")
+@testlib.skipImage("stratis not installed", "*-bootc")
 @testlib.skipImage("commit 817c957899a4 removed Statis 2 support", "rhel-8-*")
 @testlib.nondestructive
 class TestStorageStratis(storagelib.StorageCase):
@@ -584,6 +585,7 @@ systemctl restart stratisd
 
 
 @testlib.skipImage("No Stratis", "debian-*", "ubuntu-*", "arch")
+@testlib.skipImage("stratis not installed", "*-bootc")
 @testlib.skipImage("commit 817c957899a4 removed Statis 2 support", "rhel-8-*")
 class TestStorageStratisReboot(storagelib.StorageCase):
     # LUKS uses memory hard PBKDF, 1 GiB is not enough; see https://bugzilla.redhat.com/show_bug.cgi?id=1881829
@@ -897,6 +899,7 @@ class TestStorageStratisReboot(storagelib.StorageCase):
 
 
 @testlib.skipImage("No Stratis", "debian-*", "ubuntu-*", "arch")
+@testlib.skipOstree("no package installation on OSTree")
 class TestStoragePackagesStratis(packagelib.PackageCase, storagelib.StorageCase):
 
     def testStratisOndemandInstallation(self):
@@ -940,6 +943,7 @@ class TestStoragePackagesStratis(packagelib.PackageCase, storagelib.StorageCase)
 
 
 @testlib.skipImage("No Stratis", "debian-*", "ubuntu-*", "arch")
+@testlib.skipImage("stratis not installed", "*-bootc")
 @testlib.skipImage("Stratis too old", "rhel-8-*")
 class TestStorageStratisNBDE(packagelib.PackageCase, storagelib.StorageCase):
     provision = {

--- a/test/verify/check-storage-vdo
+++ b/test/verify/check-storage-vdo
@@ -24,6 +24,7 @@ import testlib
 SIZE_10G = "10000000000"
 
 
+@testlib.skipImage("VDO support not installed", "*-bootc")
 class TestStorageVDO(storagelib.StorageCase):
 
     provision = {"0": {"memory_mb": 1800}}
@@ -391,6 +392,7 @@ config: !Configuration
 
 
 @testlib.onlyImage("VDO API only supported on RHEL", "rhel-*", "centos-*")
+@testlib.skipOstree("package installation not supported on ostree images")
 class TestStoragePackagesVDO(packagelib.PackageCase, storagelib.StorageHelpers):
 
     provision = {"0": {"memory_mb": 1500}}


### PR DESCRIPTION
Final bit of https://issues.redhat.com/browse/COCKPIT-1214

I'll also check how well [centos-9-bootc/storage](https://logs-cockpit.apps.ocp.cloud.ci.centos.org/pull-22270-3b9adbd7-20250801-123916-centos-9-bootc-storage/log.html) works on our CI.

 - [x] https://github.com/cockpit-project/bots/pull/8060