### PR TITLE
sosreport: don't limit sos report download size

### DIFF
--- a/pkg/sosreport/sosreport.jsx
+++ b/pkg/sosreport/sosreport.jsx
@@ -202,7 +202,7 @@ function sosDownload(path) {
         binary: "raw",
         path,
         superuser: "require",
-        max_read_size: 150 * 1024 * 1024,
+        max_read_size: -1,
         external: {
             "content-disposition": 'attachment; filename="' + basename + '"',
             "content-type": "application/x-xz, application/octet-stream"


### PR DESCRIPTION
The default limit of `fsread` is 16MB to prevent JavaScript code to accidentally read too much data and eat up memory. The sosreport uses a raw channel and a clickable link so the data transfer is handled by the browser without concerns of JavaScript memory usage.

Since Cockpit 337 the bridge supports setting `max_read_size` to -1 which bypasses any size limitations.

https://issues.redhat.com/browse/RHEL-115165
https://issues.redhat.com/browse/RHEL-115185

---

