### PR TITLE
test: remove any leftover directory in /var/lib/pacman/sync

### DIFF
--- a/test/common/packagelib.py
+++ b/test/common/packagelib.py
@@ -82,7 +82,8 @@ class PackageCase(MachineCase):
             self.restore_file("/etc/pacman.d/mirrorlist")
             self.restore_file("/usr/share/libalpm/hooks/90-packagekit-refresh.hook")
 
-            self.machine.execute("rm /etc/pacman.conf /etc/pacman.d/mirrorlist /var/lib/pacman/sync/* "
+            self.machine.execute("rm -r /var/lib/pacman/sync/*")
+            self.machine.execute("rm /etc/pacman.conf /etc/pacman.d/mirrorlist "
                                  "/usr/share/libalpm/hooks/90-packagekit-refresh.hook")
             # Drop alpm state directory as it interferes with running offline
             self.machine.execute("test -d /var/lib/PackageKit/alpm && rm -r /var/lib/PackageKit/alpm || true")


### PR DESCRIPTION
`pacman -Syu` downloads sync database temporarily in a directory under `/var/lib/pacman/sync` moving it to its final destination. In our CI this directory is sometimes leftover so clean it up properly.

See this [test failure](https://logs-cockpit.apps.ocp.cloud.ci.centos.org/pull-22562-41217dd0-20251104-112929-arch-expensive/log.html)