### PR TITLE
storaged: Add anaconda branding support

### DIFF
--- a/pkg/storaged/anaconda.jsx
+++ b/pkg/storaged/anaconda.jsx
@@ -18,6 +18,7 @@
  */
 
 import client from "./client.js";
+import { read_os_release } from "os-release";
 
 import { decode_filename } from "./utils.js";
 import { parse_subvol_from_options } from "./btrfs/utils.jsx";
@@ -38,6 +39,32 @@ function device_name(block) {
     // Prefer symlinks in /dev/stratis/.
     return (block.Symlinks.map(decode_filename).find(n => n.indexOf("/dev/stratis/") == 0) ||
             decode_filename(block.PreferredDevice));
+}
+
+/**
+ * Initialize anaconda branding support
+ */
+export async function init_anaconda_branding() {
+    // Load anaconda-branding.css and wait for it to load
+    if (!document.querySelector('link[href*="anaconda-branding.css"]')) {
+        await new Promise((resolve) => {
+            const link = document.createElement('link');
+            link.rel = 'stylesheet';
+            link.type = 'text/css';
+            link.href = '../../static/branding/anaconda-branding.css';
+
+            link.onload = () => resolve(undefined);
+            link.onerror = () => resolve(undefined); // Still resolve on error
+
+            document.head.appendChild(link);
+        });
+    }
+
+    // Apply branding-{distro_id} class based on os-release
+    const osRelease = await read_os_release();
+    if (osRelease?.ID) {
+        document.documentElement.classList.add(`branding-${osRelease.ID}`);
+    }
 }
 
 export function remember_passphrase(block, passphrase) {

--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -35,7 +35,7 @@ import stratis3_set_key_py from "./stratis/stratis3-set-key.py";
 
 import { reset_pages } from "./pages.jsx";
 import { make_overview_page } from "./overview/overview.jsx";
-import { export_mount_point_mapping } from "./anaconda.jsx";
+import { export_mount_point_mapping, init_anaconda_branding } from "./anaconda.jsx";
 
 import { dequal } from 'dequal/lite';
 
@@ -1068,8 +1068,11 @@ function init_model(callback) {
 
                     update_indices();
                     cockpit.addEventListener("visibilitychange", () => update_lvm2_polling(true));
-                    btrfs_poll().then(() => {
+                    btrfs_poll().then(async () => {
                         client.update(true);
+                        // Initialize anaconda branding if in anaconda mode and wait for it to complete
+                        if (client.in_anaconda_mode())
+                            await init_anaconda_branding();
                         callback();
                     });
                 });


### PR DESCRIPTION
- Load anaconda-branding.css when running in anaconda mode
- Apply branding-{distro_id} CSS classes based on os-release ID
- Compatible with anaconda-webui branding system (rhinstaller/anaconda-webui#951)

When cockpit-storage is embedded in anaconda-webui, it will automatically:
1. Load /usr/share/cockpit/static/branding/anaconda-branding.css
2. Apply distribution-specific classes (e.g. branding-fedora, branding-bazzite)

Note: This is implemented in coordination with: https://github.com/rhinstaller/anaconda-webui/pull/951