### PR TITLE
bridge: Support disjunctive manifest conditions

### DIFF
--- a/doc/guide/packages.xml
+++ b/doc/guide/packages.xml
@@ -111,9 +111,13 @@ $ cockpit-bridge --packages
       <varlistentry>
         <term>conditions</term>
         <listitem><para>An optional list of <code>{"predicate": "value"}</code> objects. Cockpit will only
-          consider the package if <emphasis>all</emphasis> conditions are met. Currently supported predicates
-          are <code>path-exists</code> and <code>path-not-exists</code>. Unknown predicates are ignored.
-          This is preferable to using <code>priority</code>, but only available since Cockpit 286.</para>
+          consider the package if <emphasis>all</emphasis> conditions are met. This is preferable to using
+          <code>priority</code>.</para>
+
+          <para>Currently supported predicates are <code>path-exists</code> and <code>path-not-exists</code>
+          (since Cockpit 286), and <code>any</code> (since Cockpit 348). <code>any</code> accepts a list of
+          conditions and evaluates to true if <emphasis>at least one</emphasis> of the nested conditions is
+          met. Unknown predicates are ignored.</para>
         </listitem>
       </varlistentry>
       <varlistentry>
@@ -278,6 +282,18 @@ $ cockpit-bridge --packages
      }
   }
 }
+</programlisting>
+
+    <para>The following example shows how to use disjunctive conditions with <code>any</code>
+      to specify alternative requirements (available since Cockpit 348). This package will be available if either
+      <filename>/usr/bin/alt1</filename> or <filename>/usr/bin/alt2</filename> exists. In any case,
+      <filename>/etc/incompatible-tool</filename> must not exist.</para>
+
+<programlisting>
+  "conditions": [
+    {"any": [{"path-exists": "/usr/bin/alt1"}, {"path-exists": "/usr/bin/alt2"}]},
+    {"path-not-exists": "/etc/incompatible-tool"}
+  ]
 </programlisting>
 
   </section>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,8 @@ module = [
     'run-tests',
 
     # test/pytest
-    'test.pytest.test_packages'
+    'test.pytest.test_beiboot',
+    'test.pytest.test_packages',
 ]
 
 [tool.pylint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,10 @@ module = [
     'submanlib',
     'js_coverage',
     'webdriver_bidi',
-    'run-tests'
+    'run-tests',
+
+    # test/pytest
+    'test.pytest.test_packages'
 ]
 
 [tool.pylint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ module = [
     'cockpit.channels.stream',
     'cockpit.channels.trivial',
     'cockpit.jsonutil',
+    'cockpit.packages',
     'cockpit.protocol',
     'cockpit.transports',
     'cockpit.beipack',

--- a/src/cockpit/beiboot.py
+++ b/src/cockpit/beiboot.py
@@ -83,19 +83,11 @@ def ensure_ferny_askpass() -> Path:
 class ProxyPackagesLoader(PackagesLoader):
     file_status: Dict[str, bool]
 
-    def check_condition(self, condition: str, value: object) -> bool:
-        assert isinstance(value, str)
-        assert value in self.file_status
-
-        if condition == 'path-exists':
-            return self.file_status[value]
-        elif condition == 'path-not-exists':
-            return not self.file_status[value]
-        else:
-            raise KeyError
-
     def __init__(self, file_status: Dict[str, bool]):
         self.file_status = file_status
+
+    def path_exists(self, path: str) -> bool:
+        return self.file_status.get(path, False)
 
 
 BEIBOOT_GADGETS = {

--- a/src/cockpit/beiboot.py
+++ b/src/cockpit/beiboot.py
@@ -26,7 +26,7 @@ import shlex
 import tempfile
 import time
 from pathlib import Path
-from typing import Dict, Iterable, Literal, Optional, Sequence
+from typing import Dict, Literal, Optional, Sequence
 
 from cockpit import polyfills
 from cockpit._vendor import ferny
@@ -78,13 +78,6 @@ def ensure_ferny_askpass() -> Path:
         dest_path.chmod(0o700)
 
     return dest_path
-
-
-def get_interesting_files() -> Iterable[str]:
-    for manifest in PackagesLoader.load_manifests():
-        for condition in manifest.conditions:
-            if condition.name in ('path-exists', 'path-not-exists') and isinstance(condition.value, str):
-                yield condition.value
 
 
 class ProxyPackagesLoader(PackagesLoader):
@@ -391,7 +384,7 @@ class SshPeer(Peer):
         # Send the first-stage bootloader
         stage1 = bootloader.make_bootloader([
             *exec_cockpit_bridge_steps,
-            ('report_exists', [list(get_interesting_files())]),
+            ('report_exists', [list(PackagesLoader.get_condition_files())]),
             *beiboot_helper.steps,
         ], gadgets=BEIBOOT_GADGETS)
         transport.write(stage1.encode())

--- a/test/pytest/test_beiboot.py
+++ b/test/pytest/test_beiboot.py
@@ -1,10 +1,13 @@
 import sys
+from pathlib import Path
 
 import pytest
 
 from cockpit._vendor import ferny
 from cockpit._vendor.bei import bootloader
+from cockpit.beiboot import ProxyPackagesLoader
 from cockpit.beipack import BridgeBeibootHelper
+from cockpit.packages import Manifest
 from cockpit.peer import Peer
 from cockpit.router import Router
 
@@ -18,8 +21,26 @@ class BeibootPeer(Peer):
         await agent.communicate()
 
 
+class TestProxyPackagesLoader:
+    def test_check_conditions(self) -> None:
+        loader = ProxyPackagesLoader({'/existing': True, '/missing': False})
+
+        # Create test manifests with conditions
+        manifest_exists = Manifest(Path('/test'), {'conditions': [{'path-exists': '/existing'}]})
+        manifest_not_exists = Manifest(Path('/test'), {'conditions': [{'path-not-exists': '/missing'}]})
+        manifest_mixed = Manifest(Path('/test'), {
+            'conditions': [{'path-exists': '/existing'}, {'path-not-exists': '/missing'}]
+        })
+        manifest_fails = Manifest(Path('/test'), {'conditions': [{'path-exists': '/missing'}]})
+
+        assert loader.check_conditions(manifest_exists) is True
+        assert loader.check_conditions(manifest_not_exists) is True
+        assert loader.check_conditions(manifest_mixed) is True
+        assert loader.check_conditions(manifest_fails) is False
+
+
 @pytest.mark.asyncio
-async def test_bridge_beiboot():
+async def test_bridge_beiboot() -> None:
     # Try to beiboot a copy of the bridge and read its init message
     peer = BeibootPeer(Router([]))
     init_msg = await peer.start()

--- a/test/pytest/test_beiboot.py
+++ b/test/pytest/test_beiboot.py
@@ -32,11 +32,19 @@ class TestProxyPackagesLoader:
             'conditions': [{'path-exists': '/existing'}, {'path-not-exists': '/missing'}]
         })
         manifest_fails = Manifest(Path('/test'), {'conditions': [{'path-exists': '/missing'}]})
+        manifest_any_exists = Manifest(Path('/test'), {
+            'conditions': [{'any': [{'path-exists': '/existing'}, {'path-exists': '/missing'}]}]
+        })
+        manifest_any_fails = Manifest(Path('/test'), {
+            'conditions': [{'any': [{'path-exists': '/missing'}, {'path-not-exists': '/existing'}]}]
+        })
 
         assert loader.check_conditions(manifest_exists) is True
         assert loader.check_conditions(manifest_not_exists) is True
         assert loader.check_conditions(manifest_mixed) is True
         assert loader.check_conditions(manifest_fails) is False
+        assert loader.check_conditions(manifest_any_exists) is True
+        assert loader.check_conditions(manifest_any_fails) is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Extend the manifest conditions to support alternatives like

     {"any": [{"path-exists": "…/packagekit.service"}, {"path-exists": "…/dnfdaemon.service"}]}

---

Initial submission with "no-test" -- I'm sure there will be some changes during review, and we don't use this anywhere yet, only covered in unit tests.

## Package manifests: Add `any` test

[Package manifests](https://cockpit-project.org/guide/latest/packages.html#package-manifest) can have a list of conditions. Cockpit will only consider the package if *all* conditions are met. This release introduces an operator for alternative checks in a condition, for example

```json
"conditions": [
    {"any": [{"path-exists": "…/packagekit.service"}, {"path-exists": "…/dnfdaemon.service"}]}
]
```

That condition will be true if at least one of its subconditions matches.