### PR TITLE
arch: drop accountsservice as make dependency

### DIFF
--- a/tools/arch/PKGBUILD
+++ b/tools/arch/PKGBUILD
@@ -11,7 +11,7 @@ pkgdesc='A systemd web based user interface for Linux servers'
 arch=('x86_64')
 url='https://cockpit-project.org/'
 license=(LGPL)
-makedepends=(krb5 accountsservice json-glib glib-networking glib2-devel
+makedepends=(krb5 json-glib glib-networking glib2-devel
              git intltool gtk-doc gobject-introspection networkmanager xmlto npm
              python-build python-installer python-wheel)
 source=("cockpit-${pkgver}.tar.xz"


### PR DESCRIPTION
Cockpit already moved away from accountsservice in 5c5b20dcc3cdf85fd313377ff333b401b0aa2d0e.