### PR TITLE
test: Check browser instead of system date in TestAccounts.testBasic

### DIFF
--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -346,7 +346,8 @@ class TestAccounts(testlib.MachineCase):
 
         # HACK: lastlog does not record sessions from ssh
         if not m.ws_container:
-            b.wait_in_text("#accounts-list tbody tr:contains('paul')", m.execute("date +'%b %-d, %Y'").strip())
+            today = b.eval_js("Intl.DateTimeFormat('en', { dateStyle: 'medium' }).format()")
+            b.wait_in_text("#accounts-list tbody tr:contains('paul')", today)
 
         self.allow_journal_messages("Password quality check failed:")
         self.allow_journal_messages("The password is a palindrome")


### PR DESCRIPTION
The page formats the date using the browser's time zone, not the server's. So do the same in the test.

This fixes the regular failures of this test in European mornings, when the VM with US timezone is a day behind the browser with European/UTC time zone.

----

Fixes [this failure](https://logs-cockpit.apps.ocp.cloud.ci.centos.org/pull-22277-2c173552-20250804-025518-rhel-9-7-other/log.html) which is one of the worst rain suppliers in the weather report:

<img width="470" height="221" alt="image" src="https://github.com/user-attachments/assets/983889e3-99c0-4d62-aaed-a8fa07bd29bf" />
