### PR TITLE
test: wait for CPU load script to run

### DIFF
--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -656,9 +656,10 @@ fi
         # CPU
         # first wait until system settles down
         testlib.wait(lambda: progressValue(1) < 20)
-        m.spawn("for i in $(seq $(nproc)); do cat /dev/urandom > /dev/null & done", "cpu_hog.log")
+        m.spawn("for i in $(seq $(nproc)); do cat /dev/urandom > /dev/null & done; touch /tmp/cpu_hog", "cpu_hog.log")
+        m.execute("while [ ! -e /tmp/cpu_hog ]; do sleep 1; done")
         testlib.wait(lambda: progressValue(1) > 75)
-        m.execute("pkill -e -f [c]at.*urandom")
+        m.execute("pkill -e -f [c]at.*urandom; rm -f /tmp/cpu_hog")
         # should go back to idle usage
         # HACK: work around pmie CPU usage https://bugzilla.redhat.com/show_bug.cgi?id=2140572
         testlib.wait(lambda: progressValue(1) < 20, tries=200)


### PR DESCRIPTION
Trying to reproduce the failing TestSystemInfo.testOverview fails earlier on our graphs not updating fast enough. Robustify the test by first waiting on `cat /dev/urandom` to start.