### PR TITLE
css: Fix PF dropdown elements not being accessible

### DIFF
--- a/pkg/lib/cockpit-components-dropdown.tsx
+++ b/pkg/lib/cockpit-components-dropdown.tsx
@@ -47,6 +47,22 @@ export const KebabDropdown = ({ dropdownItems, position = "end", isDisabled = fa
     const isKebabOpen = isOpen ?? isKebabOpenInternal;
     const setKebabOpen = setIsOpen ?? setKebabOpenInternal;
 
+    /**
+     * Try to find parent Page section to append dropdown to. If we can't find it, use the default `document.body`.
+     * This is a temporary workaround to fix scrolling within iframes whenever the dropdown itself expands past the
+     * page content.
+     *
+     * To reproduce behavior:
+     *   1. Open a page with a dropdown button near the bottom of the page, like Users.
+     *   2. Resize window to make the page content height constrained.
+     *   3. Open dropdown actions for bottom user and scroll up and down.
+     *   4. Dropdown should move to be above and below the button, you should be able to scroll to see all actions.
+     *
+     * Remove once Patternfly makes it possible to use PopperJS offset function prop.
+     * @link https://github.com/patternfly/patternfly-react/issues/11987
+     * */
+    const appendTo: HTMLElement = document.querySelector(".pf-v6-c-page__main-section") || document.body;
+
     return (
         <Dropdown
             onOpenChange={isOpen => setKebabOpen(isOpen)}
@@ -64,7 +80,7 @@ export const KebabDropdown = ({ dropdownItems, position = "end", isDisabled = fa
                 </MenuToggle>
             )}
             isOpen={isKebabOpen}
-            popperProps={{ position }}
+            popperProps={{ position, appendTo }}
         >
             <DropdownList>
                 {dropdownItems}

--- a/pkg/lib/patternfly/patternfly-6-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-6-overrides.scss
@@ -365,3 +365,10 @@ $phone: 767px;
 .pf-v6-c-table .pf-v6-c-table__tbody :where(.pf-v6-c-table__th, .pf-v6-c-table__td)[data-label]::before {
     font-weight: var(--pf-t--global--font--weight--body--bold);
 }
+
+// HACK: Setting position relative helps ensure that absolute elements like
+// PF's dropdown will increase the scrollable area to see all the dropdown actions.
+// https://github.com/patternfly/patternfly-react/issues/11987
+.pf-v6-c-page__main-section {
+  position: relative;
+}

--- a/pkg/storaged/storage-controls.jsx
+++ b/pkg/storaged/storage-controls.jsx
@@ -258,12 +258,29 @@ export const StorageBarMenu = ({ label, isKebab, menuItems }) => {
         </MenuToggle>
     );
 
+    /**
+     * Try to find parent Page section to append dropdown to. If we can't find it, use the default `document.body`.
+     * This is a temporary workaround to fix scrolling within iframes whenever the dropdown itself expands past the
+     * page content.
+     *
+     * To reproduce behavior:
+     *   1. Open a page with a dropdown button near the bottom of the page, like Storage -> btrfs subvolume
+     *   2. Resize window to make the page content height constrained.
+     *   3. Open dropdown and scroll up and down
+     *   4. Dropdown should move to be above and below the button, you should be able to scroll to see all actions.
+     *
+     * Remove once Patternfly makes it possible to use PopperJS offset function prop.
+     * @link https://github.com/patternfly/patternfly-react/issues/11987
+     * @type HTMLElement
+     * */
+    const appendTo = document.querySelector(".pf-v6-c-page__main-section") || document.body;
+
     return (
         <Dropdown isOpen={isOpen}
                   onSelect={onSelect}
                   onOpenChange={isOpen => setIsOpen(isOpen)}
                   toggle={toggle}
-                  popperProps={{ position: "right" }}
+                  popperProps={{ position: "right", appendTo }}
                   shouldFocusToggleOnSelect>
             {menuItems}
         </Dropdown>);

--- a/test/verify/check-networkmanager-basic
+++ b/test/verify/check-networkmanager-basic
@@ -307,7 +307,7 @@ class TestNetworkingBasic(netlib.NetworkCase):
         b.enter_page("/system/services")
         b.wait_text(".service-name", "Network Manager")
         b.click(".service-top-panel button.pf-v6-c-menu-toggle")
-        b.click("#services-page > .pf-v6-c-menu .pf-v6-c-menu__list-item:contains('Start') button")
+        b.click("#services-page .pf-v6-c-menu .pf-v6-c-menu__list-item:contains('Start') button")
         b.wait_in_text("#statuses", "Running")
 
         # networking page should notice start from Services page

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -42,7 +42,7 @@ def performUserAction(browser, user, action):
 
 def performGroupAction(browser, group, action):
     browser.click(f"#groups-list tbody tr:contains({group}) button.pf-v6-c-menu-toggle")
-    browser.click(f"body > .pf-v6-c-menu .pf-v6-c-menu__list-item:contains({action}) button")
+    browser.click(f".pf-v6-c-menu .pf-v6-c-menu__list-item:contains({action}) button")
 
 
 def createUser(


### PR DESCRIPTION
For Patternfly's dropdown it uses PopperJS v2 under the hood, however it
does not work well within iframes with super small sizes where there is no
room to show the whole dropdown. Fixing this temporarily by making the
dropdown increase the page main sections height so that the dropdown
elements can all be accessed by scrolling.

Note, once a PF update is released with the PopperJS offset prop being
exposed we can use a better solution that relies on setting our own
offset.

How the fix looks in action:

[Kooha-2025-09-03-16-23-53.webm](https://github.com/user-attachments/assets/9c9cc0d9-8a35-49f1-96e2-916e81efcea6)

`el.querySelector` returns `null` if the query is valid and no elements were found:
https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector#return_value

Related-to: https://github.com/patternfly/patternfly-react/issues/11987
Related-to: https://github.com/cockpit-project/cockpit/pull/22381
Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
