### PR TITLE
Tests: disable tests that aren't supported on opensuse

### DIFF
--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -80,6 +80,7 @@ class TestApps(packagelib.PackageCase):
         self.allow_journal_messages("org.freedesktop.PackageKit.*org.freedesktop.DBus.Error.NoReply.*")
 
     @testlib.skipImage("TODO: works locally, unstable in CI", "arch")
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testBasic(self, urlroot: str = ""):
         b = self.browser
         m = self.machine
@@ -142,9 +143,11 @@ class TestApps(packagelib.PackageCase):
         b.wait_visible(f".app-list .pf-v6-c-data-list__item-row:contains('app-1') img[src^='{urlroot}/cockpit/channel/']")
         m.execute("! test -f /stamp-app-1-1.0-1")
 
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testWithUrlRoot(self):
         self.testBasic(urlroot="/webcon")
 
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testOsMap(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-client
+++ b/test/verify/check-client
@@ -94,11 +94,13 @@ exec "$@"
         self.m_target.execute("while pgrep -af '([c]ockpit|[s]sh-agent)' >&2; do sleep 1; done",
                               timeout=30)
 
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testBeibootNoBridge(self):
         # set up target machine: no cockpit
         self.m_target.execute("rm /usr/bin/cockpit-bridge; rm -r /usr/share/cockpit")
         self.checkLoginScenarios()
 
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testBeibootWithBridge(self):
         self.checkLoginScenarios()
 

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -1198,7 +1198,10 @@ until pgrep -f '^(/usr/[^ ]+/[^ /]*python[^ /]* )?/usr/bin/cockpit-bridge'; do s
 
         # some brands miss the images, but the OSes we CI have them all
         curl_and_compare('branding.css', 'text/css', reference='/tmp/branding.ref')
-        curl_and_compare('logo.png', 'image/png')
+        if "suse" in m.image:
+            curl_and_compare('square-hicolor.svg', 'image/svg')
+        else:
+            curl_and_compare('logo.png', 'image/png')
         curl_and_compare('favicon.ico')
 
         # do a pixel test to make sure everything looks like we expect

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -1438,6 +1438,7 @@ ProtocolHeader = X-Forwarded-Proto
 
     @testlib.skipImage("nginx not installed", "centos-*", "rhel-*", "debian-*", "ubuntu-*", "arch")
     @testlib.skipOstree("nginx not installed")
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testNginxTLS(self):
         """test proxying to Cockpit with TLS
 
@@ -1518,6 +1519,7 @@ server {
 
     @testlib.skipImage("nginx not installed", "centos-*", "rhel-*", "debian-*", "ubuntu-*", "arch")
     @testlib.skipOstree("nginx not installed")
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testNginxNoTLS(self):
         """test proxying to Cockpit with plain HTTP
 

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -420,7 +420,7 @@ class TestKdumpConfiguration(KdumpHelpers):
         b.wait_text("#kdump-target-info", "Remote over NFS, someserver:/srv/")
         conf = m.execute("cat /etc/sysconfig/kdump")
         self.assertIn('KDUMP_SAVEDIR=nfs://someserver/srv', conf)
-        self.assertNotIn("ssh://", conf)
+        self.assertNotIn("=ssh://", conf)
 
         # Check local location
         b.click("#kdump-change-target")
@@ -432,7 +432,7 @@ class TestKdumpConfiguration(KdumpHelpers):
         b.wait_text("#kdump-target-info", "Local, /var/tmp")
         conf = m.execute("cat /etc/sysconfig/kdump")
         self.assertIn('KDUMP_SAVEDIR=file:///var/tmp', conf)
-        self.assertNotIn("nfs://", conf)
+        self.assertNotIn("=nfs://", conf)
 
         # Check compression
         conf = m.execute("cat /etc/sysconfig/kdump")

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -475,6 +475,7 @@ class TestKdumpNFS(KdumpHelpers):
         "nfs": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/24", "memory_mb": 512}
     }
 
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testBasic(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -179,6 +179,7 @@ class TestHistoryMetrics(testlib.MachineCase):
         b.enter_page("/system")
         b.wait_visible('.system-information')
 
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testEvents(self):
         b = self.browser
         m = self.machine
@@ -1307,6 +1308,7 @@ BEGIN {{
 class TestMetricsPackages(packagelib.PackageCase):
     pcp_dialog_selector = "#pcp-settings-modal"
 
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testBasic(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-networkmanager-mac
+++ b/test/verify/check-networkmanager-mac
@@ -28,6 +28,7 @@ class TestNetworkingMAC(netlib.NetworkCase):
         "machine2": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/20", "dhcp": True, "memory_mb": 512}
     }
 
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testMac(self):
         b = self.browser
         m = self.machine
@@ -54,6 +55,7 @@ class TestNetworkingMAC(netlib.NetworkCase):
         b.wait_text("#network-interface-mac", new_mac.upper())
         self.assertIn(new_mac.lower(), m.execute(f"ip link show '{iface}'"))
 
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testBondMac(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-networkmanager-mtu
+++ b/test/verify/check-networkmanager-mtu
@@ -23,6 +23,7 @@ import testlib
 
 @testlib.nondestructive
 class TestNetworkingMTU(netlib.NetworkCase):
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testMtu(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-networkmanager-settings
+++ b/test/verify/check-networkmanager-settings
@@ -28,6 +28,7 @@ class TestNetworkingSettings(netlib.NetworkCase):
         "machine2": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/20", "dhcp": True, "memory_mb": 512}
     }
 
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testNoConnectionSettings(self):
         b = self.browser
         m = self.machine
@@ -151,6 +152,7 @@ class TestNetworkingSettings(netlib.NetworkCase):
             for method in unsupported_ip6_methods:
                 b.wait_not_present(f"#network-ip-settings-select-method option[value='{method}']")
 
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testOtherSettings(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-networkmanager-team
+++ b/test/verify/check-networkmanager-team
@@ -28,6 +28,7 @@ import testlib
 @testlib.skipImage("team not supported", "centos-10*", "rhel-10*")
 @testlib.nondestructive
 class TestTeam(netlib.NetworkCase):
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testBasic(self):
         b = self.browser
 
@@ -90,6 +91,7 @@ class TestTeam(netlib.NetworkCase):
         self.wait_for_iface(iface1)
         self.wait_for_iface(iface2)
 
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testActive(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -265,6 +265,7 @@ echo -e "Loaded patch modules:\nkpatch_3_10_0_1062_1_1 [enabled]\n\nInstalled pa
         # Patches should be installed
         m.execute("rpm -q kpatch-patch-" + sanitized_kernel_ver)
 
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     @testlib.nondestructive
     @testlib.skipImage("alpm PackageKit backend does not support cancelling", "arch")
     def testBasic(self):
@@ -451,6 +452,8 @@ ExecStart=/usr/local/bin/{package} infinity
 
         return startTime
 
+    @testlib.skipImage("TODO: Packagekit on Arch does not detect the pear update", "arch")
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     @testlib.skipImage("tracer not available", *OSesWithoutTracer)
     def testTracer(self):
         b = self.browser
@@ -689,6 +692,7 @@ ExecStart=/usr/local/bin/{package} infinity
 
     @testlib.skipImage("Arch Linux does not start services by default", "arch")
     @testlib.skipImage("tracer not available", *OSesWithoutTracer)
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     @testlib.nondestructive
     def testFailServiceRestart(self):
         b = self.browser
@@ -751,6 +755,7 @@ ExecStart=/usr/local/bin/{packageName}
         b.wait_visible("#restart-services-modal .pf-v6-c-alert")
 
     @testlib.skipImage("No security changelog support in packagekit", "arch")
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testInfoSecurity(self):
         b = self.browser
         m = self.machine
@@ -968,6 +973,7 @@ ExecStart=/usr/local/bin/{packageName}
         b.wait_visible("table.updates-history tbody:not(.pf-m-expanded)")
 
     @testlib.skipImage("No security changelog support in packagekit", "arch")
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     @testlib.nondestructive
     def testSecurityOnly(self):
         b = self.browser
@@ -1008,6 +1014,7 @@ ExecStart=/usr/local/bin/{packageName}
             self.check_nth_update(2, "secnocve", "1-2", "security", desc_matches=["Fix leak"])
 
     @testlib.skipImage("No changelog support in Arch Linux", "arch")
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     @testlib.nondestructive
     def testInfoTruncation(self):
         b = self.browser
@@ -1101,6 +1108,7 @@ ExecStart=/usr/local/bin/{packageName}
         b.wait_in_text(".curtains-ct h1", "Disconnected")
         self.wait_reboot()
 
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     @testlib.nondestructive
     def testUpdateError(self):
         b = self.browser
@@ -1136,6 +1144,7 @@ ExecStart=/usr/local/bin/{packageName}
         # not expecting any buttons
         self.assertFalse(b.is_present("#app button"))
 
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     @testlib.nondestructive
     def testPackageKitCrash(self):
         b = self.browser
@@ -1242,6 +1251,7 @@ ExecStart=/usr/local/bin/{packageName}
 @testlib.skipImage("TODO: Arch Linux has no cockpit-ws package, it's in cockpit", "arch")
 @testlib.skipWsContainer("no cockpit-ws package with cockpit/ws container")
 class TestWsUpdate(NoSubManCase):
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testBasic(self):
         # The main case for this is that cockpit-ws itself gets upgraded, which
         # restarts the service and terminates the connection. As we can't

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1783,7 +1783,7 @@ class TestAutoUpdatesInstall(NoSubManCase):
             b.wait_not_present("#settings")
             b.wait_not_present("#autoupdates-settings")
 
-    @testlib.skipImage("No supported auto update backend", "debian-*", "ubuntu-*", "arch")
+    @testlib.skipImage("No supported auto update backend", "debian-*", "ubuntu-*", "arch", "opensuse-tumbleweed")
     def testInstall(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -27,7 +27,7 @@ import testlib
 
 OSesWithoutTracer = ["debian-*", "ubuntu-*", "fedora-coreos", "centos-10", "rhel-10*"]
 OSesWithDnfRestart = ["centos-10", "rhel-10*"]
-OSesWithoutKpatch = ["debian-*", "ubuntu-*", "arch", "fedora-*", "centos-*"]
+OSesWithoutKpatch = ["debian-*", "ubuntu-*", "arch", "fedora-*", "centos-*", "*-tumbleweed"]
 
 
 class NoSubManCase(packagelib.PackageCase):

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -783,6 +783,7 @@ OnCalendar=daily
         b.wait_text("#received-type", "-")
         b.wait_text("#received-title", "-")
 
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testHistory(self):
 
         b = self.browser

--- a/test/verify/check-reauthorize
+++ b/test/verify/check-reauthorize
@@ -89,7 +89,7 @@ class TestReauthorize(testlib.MachineCase):
         m.execute("echo user:foobar | chpasswd")
 
         b.default_user = "user"
-        self.login_and_go("/playground/test")
+        self.login_and_go("/playground/test", superuser=False)
         b.click(".super-channel button")
         b.wait_in_text(".super-channel span", 'result: ')
 

--- a/test/verify/check-session
+++ b/test/verify/check-session
@@ -23,6 +23,7 @@ import testlib
 @testlib.nondestructive
 class TestSession(testlib.MachineCase):
 
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testBasic(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-shell-active-pages
+++ b/test/verify/check-shell-active-pages
@@ -65,7 +65,10 @@ class TestActivePages(testlib.MachineCase):
 
         # wait for prompt in first line
         b.wait_visible(".terminal .xterm-accessibility-tree")
-        b.wait_in_text(line_sel(1), '$')
+        shell_indicator = '$'
+        if "suse" in m.image:
+            shell_indicator = '>'
+        b.wait_in_text(line_sel(1), shell_indicator)
 
         # run a command that we can easily identify, and which will die with the terminal
         b.input_text("bash -c 'exec -a kitten cat'\n")

--- a/test/verify/check-shell-host-switching
+++ b/test/verify/check-shell-host-switching
@@ -153,6 +153,7 @@ class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
         self.allow_restart_journal_messages()
         self.allow_hostkey_messages()
 
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testBasic(self):
         b = self.browser
         m1 = self.machines["machine1"]

--- a/test/verify/check-shell-keys
+++ b/test/verify/check-shell-keys
@@ -25,6 +25,7 @@ KEY = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEAkRTvQCSEZNPXpA5bP82ilQn3TMeQ6z2NO3
 
 @testlib.nondestructive
 class TestKeys(testlib.MachineCase):
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testAuthorizedKeys(self):
         m = self.machine
         b = self.browser
@@ -148,6 +149,7 @@ class TestKeys(testlib.MachineCase):
 
     # Possible workaround - ssh as `admin` and just do `m.execute()`
     @testlib.skipBrowser("Firefox cannot do `cockpit.spawn`", "firefox")
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testPrivateKeys(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -450,6 +450,7 @@ class TestMultiMachine(testlib.MachineCase):
         self.assertEqual(200, http_code("/cockpit/@localhost/manifests.json"))
         self.assertEqual(403, http_code("/cockpit/@10.111.113.2/manifests.json"))
 
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testUrlRoot(self):
         b = self.browser
         m = self.machine
@@ -669,6 +670,7 @@ class TestMultiMachine(testlib.MachineCase):
 
         self.allow_hostkey_messages()
 
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testTroubleshooting(self):
         b = self.browser
         m1 = self.machine
@@ -814,6 +816,7 @@ class TestMultiMachine(testlib.MachineCase):
                                     '.*: server offered unsupported authentication methods: .*')
 
     @testlib.skipImage("TODO: Broken on Arch Linux", "arch")
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testSshKeySetup(self):
         b = self.browser
         m1 = self.machine

--- a/test/verify/check-shell-multi-machine-key
+++ b/test/verify/check-shell-multi-machine-key
@@ -111,6 +111,7 @@ class TestMultiMachineKeyAuth(testlib.MachineCase):
 
     # Possible workaround - ssh as `admin` and just do `m.execute()`
     @testlib.skipBrowser("Firefox cannot do `cockpit.spawn`", "firefox")
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testBasic(self):
         b = self.browser
         m1 = self.machine

--- a/test/verify/check-sosreport
+++ b/test/verify/check-sosreport
@@ -25,7 +25,7 @@ import testlib
 
 
 @testlib.skipOstree("No sosreport")
-@testlib.skipImage("No sosreport", "arch")
+@testlib.skipImage("No sosreport", "arch", "*suse*")
 @testlib.nondestructive
 class TestSOS(testlib.MachineCase):
 

--- a/test/verify/check-ssh-api
+++ b/test/verify/check-ssh-api
@@ -42,6 +42,7 @@ class TestSshDialog(testlib.MachineCase):
         self.machine.execute("pkill -ef [s]sh.*ferny.*127.0.0.1")
 
     @testlib.skipImage("FIXME: Assertion failed: UnknownHostDialog needs a host-key and host-fingerprint in error", "rhel-8-10")
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testPassword(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -438,7 +438,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
         self.allow_restart_journal_messages()
 
-    @testlib.skipImage("No tlog", "debian-*", "ubuntu-*", "arch")
+    @testlib.skipImage("No tlog", "debian-*", "ubuntu-*", "arch", "*suse*")
     @testlib.skipOstree("No tlog")
     @testlib.skipImage("FIXME: tlog messes up bridge frame protocol", "rhel-8-10")
     def testSessionRecordingShell(self):

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -682,6 +682,16 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
                           "/etc/pam.d/common-auth")
         elif m.image == "arch":
             self.sed_file(f"s/# deny = 3/deny = {count}/", "/etc/security/faillock.conf")
+        elif "suse" in m.image:
+            m.execute("""cat <<EOF > /etc/security/faillock.conf
+deny = 4
+EOF""")
+            m.execute("""cat <<EOF >> /etc/pam.d/common-auth
+auth     [success=1 default=bad] pam_unix.so
+auth     [default=die]  pam_faillock.so authfail
+auth     sufficient     pam_faillock.so authsucc
+auth     required       pam_deny.so
+EOF""")
         else:
             # see https://access.redhat.com/solutions/62949
             sed = ("/^auth.*pam_unix/ {"

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -39,6 +39,7 @@ class TestLogin(testlib.MachineCase):
             b.set_layout("desktop")
 
     # @testlib.skipBeiboot("no local cockpit PAM config in beiboot mode")
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testBasic(self):
         m = self.machine
         b = self.browser
@@ -224,6 +225,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
                                     "noise-rc-.*")
 
     @testlib.skipWsContainer("logs in via ssh, not cockpit-session")
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testLogging(self):
         m = self.machine
         b = self.browser
@@ -838,6 +840,7 @@ EOF""")
         b.logout()
 
     @testlib.skipWsContainer("root logins disabled by default with ssh")
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testPamAccess(self):
         b = self.browser
         m = self.machine
@@ -1067,6 +1070,7 @@ matchrule = <SUBJECT>^DC=LAN,DC=COCKPIT,CN=alice$
 
     # enable this once our cockpit/ws container can beiboot
     @testlib.skipWsContainer("client setup does not work with ws container")
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testSSH(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-storage-anaconda
+++ b/test/verify/check-storage-anaconda
@@ -668,7 +668,7 @@ AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
         self.dialog_wait_close()
         b.wait_text(self.card_row_col("Storage", 1, 3), "Unformatted data")
 
-    @testlib.skipImage("No Stratis", "debian-*", "ubuntu-*")
+    @testlib.skipImage("No Stratis", "debian-*", "ubuntu-*", "*suse*")
     @testlib.skipImage("No Anaconda", "arch")
     @testlib.destructive
     def testNoOndemandPackages(self):

--- a/test/verify/check-storage-anaconda
+++ b/test/verify/check-storage-anaconda
@@ -175,7 +175,7 @@ class TestStorageAnaconda(storagelib.StorageCase):
         b.wait(lambda: b.call_js_func('ph_count', self.card("Storage") + " tbody tr") == 1)
         b.wait_not_present(self.card_row("Storage", location="/var"))
 
-    @testlib.skipImage("No Stratis", "debian-*", "ubuntu-*", "arch")
+    @testlib.skipImage("No Stratis", "debian-*", "ubuntu-*", "arch", "*suse*")
     @testlib.skipImage("commit 817c957899a4 removed Statis 2 support", "rhel-8-*")
     def testStratis(self):
         m = self.machine

--- a/test/verify/check-storage-iscsi
+++ b/test/verify/check-storage-iscsi
@@ -21,7 +21,7 @@ import storagelib
 import testlib
 
 
-@testlib.skipImage("UDisks doesn't have support for iSCSI", "debian-*", "ubuntu-*", "arch")
+@testlib.skipImage("UDisks doesn't have support for iSCSI", "debian-*", "ubuntu-*", "arch", "*suse*")
 @testlib.skipImage("udisks2-iscsi not on image", "*-bootc")
 @testlib.nondestructive
 class TestStorageISCSI(storagelib.StorageCase):

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -537,6 +537,7 @@ class TestStorageNBDE(storagelib.StorageCase, packagelib.PackageCase):
         "tang": {"address": "10.111.112.5/20"}
     }
 
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testBasic(self):
         m = self.machine
         b = self.browser
@@ -721,6 +722,7 @@ class TestStorageNBDE(storagelib.StorageCase, packagelib.PackageCase):
         b.wait_not_present(panel + 'tr:contains("Slot 1")')
 
     @testlib.skipImage("TODO: don't know how to encrypt the rootfs", "debian-*", "ubuntu-*", "arch")
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     # this doesn't work in ostree either, but we don't run storage tests there
     @testlib.skipWsContainer("newly built root doesn't contain ws container")
     @testlib.timeout(1200)

--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -812,6 +812,7 @@ class TestStorageLvm2(storagelib.StorageCase):
         wait_partial(4)         # striped mirror has lost more than half and is kaputt
         wait_partial(6)         # raid6 is finally toast as well
 
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testLvmOnLuks(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-storage-nfs
+++ b/test/verify/check-storage-nfs
@@ -25,6 +25,7 @@ import testlib
 @testlib.nondestructive
 class TestStorageNfs(storagelib.StorageCase):
 
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testNfsClient(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -58,7 +58,7 @@ def create_legacy_pool(machine, disks, name="pool0", keydesc=None, tang=None):
     machine.execute(f"yes | stratisd-tools stratis-legacy-pool {keydesc_opt} {clevis_opt} {name} {' '.join(disks)}")
 
 
-@testlib.skipImage("No Stratis", "debian-*", "ubuntu-*", "arch")
+@testlib.skipImage("No Stratis", "debian-*", "ubuntu-*", "arch", "*suse*")
 @testlib.skipImage("stratis not installed", "*-bootc")
 @testlib.skipImage("commit 817c957899a4 removed Statis 2 support", "rhel-8-*")
 @testlib.nondestructive
@@ -584,7 +584,7 @@ systemctl restart stratisd
         self.testFilesystemSizes(legacy=True)
 
 
-@testlib.skipImage("No Stratis", "debian-*", "ubuntu-*", "arch")
+@testlib.skipImage("No Stratis", "debian-*", "ubuntu-*", "arch", "*suse*")
 @testlib.skipImage("stratis not installed", "*-bootc")
 @testlib.skipImage("commit 817c957899a4 removed Statis 2 support", "rhel-8-*")
 class TestStorageStratisReboot(storagelib.StorageCase):
@@ -920,7 +920,7 @@ class TestStorageStratisReboot(storagelib.StorageCase):
         self.testPoolResize(legacy=True)
 
 
-@testlib.skipImage("No Stratis", "debian-*", "ubuntu-*", "arch")
+@testlib.skipImage("No Stratis", "debian-*", "ubuntu-*", "arch", "*suse*")
 @testlib.skipOstree("no package installation on OSTree")
 class TestStoragePackagesStratis(packagelib.PackageCase, storagelib.StorageCase):
 
@@ -964,7 +964,7 @@ class TestStoragePackagesStratis(packagelib.PackageCase, storagelib.StorageCase)
             b.wait_not_present(stratis_action)
 
 
-@testlib.skipImage("No Stratis", "debian-*", "ubuntu-*", "arch")
+@testlib.skipImage("No Stratis", "debian-*", "ubuntu-*", "arch", "*suse*")
 @testlib.skipImage("stratis not installed", "*-bootc")
 @testlib.skipImage("Stratis too old", "rhel-8-*")
 class TestStorageStratisNBDE(packagelib.PackageCase, storagelib.StorageCase):

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -332,6 +332,7 @@ session include system-auth
         b.check_superuser_indicator("Limited access")
 
     @testlib.skipBeiboot("no local overrides/PAM config in beiboot mode")
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testMultipleBridgeConfig(self):
         b = self.browser
 

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -512,6 +512,8 @@ class TestRealms(testlib.MachineCase):
 
 
 @testlib.no_retry_when_changed
+@testlib.skipImage("freeipa not currently available", "debian-testing")
+@testlib.skipImage("ipa-client-install not available", "opensuse-tumbleweed")
 class TestIPA(TestRealms, CommonTests):
     def setUp(self):
         super().setUp()

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -1253,6 +1253,7 @@ Where=/fail
         b.wait_js_cond('window.location.pathname == "/system/services"')
 
     @testlib.nondestructive
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testServicesThemeConsistency(self):
         b = self.browser
 

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -456,6 +456,7 @@ class TestAccounts(testlib.MachineCase):
         b.click("#accounts-list > thead > tr > th:nth-child(3) > button")
         check_column_sort("[data-label='ID']")
 
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testUserPasswords(self):
         b = self.browser
         m = self.machine
@@ -950,6 +951,7 @@ class TestAccounts(testlib.MachineCase):
         b.go("#/robert")
         b.wait_text("#account-shell", custom_shell)
 
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testUnprivileged(self):
         m = self.machine
         b = self.browser
@@ -1034,6 +1036,7 @@ class TestAccounts(testlib.MachineCase):
                 return value.strip()
         return None
 
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testExpire(self):
         m = self.machine
         b = self.browser
@@ -1130,6 +1133,7 @@ class TestAccounts(testlib.MachineCase):
         self.assertEqual(self.accountExpiryInfo("scruffy", "Password expires"), "password must be changed")
 
     @testlib.skipWsContainer("User is not shown as logged in with cockpit/ws")
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     def testAccountLogs(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-users-roles
+++ b/test/verify/check-users-roles
@@ -22,6 +22,7 @@ import testlib
 
 class TestRoles(testlib.MachineCase):
 
+    @testlib.skipImage("TODO: support opensuse-tumbleweed", "*tumbleweed*")
     @testlib.nondestructive
     def testBasic(self):
         m = self.machine


### PR DESCRIPTION
This is based on cherry picked commits from https://github.com/cockpit-project/cockpit/pull/21335. Each commit disables unsupported tests on opensuse. These were cherry-picked and submitted as one pr as they're a set of minor changes on their own and all of them disable tests.