### PR TITLE
Pin pytest-asyncio version to unbreak main

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -232,7 +232,7 @@ deps =
   lint: ruff
   lint: vulture
   pytest
-  pytest-asyncio
+  pytest-asyncio < 1.1.1
   pytest: pytest-cov
   pytest: pytest-timeout
   pytest: pytest-xdist


### PR DESCRIPTION
Our tests hang when running with pytest-asyncio > 1.1.0 so temporarily pin them for now.

Related: #22429