### PR TITLE
dnf5daemon support in cockpit install dialog

### DIFF
--- a/pkg/lib/_internal/dnf5daemon.ts
+++ b/pkg/lib/_internal/dnf5daemon.ts
@@ -216,7 +216,7 @@ export class Dnf5DaemonManager implements PackageManager {
             if (progress_cb) {
                 progress_cb({
                     waiting: false,
-                    absolute_percentage: 0,
+                    percentage: 0,
                     cancel: null,
                 });
             }
@@ -292,7 +292,7 @@ export class Dnf5DaemonManager implements PackageManager {
                     cancel: null,
                     info: last_info,
                     package: last_name,
-                    absolute_percentage: last_progress,
+                    percentage: last_progress,
                     waiting: false,
                 });
         }

--- a/pkg/lib/_internal/dnf5daemon.ts
+++ b/pkg/lib/_internal/dnf5daemon.ts
@@ -1,0 +1,324 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import cockpit from "cockpit";
+import { superuser } from 'superuser';
+import { InstallProgressCB, MissingPackages, PackageManager, ProgressCB, ResolveError, InstallProgressType } from './packagemanager-abstract';
+
+let _dbus_client: cockpit.DBusClient | null = null;
+
+/**
+ * Get dnf5daemon D-Bus client
+ *
+ * This will get lazily initialized and re-initialized after dnf5daemon
+ * disconnects (due to a crash or idle timeout).
+ */
+function dbus_client() {
+    if (_dbus_client === null) {
+        _dbus_client = cockpit.dbus("org.rpm.dnf.v0", { superuser: "try", track: true });
+        _dbus_client.addEventListener("close", () => {
+            console.warn("dnf5daemon went away from D-Bus");
+            _dbus_client = null;
+        });
+    }
+
+    return _dbus_client;
+}
+
+// Reconnect when privileges change
+superuser.addEventListener("changed", () => {
+    if (_dbus_client)
+        _dbus_client.close();
+    _dbus_client = null;
+});
+
+async function open_session(): Promise<string> {
+    const [session] = await call("/org/rpm/dnf/v0", "org.rpm.dnf.v0.SessionManager",
+                                 "open_session", [{}]) as string[];
+    return session;
+}
+
+function close_session(session: string) {
+    return call("/org/rpm/dnf/v0", "org.rpm.dnf.v0.SessionManager",
+                "close_session", [session]);
+}
+
+interface ListPackage {
+    arch: { t: "s", v: string }
+    download_size: { t: "t", "v": number }
+    id: { t: "i"; v: number };
+    is_installed: { t: "b"; v: boolean };
+    name: { t: "s"; v: string };
+    release: { t: "s"; v: string };
+    version: { t: "s"; v: string };
+}
+
+interface ResolvePackage {
+    arch: { t: "s"; v: string };
+    download_size: { t: "t"; v: number };
+    epoch: { t: "s"; v: string };
+    evr: { t: "s"; v: string };
+    from_repo_id: { t: "s"; v: string };
+    full_nevra: { t: "s"; v: string };
+    id: { t: "i"; v: number };
+    install_size: { t: "t"; v: number };
+    name: { t: "s"; v: string };
+    reason: { t: "s"; v: string };
+    release: { t: "s"; v: string };
+    repo_id: { t: "s"; v: string };
+    version: { t: "s"; v: string };
+}
+
+// TransactionItemType
+type object_type = "Package" | "Group" | "Environment" | "Module" | "Skipped";
+// TransactionItemAction
+type action = "Install" | "Upgrade" | "Downgrade" | "Reinstall" | "Remove" | "Replaced" | "Reset" | "Enable" | "Disable" | "Reason Change" | "Switch"
+// TransactionItemReason
+type reason = "User" | "Dependency" | "Clean" | "Group" | "None" | "Weak Dependency" | "External User"
+type TransactionItem = [
+    object_type,
+    action,
+    reason,
+    unknown,
+    ResolvePackage
+]
+
+type InstallResolveResult = [TransactionItem[], number]
+
+/**
+ * Call a dnf5daemon method
+ */
+function call(objectPath: string, iface: string, method: string, args?: unknown[], opts?: cockpit.DBusCallOptions) {
+    return dbus_client().call(objectPath, iface, method, args, opts);
+}
+
+export class Dnf5DaemonManager implements PackageManager {
+    name: string;
+
+    constructor() {
+        this.name = 'dnf5daemon';
+    }
+
+    async check_missing_packages(pkgnames: string[], progress_cb?: ProgressCB): Promise<MissingPackages> {
+        const data: MissingPackages = {
+            extra_names: [],
+            missing_ids: [],
+            missing_names: [],
+            unavailable_names: [],
+            remove_names: [],
+            download_size: 0,
+        };
+
+        if (pkgnames.length === 0)
+            return data;
+
+        async function refresh(session: string) {
+            // refresh dnf5daemon state
+            await call(session, "org.rpm.dnf.v0.Base", "read_all_repos", []);
+            const [, resolve_result] = await call(session, "org.rpm.dnf.v0.Goal", "resolve", [{}]) as [unknown[], number];
+            if (resolve_result !== 0) {
+                const [problem] = await call(session, "org.rpm.dnf.v0.Goal", "get_transaction_problems_string", []);
+                throw new ResolveError(`Resolving read_all_repos failed with result=${resolve_result} - ${problem}`);
+            }
+
+            await call(session, "org.rpm.dnf.v0.Goal", "do_transaction", [{}]);
+        }
+
+        async function resolve(session: string) {
+            const installed_names = new Set();
+            const seen_names = new Set();
+            const package_attrs = ["name", "is_installed"];
+
+            const [results] = await call(session, "org.rpm.dnf.v0.rpm.Rpm", "list", [
+                {
+                    package_attrs: { t: 'as', v: package_attrs },
+                    scope: { t: 's', v: "all" },
+                    patterns: { t: 'as', v: pkgnames }
+                }
+            ]) as ListPackage[][];
+
+            for (const pkg of results) {
+                if (seen_names.has(pkg.name.v))
+                    continue;
+
+                if (pkg.is_installed.v) {
+                    installed_names.add(pkg.name.v);
+                } else {
+                    data.missing_ids.push(pkg.id.v);
+                    data.missing_names.push(pkg.name.v);
+                }
+
+                seen_names.add(pkg.name.v);
+            }
+
+            pkgnames.forEach((name: string) => {
+                if (!installed_names.has(name) && data.missing_names.indexOf(name) == -1)
+                    data.unavailable_names.push(name);
+            });
+        }
+
+        async function simulate(session: string) {
+            if (data.missing_ids.length === 0 || data.unavailable_names.length > 0) {
+                return null;
+            }
+
+            await call(session, "org.rpm.dnf.v0.rpm.Rpm", "install", [pkgnames, {}]);
+            const [transaction_items, result] = await call(session, "org.rpm.dnf.v0.Goal", "resolve", [{}]) as InstallResolveResult;
+            if (result !== 0) {
+                const [problem] = await call(session, "org.rpm.dnf.v0.Goal", "get_transaction_problems_string", []);
+                throw new ResolveError(`Resolving install failed with result=${result}. ${problem}`);
+            }
+
+            for (const transaction_item of transaction_items) {
+                const [object_type, action, reason, _transaction_item_attributes, pkg] = transaction_item;
+                const name = pkg.name.v;
+
+                if (object_type !== "Package") {
+                    console.error(`Simulated install for ${pkgnames} resolved an unexpected object_type=${object_type}`);
+                    continue;
+                }
+
+                data.download_size += pkg.download_size.v;
+
+                if (reason == "Dependency") {
+                    if (data.missing_names.indexOf(name) == -1)
+                        data.extra_names.push(name);
+                }
+
+                if (action == "Replaced") {
+                    if (data.remove_names.indexOf(name) == -1)
+                        data.remove_names.push(name);
+                }
+            }
+
+            // Call reset() as we don't intend to complete the transaction using `do_transaction`
+            await call(session, "org.rpm.dnf.v0.Goal", "reset", []);
+        }
+
+        function signal_emitted(_path: string, _iface: string, _signal: string, _args: unknown[]) {
+            // HACK: dnf5daemon doesn't give us an useful progress indicator so the progress percentage is hardcoded to 0.
+            if (progress_cb) {
+                progress_cb({
+                    waiting: false,
+                    absolute_percentage: 0,
+                    cancel: null,
+                });
+            }
+        }
+
+        let session: string | null = null;
+        const client = dbus_client();
+        const subscription = client.subscribe({}, signal_emitted);
+
+        try {
+            session = await open_session();
+            await refresh(session);
+            await resolve(session);
+            await simulate(session);
+        } catch (err) {
+            console.warn(err);
+            throw err;
+        } finally {
+            if (session)
+                await close_session(session);
+        }
+
+        subscription.remove();
+        // HACK: close the client so subscribe matches are actually dropped. https://github.com/cockpit-project/cockpit/issues/21905
+        client.close();
+
+        return data;
+    }
+
+    async install_missing_packages(data: MissingPackages, progress_cb?: InstallProgressCB): Promise<void> {
+        if (!data || data.missing_ids.length === 0)
+            return;
+
+        let last_info: number;
+        let last_progress = 0;
+        let last_name: string;
+        let total_packages: number;
+
+        function signal_emitted(_path: string, _iface: string, signal: string, args: unknown[]) {
+            switch (signal) {
+            // download_add_new(o session_object_path, s download_id, s description, x total_to_download)
+            case 'download_add_new': {
+                last_info = InstallProgressType.DOWNLOADING;
+                last_name = args[2] as string;
+                break;
+            }
+            // download_progress(o session_object_path, s download_id, x total_to_download, x downloaded)
+            case 'download_progress': {
+                last_info = InstallProgressType.DOWNLOADING;
+                break;
+            }
+            // download_end(o session_object_path, s download_id, u transfer_status, s message)
+            case 'download_end':
+                last_info = 0;
+                last_name = "";
+                break;
+            // transaction_before_begin(o session_object_path, t total)
+            case 'transaction_before_begin':
+                [, total_packages] = args as [string, number];
+                last_info = InstallProgressType.INSTALLING;
+                break;
+            // transaction_elem_progress(o session_object_path, s nevra, t processed, t total)
+            case 'transaction_elem_progress': {
+                let processed = 0;
+                [, last_name, processed,] = args as [string, string, number, number];
+                last_progress = processed / total_packages * 100;
+                break;
+            }
+            }
+
+            if (progress_cb)
+                progress_cb({
+                    cancel: null,
+                    info: last_info,
+                    package: last_name,
+                    absolute_percentage: last_progress,
+                    waiting: false,
+                });
+        }
+
+        const client = dbus_client();
+        const subscription = client.subscribe({}, signal_emitted);
+        let session: string | null = null;
+
+        try {
+            session = await open_session();
+            await call(session, "org.rpm.dnf.v0.rpm.Rpm", "install", [data.missing_names, {}]);
+            const [, resolve_result] = await call(session, "org.rpm.dnf.v0.Goal", "resolve", [{}]);
+
+            if (resolve_result !== 0) {
+                const [problem] = await call(session, "org.rpm.dnf.v0.Goal", "get_transaction_problems_string", []);
+                throw new ResolveError(`Resolving install failed with result=${resolve_result} ${problem}`);
+            }
+            await call(session, "org.rpm.dnf.v0.Goal", "do_transaction", [{}]);
+        } catch (err) {
+            console.warn("install error", err);
+        } finally {
+            if (session)
+                await close_session(session);
+        }
+
+        subscription.remove();
+        client.close();
+    }
+}

--- a/pkg/lib/_internal/packagekit.ts
+++ b/pkg/lib/_internal/packagekit.ts
@@ -1,0 +1,54 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { InstallProgressCB, MissingPackages, PackageManager, ProgressCB, InstallProgressType, InstallProgressData } from './packagemanager-abstract';
+import * as PK from "packagekit.js";
+
+const InstallProgressMap = {
+    [PK.Enum.INFO_DOWNLOADING]: InstallProgressType.DOWNLOADING,
+    [PK.Enum.INFO_UPDATING]: InstallProgressType.UPDATING,
+    [PK.Enum.INFO_REMOVING]: InstallProgressType.REMOVING,
+    [PK.Enum.INFO_INSTALLING]: InstallProgressType.INSTALLING,
+    [PK.Enum.INFO_REINSTALLING]: InstallProgressType.REINSTALLING,
+    [PK.Enum.INFO_DOWNGRADING]: InstallProgressType.DOWNGRADING,
+};
+
+export class PackageKitManager implements PackageManager {
+    name: string;
+
+    constructor() {
+        this.name = "packagekit";
+    }
+
+    async check_missing_packages(pkgnames: string[], progress_cb?: ProgressCB): Promise<MissingPackages> {
+        return PK.check_missing_packages(pkgnames, progress_cb);
+    }
+
+    async install_missing_packages(data: MissingPackages, progress_cb?: InstallProgressCB): Promise<void> {
+        // Maps PackageKit state to our own PackageManager state temporary
+        // until all pkg/lib/packagekit use cases are supported by the PackageManager abstraction.
+        function convert_progress_cb(data: InstallProgressData) {
+            data.info = InstallProgressMap[data.info];
+            if (progress_cb)
+                progress_cb(data);
+        }
+
+        return PK.install_missing_packages(data, convert_progress_cb);
+    }
+}

--- a/pkg/lib/_internal/packagemanager-abstract.ts
+++ b/pkg/lib/_internal/packagemanager-abstract.ts
@@ -1,0 +1,92 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <https://www.gnu.org/licenses/>.
+ */
+
+export interface ProgressData {
+    // PackageManager waits on a lock or another operation to finish
+    waiting: boolean
+    // If not null, the operation can be cancelled
+    cancel?: (() => void) | null
+    // Transaction percentage
+    absolute_percentage: number
+}
+
+export type ProgressCB = (data: ProgressData) => void;
+export interface InstallProgressData extends ProgressData {
+    // One of the Enum states
+    info: number
+    // Package being downloaded or installed
+    package: string
+}
+
+export type InstallProgressCB = (data: InstallProgressData) => void;
+
+export interface MissingPackages {
+    // Packages that were requested, are currently not installed, and can be installed
+    missing_names: string[]
+    // The full package IDs corresponding to missing_names (the ID format is backend specific)
+    missing_ids: number[]
+    // Packages that were requested, are currently not installed, but can't be found in any repository
+    unavailable_names: string[]
+
+    // If unavailable_names is empty, a simulated installation of the missing packages
+    // is done and the result also contains these fields:
+
+    // Packages that need to be installed as dependencies of missing_names
+    extra_names: string[]
+    // Packages that need to be removed
+    remove_names: string[]
+    // Bytes that need to be downloaded
+    download_size: number
+}
+
+export enum InstallProgressType {
+    DOWNLOADING,
+    UPDATING,
+    INSTALLING,
+    REMOVING,
+    REINSTALLING,
+    DOWNGRADING,
+}
+
+export interface PackageManager {
+  name: string
+  check_missing_packages(pkgnames: string[], progress_cb?: ProgressCB): Promise<MissingPackages>;
+  install_missing_packages(data: MissingPackages, progress_cb?: InstallProgressCB): Promise<void>;
+}
+
+export class UnsupportedError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "UnsupportedError";
+    }
+}
+
+export class NotFoundError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "NotFoundError";
+    }
+}
+
+export class ResolveError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "ResolveError";
+    }
+}

--- a/pkg/lib/_internal/packagemanager-abstract.ts
+++ b/pkg/lib/_internal/packagemanager-abstract.ts
@@ -23,7 +23,7 @@ export interface ProgressData {
     // If not null, the operation can be cancelled
     cancel?: (() => void) | null
     // Transaction percentage
-    absolute_percentage: number
+    percentage: number
 }
 
 export type ProgressCB = (data: ProgressData) => void;

--- a/pkg/lib/cockpit.d.ts
+++ b/pkg/lib/cockpit.d.ts
@@ -237,6 +237,12 @@ declare module 'cockpit' {
         [property: string]: unknown;
     }
 
+    interface DBusClientEvents extends EventMap {
+        notify(data: unknown): void;
+        meta(data: unknown): void;
+        owner(owner: string): void;
+    }
+
     interface DBusOptions {
         bus?: string;
         address?: string;
@@ -258,7 +264,7 @@ declare module 'cockpit' {
         wait(callback?: () => void): Promise<void>;
     }
 
-    interface DBusClient {
+    interface DBusClient extends EventSource<DBusClientEvents> {
         readonly unique_name: string;
         readonly options: DBusOptions;
         proxy(interface?: string, path?: string, options?: { watch?: boolean }): DBusProxy;

--- a/pkg/lib/packagekit.js
+++ b/pkg/lib/packagekit.js
@@ -234,7 +234,7 @@ export function cancellableTransaction(method, arglist, progress_cb, signalHandl
         let allow_wait_status = false;
         const progress_data = {
             waiting: false,
-            absolute_percentage: 0,
+            percentage: 0,
             cancel: null
         };
 
@@ -251,7 +251,7 @@ export function cancellableTransaction(method, arglist, progress_cb, signalHandl
                 if ("AllowCancel" in props)
                     progress_data.cancel = props.AllowCancel ? cancel : null;
                 if ("Percentage" in props && props.Percentage <= 100)
-                    progress_data.absolute_percentage = props.Percentage;
+                    progress_data.percentage = props.Percentage;
 
                 progress_cb(progress_data);
             }

--- a/pkg/lib/packagekit.js
+++ b/pkg/lib/packagekit.js
@@ -313,6 +313,7 @@ export function cancellableTransaction(method, arglist, progress_cb, signalHandl
  */
 
 export function check_missing_packages(names, progress_cb) {
+    const install_ids = [];
     const data = {
         missing_ids: [],
         missing_names: [],
@@ -354,8 +355,6 @@ export function check_missing_packages(names, progress_cb) {
     }
 
     function simulate(data) {
-        data.install_ids = [];
-        data.remove_ids = [];
         data.extra_names = [];
         data.remove_names = [];
 
@@ -367,11 +366,10 @@ export function check_missing_packages(names, progress_cb) {
                                               Package: (info, package_id) => {
                                                   const name = package_id.split(";")[0];
                                                   if (info == Enum.INFO_REMOVING) {
-                                                      data.remove_ids.push(package_id);
                                                       data.remove_names.push(name);
                                                   } else if (info == Enum.INFO_INSTALLING ||
                                                              info == Enum.INFO_UPDATING) {
-                                                      data.install_ids.push(package_id);
+                                                      install_ids.push(package_id);
                                                       if (data.missing_names.indexOf(name) == -1)
                                                           data.extra_names.push(name);
                                                   }
@@ -390,9 +388,9 @@ export function check_missing_packages(names, progress_cb) {
 
     function get_details(data) {
         data.download_size = 0;
-        if (data.install_ids.length > 0) {
+        if (install_ids.length > 0) {
             return cancellableTransaction("GetDetails",
-                                          [data.install_ids],
+                                          [install_ids],
                                           progress_cb,
                                           {
                                               Details: details => {

--- a/pkg/lib/packagemanager.ts
+++ b/pkg/lib/packagemanager.ts
@@ -1,0 +1,84 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import cockpit from 'cockpit';
+
+import { PackageManager, InstallProgressType, UnsupportedError, NotFoundError } from './_internal/packagemanager-abstract';
+import { Dnf5DaemonManager } from './_internal/dnf5daemon';
+import { PackageKitManager } from './_internal/packagekit';
+
+function debug(...args: unknown[]) {
+    if (window.debugging == 'all' || window.debugging?.includes('packagemanager'))
+        console.debug('packagemanager', ...args);
+}
+
+async function is_immutable_os() {
+    try {
+        const options = await cockpit.spawn(["findmnt", "-T", "/usr", "-n", "-o", "VFS-OPTIONS"]);
+        return options.split(",").indexOf("ro") >= 0;
+    } catch (err) {
+        debug("Unable to detect immutable OS", err);
+        return false;
+    }
+}
+
+async function detect_dnf5daemon() {
+    try {
+        const client = cockpit.dbus("org.rpm.dnf.v0", { superuser: "try" });
+        await client.call("/org/rpm/dnf/v0", "org.freedesktop.DBus.Peer", "Ping", []);
+        return true;
+    } catch (err) {
+        debug("dnf5daemon not supported", err);
+        return false;
+    }
+}
+
+async function detect_packagekit() {
+    try {
+        const client = cockpit.dbus("org.freedesktop.PackageKit", { superuser: "try" });
+        await client.call("/org/freedesktop/PackageKit", "org.freedesktop.DBus.Properties",
+                          "Get", ["org.freedesktop.PackageKit", "VersionMajor"]);
+        return true;
+    } catch (err) {
+        debug("PackageKit not supported", err);
+        return false;
+    }
+}
+
+// Cache result for a session
+export async function getPackageManager(): Promise<PackageManager> {
+    const [unsupported, has_dnf5daemon, has_packagekit] = await Promise.all([is_immutable_os(), detect_dnf5daemon(), detect_packagekit()]);
+
+    if (unsupported)
+        throw new UnsupportedError("Cockpit does not support installing additional packages on immutable operating systems");
+
+    if (has_dnf5daemon) {
+        debug("constructing dnf5daemon");
+        return Promise.resolve(new Dnf5DaemonManager());
+    }
+
+    if (has_packagekit) {
+        debug("constructing packagekit");
+        return Promise.resolve(new PackageKitManager());
+    }
+
+    throw new NotFoundError("No package manager found");
+}
+
+export { InstallProgressType };

--- a/pkg/networkmanager/dialogs-common.jsx
+++ b/pkg/networkmanager/dialogs-common.jsx
@@ -19,7 +19,7 @@
 
 import React, { useContext, useEffect, useState } from 'react';
 import cockpit from 'cockpit';
-import * as packagekit from 'packagekit.js';
+import { getPackageManager } from "packagemanager";
 
 import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
 import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox/index.js";
@@ -202,12 +202,16 @@ export const NetworkAction = ({ buttonText, iface, connectionSettings, type }) =
             try {
                 await cockpit.script("command -v wg");
             } catch {
-                const packagekitExits = await packagekit.detect();
                 const os_release = await read_os_release();
 
-                // RHEL 8 does not have wireguard-tools
-                if (packagekitExits && os_release.PLATFORM_ID !== "platform:el8")
-                    await install_dialog("wireguard-tools");
+                try {
+                    await getPackageManager();
+                    // RHEL 8 does not have wireguard-tools
+                    if (os_release.PLATFORM_ID !== "platform:el8")
+                        await install_dialog("wireguard-tools");
+                } catch (exc) {
+                    console.log("no package manager support");
+                }
             }
         }
     }

--- a/pkg/systemd/overview-cards/realmd.jsx
+++ b/pkg/systemd/overview-cards/realmd.jsx
@@ -37,8 +37,8 @@ import { superuser } from "superuser";
 import { useEvent } from "hooks.js";
 import { FormHelper } from "cockpit-components-form-helper";
 import { install_dialog } from "cockpit-components-install-dialog.jsx";
-import * as packagekit from "packagekit.js";
 import { useDialogs } from "dialogs.jsx";
+import { getPackageManager } from 'packagemanager';
 
 import "./realmd.scss";
 
@@ -68,13 +68,12 @@ export class RealmdClient {
     onClose(ev, options) {
         if (options.problem === "not-found") {
             // see if we can install it
-            packagekit.detect().then(exists => {
-                if (exists) {
-                    this.error = _("Joining a domain requires installation of realmd");
-                    this.install_realmd = true;
-                } else {
-                    this.error = _("Cannot join a domain because realmd is not available on this system");
-                }
+            getPackageManager().then(() => {
+                this.error = _("Joining a domain requires installation of realmd");
+                this.install_realmd = true;
+                this.dispatchEvent("changed");
+            }).catch(exc => {
+                this.error = _("Cannot join a domain because realmd is not available on this system");
                 this.dispatchEvent("changed");
             });
         } else {

--- a/test/common/packagelib.py
+++ b/test/common/packagelib.py
@@ -154,6 +154,7 @@ Server = file://{empty_repo_dir}
                       content: Mapping[str, Mapping[str, str] | str] | None = None,
                       arch: str | None = None, provides: str | None = None,
                       conflicts: str | None = None,
+                      obsoletes: str | None = None,
                       **updateinfo: str | list[str]) -> None:
         """Create a dummy package in repo_dir on self.machine
 
@@ -169,7 +170,7 @@ Server = file://{empty_repo_dir}
                                  arch=arch, provides=provides, conflicts=conflicts)
         else:
             self.createRpm(name, version, release, depends, postinst, install=install, content=content,
-                           arch=arch, provides=provides, conflicts=conflicts)
+                           arch=arch, provides=provides, conflicts=conflicts, obsoletes=obsoletes)
         if updateinfo:
             self.updateInfo[name, version, release] = updateinfo
 
@@ -234,6 +235,7 @@ Description: dummy {name}
                   content: Mapping[str, Mapping[str, str] | str] | None = None,
                   arch: str | None = None,
                   provides: str | None = None,
+                  obsoletes: str | None = None,
                   conflicts: str | None = None) -> None:
         """Create a dummy rpm in repo_dir on self.machine
 
@@ -249,6 +251,7 @@ Description: dummy {name}
 
         conflicts = f"Conflicts: {conflicts}\n" if conflicts is not None else ""
         provides = f"Provides: {provides}\n" if provides is not None else ""
+        obsoletes = f"Obsoletes: {obsoletes}\n" if obsoletes is not None else ""
 
         if arch is None:
             arch = self.primary_arch
@@ -276,6 +279,7 @@ License: BSD
 {architecture}
 {requires}
 {conflicts}
+{obsoletes}
 
 %define _build_id_links none
 

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1373,7 +1373,8 @@ class TestMetricsPackages(packagelib.PackageCase):
         self.createPackage("pcp", "999", "1", content=pcp_content, postinst="systemctl daemon-reload")
         self.createPackage(redis_package, "999", "1", content=redis_content, postinst="systemctl daemon-reload")
         self.enableRepo()
-        m.execute("pkcon refresh")
+        if self.backend != "dnf5":
+            m.execute("pkcon refresh")
 
         # install c-pcp from the empty state
         self.login_and_go("/metrics")

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1898,12 +1898,30 @@ class TestInstallDialog(NoSubManCase):
         b.wait_text("#dialog .scale-up-ct", "Additional packages:test-webengine")
         self.install_packages()
 
-        # Test conflicting packages are shown as removed
-        self.show_install_dialog("breaking-software")
-        b.wait_in_text("#dialog", "breaking-software will be installed.")
-        # The svg icon creates a tiny bit of whitespace
-        b.wait_text("#dialog .scale-up-ct", " Removals:ok-software")
-        self.install_packages()
+        if self.backend != "dnf5":
+            # Test conflicting packages are shown as removed
+            self.show_install_dialog("breaking-software")
+            b.wait_in_text("#dialog", "breaking-software will be installed.")
+            # The svg icon creates a tiny bit of whitespace
+            b.wait_text("#dialog .scale-up-ct", " Removals:ok-software")
+            self.install_packages()
+        else:
+            # package which is replaced with another package
+            self.createPackage("good-software", "998", "1", install=True)
+            self.createPackage("awesome-software", "999", "1", provides="good-software = 999", obsoletes="good-software < 999")
+            self.enableRepo()
+
+            self.show_install_dialog("awesome-software")
+            b.wait_in_text("#dialog", "awesome-software will be installed.")
+            # The svg icon creates a tiny bit of whitespace
+            b.wait_text("#dialog .scale-up-ct", " Removals:good-software")
+            self.install_packages()
+
+            # Conflicting packages require setting `allow_erasing`.
+            self.show_install_dialog("breaking-software")
+            b.wait_in_text("#dialog", "breaking-software will be installed.")
+            b.wait_in_text("#dialog .pf-v6-c-alert__title", "Resolving install failed with result=2")
+            b.wait_in_text("#dialog .pf-v6-c-alert__title", "installed package ok-software-998-1.noarch conflicts with ok-software provided by breaking-software-999")
 
 
 if __name__ == '__main__':

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -1167,7 +1167,9 @@ class TestPackageInstall(packagelib.PackageCase):
 
         m.execute("dpkg --purge realmd 2>/dev/null || rpm --erase realmd || dnf remove -y realmd")
 
-        # case 1: disable PackageKit
+        # case 1: disable package backend
+        if self.backend == 'dnf5':
+            m.execute("systemctl mask dnf5daemon-server; systemctl stop dnf5daemon-server.service || true")
         m.execute("systemctl mask packagekit; systemctl stop packagekit.service || true")
         self.allow_browser_errors('checkRealm failed.*"problem":"not-found"')
         self.login_and_go("/system")
@@ -1176,7 +1178,9 @@ class TestPackageInstall(packagelib.PackageCase):
         self.waitTooltip("realmd is not available on this system")
         b.logout()
 
-        # case 2: enable PackageKit, but no realmd package available
+        # case 2: enable package backend, but no realmd package available
+        if self.backend == 'dnf5':
+            m.execute("systemctl unmask dnf5daemon-server")
         m.execute("systemctl unmask packagekit")
         self.login_and_go("/system")
         # Joining a domain should bring up the install dialog
@@ -1194,7 +1198,8 @@ class TestPackageInstall(packagelib.PackageCase):
         # case 3: provide an available realmd package
         self.createPackage("realmd", "1", "1", content={"/realmd-stub": ""})
         self.enableRepo()
-        m.execute("pkcon refresh")
+        if self.backend != 'dnf5':
+            m.execute("pkcon refresh")
 
         self.login_and_go("/system")
 

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -123,6 +123,9 @@ Requires: cockpit-system
 # Optional components
 Recommends: (cockpit-storaged if udisks2)
 Recommends: (cockpit-packagekit if dnf)
+%if 0%{?suse_version} == 0
+Recommends: (dnf5-daemonserver if dnf5)
+%endif
 Suggests: python3-pcp
 
 %if 0%{?rhel} == 0
@@ -321,7 +324,6 @@ Provides: cockpit-users = %{version}-%{release}
 Requires: NetworkManager >= 1.6
 Requires: sos
 Requires: sudo
-Recommends: PackageKit
 Recommends: setroubleshoot-server >= 3.3.3
 Recommends: /usr/bin/kdumpctl
 Suggests: NetworkManager-team


### PR DESCRIPTION
Some things left for discussion:

* [x] make cockpit recommends dnf5deamon-server, afaik it is not installed by default. (nor is packagekit, but I guess most people have it via cockpit-packagekit)
* [x] Cache getPackageManager result? (Needs to re-act on superuser changes)
* [ ] Difference in allow_erasing from PackageKit

Depends on:
* [x] https://github.com/cockpit-project/cockpit/pull/22426



cockpit-packagekit page will now prefer dnf5daemon for these parts, but it won't depend on dnf5daemon-server. This is kinda akward
```
pkg/packagekit/autoupdates.jsx:import { install_dialog } from "cockpit-components-install-dialog.jsx";
pkg/packagekit/kpatch.jsx:import { install_dialog } from "cockpit-components-install-dialog.jsx";
```

### Allow erasing problem

PackageKit by default seems to enable `allow_erasing`, while dnf5daemon does not.

<img width="821" height="282" alt="image" src="https://github.com/user-attachments/assets/1bd7951f-ed1f-4341-a04a-cdf657fe2bd4" />

```
[root@fedora-43-127-0-0-2-2201 ~]# pkcon install breaking-software                                                                                          17:05:51 [45/62]
Resolving                               [=========================]
Finished                                [                         ] (0%)
The following packages have to be installed:
 breaking-software-999-1.noarch dummy breaking-software
The following packages have to be removed:
 ok-software-998-1.noarch       dummy ok-software
Proceed with changes? [N/y] N
```

```
[root@fedora-43-127-0-0-2-2201 ~]# dnf install --allowerasing breaking-software
Updating and loading repositories:
Repositories loaded.
Package                                                   Arch          Version                                                   Repository                            Size
Removing dependent packages:
 ok-software                                              noarch        998-1                                                     <unknown>                          0.0   B
Installing:
 breaking-software                                        noarch        999-1                                                     updates                            0.0   B

Transaction Summary:
 Installing:         1 package
 Removing:           1 package

Total size of inbound packages is 7 KiB. Need to download 7 KiB.
After this operation, 0 B extra will be used (install 0 B, remove 0 B).
Is this ok [y/N]: n
```

Easily supported with:

```
diff --git a/pkg/lib/_internal/dnf5daemon.ts b/pkg/lib/_internal/dnf5daemon.ts
index 1171a324a..76f59fd06 100644
--- a/pkg/lib/_internal/dnf5daemon.ts
+++ b/pkg/lib/_internal/dnf5daemon.ts
@@ -178,7 +178,7 @@ export class Dnf5DaemonManager implements PackageManager {
             }

             await call(session, "org.rpm.dnf.v0.rpm.Rpm", "install", [pkgnames, {}]);
-            const [transaction_items, result] = await call(session, "org.rpm.dnf.v0.Goal", "resolve", [{}]) as InstallResolveResult;
+            const [transaction_items, result] = await call(session, "org.rpm.dnf.v0.Goal", "resolve", [{ allow_erasing: { t: 'b', v: true } }]) as InstallResolveResult;
             if (result !== 0) {
                 const [problem] = await call(session, "org.rpm.dnf.v0.Goal", "get_transaction_problems_string", []);
                 throw new ResolveError(`Resolving install failed with result=${result}. ${problem}`);
@@ -298,7 +298,7 @@ export class Dnf5DaemonManager implements PackageManager {
         try {
             session = await open_session();
             await call(session, "org.rpm.dnf.v0.rpm.Rpm", "install", [data.missing_names, {}]);
-            const [, resolve_result] = await call(session, "org.rpm.dnf.v0.Goal", "resolve", [{}]);
+            const [, resolve_result] = await call(session, "org.rpm.dnf.v0.Goal", "resolve", [{ allow_erasing: { t: 'b', v: true } }]);

             if (resolve_result !== 0) {
                 const [problem] = await call(session, "org.rpm.dnf.v0.Goal", "get_transaction_problems_string", []);
```
