### PR TITLE
networking: Fix renaming of bridges and other groups

### DIFF
--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -1764,10 +1764,7 @@ export function set_member(model, group_connection, group_settings, member_type,
         /* Turn the main_connection into a member for group.
          */
 
-        const group_iface = group_connection
-            ? group_connection.Interfaces[0].Name
-            : group_settings.connection.interface_name;
-
+        const group_iface = group_settings.connection.interface_name;
         if (!group_iface)
             return false;
 
@@ -1801,10 +1798,12 @@ export function set_member(model, group_connection, group_settings, member_type,
         }
 
         return settings_applier(model, iface.Device, main_connection)(member_settings).then(function () {
-            // If the group already exists, activate or deactivate the member immediately so that
-            // the settings actually apply and the interface becomes a member.  Otherwise we
-            // activate it later when the group is created.
-            if (group_connection) {
+            // If the group already exists (with the correct name),
+            // activate or deactivate the member immediately so that
+            // the settings actually apply and the interface becomes a
+            // member.  Otherwise we activate it later when the group
+            // is created.
+            if (group_connection && group_connection.Interfaces[0].Name == group_iface) {
                 const group_dev = group_connection.Interfaces[0].Device;
                 if (group_dev && group_dev.ActiveConnection)
                     return main_connection.activate(iface.Device);

--- a/test/verify/check-networkmanager-bond
+++ b/test/verify/check-networkmanager-bond
@@ -163,14 +163,17 @@ class TestBonding(netlib.NetworkCase):
         iface = m.execute("cd /sys/class/net; ls -d e* | head -n1").strip()
         b.wait_visible(f"tr[data-interface='{iface}']")
 
-        # Make a simple bond without any members.  This is enough to
-        # test the renaming.
+        iface1 = "cockpit1"
+        self.add_veth(iface1, dhcp_cidr="10.111.113.1/24", dhcp_range=['10.111.113.2', '10.111.113.254'])
+        self.nm_activate_eth(iface1)
+        self.wait_for_iface(iface1)
 
         b.click("button:contains('Add bond')")
         b.wait_visible("#network-bond-settings-dialog")
         b.select_from_dropdown("#network-bond-settings-link-monitoring-select", "arp")
         b.set_input_text("#network-bond-settings-monitoring-targets-input", "1.1.1.1")
         b.set_input_text("#network-bond-settings-interface-name-input", "tbond")
+        b.set_checked(f"input[data-iface='{iface1}']", val=True)
         b.click("#network-bond-settings-dialog button:contains('Add')")
         b.wait_not_present("#network-bond-settings-dialog")
 
@@ -179,7 +182,6 @@ class TestBonding(netlib.NetworkCase):
 
         b.click("#networking-interfaces tr[data-interface='tbond'] button")
         self.wait_onoff("#network-interface .pf-v6-c-card__header", val=True)
-        self.wait_for_iface_setting('Status', 'Configuring')
 
         self.configure_iface_setting('Bond')
         b.wait_visible("#network-bond-settings-dialog")
@@ -192,6 +194,10 @@ class TestBonding(netlib.NetworkCase):
         b.click("#network-bond-settings-dialog button:contains('Save')")
         b.wait_not_present("#network-bond-settings-dialog")
         b.wait_text("#network-interface-name", "tbond3000")
+
+        # Check that the member is still there and active
+        b.wait_visible(f"#network-interface-members tr[data-interface='{iface1}']")
+        self.wait_onoff(f"#network-interface-members tr[data-interface='{iface1}']", val=True)
 
     def testActive(self):
         b = self.browser


### PR DESCRIPTION
Always use the new interface name of a group in member settings and only activate the members immediately when the group name has not changed.

[RHEL-117883](https://issues.redhat.com/browse/RHEL-117883)

- [x] tests for renaming
