### PR TITLE
release: Remove GH CLI as we cannot use it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,11 +135,6 @@ jobs:
           git commit -m "Update to version ${{ github.ref_name }}"
           git show
           git push git@github.com:cockpit-project/org.cockpit_project.CockpitClient HEAD
-          gh pr create \
-            --fill \
-            -H cockpit-project:${{ github.ref_name }} \
-            -R flathub/org.cockpit_project.CockpitClient
-
 
   node-cache:
     # doesn't depend on it, but let's make sure the build passes before we do this


### PR DESCRIPTION
We do not have any permissions within GitHub to create PRs across
organizations. There might be a possibility to handle this but as it is
currently failing for each release we should remove it.

Related-to: https://github.com/cockpit-project/cockpit/pull/22137
Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
