### PR TITLE
packagekit: Consistent update width

### DIFF
--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -80,6 +80,7 @@ import { debug, watchRedHatSubscription } from './utils';
 import callTracerScript from './callTracer.py';
 
 import "./updates.scss";
+import { Truncate } from '@patternfly/react-core/dist/esm/components/Truncate/index.js';
 
 const _ = cockpit.gettext;
 
@@ -586,10 +587,11 @@ const ApplyUpdates = ({ transactionProps, actions, onCancel, rebootAfter, setReb
         <div className="progress-main-view">
             <Grid hasGutter>
                 <GridItem span={12}>
-                    <div className="progress-description">
-                        <Spinner size="md" />
-                        <strong>{ PK_STATUS_STRINGS[lastAction?.status] || PK_STATUS_STRINGS[PK.Enum.STATUS_UPDATE] }</strong>
-                        &nbsp;{curPackage}
+                    <div className="progress-description pf-v6-u-display-flex">
+                        <Spinner size="md" isInline />
+                        <strong>{PK_STATUS_STRINGS[lastAction?.status] || PK_STATUS_STRINGS[PK.Enum.STATUS_UPDATE]}</strong>
+                        &nbsp;
+                        <Truncate content={curPackage} />
                     </div>
                     <Progress title={remain}
                               aria-label={remain ? _("Time remaining: ") : _("Update progress")}

--- a/pkg/packagekit/updates.scss
+++ b/pkg/packagekit/updates.scss
@@ -1,7 +1,10 @@
 @use "ct-card";
 @use "page";
+@use "global-variables" as *;
 
 @use "@patternfly/patternfly/utilities/Spacing/spacing.css";
+// For .pf-v6-u-display-flex
+@use "@patternfly/patternfly/utilities/Display/display.css";
 
 /* Style the list cards as ct-cards */
 .pf-v6-c-page__main-section .pf-v6-c-card {
@@ -112,9 +115,14 @@ div.changelog {
 
 /* don't let the install progress bar get too wide */
 .progress-main-view {
+  inline-size: 50vw;
   max-inline-size: 60rem;
   margin-block: 10ex 0;
   margin-inline: auto;
+
+  @media screen and (max-width: $pf-v6-global--breakpoint--sm - 1) {
+    inline-size: 100%;
+  }
 
   .pf-v6-l-grid {
     align-items: end;


### PR DESCRIPTION
Adds a few CSS rules and modifies the styling a bit to ensure that we
get truncated text for packages that have long package names and also
get a consistent width of the progress bar so nothing moves around.

Should make the experience much easier and the switch is now functional.

Fixes: https://github.com/cockpit-project/cockpit/issues/22415
Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
