### PR TITLE
test: fixup matching /var/log/wtmp.db

### DIFF
--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -256,7 +256,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         m.start_cockpit()
 
         # Clean out the relevant logfiles
-        m.execute("truncate -s0 /var/log/{[bw]tmp{.db},lastlog} /run/utmp")
+        m.execute("truncate -s0 /var/log/{[bw]tmp{,.db},lastlog} /run/utmp")
 
         if m.image == "arch":
             self.sed_file("s/# deny = 3/deny = 4/", "/etc/security/faillock.conf")

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -113,7 +113,7 @@ class TestAccounts(testlib.MachineCase):
         m = self.machine
 
         # Clean out the relevant logfiles
-        m.execute("truncate -s0 /var/log/{[bw]tmp{.db},lastlog} /run/utmp")
+        m.execute("truncate -s0 /var/log/{[bw]tmp{,.db},lastlog} /run/utmp")
         m.execute("rm -f /var/lib/lastlog/lastlog2.db /var/lib/wtmpdb/wtmp.db")
 
         self.login_and_go("/users")
@@ -461,7 +461,7 @@ class TestAccounts(testlib.MachineCase):
         m = self.machine
 
         # Clean out the relevant logfiles
-        m.execute("truncate -s0 /var/log/{[bw]tmp{.db},lastlog} /run/utmp")
+        m.execute("truncate -s0 /var/log/{[bw]tmp{,.db},lastlog} /run/utmp")
         m.execute("rm -f /var/lib/lastlog/lastlog2.db /var/lib/wtmpdb/wtmp.db")
 
         self.login_and_go("/users")
@@ -1135,7 +1135,7 @@ class TestAccounts(testlib.MachineCase):
         m = self.machine
 
         # Clean out the relevant logfiles
-        m.execute("truncate -s0 /var/log/{[bw]tmp{.db},lastlog} /run/utmp")
+        m.execute("truncate -s0 /var/log/{[bw]tmp{,.db},lastlog} /run/utmp")
         m.execute("rm -f /var/lib/lastlog/lastlog2.db /var/lib/wtmpdb/wtmp.db")
 
         # First login: no entries yet


### PR DESCRIPTION
468ce85a4ec626e3ba642 was slightly wrong in that it missed a comma, so not optionally matching wtmp.db.