### PR TITLE
realmd: Add `autocomplete` to Join realm inputs

### DIFF
--- a/pkg/systemd/overview-cards/realmd.jsx
+++ b/pkg/systemd/overview-cards/realmd.jsx
@@ -430,14 +430,15 @@ const JoinDialog = ({ realmd_client }) => {
                     <FormGroup label={ _("Domain address") } fieldId="realms-op-address" validated={addressValid}>
                         <TextInput id="realms-op-address" placeholder="domain.example.com"
                                    data-discover={ (!addressValid || addressValid == "default") ? null : "done" }
+                                   autoComplete="url"
                                    value={address} onChange={(_event, value) => validateAddress(value)} isDisabled={pending} />
                     </FormGroup>
 
                     <FormGroup label={ _("Domain administrator name") } fieldId="realms-op-admin">
-                        <TextInput id="realms-op-admin" placeholder="admin" value={admin} onChange={(_event, value) => setAdmin(value)} isDisabled={pending} />
+                        <TextInput id="realms-op-admin" placeholder="admin" value={admin} autoComplete="username" onChange={(_event, value) => setAdmin(value)} isDisabled={pending} />
                     </FormGroup>
                     <FormGroup label={ _("Domain administrator password") } fieldId="realms-op-admin-password">
-                        <TextInput id="realms-op-admin-password" type="password" value={adminPassword} onChange={(_event, value) => setAdminPassword(value)} isDisabled={pending} />
+                        <TextInput id="realms-op-admin-password" type="password" value={adminPassword} autoComplete="current-password" onChange={(_event, value) => setAdminPassword(value)} isDisabled={pending} />
                     </FormGroup>
                     <FormHelper fieldId="realms-op-address" helperText={domainHelperText} helperTextInvalid={addressValid == "error" && domainHelperText} icon={domainHelperIcon} />
                 </Form>


### PR DESCRIPTION
A suggestion came up in the browser during my manual testing to add
autocomplete to the admin password field within the Join realm modal.

This adds the `autocomplete` to domain, username, and password fields.

Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
