### PR TITLE
test: Fix udisks version comparison

### DIFF
--- a/test/verify/check-storage-smart
+++ b/test/verify/check-storage-smart
@@ -28,7 +28,7 @@ class TestStorageSmart(storagelib.StorageSmartCase):
 
     def udisks_mock_smart_supported(self):
         m = self.machine
-        # udisks2 version > 2.10.1 is required to mock SMART data on virtual disks
+        # udisks2 version > 2.10.90 is required to mock SMART data on virtual disks
         if m.image.startswith("fedora") or m.image.startswith("rhel") or m.image.startswith("centos"):
             version_str = self.machine.execute("rpm -q udisks2 --qf '%{NAME} %{VERSION}\n'").strip()
         elif m.image.startswith("debian") or m.image.startswith("ubuntu"):
@@ -40,7 +40,7 @@ class TestStorageSmart(storagelib.StorageSmartCase):
 
         version = tuple(int(v) for v in version_str.split()[1].split('-')[0].split('.'))
 
-        return version > (2, 10, 1)
+        return version > (2, 10, 90)
 
     def has_new_libblockdev(self):
         m = self.machine


### PR DESCRIPTION
udisks 2.10.x only gets selected bug fixes [1], it does not (and probably will not) get the SMART mocking. That's only for the next minor release. 2.10.90 is the first beta which should work.

[1] https://github.com/storaged-project/udisks/commits/2.10.x-branch/

---

Fixes https://github.com/cockpit-project/bots/pull/8199