### PR TITLE
playground: add test page for the install dialog

### DIFF
--- a/files.js
+++ b/files.js
@@ -28,6 +28,7 @@ const info = {
         "playground/journal.jsx",
         "playground/remote.tsx",
         "playground/terminal.tsx",
+        "playground/packagemanager.tsx",
 
         "selinux/selinux.js",
         "shell/shell.jsx",
@@ -122,6 +123,7 @@ const info = {
         "playground/journal.html",
         "playground/remote.html",
         "playground/terminal.html",
+        "playground/packagemanager.html",
 
         "selinux/index.html",
 

--- a/pkg/base1/test-http.js
+++ b/pkg/base1/test-http.js
@@ -82,6 +82,9 @@ QUnit.test("simple request", assert => {
                         },
                         test: {
                             label: "Playground"
+                        },
+                        packagemanager: {
+                            label: "PackageManager (install dialog)"
                         }
                     },
                     preload: ["preloaded"],

--- a/pkg/playground/manifest.json
+++ b/pkg/playground/manifest.json
@@ -47,6 +47,9 @@
         },
         "terminal": {
             "label": "Terminal"
+        },
+        "packagemanager": {
+            "label": "PackageManager (install dialog)"
         }
     },
     "preload": [ "preloaded" ],

--- a/pkg/playground/packagemanager.html
+++ b/pkg/playground/packagemanager.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Cockpit Package Manager Integration</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link href="packagemanager.css" type="text/css" rel="stylesheet" />
+    <script src="../base1/cockpit.js"></script>
+    <script src="packagemanager.js"></script>
+</head>
+<body class="pf-v6-m-tabular-nums">
+    <div id="packagemanager"></div>
+</body>
+</html>

--- a/pkg/playground/packagemanager.tsx
+++ b/pkg/playground/packagemanager.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { createRoot } from "react-dom/client";
+
+import '../lib/patternfly/patternfly-6-cockpit.scss';
+
+import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
+import { Card, CardBody, CardTitle } from '@patternfly/react-core/dist/esm/components/Card/index.js';
+import { Content } from "@patternfly/react-core/dist/esm/components/Content/index.js";
+import { Page, PageSection } from "@patternfly/react-core/dist/esm/components/Page/index.js";
+import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput/index.js";
+
+import { install_dialog } from "../lib/cockpit-components-install-dialog.jsx";
+
+import 'cockpit-dark-theme'; // once per page
+import 'page.scss';
+
+const PackageManagerPage = () => {
+    const [isInstalling, setIsInstalling] = React.useState(false);
+    const [installPackages, setInstallPackages] = React.useState("");
+
+    const openInstallDialog = async () => {
+        setIsInstalling(true);
+        try {
+            await install_dialog(installPackages.split(","));
+        } finally {
+            setIsInstalling(false);
+        }
+    };
+
+    return (
+        <Page isContentFilled className="no-masthead-sidebar">
+            <PageSection hasBodyWrapper={false}>
+                <Content>
+                    <Card>
+                        <CardTitle id="install-card-title">Install dialog test</CardTitle>
+                        <CardBody>
+                            <TextInput id="install-packages" value={installPackages} onChange={(_event, value) => setInstallPackages(value)} />
+                            <Button id="install-button" variant="primary" onClick={() => openInstallDialog()} isLoading={isInstalling}>Install Package</Button>
+                        </CardBody>
+                    </Card>
+                </Content>
+            </PageSection>
+        </Page>
+    );
+};
+
+document.addEventListener("DOMContentLoaded", async () => {
+    const root = createRoot(document.getElementById("packagemanager")!);
+    root.render(<PackageManagerPage />);
+});

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1841,5 +1841,70 @@ WantedBy=basic.target
         b.wait_visible("#automatic-updates-dialog")
 
 
+@testlib.skipOstree("Image uses OSTree")
+@testlib.nondestructive
+class TestInstallDialog(NoSubManCase):
+
+    def show_install_dialog(self, *packages: str):
+        b = self.browser
+        b.set_input_text("#install-packages", ",".join(packages))
+        b.click("#install-button")
+        b.wait_in_text("#dialog", "Install software")
+
+    def install_packages(self):
+        b = self.browser
+        b.click("#dialog button:contains('Install')")
+        # assert some progress
+        b.wait_not_present("#dialog")
+
+    def testBasic(self):
+        b = self.browser
+        m = self.machine
+
+        # dummy package
+        self.createPackage("dummy", "1", "1")
+
+        # package which depends on another package
+        self.createPackage("test-webserver", "998", "1", depends="test-webengine")
+        self.createPackage("test-webengine", "998", "1")
+
+        # package which conflicts with another package
+        self.createPackage("ok-software", "998", "1", install=True)
+        self.createPackage("breaking-software", "999", "1", conflicts="ok-software")
+
+        # Test error condition, package not being available yet
+        self.login_and_go('/playground/packagemanager')
+        b.wait_in_text("#install-card-title", "Install dialog test")
+        self.show_install_dialog("dummy")
+        b.wait_in_text("#dialog .pf-v6-c-alert__title", "dummy is not available from any repository.")
+        b.wait_visible("#dialog button.pf-m-primary:disabled")
+        b.click("#dialog button.cancel")
+        b.wait_not_present("#dialog")
+
+        # Install dummy which is now available
+        # Also works around https://github.com/PackageKit/PackageKit/issues/893
+        self.enableRepo()
+        if self.backend != "dnf5":
+            m.execute("pkcon refresh force")
+
+        self.show_install_dialog("dummy")
+        b.wait_in_text("#dialog", "dummy will be installed.")
+        self.install_packages()
+
+        # Test that additional installed packages are shown in the dialog
+        b.wait_in_text("#install-card-title", "Install dialog test")
+        self.show_install_dialog("test-webserver")
+        b.wait_in_text("#dialog", "test-webserver will be installed.")
+        b.wait_text("#dialog .scale-up-ct", "Additional packages:test-webengine")
+        self.install_packages()
+
+        # Test conflicting packages are shown as removed
+        self.show_install_dialog("breaking-software")
+        b.wait_in_text("#dialog", "breaking-software will be installed.")
+        # The svg icon creates a tiny bit of whitespace
+        b.wait_text("#dialog .scale-up-ct", " Removals:ok-software")
+        self.install_packages()
+
+
 if __name__ == '__main__':
     testlib.test_main()

--- a/test/verify/check-storage-nfs
+++ b/test/verify/check-storage-nfs
@@ -332,6 +332,7 @@ class TestStoragePackagesNFS(packagelib.PackageCase, storagelib.StorageCase):
         # anything on the Debian test images, for unknown reasons.  So
         # we install a dummy package to warm up all parts of the
         # machinery and distribute the fluids evenly.
+        # https://github.com/PackageKit/PackageKit/issues/893
         #
         if "debian" in m.image or "ubuntu" in m.image:
             m.execute("pkcon refresh; pkcon install -y dummy")


### PR DESCRIPTION
Test various install dialog scenarios in a controlled environment in preparation for supporting and verifying our dnf5daemon backend implementation.