### PR TITLE
logs: Initialize identifiers as empty array

### DIFF
--- a/pkg/systemd/logs.jsx
+++ b/pkg/systemd/logs.jsx
@@ -102,7 +102,7 @@ export const LogsPage = () => {
     const full_grep = getGrepFiltersFromOptions({ options })[0];
 
     /* Initial state */
-    const [currentIdentifiers, setCurrentIdentifiers] = useState(undefined);
+    const [currentIdentifiers, setCurrentIdentifiers] = useState([]);
     const [dataFollowing, setDataFollowing] = useState(follow);
     const [filteredQuery, setFilteredQuery] = useState(undefined);
     const [journalPrio, setJournalPrio] = useState(getPrioFilterOption(options));


### PR DESCRIPTION
Within logs you could sometimes get a race condition or unexpected
behaviour that caused the identifiers to be `undefined` and us calling
`Array.prototype.include()` on it which causes a `TypeError`. Fixing
this as best we can (for now) we can initialize it to an empty array
instead.

I have yet to be able to reproduce this issue, so instead this commit
mitigates the issue as best as possible in hopes it also fixed the issue.

Related-to: #22311
Signed-off-by: Freya Gustavsson <freya@venefilyn.se>