### PR TITLE
testlib: Add one more retryable Chromium error

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -840,6 +840,7 @@ class Browser:
                     # chromium
                     "Execution context was destroyed",
                     "Cannot find context",
+                    "Inspected target navigated or closed",
                     # firefox
                     "MessageHandlerFrame' destroyed",
                     # page helpers not yet loaded


### PR DESCRIPTION
This error happens with Chromium 142.0.7444.59 on login and probably whenever the page is reloaded.