### PR TITLE
ws: Send "close" message when browser closes external channel

### DIFF
--- a/src/ws/cockpitchannelsocket.c
+++ b/src/ws/cockpitchannelsocket.c
@@ -98,6 +98,8 @@ cockpit_channel_socket_close (CockpitChannel *channel,
         code = WEB_SOCKET_CLOSE_NORMAL;
       web_socket_connection_close (self->socket, code, problem);
     }
+
+  COCKPIT_CHANNEL_CLASS(cockpit_channel_socket_parent_class)->close (channel, problem);
 }
 
 static void


### PR DESCRIPTION
When a browser opens a "/cockpit/channel?..." URL, a corresponding channel is opened by cockpit-ws to the bridge and the browser connection is upgraded to a WebSocket.

When the bridge closes this channel, cockpit-ws closes the WebSocket. This is good.

When the browser closes the WebSocket, cockpit-ws does not close the channel to the bridge. This is not good.

The in-page VNC viewer of Cockpit Machines works with such a external channel, but it will only ever be closed by the browser, never by the server.  When this happens in the middle of a session, the TCP connection from the bridge to the VNC server in qemu stays open. Cockpit Machines does a lot of reconnections, and will pretty easily reach the connection limit of qemu.

Worse, if Cockpit Machines opens a "non-shared" connection, this connection will invisibly stay open until the end of the session and will prevent any other connections.

The bug is that CockpitChannelSocket overrides the "close" method of CockpitChannel completely. It should both close the WebSocket (if still open) and the bridge channel (if still open). This is done here by invoking the "close" method of the parent class as well.