### PR TITLE
lib: basename: /home translates into home

### DIFF
--- a/pkg/base1/test-path.ts
+++ b/pkg/base1/test-path.ts
@@ -49,6 +49,9 @@ QUnit.test("basename", function (assert) {
         ["foo", "foo"],
         ["bar/foo/", "foo"],
         ["//bar//foo///", "foo"],
+        ["/home/admin/", "admin"],
+        ["/home/", "home"],
+        ["/home", "home"],
         ["/", "/"],
     ];
 

--- a/pkg/lib/cockpit-path.ts
+++ b/pkg/lib/cockpit-path.ts
@@ -41,7 +41,7 @@ export function basename(path : string): string {
     const pos = norm.lastIndexOf("/");
     if (pos < 0)
         return norm;
-    else if (pos == 0)
+    else if (pos === 0 && norm.length === 1)
         return "/";
     else
         return norm.substring(pos + 1);


### PR DESCRIPTION
Just like `basename /home` returns `home` our JavaScript implementation should do the same.

* [ ] update cockpit-files with this fix afterwards for https://github.com/cockpit-project/cockpit-files/issues/1150
