### PR TITLE
test: drop RHEL 10 container firewall workaround

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -69,11 +69,6 @@ systemctl start firewalld
 firewall-cmd --add-service=cockpit --permanent
 firewall-cmd --add-service=cockpit
 
-# HACK: https://bugzilla.redhat.com/show_bug.cgi?id=2273078
-if grep -q platform:el10 /etc/os-release; then
-    export NETAVARK_FW=nftables
-fi
-
 # HACK: unbreak subuid assignment for new users; see
 # https://bugzilla.redhat.com/show_bug.cgi?id=2382662
 # https://issues.redhat.com/browse/RHEL-103765

--- a/test/vm.install
+++ b/test/vm.install
@@ -56,11 +56,6 @@ if [ "${PLATFORM_ID#platform:el}" != "$PLATFORM_ID" ]; then
     echo 'Defaults secure_path = /sbin:/usr/sbin:/usr/local/bin:/bin:/usr/bin' > /etc/sudoers.d/usr-local
 fi
 
-if [ "$PLATFORM_ID" = "platform:el10" ]; then
-    # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=2273078
-    printf  '[network]\nfirewall_driver = "nftables"\n' > /etc/containers/containers.conf
-fi
-
 # HACK: unbreak subuid assignment for current and new users; see
 # https://bugzilla.redhat.com/show_bug.cgi?id=2382662
 # https://issues.redhat.com/browse/RHEL-103765


### PR DESCRIPTION
This was fixed in Fedora-41 and CentOS/RHEL 10.