### PR TITLE
flatpak: Compose URL for screenshots mirror

### DIFF
--- a/containers/flatpak/install
+++ b/containers/flatpak/install
@@ -23,6 +23,7 @@ flatpak run \
         "$@" \
         --force-clean \
         --mirror-screenshots-url=https://dl.flathub.org/media \
+        --compose-url-policy=full \
         --install flatpak-build-dir "${MANIFEST}"
 
 flatpak run \


### PR DESCRIPTION
We started getting errors for our flatpak CI runs a few weeks ago. Which
coincided with an upstream infrastructure issue which would explain the
screenshots error. After infra was fixed and the fact that we didn't get
any successful runs, something else was going on.

Turns out that `flatpak-builder` had a release which changed the
behaviour of `--compose-url-policy` to default to `partial` instead of
`full` which was used before. Our fix is simple, just change it back to
`full`

Fixes: https://github.com/cockpit-project/cockpit/issues/22444
Related-to: https://github.com/flatpak/flatpak-builder/pull/652
Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
