### PR TITLE
WIP! login: Add passkey to users

### DIFF
--- a/pkg/static/login.html
+++ b/pkg/static/login.html
@@ -155,6 +155,14 @@
             </button>
             <a id="get-out-link" href="/" translate="yes">Cancel</a>
           </div>
+
+          <div class="form-group login-actions">
+            <button class="pf-v6-c-button pf-m-primary login-passkey-button" id="login-passkey-button" type="submit">
+              <span class="spinner"></span>
+              <span id="login-passkey-button-text" class="button-text" translate="yes">Log in with passkey</span>
+            </button>
+            <a id="get-out-link" href="/" translate="yes">Cancel</a>
+          </div>
         </form>
       </div>
 

--- a/pkg/users/account-details.js
+++ b/pkg/users/account-details.js
@@ -48,6 +48,7 @@ import { account_shell_dialog } from "./shell-dialog.js";
 import { set_password_dialog, reset_password_dialog } from "./password-dialogs.js";
 import { AccountLogs } from "./account-logs-panel.jsx";
 import { AuthorizedKeys } from "./authorized-keys-panel.js";
+import { AccountPasskeys } from "./account-passkeys.js";
 import { get_locked } from "./utils.js";
 
 const _ = cockpit.gettext;
@@ -342,6 +343,7 @@ export function AccountDetails({ account, groups, isLoading, current_user, shell
                             </Form>
                         </CardBody>
                     </Card>
+                    <AccountPasskeys account={account} />
                     <AuthorizedKeys name={account.name} home={account.home} allow_mods={self_mod_allowed} />
                     <AccountLogs name={account.name} />
                 </Gallery>

--- a/pkg/users/account-passkeys.tsx
+++ b/pkg/users/account-passkeys.tsx
@@ -1,0 +1,61 @@
+import cockpit from "cockpit";
+import React, { useState } from 'react';
+
+import { Card, CardBody, CardHeader, CardTitle } from "@patternfly/react-core/dist/esm/components/Card";
+import { Button } from "@patternfly/react-core";
+
+const _ = cockpit.gettext;
+
+function createCredentials() {
+    navigator.credentials.create({
+        publicKey: {
+            challenge: new Uint8Array([
+                // must be a cryptographically random number sent from a server
+                0x8c, 0x0a, 0x26, 0xff, 0x22, 0x91, 0xc1, 0xe9, 0xb9, 0x4e, 0x2e, 0x17,
+                0x1a, 0x98, 0x6a, 0x73, 0x71, 0x9d, 0x43, 0x48,
+            ]),
+            rp: { id: "localhost", name: "cockpit" },
+            user: {
+                id: new Uint8Array([0x1a, 0x98, 0x6a, 0x73, 0x71, 0x9d, 0x43]),
+                name: "jamiedoe",
+                displayName: "Jamie Doe",
+            },
+            attestation: "none",
+            timeout: 60000,
+            pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+        },
+    }).then(credential => {
+        console.log("passkey", credential)
+    });
+}
+
+export function AccountPasskeys (account: any) {
+    // check for secure context
+    if (!window.isSecureContext) {
+        return <>This web page was not loaded in a secure context (https). Please try loading the page again using https or make sure you are using a browser with secure context support.</>
+    }
+
+    // check for WebAuthn CR features
+    if (window.PublicKeyCredential === undefined ||
+        typeof window.PublicKeyCredential !== "function" ||
+        typeof window.PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable !== "function") {
+        return <>WebAuthn is not currently supported by this browser. See this webpage for a list of supported browsers: <a href="https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API#Browser_compatibility">Web Authentication: Browser Compatibility</a></>
+    }
+
+    return (
+        <Card isPlain id="account-passkeys">
+            <CardHeader>
+                <CardTitle component="h2">Passkeys</CardTitle>
+            </CardHeader>
+            <CardBody>
+                <Button variant="primary" ouiaId="Primary" onClick={() => createCredentials()}>
+                    Create passkey
+                </Button>
+            </CardBody>
+        </Card>
+    );
+}
+
+// export function instance(user_name, home_dir) {
+//     return new AccountPasskeys(user_name, home_dir);
+// }

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -512,6 +512,262 @@ class TestRealms(testlib.MachineCase):
 
 
 @testlib.no_retry_when_changed
+class TestPasskey(TestRealms, CommonTests):
+    def setUp(self):
+        super().setUp()
+        self.admin_user = "admin"
+        self.admin_password = "foobarfoo"
+        self.alice_password = "WonderLand123"
+        self.expected_server_software = "ipa"
+        self.machines["services"].execute("/root/run-freeipa")
+        # Wait for FreeIPA to come up and DNS to work as expected
+        # https://bugzilla.redhat.com/show_bug.cgi?id=1071356#c11
+        testlib.wait(lambda: self.machine.execute("nslookup -type=SRV _ldap._tcp.cockpit.lan"))
+
+        maybe_setup_fake_chrony(self.machine)
+
+        # wait until FreeIPA started up
+        self.machines["services"].execute(
+            """podman exec -i freeipa sh -ec '
+            while ! echo %s | kinit -f %s; do sleep 5; done
+            while ! ipa user-find >/dev/null; do sleep 5; done'
+            """
+            % (self.admin_password, self.admin_user),
+            timeout=300,
+        )
+
+        # during image creation the /var/cache directory gets cleaned up, recreate the krb5rcache
+        self.machine.execute("mkdir -pZ /var/cache/krb5rcache")
+
+        # IPA CA cert has OCSP entry with that host name, make it available
+        self.machine.execute("echo '10.111.112.100 ipa-ca.cockpit.lan' >> /etc/hosts")
+
+        # HACK: Figure out why this happens
+        self.allow_journal_messages(""".*didn't receive expected "authorize" message""", "cockpit-session:$")
+        self.allow_journal_messages("/bin/bash: /home/admin/.bashrc: Permission denied")
+
+    def checkBackendSpecifics(self):
+        """Check domain backend specific integration"""
+
+        m = self.machine
+        b = self.browser
+
+        def cockpit_sessions():
+            """Return list of users who have a running Cockpit session"""
+            # unfortunately the session type isn't part of the list view/query
+            # --json=short is very recent, not yet available in Fedora 40 and older; so parse lines
+            users = []
+            for line in m.execute("loginctl --no-legend list-sessions").strip().splitlines():
+                fields = line.split()
+                info = m.execute(f"loginctl show-session {fields[0]}")
+                if "Type=web" in info and "State=closing" not in info:
+                    users.append(fields[2])
+            return users
+
+        def wait_cockpit_sessions(expected):
+            # "assertEqual" returns None when successful, but
+            # testlib.wait wants to see something truthy, that's why
+            # we add the "or True".
+            testlib.wait(lambda: self.assertEqual(cockpit_sessions(), expected) or True)
+
+        # should have added SPN to ws keytab
+        output = m.execute(["klist", "-k", "/etc/cockpit/krb5.keytab"])
+        self.assertIn("HTTP/x0.cockpit.lan@COCKPIT.LAN", output)
+
+        # validate Kerberos setup for ws
+        m.execute(f"echo {self.admin_password} | kinit -f {self.admin_user}@COCKPIT.LAN")
+        m.execute(WAIT_KRB_SCRIPT.format(f"{self.admin_user}@cockpit.lan"), timeout=300)
+
+        # kerberos login should work
+        output = m.execute([
+            "curl",
+            "-s",
+            "--negotiate",
+            "--delegation",
+            "always",
+            "-u",
+            ":",
+            "-D",
+            "-",
+            "http://x0.cockpit.lan:9090/cockpit/login",
+        ])
+        self.assertIn("HTTP/1.1 200 OK", output)
+        self.assertIn('"csrf-token"', output)
+
+        # Restart cockpit with SSL enabled, this should have gotten an SSL cert from FreeIPA
+        m.stop_cockpit()
+        m.start_cockpit(tls=True)
+        # OpenSSL and curl should use the system PKI which should trust the IPA server CA
+        out = m.execute("openssl s_client -verify 5 -verify_return_error -connect localhost:9090")
+        self.assertRegex(out, "subject=/?O *= *COCKPIT.LAN.*CN *= *x0.cockpit.lan", out)
+        self.assertRegex(out, "issuer=/?O *= *COCKPIT.LAN.*CN *= *Certificate Authority")
+        self.assertIn("Content-Type: text/html", m.execute("curl --head https://x0.cockpit.lan:9090"))
+        # don't leave the secret key copy behind
+        m.execute("! test -e /run/cockpit/ipa.key")
+        # cockpit-certificate-ensure agrees
+        self.assertIn(
+            "/etc/cockpit/ws-certs.d/10-ipa.cert", m.execute(f"{self.libexecdir}/cockpit-certificate-ensure --check")
+        )
+        # correct permissions
+        self.assertEqual("root:root/640", m.execute("stat --printf '%U:%G/%a' /etc/cockpit/ws-certs.d/10-ipa.key"))
+        # cert is being tracked
+        out = m.execute("ipa-getcert list")
+        self.assertIn("MONITORING", out)
+        # certmonger must be able to directly write and auto-refresh the certificates
+        self.assertIn("/etc/cockpit/ws-certs.d/10-ipa.key", out)
+        # ensure that refreshing works
+        old_cert = m.execute("cat /etc/cockpit/ws-certs.d/10-ipa.cert").strip()
+        m.execute("ipa-getcert rekey --verbose --wait -f /etc/cockpit/ws-certs.d/10-ipa.cert")
+        new_cert = m.execute("cat /etc/cockpit/ws-certs.d/10-ipa.cert").strip()
+        self.assertNotEqual(old_cert, new_cert)
+
+        # Restart without SSL (IPA certificate is not on the testing host)
+        m.stop_cockpit()
+        m.start_cockpit()
+
+        # check respecting FreeIPA's/sssd's ssh known host keys; login_and_go() does not expect/answer
+        # unknown host prompts
+        b.login_and_go(user=f"{self.admin_user}@cockpit.lan", password=self.admin_password)
+        # starts proper session
+        wait_cockpit_sessions(["admin@cockpit.lan"])
+        b.logout()
+
+        # does not leak any processes or the session itself
+        wait_cockpit_sessions([])
+
+        # FIXME: Something above triggers this error message
+        self.allow_journal_messages("Received unexpected TLS connection and no certificate was configured")
+
+    @testlib.timeout(900)
+    def testClientCertAuthentication(self):
+        m = self.machine
+        b = self.browser
+
+        ipa_machine = self.machines["services"]
+        # set up an IPA user with a TLS certificate; can't use "admin" due to https://pagure.io/freeipa/issue/6683
+        ipa_machine.execute(f"""podman exec -i freeipa sh -exc '
+ipa user-add --first=Alice --last="Developer" --shell=/bin/bash alice
+yes "{self.alice_password}" | ipa user-mod --password alice
+ipa user-mod --password-expiration=2030-01-01T00:00:00Z alice' """)
+
+        # self.checkClientCertAuthentication()
+
+        # the above password login implicitly creates a persistent user ticket
+        # alice_klist_cmd = "su -c klist alice"
+        # persistent_ticket = m.execute(alice_klist_cmd)
+
+        # enable sudo passkey authentication
+        # m.execute(r"""#!/bin/sh -eu
+        # sed -i '/\[domain\/cockpit.lan\]/ a pam_gssapi_services = sudo, sudo-i' /etc/sssd/sssd.conf
+        # sed -i '1 a auth sufficient pam_passkey_auth.so' /etc/pam.d/sudo
+        # systemctl restart sssd
+        # """)
+
+        # enable ssh GSSAPI authentication
+        # m.execute("sed -ri 's/#GSSAPIAuthentication.*/GSSAPIAuthentication yes/' /etc/ssh/sshd_config")
+        # m.execute(self.restart_sshd)
+
+        # avoid "unknown host" error in SSH
+        # m.execute("su -c 'mkdir -p ~/.ssh; ssh-keyscan localhost > ~/.ssh/known_hosts' alice")
+
+        # the test below assumes exactly one running bridge
+        m.execute("! pgrep cockpit-bridge")
+
+        # check S4U proxy ticket for the user (not functional for anything without delegation rules)
+        # this is specific to IPA, as with AD cockpit-ws does not get a keytab
+
+        # as we can't do cert auth in the browser, splice socat in between to do that for us
+        # m.execute(f"""! selinuxenabled || semanage port -m -t websm_port_t -p tcp 443
+        #               mkdir -p /run/systemd/system/cockpit.socket.d/
+        #               printf "[Socket]\nListenStream=\nListenStream=443" > /run/systemd/system/cockpit.socket.d/listen.conf
+        #               sed -i '/\\[WebService/ aOrigins = http://{m.web_address}:{m.web_port}' /etc/cockpit/cockpit.conf""")
+        # m.spawn(
+        #     "socat TCP-LISTEN:9090,reuseaddr,fork OPENSSL:x0.cockpit.lan:443,cert=/var/tmp/alice.pem,key=/var/tmp/alice.key",
+        #     "socat-certauth.log",
+        # )
+        m.start_cockpit(tls=True)
+
+        # S4U ticket is in the session
+        b.open("/system/terminal")
+        testlib.sit()
+        return None
+        b.enter_page("/system/terminal")
+        b.wait_in_text(".terminal .xterm-accessibility-tree", "alice")
+        b.input_text("klist\n")
+        b.wait_in_text(".terminal .xterm-accessibility-tree", "Ticket cache: FILE:/run/user")
+        b.wait_in_text(".terminal .xterm-accessibility-tree", "Default principal: alice@COCKPIT.LAN")
+        b.wait_in_text(".terminal .xterm-accessibility-tree", "for client HTTP/x0.cockpit.lan@COCKPIT.LAN")
+        self.assertIn("cockpit-session-", m.execute("ls /run/user/$(id -u alice)/*.ccache"))
+        ccache_env = m.execute("xargs -0n1 < /proc/$(pgrep cockpit-bridge)/environ | grep KRB5CCNAME=").strip()
+
+        # does not interfere with persistent ticket in other sessions
+        self.assertEqual(m.execute(alice_klist_cmd), persistent_ticket)
+
+        # destroy global user ccache, so that sudo/ssh really have to use the ccache_env one
+        m.execute("su -c 'kdestroy || true' alice")
+
+        # sanity check: sudo and ssh do not work without a ticket and password
+        self.assertIn("no askpass program", m.execute("su -c '! sudo -A whoami' alice 2>&1"))
+        self.assertIn("Permission denied", m.execute("su -c '! ssh x0.cockpit.lan 2>&1' alice"))
+
+        # in default configuration, ticket is not trusted by IPA
+        self.assertIn("no askpass program", m.execute(f"su -c '! {ccache_env} sudo -A whoami' alice 2>&1"))
+        self.assertIn("Permission denied", m.execute(f"su -c '! {ccache_env} ssh x0.cockpit.lan 2>&1' alice"))
+        b.switch_to_top()
+        b.open_superuser_dialog()
+        b.wait_in_text(".pf-v6-c-modal-box:contains('Switch to administrative access')", "Password for alice:")
+        b.click(".pf-v6-c-modal-box:contains('Switch to administrative access') .btn-cancel")
+        b.wait_not_present(".pf-v6-c-modal-box:contains('Switch to administrative access')")
+
+        # set up delegation rule
+        script = """
+        ipa servicedelegationtarget-add cockpit-target
+        ipa servicedelegationtarget-add-member cockpit-target --principals="host/x0.cockpit.lan@COCKPIT.LAN"
+        ipa servicedelegationrule-add cockpit-delegation
+        ipa servicedelegationrule-add-member cockpit-delegation --principals="HTTP/x0.cockpit.lan@COCKPIT.LAN"
+        ipa servicedelegationrule-add-target cockpit-delegation --servicedelegationtargets="cockpit-target"
+        """
+        ipa_machine.execute(f"podman exec freeipa bash -euc '{script}'")
+
+        b.become_superuser(passwordless=True)
+        self.assertEqual("root\n", m.execute(f"su -c '{ccache_env} sudo -A whoami' alice"))
+
+        b.go("/system")
+        b.enter_page("/system")
+        b.wait_visible("#reboot-button")
+
+        # CLI ssh works with the delegated ticket
+        out = m.execute(f"su -c '{ccache_env} ssh -vv -K x0.cockpit.lan echo hello' alice")
+        self.assertEqual(out.strip(), "hello")
+
+        # cockpit session through ssh works with the delegated ticket
+        b.switch_to_top()
+        b.go("/@x0.cockpit.lan/system")
+        # only ack the addition of host, no authentication/password
+        b.click("#machine-troubleshoot")
+        b.wait_visible("#hosts_setup_server_dialog")
+        b.click("#hosts_setup_server_dialog button:contains(Add)")
+        b.wait_not_present("#hosts_setup_server_dialog")
+        b.wait_visible("#hosts_connect_server_dialog")
+        b.click("#hosts_connect_server_dialog button.pf-m-warning")
+
+        # Getting root privs through sudo with kerberos in the remote SSH session does not currently work.
+        # ssh -K is supposed to forward the credentials cache, but doesn't; klist in the ssh session is empty
+        # and there is no ccache.
+        b.enter_page("/system", "x0.cockpit.lan")
+        b.wait_visible(".pf-v6-c-alert:contains('Web console is running in limited access mode.')")
+        b.wait_not_present("#reboot-button")
+
+        # S4U proxy ticket gets cleaned up on logout
+        b.logout()
+        m.execute("while ls /run/user/$(id -u alice)/*.ccache; do sleep 1; done")
+        m.execute(f"! su -c '{ccache_env} klist' alice")
+
+        # FIXME: Something above triggers this error message
+        self.allow_journal_messages("Received unexpected TLS connection and no certificate was configured")
+
+
+@testlib.no_retry_when_changed
 class TestIPA(TestRealms, CommonTests):
     def setUp(self):
         super().setUp()
@@ -778,6 +1034,8 @@ ipa-advise enable-admins-sudo | sh -ex
 
         # S4U ticket is in the session
         b.open("/system/terminal")
+        testlib.sit()
+        return None
         b.enter_page("/system/terminal")
         b.wait_in_text(".terminal .xterm-accessibility-tree", "alice")
         b.input_text("klist\n")


### PR DESCRIPTION
Work in progress and doesn't do anything at the moment. In short I
wanted a test to setup sssd first with correct configuration and then
make it possible to configure passkeys in the browser. After that's done
I'll continue working on writing the login page itself.

As the browser and terminal are slightly different I figure adding a
passkey through the browser is almost a necessity before getting the
login to work. Otherwise it might not work at all for the login if you
use something like a FIDO2 key to register within the terminal and then
try in the browser.

Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
