### PR TITLE
test: Make "select-space" selectors precise

### DIFF
--- a/pkg/storaged/dialog.jsx
+++ b/pkg/storaged/dialog.jsx
@@ -843,8 +843,10 @@ export const SelectSpaces = (tag, title, options) => {
                                             ]}
                             />);
 
+                        const key = block || desc;
+
                         return (
-                            <DataListItem key={spc.block ? spc.block.Device : spc.desc}>
+                            <DataListItem data-space-name={key} key={key}>
                                 <DataListItemRow>
                                     <DataListCheck id={(spc.block ? spc.block.Device : spc.desc) + "-row-checkbox"}
                                                    isDisabled={options.min_selected &&
@@ -887,8 +889,10 @@ export const SelectSpace = (tag, title, options) => {
                                 change(spc);
                         };
 
+                        const key = block || desc;
+
                         return (
-                            <DataListItem key={spc.block ? spc.block.Device : spc.desc}>
+                            <DataListItem data-space-name={key} key={key}>
                                 <DataListItemRow>
                                     <div className="pf-v6-c-data-list__item-control">
                                         <div className="pf-v6-c-data-list__check">

--- a/test/common/storagelib.py
+++ b/test/common/storagelib.py
@@ -180,7 +180,7 @@ class StorageHelpers(MachineCase):
         elif ftype == "select-spaces":
             assert isinstance(val, dict)
             for label, value in val.items():
-                self.browser.set_checked(f'{sel} :contains("{label}") input', value)
+                self.browser.set_checked(f'{sel} [data-space-name="{label}"] input', value)
         elif ftype == "size-slider":
             self.browser.set_val(sel + " .size-unit select", "1000000")
             self.browser.set_input_text(sel + " .size-text input", str(val))

--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -853,8 +853,8 @@ class TestStorageStratisReboot(storagelib.StorageCase):
         # Create a pool
         if not legacy:
             self.dialog_with_retry(trigger=lambda: self.click_devices_dropdown("Create Stratis pool"),
-                                   expect=lambda: self.dialog_is_present('disks', "lvol0"),
-                                   values={"disks": {"lvol0": True}})
+                                   expect=lambda: self.dialog_is_present('disks', "/dev/vgroup0/lvol0"),
+                                   values={"disks": {"/dev/vgroup0/lvol0": True}})
         else:
             create_legacy_pool(m, disks=["/dev/vgroup0/lvol0"])
 


### PR DESCRIPTION
Stop using `:contains()` for selecting a member of a compound device. This fixes a common flake where `add_loopback_disk()` creates e.g. /dev/loop1 and /dev/loop10, and trying to select the former becomes an ambiguous selector.

To make that robust, add a `data-space-name` attribute to each list item. Use that as the `key` as well, to get an actually sensible name (like "/dev/loop1") instead of some object hash gibberish.

It would be really nice to use these in the actual DataListCheck `id` attribute, but IDs like `/dev/loop0-row-checkbox` work poorly -- so keep the object hash for these.

Spell out the device name in `TestStorageStratisReboot.testPoolResize` to work with the strict selection.

---

This fixes our top flake on the [weather report](https://ci-weather-cockpit.apps.ocp.cloud.ci.centos.org/tests.html?repo=cockpit-project%2Fcockpit&days=7)

<img width="630" height="213" alt="image" src="https://github.com/user-attachments/assets/71a27214-7426-4f8c-898f-a92e05e301d7" />

I remember similar cases before, when we hacked around that by hardcoding e.g. `self.add_loopback_disk(name="loop4")`. That is prone to EBUSY. However, some of these appear in pixel tests, so I didn't change these.

[example log](https://logs-cockpit.apps.ocp.cloud.ci.centos.org/pull-22270-b40eaaf6-20250804-104431-centos-9-bootc-storage/log.html)