### PR TITLE
pytest: use SIGTERM instead of SIGINT

### DIFF
--- a/test/pytest/test_transport.py
+++ b/test/pytest/test_transport.py
@@ -264,8 +264,8 @@ class TestSubprocessTransport:
     @pytest.mark.asyncio
     async def test_send_signal(self) -> None:
         protocol, transport = self.subprocess(['cat'])
-        transport.send_signal(signal.SIGINT)
-        await protocol.eof_and_exited_with_code(-signal.SIGINT)
+        transport.send_signal(signal.SIGTERM)
+        await protocol.eof_and_exited_with_code(-signal.SIGTERM)
 
     @pytest.mark.asyncio
     async def test_pid(self) -> None:


### PR DESCRIPTION
For some reason, `cat` is getting spawned in a way that results in it ignoring SIGINT when run inside of a pbuilder on debian-testing.  I'm sure there's a realllly interesting reason for that but Martin has politely suggested that I "pick my battles" on this one, and that sounds good enough to me.