### PR TITLE
test: make run command compatible with Rust coreutils

### DIFF
--- a/test/verify/check-shell-active-pages
+++ b/test/verify/check-shell-active-pages
@@ -68,10 +68,10 @@ class TestActivePages(testlib.MachineCase):
         b.wait_in_text(line_sel(1), '$')
 
         # run a command that we can easily identify, and which will die with the terminal
-        b.input_text("bash -c 'exec -a kitten cat'\n")
+        b.input_text("sleep 42\n")
 
         # wait for command to run
-        m.execute("until pgrep -afx kitten; do sleep 1; done")
+        m.execute("until pgrep -afx 'sleep 42'; do sleep 1; done")
 
         # now close the page
         showPagesAssertCount(3)
@@ -90,7 +90,7 @@ class TestActivePages(testlib.MachineCase):
         b.wait_not_present("iframe[name='cockpit1:localhost/system/terminal']")
 
         # running shell command should disappear on the system
-        m.execute("while pgrep -afx kitten; do sleep 1; done")
+        m.execute("while pgrep -afx 'sleep 42'; do sleep 1; done")
 
         # there should only be the original page left
         showPagesAssertCount(1)


### PR DESCRIPTION
The Ubuntu 25.10 switch to Rust coreutils no longer allows one to set argv[0] throws a "security violation". As we need just an unique process to identify if it runs and gets cleaned up change it to `sleep 42` which works with any coreutils version.

root@ubuntu:~# bash -c 'exec -a kitten cat'
Security violation: Requested utility `kitten` does not match executable name:
  /usr/lib/cargo/bin/coreutils/cat