### PR TITLE
make-sysext: Fix start/stop for other extensions, Use run0 instead of sudo

### DIFF
--- a/tools/make-sysext
+++ b/tools/make-sysext
@@ -89,7 +89,7 @@ else
 fi
 
 if systemd-detect-virt --quiet --container; then
-    flatpak-spawn --host sudo -S "$0" "$arg"
+    flatpak-spawn --host run0 "$0" "$arg"
 else
-    sudo "$0" "$arg"
+    run0 "$0" "$arg"
 fi


### PR DESCRIPTION
See commit messages for details. This works well on my current system now. @jelly do you mind testing on Arch?