### PR TITLE
apps: add Arch Linux appstream package

### DIFF
--- a/pkg/apps/manifest.json
+++ b/pkg/apps/manifest.json
@@ -20,7 +20,8 @@
             "debian": ["appstream"]
         },
         "appstream_data_packages": {
-            "fedora": ["appstream-data"]
+            "fedora": ["appstream-data"],
+            "arch": ["archlinux-appstream-data"]
         }
     }
 }

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -79,7 +79,6 @@ class TestApps(packagelib.PackageCase):
         # ignore the corresponding journal entry
         self.allow_journal_messages("org.freedesktop.PackageKit.*org.freedesktop.DBus.Error.NoReply.*")
 
-    @testlib.skipImage("TODO: works locally, unstable in CI", "arch")
     def testBasic(self, urlroot: str = ""):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
For showing the available Cockpit appstream packages install the relevant appstream data package on Arch Linux.