### PR TITLE
packagekit: skip old transactions with an invalid time specification

### DIFF
--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -1312,7 +1312,12 @@ class OsUpdates extends React.Component {
                     // data looks like:
                     // downloading\tbash-completion;1:2.6-1.fc26;noarch;updates-testing
                     // updating\tbash-completion;1:2.6-1.fc26;noarch;updates-testing
-                const pkgs = { _time: Date.parse(timeSpec) };
+                const _time = Date.parse(timeSpec);
+                if (isNaN(_time)) {
+                    debug(`Transaction has an invalid timespec=${timeSpec}`);
+                    return;
+                }
+                const pkgs = { _time };
                 let empty = true;
                 data.split("\n").forEach(line => {
                     const fields = line.trim().split("\t");


### PR DESCRIPTION
Some users report that the Cockpit software updates page oopses on Debian. Decoding the traceback leads to the oops coming from `timeformat.dateTime(update.time)` in the `History` component in `history.jsx`. We never validate if the `timeSpec` returns a valid date so this is the likely cause of the oops.

This change will omit some updates from the updates view but as updates without a valid date cannot be compared to ones with a date it feels better to omit them.

Related: #22552


---

This feels like a packagekit bug but there is no good UI / command line to easily figure that out.