### PR TITLE
shell-modals: fix language selected in dialog

### DIFF
--- a/pkg/shell/shell-modals.tsx
+++ b/pkg/shell/shell-modals.tsx
@@ -108,7 +108,7 @@ export const LangModal = ({
     dialogResult,
     state
 }: LangModalProps) => {
-    const language = document.cookie.replace(/(?:(?:^|.*;\s*)CockpitLang\s*=\s*([^;]*).*$)|^.*$/, "$1") || "en-us";
+    const language = document.cookie.replace(/(?:(?:^|.*;\s*)CockpitLang\s*=\s*([^;]*).*$)|^.*$/, "$1") || navigator.language.toLowerCase() || "en-us";
 
     const [selected, setSelected] = useState(language);
     const [searchInput, setSearchInput] = useState("");


### PR DESCRIPTION
when `CockpitLang` is not set (the default when first logging in), the Language Dialog selects "en-us" even when the browser language is something else (e.g. PL, FR) and Cockpit already displays in that language.