### PR TITLE
packit: Drop Fedora 41, add Fedora 43

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -29,8 +29,8 @@ jobs:
     identifier: self
     trigger: pull_request
     targets: &test_targets
-      fedora-41: {}
       fedora-42: {}
+      fedora-43: {}
       fedora-latest-aarch64: {}
       fedora-rawhide: {}
       centos-stream-9-x86_64:
@@ -97,19 +97,19 @@ jobs:
     trigger: release
     dist_git_branches:
       - fedora-development
-      - fedora-41
       - fedora-42
+      - fedora-43
 
   - job: koji_build
     trigger: commit
     dist_git_branches:
       - fedora-development
-      - fedora-41
       - fedora-42
+      - fedora-43
 
   - job: bodhi_update
     trigger: commit
     dist_git_branches:
       # rawhide updates are created automatically
-      - fedora-41
       - fedora-42
+      - fedora-43


### PR DESCRIPTION
Note that we already sort of test f43 through fedora-latest-aarch64, e.g. [this run](https://artifacts.dev.testing-farm.io/5db1b71c-a99d-495b-90b7-89937d094131/) from #22364. But our external projects like https://github.com/stratis-storage/stratisd/pull/3899 are testing cockpit on x86_64 already, and find [regressions](https://artifacts.dev.testing-farm.io/7c15ca3e-1cd0-4014-aaeb-aa45073bfdf3/), so let's run them here as well. Also, we *have to* release to F43 now.

We also need to set up our own bots testing on F43 ASAP.