### PR TITLE
testlib: Fix compatibility with current pytest; some small packaging tweaks

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1731,13 +1731,17 @@ class MachineCase(unittest.TestCase):
             result = self.defaultTestResult()
             errors = result.errors
             self._feedErrorsToResult(result, self._outcome.errors)
-        elif hasattr(self._outcome, 'result') and hasattr(self._outcome.result, '_excinfo'):
+        elif hasattr(self._outcome, 'result') and getattr(self._outcome.result, '_excinfo', None) is not None:
             # pytest emulating unittest
-            assert isinstance(self._outcome.result._excinfo, str)
-            return self._outcome.result._excinfo
+            if isinstance(self._outcome.result._excinfo, str):
+                return self._outcome.result._excinfo
+            else:
+                assert isinstance(self._outcome.result._excinfo, list)
+                return str(self._outcome.result._excinfo[0])
+
         else:
-            # Python 3.11+ now records errors and failures seperate
-            errors = self._outcome.result.errors + self._outcome.result.failures
+            # Python 3.11+ now records errors and failures separate
+            errors = getattr(self._outcome.result, 'errors', []) + getattr(self._outcome.result, 'failures', [])
 
         try:
             return errors[0][1]

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -573,7 +573,7 @@ Requires: udisks2 >= 2.9
 Recommends: udisks2-lvm2 >= 2.9
 Recommends: udisks2-iscsi >= 2.9
 %if ! 0%{?rhel}
-Recommends: udisks2-btrfs >= 2.9
+Recommends: (udisks2-btrfs >= 2.9 if btrfs-progs)
 %endif
 Recommends: device-mapper-multipath
 Recommends: clevis-luks

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -154,6 +154,11 @@ Description: Cockpit Web Service
  .
  Install sssd-dbus for supporting client certificate/smart card authentication
  via sssd/FreeIPA.
+ .
+ Install python3 for running cockpit-desktop. That presents Cockpit in a
+ WebKit view or a web browser without having to run cockpit.service. That
+ feature additionally needs either gir1.2-webkit2-* or a web browser
+ installed.
 
 Package: cockpit-sosreport
 Architecture: all

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -114,7 +114,8 @@ Suggests: udisks2-btrfs,
 Description: Cockpit user interface for storage
  The Cockpit components for interacting with storage.
  .
- Install udisks2-lvm2 if you use LVM and want to manage it with Cockpit.
+ Install udisks2-lvm2 or udisks2-btrfs if you have LVM/btrfs devices and want
+ to manage them with Cockpit.
 
 Package: cockpit-system
 Architecture: all


### PR DESCRIPTION
Fixes #21602

The packaging tweaks are too small to warrant their own PR, but piggy-backing here is fine.