### PR TITLE
dom: Replace deprecated `<tt>` element

### DIFF
--- a/pkg/systemd/terminal.jsx
+++ b/pkg/systemd/terminal.jsx
@@ -229,7 +229,7 @@ const _ = cockpit.gettext;
                 <Page className="pf-m-no-sidebar">
                     <PageSection hasShadowBottom>
                         <div className="terminal-group">
-                            <tt className="terminal-title">{this.state.title}</tt>
+                            <code className="terminal-title">{this.state.title}</code>
                             <Toolbar id="toolbar">
                                 <ToolbarContent>
                                     <ToolbarGroup>


### PR DESCRIPTION
Replaces DOM element `<tt>` with `<code>`. This is done as `<tt>` is
deprecated and not recommended and is similar to `<code>`.

Related-to: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/tt
Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
