### PR TITLE
Components dialog bugs

### DIFF
--- a/pkg/lib/cockpit-components-dialog.jsx
+++ b/pkg/lib/cockpit-components-dialog.jsx
@@ -134,7 +134,7 @@ class DialogFooter extends React.Component {
 
         let wait_element;
         let actions_disabled = false;
-        let cancel_disabled;
+        const cancel_disabled = this.state.action_in_progress && !this.state.action_progress_cancel;
         if (this.state.action_in_progress) {
             actions_disabled = true;
             wait_element = <div className="dialog-wait-ct">


### PR DESCRIPTION
At least the last commit is nice to have for dnf5daemon and packagekit(!) as they both dont support cancelling the install bit of the install-dialog.