### PR TITLE
flatpak: Bump GNOME runtime to 48

### DIFF
--- a/containers/flatpak/prepare
+++ b/containers/flatpak/prepare
@@ -86,7 +86,7 @@ def create_manifest(
     return {
         'app-id': FLATPAK_ID,
         'runtime': 'org.gnome.Platform',
-        'runtime-version': '47',
+        'runtime-version': '48',
         'sdk': 'org.gnome.Sdk',
         'command': 'cockpit-client',
         'rename-icon': 'cockpit-client',


### PR DESCRIPTION
Previously on 47 which is EOL next month.

Related-to: https://github.com/flathub/org.cockpit_project.CockpitClient/pull/67
Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
