### PR TITLE
test: ubuntu-stable changed sosreport directory to /var/tmp

### DIFF
--- a/test/verify/check-sosreport
+++ b/test/verify/check-sosreport
@@ -36,7 +36,7 @@ class TestSOS(testlib.MachineCase):
         # Older Debian and Ubuntu systems have sosreport in /tmp
         # Newer versions of sosreport changed to /var/tmp
         # https://github.com/sosreport/sos/pull/4090
-        if m.image in ["debian-trixie", "ubuntu-stable", "ubuntu-2204", "ubuntu-2404"]:
+        if m.image in ["debian-trixie", "ubuntu-2204", "ubuntu-2404"]:
             self.report_dir = "/tmp"
         else:
             self.report_dir = "/var/tmp"


### PR DESCRIPTION
Needs to land in lockstep with https://github.com/cockpit-project/bots/pull/8345