### PR TITLE
test: Fix race condition in TestStorageU{,nu}sed.testUnused

### DIFF
--- a/test/verify/check-storage-unused
+++ b/test/verify/check-storage-unused
@@ -50,6 +50,7 @@ mkpart logical ext2 2 24 \
 mkpart logical ext2 24 48"""
         m.execute(f"parted -s {disk1} {script}")
         m.execute("udevadm settle")
+        m.execute(f"until udevadm info --query=all {disk1}5 | grep -q ID_PART_TABLE_TYPE=dos; do sleep 0.1; done")
         m.execute(f"mke2fs -q -L TEST {disk1}5")
 
         b.eval_js("""

--- a/test/verify/check-storage-used
+++ b/test/verify/check-storage-used
@@ -35,9 +35,12 @@ class TestStorageUsed(storagelib.StorageCase):
         m.execute(f"parted -s {disk} mktable msdos")
         m.execute(f"parted -s {disk} mkpart primary ext2 1M 25")
         m.execute("udevadm settle")
+        m.execute(f"until udevadm info --query=all {disk} | grep -q ID_PART_TABLE_TYPE=dos; do sleep 0.1; done")
         m.execute(f"echo einszweidrei | cryptsetup luksFormat --pbkdf-memory 32768 {disk}1")
         m.execute(f"echo einszweidrei | cryptsetup luksOpen {disk}1 dm-test")
         m.execute("udevadm settle")
+        m.execute("until [ -b /dev/mapper/dm-test ]; do sleep 0.1; done")
+        m.execute("until udevadm info --query=all /dev/mapper/dm-test | grep -q DM_NAME=dm-test; do sleep 0.1; done")
         m.execute("mke2fs -q -L TEST /dev/mapper/dm-test")
         m.execute(f"mount /dev/mapper/dm-test {self.mnt_dir}")
 


### PR DESCRIPTION
The block device isn't immediately read for use after parted. We need to wait for it to be present *and* scanned by udev, otherwise mkfs/cryptsetup reject it.

Fixes 75% test failure on our CI.


----

That's our worst [weather report cloud provider](https://ci-weather-cockpit.apps.ocp.cloud.ci.centos.org/tests.html?repo=cockpit-project%2Fcockpit&days=7&test=test%2Fverify%2Fcheck-storage-unused+TestStorageUnused.testUnused):

<img width="618" height="176" alt="image" src="https://github.com/user-attachments/assets/146912ad-c080-47db-a321-613454718434" />

[example log](https://logs-cockpit.apps.ocp.cloud.ci.centos.org/pull-20060-e56e3023-20250904-094416-debian-testing-storage/log.html)
