### PR TITLE
ci: Use `--with-token` on `gh auth`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,7 +135,9 @@ jobs:
           git commit -m "Update to version ${{ github.ref_name }}"
           git show
           git push git@github.com:cockpit-project/org.cockpit_project.CockpitClient HEAD
-          gh auth login
+
+          echo {{ GITHUB_TOKEN }} | gh auth login --with-token
+
           gh pr create \
             --fill \
             -H cockpit-project:${{ github.ref_name }} \


### PR DESCRIPTION
This was mentioned previously while we tried using just envvar
`GITHUB_TOKEN` and `GH_TOKEN`. Neither of which worked as `gh` cli
complains that the token is set.

Since we're in CI, unsetting the token isn't ideal nor something I want
to do. But we can use a similar method to what is used elsewhere by
explicitly providing the token like this:
```bash
gh auth --with-token <TOKEN>
```

Related-to: Related-to: https://github.com/FreeTubeApp/FreeTube/blob/865a4a2ab0b61062d36a223cd52f966f9a0d4306/.github/workflows/flatpak.yml#L119-L121
Related-to: https://cli.github.com/manual/gh_auth_login
Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
