### PR TITLE
bridge: Support Fedora 43 for beibooting, drop 40

### DIFF
--- a/src/cockpit/osinfo.py
+++ b/src/cockpit/osinfo.py
@@ -16,9 +16,9 @@ supported_oses: 'list[dict[str, str | None]]' = [
     # rolling release
     {"ID": "debian", "VERSION_ID": None},
 
-    {"ID": "fedora", "VERSION_ID": "40"},
     {"ID": "fedora", "VERSION_ID": "41"},
     {"ID": "fedora", "VERSION_ID": "42"},
+    {"ID": "fedora", "VERSION_ID": "43"},
 
     {"ID": "ubuntu", "VERSION_ID": "22.04"},
     {"ID": "ubuntu", "VERSION_ID": "24.04"},


### PR DESCRIPTION
Corresponding to our current test map.

---

This fixes [these failures](https://logs-cockpit.apps.ocp.cloud.ci.centos.org/pull-8161-f8e502d7-20250826-050334-fedora-43-expensive-cockpit-project-cockpit/log.html) from https://github.com/cockpit-project/bots/pull/8161