### PR TITLE
ci: Use `GITHUB_TOKEN` instead of `GH_TOKEN`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
     needs: source
     environment: flathub
     env:
-      GH_TOKEN: ${{ secrets.COCKPITUOUS_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.COCKPITUOUS_TOKEN }}
     permissions: {}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
With `gh` it does not allow us to use `GITHUB_TOKEN` and `GH_TOKEN` at
the same time. For some reason this isn't explained in the docs and
instead there is an issue on GH CLI repo that recommends just setting
`GITHUB_TOKEN` itself instead.

Fingers crossed, otherwise there is another solution to try where we can
explicitly use `--with-token` argument but we'd have to provide it
through stdin.

Related-to: https://github.com/cli/cli/issues/2922
Related-to: https://github.com/FreeTubeApp/FreeTube/blob/865a4a2ab0b61062d36a223cd52f966f9a0d4306/.github/workflows/flatpak.yml#L119-L121
Related-to: https://cli.github.com/manual/gh_auth_login
Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
