### PR TITLE
test: inspect all links in the package update security description

### DIFF
--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -844,13 +844,7 @@ ExecStart=/usr/local/bin/{packageName}
         self.assertEqual(b.attr(sel + " td.changelog a", "target"), "_blank")
         # verify Markdown formatting in details
         self.assertEqual(b.text(sel + " .pf-v6-c-table__expandable-row.pf-m-expanded em"), "more")  # *more*
-        self.assertEqual(
-            b.attr(sel + " .pf-v6-c-table__expandable-row.pf-m-expanded a:first-of-type", "href"),
-            "http://unicorn.example.com",
-        )
-        self.assertEqual(
-            b.attr(sel + " .pf-v6-c-table__expandable-row.pf-m-expanded a:first-of-type", "target"), "_blank"
-        )
+        b.wait_visible(sel + ' .pf-v6-c-table__expandable-row.pf-m-expanded a[href="http://unicorn.example.com"][target="_blank"]')
 
         # verify that changelog is absent in mobile
         b.set_layout("mobile")


### PR DESCRIPTION
In packagekit 1.3.2-1 the description format changed making our selector ambigious. As we don't want to assert if the first link contains unicorn.example.com but if *any* link in the description does, exactly test for that.

https://github.com/PackageKit/PackageKit/commit/c7508778a1ead262c425a305bd02a92ee2ab2cc8