### PR TITLE
pkg: Include branding.css into all pages

### DIFF
--- a/doc/branding.md
+++ b/doc/branding.md
@@ -74,3 +74,15 @@ body.login-pf {
 
 Notice how we can use variables from `/etc/os-release` in the branding.
 The value for these variables come from the machine that cockpit is logged into.
+
+`branding.css` may also set the `--ct-color-host-accent` CSS variable to change
+the Cockpit Shell panel's accent color. You can also customize
+[PatternFly's brand colors](https://www.patternfly.org/design-foundations/colors/#brand-colors)
+and other PatternFly variables. For example:
+
+```css
+:root {
+    --ct-color-host-accent: #c00 !important;
+    --pf-t--global--color--brand--default: red;
+}
+```

--- a/pkg/apps/index.html
+++ b/pkg/apps/index.html
@@ -23,6 +23,7 @@ along with Cockpit; If not, see <https://www.gnu.org/licenses/>.
     <title translate="yes">Applications</title>
     <meta charset="utf-8" />
     <link href="apps.css" type="text/css" rel="stylesheet" />
+    <link href="../../static/branding.css" rel="stylesheet" />
     <script type="text/javascript" src="../base1/cockpit.js"></script>
     <script type="text/javascript" src="../base1/po.js"></script>
     <script type="text/javascript" src="po.js"></script>

--- a/pkg/kdump/index.html
+++ b/pkg/kdump/index.html
@@ -25,6 +25,7 @@ along with Cockpit; If not, see <https://www.gnu.org/licenses/>.
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
     <link rel="stylesheet" href="kdump.css" />
+    <link href="../../static/branding.css" rel="stylesheet" />
 
     <script type="text/javascript" src="kdump.js"></script>
     <script type="text/javascript" src="../base1/po.js"></script>

--- a/pkg/metrics/index.html
+++ b/pkg/metrics/index.html
@@ -23,6 +23,7 @@ along with this package; If not, see <https://www.gnu.org/licenses/>.
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
     <link rel="stylesheet" href="index.css" />
+    <link href="../../static/branding.css" rel="stylesheet" />
 
     <script type="text/javascript" src="../base1/cockpit.js"></script>
     <script type="text/javascript" src="../manifests.js"></script>

--- a/pkg/networkmanager/index.html
+++ b/pkg/networkmanager/index.html
@@ -24,6 +24,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link href="networkmanager.css" type="text/css" rel="stylesheet" />
+  <link href="../../static/branding.css" rel="stylesheet" />
   <script src="../base1/cockpit.js"></script>
   <script src="../manifests.js"></script>
   <script src="../base1/po.js"></script>

--- a/pkg/packagekit/index.html
+++ b/pkg/packagekit/index.html
@@ -24,6 +24,7 @@ along with Cockpit; If not, see <https://www.gnu.org/licenses/>.
   <meta charset="utf-8" />
 
   <link href="updates.css" rel="stylesheet" />
+  <link href="../../static/branding.css" rel="stylesheet" />
 
   <script src="../base1/cockpit.js"></script>
   <script src="../base1/po.js"></script>

--- a/pkg/playground/index.html
+++ b/pkg/playground/index.html
@@ -5,6 +5,7 @@
     <title>Cockpit Development Playground</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link href="index.css" type="text/css" rel="stylesheet" />
+    <link href="../../static/branding.css" rel="stylesheet" />
     <script src="../base1/cockpit.js"></script>
     <script src="../manifests.js"></script>
     <script src="index.js"></script>

--- a/pkg/selinux/index.html
+++ b/pkg/selinux/index.html
@@ -25,6 +25,7 @@ along with Cockpit; If not, see <https://www.gnu.org/licenses/>.
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
     <link rel="stylesheet" href="selinux.css" />
+    <link href="../../static/branding.css" rel="stylesheet" />
 
     <script type="text/javascript" src="../base1/cockpit.js"></script>
     <script type="text/javascript" src="../base1/po.js"></script>

--- a/pkg/sosreport/index.html
+++ b/pkg/sosreport/index.html
@@ -22,6 +22,7 @@ along with Cockpit; If not, see <https://www.gnu.org/licenses/>.
     <title translate="yes">Diagnostic reports</title>
     <meta charset="utf-8" />
     <link href="sosreport.css" rel="stylesheet" />
+    <link href="../../static/branding.css" rel="stylesheet" />
     <script type="text/javascript" src="../base1/cockpit.js"></script>
     <script type="text/javascript" src="../base1/po.js"></script>
     <script type="text/javascript" src="po.js"></script>

--- a/pkg/storaged/index.html
+++ b/pkg/storaged/index.html
@@ -24,6 +24,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link href="storaged.css" type="text/css" rel="stylesheet" />
+    <link href="../../static/branding.css" rel="stylesheet" />
     <script src="../base1/cockpit.js"></script>
     <script src="../base1/po.js"></script>
     <script src="../manifests.js"></script>

--- a/pkg/systemd/index.html
+++ b/pkg/systemd/index.html
@@ -6,6 +6,7 @@
   <meta name="description" content="" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="overview.css" />
+  <link href="../../static/branding.css" rel="stylesheet" />
   <script type="text/javascript" src="../base1/cockpit.js"></script>
   <script type="text/javascript" src="../base1/po.js"></script>
   <script type="text/javascript" src="overview.js"></script>

--- a/pkg/users/index.html
+++ b/pkg/users/index.html
@@ -24,6 +24,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link href="users.css" type="text/css" rel="stylesheet" />
+    <link href="../../static/branding.css" rel="stylesheet" />
     <script src="../base1/cockpit.js"></script>
     <script src="../base1/po.js"></script>
     <script src="po.js"></script>

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -1219,6 +1219,20 @@ until pgrep -f '^(/usr/[^ ]+/[^ /]*python[^ /]* )?/usr/bin/cockpit-bridge'; do s
 
         b.wait_text("#brand", expected)
 
+        # customize branding
+        if not m.ws_container and not m.ostree_image:
+            self.write_file(f"{branddir}/branding.css", """
+    :root {
+        --pf-t--global--color--brand--default: #FF5001;
+    }""")
+            b.reload(ignore_cache=True)
+            b.login_and_go("/system", superuser=False)
+            # PF button uses PF brand color, check that
+            b.wait_visible('.ct-limited-access-alert button')
+            bgcol = b.eval_js(
+                "getComputedStyle(document.querySelector('.ct-limited-access-alert button')).backgroundColor")
+            self.assertEqual(bgcol, "rgb(255, 80, 1)")
+
     @testlib.skipOstree("tests cockpit-ws package")
     @testlib.skipWsContainer("tests cockpit-ws package")
     @testlib.nondestructive


### PR DESCRIPTION
This has no effect right now, as the only things that current branding.scss affects are the login page (`#brand` and `#badge`) and the shell (`--ct-color-host-accent`). But we want to make branding more customizable with e.g. [1], which should apply to all pages consistently.

In particular, this also allows Anaconda to customize/brand the storage page [2].

Document the possibility of customization and test this with setting `--pf-t--global--color--brand--default`.

Part of #21338

[1] https://www.patternfly.org/design-foundations/colors/#brand-colors
[2] https://github.com/rhinstaller/anaconda-webui/pull/951

## Support branding Cockpit pages

Cockpit's [branding CSS](https://github.com/cockpit-project/cockpit/blob/main/doc/branding.md) so far only applied to the Login page and the Shell. With this version it gets applied to all Cockpit pages. This allows distributors more customization possibilities, such as changing [PatternFly brand colors](https://www.patternfly.org/design-foundations/colors/#brand-colors).