### PR TITLE
workflows: move anaconda workflow to Fedora 41

### DIFF
--- a/.github/workflows/trigger-anaconda.yml
+++ b/.github/workflows/trigger-anaconda.yml
@@ -19,7 +19,7 @@ jobs:
     permissions:
       contents: read
       statuses: write
-    container: registry.fedoraproject.org/fedora:41
+    container: registry.fedoraproject.org/fedora:42
     # this polls for a COPR build, which can take long
     timeout-minutes: 120
 


### PR DESCRIPTION
We dropped building on Fedora-41 in ff75fd9d521208bc14f36c5589ed6.