### PR TITLE
testlib: fix globbing in unused pixeltests check

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1599,7 +1599,7 @@ class Browser:
         if not (Image and self.pixels_label):
             return
 
-        pixel_references = set(glob.glob(os.path.join(TEST_DIR, "reference", self.pixels_label + "*-pixels.png")))
+        pixel_references = set(glob.glob(os.path.join(TEST_DIR, "reference", self.pixels_label + "-*-pixels.png")))
         unused = pixel_references - self.used_pixel_references
         for u in unused:
             print("Unused reference image " + os.path.basename(u))


### PR DESCRIPTION
If `self.pixels_label` is a substring of another label the teardown function which verifies that all pixel referenceswere used would fail as it also matches pixels from a different test.