### PR TITLE
css: Remove radio and checkbox overrides in network manager

### DIFF
--- a/pkg/networkmanager/networking.scss
+++ b/pkg/networkmanager/networking.scss
@@ -118,18 +118,8 @@ th {
   overflow: visible;
 }
 
-// Use a grid to lay out elements. This could've been a flex, but a grid lets
-// us size elements from the parent element instead of having to specify
-// individual elements
-#network-mtu-settings-custom + .pf-v6-c-radio__label {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  align-items: baseline;
-  gap: var(--pf-t--global--spacer--md);
-}
-
 // Set the width of the input element; with a little extra space
-.mtu-label-input > input {
+.mtu-label-input {
   inline-size: 7ch;
   font-variant: tabular-nums;
 }
@@ -244,32 +234,6 @@ th {
 
 #add-zone-dialog .add-zone-zones .pf-v6-c-radio__label {
   text-transform: capitalize;
-}
-
-/* Move firewalld zones higher in z-index (so lines can go behind) */
-.add-zone-zones-firewalld {
-  input {
-    position: relative;
-    z-index: 2;
-  }
-
-  > label {
-    /* FIXME: Add lines behind the radio buttons */
-    &::after {
-      border-block-end: 1px solid #d1d1d1;
-      content: "";
-    }
-
-    /* Start line at the midpoint for the first radio */
-    &:first-of-type::after {
-      inset-inline-start: 50%;
-    }
-
-    /* End line at the midpoint for the last radio */
-    &:last-of-type::after {
-      inset-inline-end: 50%;
-    }
-  }
 }
 
 /* Display labels below buttons */


### PR DESCRIPTION
Network MTU has been changed to fit better. Previously, the label text and text input was both on the same line but this was now changed as more overrides were removed. With the override removal this fixes the alignment issue that was present in [previous pixel tests](https://github.com/user-attachments/assets/ee97706d-e6ad-4709-ac05-61f3c4139a58).

How it is right now
<img width="840" height="233" alt="image" src="https://github.com/user-attachments/assets/e77c10ac-58f4-408d-bf1b-66e5d4ea1221" />

And if we remove the existing overrides we get this:
<img width="445" height="363" alt="image" src="https://github.com/user-attachments/assets/5152f362-2dba-4c8a-be80-d910951a3690" />


---

We have one issue that was addressed and while this was being improved I
also changed the behaviour to further make it clearer to the user what
to do or what is happening.

As the input itself should not be within a label due to it being
undefined behaviour, this has now been moved to Patternfly's input body
instead. This means it is on a new line and not on the same line, which
does cause some confusion if you have automatic selected and have MTU
set to 5 for example.

To resolve any confusion this improvement:
- Automatically selects Custom if MTU value is set
- Automatically selects Auto if MTU value is empty
- Validates MTU value on-the-go as well as on submit

Demo:

[Kooha-2025-10-09-16-14-39.webm](https://github.com/user-attachments/assets/dc773c6f-fc23-478a-9e18-a103260200db)

