### PR TITLE
storage: anaconda: dropdown menus hidden behind non-scrollable content

### DIFF
--- a/pkg/storaged/storage-anaconda.scss
+++ b/pkg/storaged/storage-anaconda.scss
@@ -19,3 +19,15 @@
     --pf-v6-c-card--BorderColor: transparent;
   }
 }
+
+body:has(.anaconda) {
+  // HACK - https://github.com/patternfly/patternfly-react/issues/11987
+  // Allow scrolling if a dropdown menu gets positioned outside the bounds of the window.
+  // This is easier to reproduce on 1080p or lower resolutions
+  // remove this once the proper fix is implemented on PF and the rest of cockpit
+  // (see https://bugzilla.redhat.com/show_bug.cgi?id=2388785)
+  overflow-y: auto !important;
+  // containers like pf-v6-c-page won't expand with the viewport when dropdown menus are created
+  // on lower resolutions, so we force all background to match the default
+  background: var(--pf-t--global--background--color--primary--default);
+}


### PR DESCRIPTION
Fix an edge case where the dropdown menus for modifying partitions get hidden under certain conditions[1]. This fixes a blocker for Fedora 43[2].

Opening as a different PR as #22381 would depend on changes on upstream Patternfly and #22413 can't be merged yet[3].

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=2388785
[2]: https://pagure.io/fedora-qa/blocker-review/issue/1873
[3]:  https://github.com/cockpit-project/cockpit/pull/22413#pullrequestreview-3200622748

Resolves: INSTALLER-4272