### PR TITLE
npm: Remove unused argparse

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@types/react-dom": "18.3.1",
     "@types/throttle-debounce": "5.0.2",
     "@typescript-eslint/eslint-plugin": "8.38.0",
-    "argparse": "2.0.1",
     "esbuild": "0.25.9",
     "esbuild-sass-plugin": "3.3.1",
     "esbuild-wasm": "0.25.9",


### PR DESCRIPTION
We have argparse, but that is within our python codebase. There is
nothing we use with NPM argparse within any of our projects as far as I
can tell.

Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
