### PR TITLE
lib: Allow providing arguments to `systemd-run`

### DIFF
--- a/examples/long-running-process/index.html
+++ b/examples/long-running-process/index.html
@@ -19,7 +19,8 @@
                 </div>
 
                 <div>
-                    <input id="command" type="text" />
+                    <input id="command" type="text" placeholder="command" />
+                    <input id="sysrun-args" type="text" placeholder="systemd-run arguments"/>
                     <button id="run" disabled>Start</button>
                 </div>
 

--- a/examples/long-running-process/index.js
+++ b/examples/long-running-process/index.js
@@ -3,7 +3,7 @@
 import { LongRunningProcess, ProcessState } from './long-running-process.js';
 
 // DOM objects
-let state, command, run_button, output;
+let state, command, runArgs, run_button, output;
 
 // default shell command for the long-running process to run
 const default_command = "date; for i in `seq 30`; do echo $i; sleep 1; done";
@@ -54,6 +54,7 @@ function update(process) {
 cockpit.transport.wait(() => {
     state = document.getElementById("state");
     command = document.getElementById("command");
+    runArgs = document.getElementById("sysrun-args");
     run_button = document.getElementById("run");
     output = document.getElementById("output");
 
@@ -76,11 +77,14 @@ cockpit.transport.wait(() => {
             process.terminate();
         else if (process.state === ProcessState.FAILED)
             process.reset();
-        else
-            process.run(["/bin/sh", "-ec", command.value])
+        else {
+            // Split string and filter out empty array values
+            const runArgsList = runArgs.value.split(" ").filter(i => i);
+            process.run(["/bin/sh", "-ec", command.value], {}, runArgsList)
                     .catch(ex => {
                         state.textContent = "Error: " + ex.toString();
                         run_button.setAttribute("disabled", "");
                     });
+        }
     });
 });

--- a/test/verify/check-examples
+++ b/test/verify/check-examples
@@ -167,7 +167,9 @@ class TestLongRunning(testlib.MachineCase):
         b.wait_text("#state", "cockpit-longrunning.service stopped")
 
         # cancel long-running command
-        b.set_val("#command", "for i in $(seq 100); do echo LONG$i; sleep 1; done")
+        b.set_val("#command", "for i in $(seq 100); do echo $FOOBAR$i; sleep 1; done")
+        # ensure we can set systemd-run arguments
+        b.set_val("#sysrun-args", '--setenv=FOOBAR=LONG')
         b.wait_text("button#run", "Start")
         b.click("button#run")
         b.wait_text("#state", "cockpit-longrunning.service running")


### PR DESCRIPTION
Would allow users to call `LongRunningProcess.run()` with an argument
list that can include stuff like `setenv=FOO=BAR` and other
`systemd-run` related arguments.

Fixes: https://github.com/cockpit-project/cockpit/issues/22454
Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
