### PR TITLE
test: Add row selector for restorecon button

### DIFF
--- a/test/verify/check-selinux
+++ b/test/verify/check-selinux
@@ -190,7 +190,7 @@ class TestSelinux(testlib.MachineCase):
                 b.wait_in_text(row_selector + " tr.pf-m-expanded .ct-listing-panel-body", "you can run restorecon")
 
                 # and it can be applied
-                btn_sel = f".selinux-details:contains('you can run restorecon') button{self.default_btn_class}"
+                btn_sel = f"{row_selector} .selinux-details:contains('you can run restorecon') button{self.default_btn_class}"
                 b.click(btn_sel)
 
                 # the button should disappear


### PR DESCRIPTION
We weren't specific enough the DOM query for the restorecon button. This
meant that when selinux-policy updated the defaults of `sshd-session` we
had too ambiguous of a query due to there now being SELinux alerts for
both read and open access of `~/.ssh/authorized_keys`.

Adding the row selector we already use in the test should be good enough
to correct this mistake.

Fixes: https://github.com/cockpit-project/cockpit/issues/22461
Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
