### PR TITLE
css: Revert checkbox radio override

### DIFF
--- a/pkg/lib/page.scss
+++ b/pkg/lib/page.scss
@@ -195,6 +195,20 @@ body {
   color: var(--pf-t--global--icon--color--status--danger--default);
 }
 
+// When we have elements within a select you can use this helper class to align on a baseline.
+// You might have used radio or checkbox wrong if you need to use this.
+//   - Don't have inputs or selectable items within a radio/checkbox label.
+//   - Instead of aligning on a baseline, put the text in the label and everything else in a description.
+.pf-v6-c-radio,
+.pf-v6-c-check {
+  &__input {
+    .ct-align-center & {
+      margin-block: auto;
+      align-self: unset;
+      transform: unset;
+    }
+  }
+}
 
 // To be used only from testlib.py for pixel-tests
 .pixel-test {

--- a/pkg/lib/patternfly/patternfly-6-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-6-overrides.scss
@@ -192,33 +192,6 @@ $phone: 767px;
   }
 }
 
-// Realign the radio and checks: https://github.com/patternfly/patternfly/issues/5802
-.pf-v6-c-radio,
-.pf-v6-c-check {
-  // `baseline` is different in Firefox than Chrome & WebKit; use `normal`
-  align-items: normal;
-
-  // Remove incorrect PF settings on the children
-  &__label,
-  &__input {
-    margin-block: auto;
-    align-self: unset;
-    transform: unset;
-  }
-
-  // Slightly shift the radio and check widgets
-  &__input {
-    // Shift up the checks/radios for (most) browsers
-    transform: translateY(-1px);
-    // Mozilla doesn't need the translation, so undo it
-    -moz-transform: none;  // stylelint-disable-line property-no-vendor-prefix
-    // If the size is not specified, browsers may size it between 12px - 16px; so let's set it to the font size (which winds up 16px)
-    block-size: var(--pf-t--global--font--size--md);
-    // Use the height for width too
-    aspect-ratio: 1;
-  }
-}
-
 // PF Modals has a brighter background than normal pages in dark mode.
 // Tables are made to match the background but since modals change background
 // this is something we need to change ourselves

--- a/pkg/networkmanager/mtu.jsx
+++ b/pkg/networkmanager/mtu.jsx
@@ -82,6 +82,7 @@ export const MtuDialog = ({ connection, dev, settings }) => {
                        value="auto" />
                 <Radio id={idPrefix + "-custom"}
                        isChecked={mode == "custom"}
+                       className="ct-align-center"
                        label={
                            <>
                                <span>{_("Set to")}</span>

--- a/pkg/networkmanager/networking.scss
+++ b/pkg/networkmanager/networking.scss
@@ -251,8 +251,6 @@ th {
   input {
     position: relative;
     z-index: 2;
-    inline-size: 16px;
-    block-size: 16px;
   }
 
   > label {


### PR DESCRIPTION
Since 2 years ago there has been an override to make the Patternfly
radio and checkbox components aligned correctly. This is no longer
necessary and instead causes alignment issues with PF6 styling.

Removing these overrides will save headaches later on instead of trying
to come up with a fix for it that we don't need.