### PR TITLE
css: Fix Tab selection not showing

### DIFF
--- a/pkg/lib/page.scss
+++ b/pkg/lib/page.scss
@@ -160,10 +160,6 @@ a.disabled:hover {
   --ct-color-list-critical-alert-text: var(--pf-v6-global--palette--red-8888);
 }
 
-[hidden] {
-  display: none !important;
-}
-
 // Let PF4 handle the scrolling through page component otherwise we might get double scrollbar
 html:not(.index-page) body {
   overflow-block: hidden;

--- a/pkg/lib/patternfly/patternfly-6-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-6-overrides.scss
@@ -74,7 +74,18 @@ $phone: 767px;
   min-inline-size: min-content;
 }
 
+
 .pf-v6-c-card {
+  // FIXME: Using an expandable content within a card would cause the card to be scrollable while nothing
+  // would be in view. Makes it look like there is something to scroll to when there isn't anything.
+  // PF deliberately makes expandable `[hidden]` content have `display: revert` which would make them have
+  // `display: block` or whatever is default from the browser. They do this to make animations work.
+  // Until fixed upstream we revert their `display: revert` rule.
+  // https://github.com/patternfly/patternfly/issues/7746
+  .pf-v6-c-expandable-section__content:where([hidden]) {
+    display: none;
+  }
+
   // https://github.com/patternfly/patternfly/issues/3959
   // TODO @Venefilyn: Change so we use .pf-m-no-offset, then remove this
   // --pf-v6-c-card__header-toggle--MarginTop: 0;

--- a/pkg/shell/hosts.tsx
+++ b/pkg/shell/hosts.tsx
@@ -256,14 +256,16 @@ export class CockpitHosts extends React.Component {
                 status={m.state === "failed" ? { type: "error", title: _("Connection error") } : null}
                 className={m.state || ""}
                 onClick={() => this.onHostSwitch(m)}
-                actions={<>
-                    <Tooltip content={_("Edit")} position="right">
-                        <Button icon={<EditIcon />} isDisabled={m.address === "localhost"} className="nav-action" hidden={!editing} onClick={_e => this.onHostEdit(m)} key={m.label + "edit"} variant="secondary" />
-                    </Tooltip>
-                    <Tooltip content={_("Remove")} position="right">
-                        <Button icon={<MinusIcon />} isDisabled={m.address === "localhost"} onClick={e => this.onRemove(e, m)} className="nav-action" hidden={!editing} key={m.label + "remove"} variant="danger" />
-                    </Tooltip>
-                </>}
+                actions={
+                    editing && <>
+                        <Tooltip content={_("Edit")} position="right">
+                            <Button icon={<EditIcon />} isDisabled={m.address === "localhost"} className="nav-action" hidden={!editing} onClick={_e => this.onHostEdit(m)} key={m.label + "edit"} variant="secondary" />
+                        </Tooltip>
+                        <Tooltip content={_("Remove")} position="right">
+                            <Button icon={<MinusIcon />} isDisabled={m.address === "localhost"} onClick={e => this.onRemove(e, m)} className="nav-action" hidden={!editing} key={m.label + "remove"} variant="danger" />
+                        </Tooltip>
+                    </>
+                }
         />;
         const label = current_machine?.label || "";
         const user = current_machine?.user || this.state.current_user;

--- a/test/common/test-functions.js
+++ b/test/common/test-functions.js
@@ -219,7 +219,7 @@ window.ph_set_checked = function(sel, val) {
 
 window.ph_is_visible = function(sel) {
     const el = window.ph_find(sel);
-    return el.tagName == "svg" || ((el.offsetWidth > 0 || el.offsetHeight > 0) && !(el.style.visibility == "hidden" || el.style.display == "none"));
+    return el.tagName == "svg" || ((el.offsetWidth > 0 || el.offsetHeight > 0) && !(getComputedStyle(el).visibility == "hidden" || getComputedStyle(el).display == "none"));
 };
 
 window.ph_is_present = function(sel) {

--- a/test/verify/check-shell-host-switching
+++ b/test/verify/check-shell-host-switching
@@ -70,7 +70,7 @@ class HostSwitcherHelpers:
         b.click(f".nav-item a[href='/@{address}'] + span button.nav-action.pf-m-danger")
         if second_to_last:
             b.wait_not_present("button:contains('Stop editing hosts')")
-            b.wait_not_visible(".nav-item a[href='/'] + span button.nav-action.pf-m-danger")
+            b.wait_not_present(".nav-item a[href='/'] + span button.nav-action.pf-m-danger")
         else:
             b.click("button:contains('Stop editing hosts')")
 
@@ -249,8 +249,8 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
         b.wait_visible(".nav-item a[href='/@10.111.113.2'] + span button.nav-action.pf-m-secondary:not(:disabled)")
         b.assert_pixels(".edit-hosts", "edit-hosts")
         b.click("button:contains('Stop editing hosts')")
-        b.wait_not_visible(".nav-item a[href='/'] + span button.nav-action.pf-m-danger")
-        b.wait_not_visible(".nav-item a[href='/@10.111.113.2'] + span button.nav-action.pf-m-secondary")
+        b.wait_not_present(".nav-item a[href='/'] + span button.nav-action.pf-m-danger")
+        b.wait_not_present(".nav-item a[href='/@10.111.113.2'] + span button.nav-action.pf-m-secondary")
 
         b.wait_not_present(".nav-item a[href='/@10.111.113.2'] .nav-status")
 
@@ -447,8 +447,8 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
         b.wait_visible(".nav-item a[href='/@10.111.113.2'] + span button.nav-action.pf-m-danger:not(:disabled)")
         b.wait_visible(".nav-item a[href='/@10.111.113.2'] + span button.nav-action.pf-m-secondary:not(:disabled)")
         b.click("button:contains('Stop editing hosts')")
-        b.wait_not_visible(".nav-item a[href='/'] + span button.nav-action.pf-m-danger")
-        b.wait_not_visible(".nav-item a[href='/@10.111.113.2'] + span button.nav-action.pf-m-secondary")
+        b.wait_not_present(".nav-item a[href='/'] + span button.nav-action.pf-m-danger")
+        b.wait_not_present(".nav-item a[href='/@10.111.113.2'] + span button.nav-action.pf-m-secondary")
 
         b.wait_not_present(".nav-item a[href='/@10.111.113.2'] .nav-status")
 


### PR DESCRIPTION
**TL;DR:** 
- We set `display: none` to `hidden` DOM elements which caused animations to not function properly
  - Animations slowed down to 25% to make the issue easier to spot:

[video of the selected tab not working](https://github.com/user-attachments/assets/c78cabfe-da3d-4d6e-a5f6-b1b73acdf48b)

<details>
<summary>css: Remove `display: none` from `[hidden]`</summary>

This was a valid change back in the day due to the way `hidden` DOM
elements were being used and handled by the browser. It is still a
normal syntax for indicating that an element is not being displayed (but
still rendered), but there is no elements from Patternfly or otherwise
that should be popping in or being rendered weirdly anymore.

All relevant bugs were fixed in Patternfly v4 and v5.

One of the main benefits of reverting this change and letting `hidden`
be a normal element that is just not shown is that we can have
animations displayed better from various project, such as Patternfly
with their tab animations. Without this change we would not be able to
get proper animations without janky hacks.

**How the Tabs bug happened**
If you added Tabs to a component that was hidden inside an element, such
as an `<ExpandableContent>` component, it would first be rendered as
normal and then get the CSS applied to it with the `display: none`. As
the component was rendered it would try to get its offset in the viewer
to be able to render the underline for the tab selection, but this would
return `0` for both block and inline. Technically, this would render the
Tab selection in the top left of the window but we would never see it as
it had to be inside the visible Tabs component area.

@tomasmatus recorded a video of the bug that also showed a render that
happened after 4 seconds or so, this render was unrelated and instead
seems to point to a browser extension or otherwise that caused a resize
event to trigger or a DOM rerender. Exact cause why it rerendered after
4 seconds is unknown.

Fixes: cockpit-project#22331
Related-to: cockpit-project/cockpit-podman#2207 (comment)
Related-to: cockpit-project#13207
Related-to: cockpit-project#13265

</details>

