### PR TITLE
systemd: show a warning if the last shutdown/reboot was unclean

### DIFF
--- a/pkg/systemd/overview-cards/healthCard.tsx
+++ b/pkg/systemd/overview-cards/healthCard.tsx
@@ -24,6 +24,7 @@ import cockpit from "cockpit";
 import { PageStatusNotifications } from "../page-status.jsx";
 import { InsightsStatus } from "./insights.jsx";
 import { ShutDownStatus } from "./shutdownStatus.jsx";
+import { UncleanShutdownStatus } from "./uncleanShutdownStatus.jsx";
 import LastLogin from "./lastLogin.jsx";
 import { CryptoPolicyStatus } from "./cryptoPolicies.jsx";
 
@@ -41,6 +42,7 @@ export const HealthCard = () =>
                 <InsightsStatus />
                 <CryptoPolicyStatus />
                 <ShutDownStatus />
+                <UncleanShutdownStatus />
                 <SmartOverviewStatus />
                 <LastLogin />
             </ul>

--- a/pkg/systemd/overview-cards/uncleanShutdownStatus.jsx
+++ b/pkg/systemd/overview-cards/uncleanShutdownStatus.jsx
@@ -1,0 +1,99 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import React, { useState } from 'react';
+import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
+import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex/index.js";
+import { Icon } from "@patternfly/react-core/dist/esm/components/Icon/index.js";
+import { ExclamationTriangleIcon } from "@patternfly/react-icons";
+
+import cockpit from "cockpit";
+
+import { useInit } from 'hooks';
+
+const _ = cockpit.gettext;
+
+export const UncleanShutdownStatus = () => {
+    const [uncleanShutdownId, setUncleanShutdownId] = useState(null);
+    const [uncleanShutdownStatusVisible, setUncleanShutdownStatusVisible] = useState(false);
+
+    useInit(() => {
+        cockpit.spawn(
+            ["last", "--system", "--limit=2", "--time-format=iso", "shutdown", "reboot"],
+            { environ: ["LC_ALL=C"], err: "message", }
+        ).then((data) => {
+            const previous_boot = data.split("\n")[1];
+            if (previous_boot === undefined)
+                return;
+
+            // "crash" on wtmpdb, "still running" on util-linux
+            if (!previous_boot.includes("crash") && !previous_boot.includes("still running"))
+                return;
+
+            const lines = previous_boot.split(/ +/);
+            const started = new Date(lines[4]);
+            if (isNaN(started)) {
+                console.warn("cannot parse start date of last line", previous_boot);
+            } else {
+                const epoch = started.getTime().toString();
+                setUncleanShutdownId(epoch);
+                setUncleanShutdownStatusVisible(epoch != cockpit.sessionStorage.getItem("dismissed-unclean-shutdown-id"));
+            }
+        });
+    });
+
+    if (!uncleanShutdownId || !uncleanShutdownStatusVisible) {
+        return null;
+    }
+
+    function hideAlert() {
+        setUncleanShutdownStatusVisible(false);
+        cockpit.sessionStorage.setItem('dismissed-unclean-shutdown-id', uncleanShutdownId);
+    }
+
+    return (
+        <li id="unclean-shutdown-status">
+            <Flex flexWrap={{ default: 'nowrap' }}>
+                <FlexItem>
+                    <Icon status="danger">
+                        <ExclamationTriangleIcon />
+                    </Icon>
+                </FlexItem>
+                <div>
+                    <div className="pf-v6-u-text-break-word pf-v6-u-text-color-status-danger">
+                        {_("Unclean shutdown")}
+                    </div>
+                    <Flex>
+                        <Button variant="link" isInline
+                                    className="pf-v6-u-font-size-sm"
+                                    onClick={() => cockpit.jump("/system/logs#/?boot=-1")}>
+                            {_("View logs")}
+                        </Button>
+                        <Button variant="link" isInline
+                                    className="pf-v6-u-font-size-sm"
+                                    onClick={() => hideAlert()}
+                                    id="unclean-shutdown-status-dismiss">
+                            {_("Dismiss")}
+                        </Button>
+                    </Flex>
+                </div>
+            </Flex>
+        </li>
+    );
+};

--- a/test/verify/check-system-shutdown-restart
+++ b/test/verify/check-system-shutdown-restart
@@ -145,5 +145,80 @@ class TestShutdownRestart(testlib.MachineCase):
         m.wait_poweroff()
 
 
+class TestUncleanShutdownStatus(testlib.MachineCase):
+
+    def _cleanReboot(self):
+        m = self.machine
+        b = self.browser
+        b.click("#reboot-button")
+        b.wait_popup("shutdown-dialog")
+        b.wait_in_text(f"#shutdown-dialog button{self.danger_btn_class}", 'Reboot')
+        b.set_input_text("#message", "Rebooting for maintenance")
+        b.click("#delay")
+        b.click("button:contains('No delay')")
+        b.wait_text("#delay .pf-v6-c-menu-toggle__text", "No delay")
+        b.click(f"#shutdown-dialog button{self.danger_btn_class}")
+
+        b.switch_to_top()
+        b.wait_in_text(".curtains-ct h1", "Disconnected")
+
+        self.wait_reboot()
+        m.start_cockpit()
+        b.click("#machine-reconnect")
+        b.wait_visible("#login")
+        self.login_and_go("/system")
+
+    def _uncleanReboot(self):
+        m = self.machine
+        b = self.browser
+        m.spawn("reboot -f", "reboot")
+
+        b.switch_to_top()
+        with b.wait_timeout(30):
+            b.wait_in_text(".curtains-ct h1", "Disconnected")
+
+        self.wait_reboot()
+        m.start_cockpit()
+        b.click("#machine-reconnect")
+        b.wait_visible("#login")
+        self.login_and_go("/system")
+
+    def testBasic(self):
+        m = self.machine
+        b = self.browser
+
+        # Disable pre-loading packagekit, dnf needs-restarting (dnf 4) consumes tons of cpu/memory on RHEL-10-1
+        self.disable_preload("packagekit")
+
+        m.start_cockpit()
+        self.login_and_go("/system")
+
+        # Clean reboot
+        self._cleanReboot()
+        b.wait_visible('#system_information_os_text')
+        b.wait_not_present("#unclean-shutdown-status")
+
+        # Unclean reboot
+        self._uncleanReboot()
+        b.wait_visible("#unclean-shutdown-status")
+        b.wait_in_text("#unclean-shutdown-status", "Unclean shutdown")
+
+        # Link to logs page
+        b.click("#unclean-shutdown-status button:contains('View logs')")
+        b.switch_to_top()
+        b.wait_js_cond('window.location.pathname == "/system/logs"')
+        b.wait_js_cond('window.location.hash == "#/?boot=-1"')
+
+        # Dismiss
+        b.go("/system")
+        b.enter_page("/system")
+        b.click("#unclean-shutdown-status-dismiss")
+        b.wait_not_present("#unclean-shutdown-status")
+
+        # Clean reboot
+        self._cleanReboot()
+        b.wait_not_present("#unclean-shutdown-status")
+
+
 if __name__ == '__main__':
     testlib.test_main()


### PR DESCRIPTION
Fixes #12947

### Additional Notes

- No copyright header has been included in the new files. I'm unsure what is appropriate.
- If the `last` command is missing from the system, it fails silently: no warning is displayed and nothing is logged.
- The dismissal of the warning is not persistent; it reappears after logout/login, similar to how MOTD messages behave.
- No pixel tests have been included.

Please let me know if anything needs to be revised.

* [ ] the log pages boot link does not seem to properly filter on the given boot, needs debugging.

---

## Shown a warning if the last shutdown/reboot was unclean

Cockpit's healtchard will now show warning when the system was shutdown uncleanly. 

<img width="344" height="418" alt="image" src="https://github.com/user-attachments/assets/901c6c8a-d110-4f52-8075-85f3c0b0d5ff" />
