### PR TITLE
copr: Set subscription-manager as weak dep

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -132,7 +132,7 @@ Recommends: (cockpit-ostree if rpm-ostree)
 Suggests: cockpit-selinux
 %endif
 %if 0%{?rhel} && 0%{?centos} == 0
-Requires: subscription-manager-cockpit
+Recommends: subscription-manager-cockpit
 %endif
 
 BuildRequires:  python3-devel


### PR DESCRIPTION
Currently within Copr on our `@cockpit/cockpit-preview` we have releases
for EPEL 9 and 10. Both of which require `subscription-manager` to be
installed.

However, this isn't guaranteed to be RHEL or CentOS Linux as we also
have non-subscription related CentOS Linux itself, we also have the
CentOS forks Alma Linux and Rocky Linux in which neither can provide
`subscription-manager`.

Demoting this from `Requires` to `Recommends` should help with
installing EPEL releases from @cockpit/cockpit-preview` within Alma and
Rocky distributions.

Related-to: https://discussion.fedoraproject.org/t/3249/2
Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
