### PR TITLE
docs: adjust ssh config installation guide to only enable password authentication for localhost for more security

### DIFF
--- a/containers/ws/README.md
+++ b/containers/ws/README.md
@@ -40,13 +40,18 @@ host's users and their passwords to log in, and Cockpit's branding will adjust
 to the host operating system.
 
 1. Enable password based SSH logins, unless you only use [SSO logins](https://cockpit-project.org/guide/latest/sso.html).
-   To do this, create a config file `/etc/ssh/sshd_config.d/02-enable-passwords.conf` and add the following content:
+   From localhost only:
+   ```bash
+    cat << EOF > /etc/ssh/sshd_config.d/02-enable-passwords.conf
+    # enables Cockpit web login without exposing password auth to network
+    Match Address 127.0.0.1,::1
+      PasswordAuthentication yes
+    EOF
    ```
-   # enables Cockpit web login without exposing password auth to network
-   Match Address 127.0.0.1,::1
-     PasswordAuthentication yes
+   Or from any host:
+   ```bash
+    echo 'PasswordAuthentication yes' | sudo tee /etc/ssh/sshd_config.d/02-enable-passwords.conf
    ```
-2. Restart SSH:
    ```
    sudo systemctl try-restart sshd
    ```


### PR DESCRIPTION
This idea came from https://github.com/ublue-os/ucore/issues/275 / https://github.com/ublue-os/ucore/pull/286 so credits to them.

Basically you only localhost authentication and it should work. :)

IMHO, this is a quite good security feature and should thus be highlighted here in the official guides, as you can then still keep public key authentication for "normal" SSH.