### PR TITLE
css: Fix table row border in cards

### DIFF
--- a/pkg/lib/patternfly/patternfly-6-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-6-overrides.scss
@@ -347,6 +347,11 @@ $phone: 767px;
 
 /* FIXME: Temporary rework plain cards to make it look like how PF6 is designed, removing the extra padding */
 .pf-v6-c-card.pf-m-plain {
+  // Plain PF Cards just remove the border color and background, but we should also make sure that the radius is
+  // removed so that tables etc. don't get weird borders on the first and last cell.
+  // This mostly happens when we're not using card body
+  border-radius: 0;
+
   .pf-v6-c-card__header {
     padding-inline: 0;
   }


### PR DESCRIPTION
Within plain PF cards where we have elements with visible borders near
the start or end of the card it has a chance to crop the border. For
most components this happens when we don't use the card body itself,
such as when we have a table within a card and don't want the spacing
from the card body.

To fix this we just remove the border radius so that it will be pretty
much like normal.

Fixes: https://issues.redhat.com/browse/RHEL-97183
Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
