### PR TITLE
cockpit: update ssh prompt host key fingerprint matching

### DIFF
--- a/src/cockpit/beiboot.py
+++ b/src/cockpit/beiboot.py
@@ -171,7 +171,7 @@ class AuthorizeResponder(ferny.AskpassHandler):
 
         # FIXME: is this a host key prompt? This should be handled more elegantly,
         # see https://github.com/cockpit-project/cockpit/pull/19668
-        fp_match = re.search(r'\n(\w+) key fingerprint is ([^.]+)\.', prompt)
+        fp_match = re.search(r'\n(\w+) key fingerprint is:? ([^.]+)\.', prompt)
         # let ssh resolve aliases, don't use our original "destination"
         host_match = re.search(r"authenticity of host '([^ ]+) ", prompt)
         args = {}


### PR DESCRIPTION
openssh 10.2p1 changed the prompt output slightly, compared to the old version in that it now includes colon and no dot at the end.

+ED25519 key fingerprint is: SHA256:xD6UcDvVDpRNIKew3CVJtajlPujToVumgISXdunBUfY 
-ED25519 key fingerprint is SHA256:YDOcdZxLSmDEM2xGgyAs5lFUbUXK2F8zi0yRbpiA2oo.