### PR TITLE
flatpak/gh auth by file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
     needs: source
     environment: flathub
     env:
-      GITHUB_TOKEN: ${{ secrets.COCKPITUOUS_TOKEN }}
+      COCKPITUOUS_TOKEN: ${{ secrets.COCKPITUOUS_TOKEN }}
     permissions: {}
     runs-on: ubuntu-latest
     steps:
@@ -136,7 +136,8 @@ jobs:
           git show
           git push git@github.com:cockpit-project/org.cockpit_project.CockpitClient HEAD
 
-          echo {{ GITHUB_TOKEN }} | gh auth login --with-token
+          echo ${{ env.COCKPITUOUS_TOKEN }} >> auth.txt
+          gh auth login --with-token < auth.txt
 
           gh pr create \
             --fill \


### PR DESCRIPTION
- **flatpak: `gh auth` by file instead of CLI args**
- **flatpak: Use `COCKPITUOUS` token for checkout**
