### PR TITLE
test: clean up various debian-stable references

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -81,7 +81,7 @@ See below for details.
 You can conduct manual interactive testing against a test image by starting the
 image like so:
 
-     bots/vm-run -s cockpit.socket debian-stable
+     bots/vm-run -s cockpit.socket arch
 
 Once the machine is booted and the cockpit socket has been activated, a
 message will be printed describing how to access the virtual machine, via
@@ -96,7 +96,7 @@ By default, it's only possible to contact the virtual machine from the host
 machine on which it's running.   If you want to conduct manual testing from
 other devices on your network, set `TEST_BIND_GLOBAL=1`, for example:
 
-     TEST_BIND_GLOBAL=1 bots/vm-run -s cockpit.socket debian-stable
+     TEST_BIND_GLOBAL=1 bots/vm-run -s cockpit.socket arch
 
 This will bind the Cockpit and SSH ports to all interfaces, making it possible
 to access a URL like http://yourhost.local:9091/ to test Cockpit from another
@@ -174,7 +174,7 @@ to push pixel tests.
 You can set these environment variables to configure the test suite:
 
  * `TEST_OS`: The OS to run the tests in, like "fedora-coreos" or
-    "debian-stable". See the "cockpit-project/cockpit" section in the
+    "debian-testing". See the "cockpit-project/cockpit" section in the
     [test map](https://github.com/cockpit-project/bots/blob/main/lib/testmap.py)
     for all supported values. "fedora-41" is the default (`TEST_OS_DEFAULT` in
     bots' [constants.py](https://github.com/cockpit-project/bots/blob/main/lib/constants.py)).

--- a/test/common/packagelib.py
+++ b/test/common/packagelib.py
@@ -122,7 +122,7 @@ Server = file://{empty_repo_dir}
         self.machine.execute("systemctl reset-failed packagekit || true")
         self.restore_file("/var/lib/PackageKit/transactions.db")
 
-        if self.image in ["debian-stable", "debian-testing"]:
+        if self.image in ["debian-trixie", "debian-testing"]:
             # PackageKit tries to resolve some DNS names, but our test VM is offline;
             # temporarily disable the name server to fail quickly
             self.machine.execute("mv /etc/resolv.conf /etc/resolv.conf.test")

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1876,10 +1876,7 @@ class MachineCase(unittest.TestCase):
 
         # only enabled by default on released OSes; see pkg/shell/manifest.json
         self.multihost_enabled = image.startswith(("rhel-9", "centos-9")) or image in [
-                "ubuntu-2204", "ubuntu-2404", "debian-stable"]
-        # Transitional code while we move ubuntu-stable from 24.04 to 24.10
-        if image == "ubuntu-stable" and m.execute(". /etc/os-release; echo $VERSION_ID").strip() == "24.04":
-            self.multihost_enabled = True
+                "ubuntu-2204", "ubuntu-2404"]
 
     def nonDestructiveSetup(self) -> None:
         """generic setUp/tearDown for @nondestructive tests"""

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -488,7 +488,7 @@ class TestConnection(testlib.MachineCase):
 
         # certmonger generated certificate; asciibetically later than the above
         # not all images have certmonger
-        if m.image not in ["debian-stable", "debian-testing", "fedora-coreos", "arch", "centos-9-bootc"]:
+        if m.image not in ["fedora-coreos", "arch", "centos-9-bootc"]:
             hostname = m.execute("hostname --fqdn").strip()
             m.execute(f"getcert request -f /etc/cockpit/ws-certs.d/monger.cert -k /etc/cockpit/ws-certs.d/monger.key -D {hostname} --ca=local --wait")
             self.addCleanup(m.execute, "getcert stop-tracking -f /etc/cockpit/ws-certs.d/monger.cert")

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -463,7 +463,7 @@ class TestHistoryMetrics(testlib.MachineCase):
 
         # Now add the journal
         # Older systemds get a slightly wrong log window with --since/until, so only run on newer ones
-        if re.search(r"centos-[89]|rhel-[89]|debian-stable|ubuntu-2204", self.machine.image):
+        if re.search(r"centos-[89]|rhel-[89]|ubuntu-2204", self.machine.image):
             return
 
         m.upload(["verify/files/metrics-archives/journal.journal.gz"], "/tmp")

--- a/test/verify/check-networkmanager-checkpoints
+++ b/test/verify/check-networkmanager-checkpoints
@@ -53,17 +53,16 @@ class TestNetworkingCheckpoints(netlib.NetworkCase):
             b.click("#confirm-breaking-change-popup button:contains('Keep connection')")
         b.wait_not_present("#confirm-breaking-change-popup")
 
-        if m.image not in ["debian-testing", "debian-stable"]:
-            # Change IP
-            self.configure_iface_setting('IPv4')
-            b.wait_visible("#network-ip-settings-dialog")
-            b.select_from_dropdown("#network-ip-settings-select-method", "manual")
-            b.set_input_text('#network-ip-settings-address-0', "1.2.3.4")
-            b.set_input_text('#network-ip-settings-netmask-0', "24")
-            b.click("#network-ip-settings-save")
-            with b.wait_timeout(60):
-                b.click("#confirm-breaking-change-popup button:contains('Keep connection')")
-            b.wait_not_present("#confirm-breaking-change-popup")
+        # Change IP
+        self.configure_iface_setting('IPv4')
+        b.wait_visible("#network-ip-settings-dialog")
+        b.select_from_dropdown("#network-ip-settings-select-method", "manual")
+        b.set_input_text('#network-ip-settings-address-0', "1.2.3.4")
+        b.set_input_text('#network-ip-settings-netmask-0', "24")
+        b.click("#network-ip-settings-save")
+        with b.wait_timeout(60):
+            b.click("#confirm-breaking-change-popup button:contains('Keep connection')")
+        b.wait_not_present("#confirm-breaking-change-popup")
 
     @testlib.skipImage("Main interface settings are read-only", "debian-*")
     @testlib.skipImage("no dhclient on OS image", "arch", "centos-10*", "rhel-10*")

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -872,7 +872,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
         # set up local (NIS) sssd provider and certificate mapping
         # newer sssd drops "file" provider, but the "proxy" provider cannot do this yet in old versions
-        if m.image in ["debian-stable", "ubuntu-2204"]:
+        if m.image in ["ubuntu-2204"]:
             id_provider = "id_provider = files"
         else:
             id_provider = """id_provider = proxy

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -1414,7 +1414,7 @@ WantedBy=multi-user.target
         m.execute("systemctl stop test.service")
         self.check_service_details(["Read-only", "Disabled"], [], enabled=False, onoff=False, kebab=False)
 
-    @testlib.skipImage("no quadlet (pod) support", "debian-stable", "ubuntu-2204", "ubuntu-2404", "rhel-8-10")
+    @testlib.skipImage("no quadlet (pod) support", "ubuntu-2204", "ubuntu-2404", "rhel-8-10")
     @testlib.nondestructive
     def testQuadlets(self):
         m = self.machine


### PR DESCRIPTION
This image is no longer being tested and will soon be dropped from the bots.

While we're at it, try to clean up a few adjacent things:

 - an old transitional shim to help us move the ubuntu-stable image between versions.  That should have gone out long ago.

 - some cases where I suspect things have been fixed in debian-testing since the workarounds were added (since they appear to be working in -trixie).