### PR TITLE
css: Create inline card modifier

### DIFF
--- a/pkg/apps/application.jsx
+++ b/pkg/apps/application.jsx
@@ -111,7 +111,7 @@ export const Application = ({ metainfo_db, id, progress, action }) => {
         }
 
         return (
-            <Card isPlain>
+            <Card isPlain className="ct-pf-card-inline">
                 <CardHeader actions={{
                     actions: <>{progress_or_launch}<ActionButton comp={comp} progress={progress} action={action} /></>,
                 }}>

--- a/pkg/kdump/kdump-view.jsx
+++ b/pkg/kdump/kdump-view.jsx
@@ -617,7 +617,7 @@ ${enableCrashKernel}
                             {alertDetail}
                         </Alert>
                     }
-                    <Card isPlain>
+                    <Card isPlain className="ct-pf-card-inline">
                         <CardTitle>
                             <Title headingLevel="h4" size="xl">
                                 {_("Kdump settings")}

--- a/pkg/lib/cockpit-components-logs-panel.jsx
+++ b/pkg/lib/cockpit-components-logs-panel.jsx
@@ -169,7 +169,7 @@ export class LogsPanel extends React.Component {
         const actions = (this.state.logs.length > 0 && this.props.goto_url) && <Button variant="secondary" onClick={e => cockpit.jump(this.props.goto_url)}>{_("View all logs")}</Button>;
 
         return (
-            <Card isPlain className="cockpit-log-panel">
+            <Card isPlain className="cockpit-log-panel ct-pf-card-inline">
                 <CardHeader actions={{ actions }}>
                     <CardTitle>{this.props.title}</CardTitle>
                 </CardHeader>

--- a/pkg/lib/cockpit-components-modifications.jsx
+++ b/pkg/lib/cockpit-components-modifications.jsx
@@ -155,7 +155,7 @@ export const Modifications = ({ entries, failed, permitted, title, shell, ansibl
                 <ModificationsExportDialog shell={shell} ansible={ansible}
                 onClose={() => setShowDialog(false)} />
             }
-            <Card isPlain className="modifications-table">
+            <Card isPlain className="modifications-table ct-pf-card-inline">
                 <CardHeader>
                     <CardTitle component="h2">{title}</CardTitle>
                     { !emptyRow &&

--- a/pkg/lib/ct-card.scss
+++ b/pkg/lib/ct-card.scss
@@ -10,6 +10,23 @@
   font-size: var(--pf-t--global--font--size--2xl);
 }
 
+/* FIXME: Custom plain PF card modifier to make it look like PF6 without it being a card */
+.pf-v6-c-card.pf-m-plain.ct-pf-card-inline {
+  // Plain PF Cards just remove the border color and background, but we should also make sure that the radius is
+  // removed so that tables etc. don't get weird borders on the first and last cell.
+  // This mostly happens when we're not using card body
+  border-radius: 0;
+
+  .pf-v6-c-card__header, > .pf-v6-c-card__title {
+    padding-inline: 0;
+  }
+
+  .pf-v6-c-card__body.contains-list {
+    padding: 0;
+  }
+}
+
+
 .ct-cards-grid {
   --ct-grid-columns: 2;
   --pf-v6-l-gallery--GridTemplateColumns: repeat(var(--ct-grid-columns), 1fr);

--- a/pkg/lib/patternfly/patternfly-6-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-6-overrides.scss
@@ -299,22 +299,6 @@ $phone: 767px;
   }
 }
 
-/* FIXME: Temporary rework plain cards to make it look like how PF6 is designed, removing the extra padding */
-.pf-v6-c-card.pf-m-plain {
-  // Plain PF Cards just remove the border color and background, but we should also make sure that the radius is
-  // removed so that tables etc. don't get weird borders on the first and last cell.
-  // This mostly happens when we're not using card body
-  border-radius: 0;
-
-  .pf-v6-c-card__header, > .pf-v6-c-card__title {
-    padding-inline: 0;
-  }
-
-  .pf-v6-c-card__body.contains-list {
-    padding: 0;
-  }
-}
-
 // FIXME: Temporary rework table cards in mobile/small view to have row dividers between each row.
 .pf-v6-c-card.ct-small-table-card {
   border-block-start: var(--pf-t--global--border--width--100) solid var(--pf-t--global--border--color--default);

--- a/pkg/metrics/metrics.jsx
+++ b/pkg/metrics/metrics.jsx
@@ -1954,7 +1954,7 @@ class MetricsHistory extends React.Component {
                 <PageSection hasBodyWrapper={false} className="metrics-history-section">
                     <>
                         { this.state.hours.length > 0 &&
-                        <Card isPlain>
+                        <Card isPlain className='ct-pf-card-inline'>
                             <CardBody className="metrics-history">
                                 { this.state.hours.map((time, i) => {
                                     const date_time = new Date(time);

--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -214,7 +214,7 @@ function ZoneSection(props) {
         }
     ];
 
-    return <Card isPlain className="zone-section" data-id={props.zone.id}>
+    return <Card isPlain className="zone-section ct-pf-card-inline" data-id={props.zone.id}>
         <CardHeader actions={{ actions }} className="zone-section-heading">
             <Flex alignItems={{ default: 'alignSelfBaseline' }} spaceItems={{ default: 'spaceItemsXl' }}>
                 <CardTitle component="h2">

--- a/pkg/networkmanager/network-interface-members.jsx
+++ b/pkg/networkmanager/network-interface-members.jsx
@@ -195,7 +195,7 @@ export const NetworkInterfaceMembers = ({
     );
 
     return (
-        <Card isPlain id="network-interface-members" className="network-interface-members">
+        <Card isPlain id="network-interface-members" className="network-interface-members ct-pf-card-inline">
             <CardHeader actions={{ actions: add_btn }}>
                 <CardTitle component="h2">{_("Interface members")}</CardTitle>
             </CardHeader>

--- a/pkg/networkmanager/network-interface.jsx
+++ b/pkg/networkmanager/network-interface.jsx
@@ -717,7 +717,7 @@ export const NetworkInterfacePage = ({
             </PageSection>
             <PageSection hasBodyWrapper={false}>
                 <Gallery hasGutter>
-                    <Card isPlain className="network-interface-details">
+                    <Card isPlain className="network-interface-details ct-pf-card-inline">
                         <CardHeader actions={{
                             actions: (
                                 <>

--- a/pkg/networkmanager/network-main.jsx
+++ b/pkg/networkmanager/network-main.jsx
@@ -153,7 +153,7 @@ export const NetworkPage = ({ privileged, operationInProgress, usage_monitor, pl
             </PageSection>
             <PageSection hasBodyWrapper={false}>
                 <Gallery hasGutter>
-                    {firewall.installed && <Card isPlain id="networking-firewall-summary">
+                    {firewall.installed && <Card isPlain id="networking-firewall-summary" className="ct-pf-card-inline">
                         <CardHeader actions={{
                             actions: <Button variant="secondary" id="networking-firewall-link"
                                         component="a"
@@ -175,7 +175,7 @@ export const NetworkPage = ({ privileged, operationInProgress, usage_monitor, pl
                             </Button>
                         </CardBody>
                     </Card>}
-                    <Card isPlain id="networking-interfaces">
+                    <Card isPlain id="networking-interfaces" className="ct-pf-card-inline">
                         <CardHeader actions={{ actions }}>
                             <CardTitle component="h2">{_("Interfaces")}</CardTitle>
                         </CardHeader>
@@ -190,7 +190,7 @@ export const NetworkPage = ({ privileged, operationInProgress, usage_monitor, pl
                                       rows={managed} />
                     </Card>
                     {unmanaged.length > 0 &&
-                    <Card isPlain id="networking-unmanaged-interfaces">
+                    <Card isPlain id="networking-unmanaged-interfaces" className="ct-pf-card-inline">
                         <CardHeader>
                             <CardTitle component="h2">{_("Unmanaged interfaces")}</CardTitle>
                         </CardHeader>

--- a/pkg/playground/react-demo-cards.jsx
+++ b/pkg/playground/react-demo-cards.jsx
@@ -26,21 +26,21 @@ import { Gallery, GalleryItem } from "@patternfly/react-core/dist/esm/layouts/Ga
 
 const CardsDemo = () => {
     const cards = [
-        <Card isPlain isCompact key="card1">
+        <Card isPlain isCompact key="card1" className="ct-pf-card-inline">
             <CardBody>I'm a card in a gallery</CardBody>
         </Card>,
-        <Card isPlain isCompact key="card2">
+        <Card isPlain isCompact key="card2" className="ct-pf-card-inline">
             <CardBody>I'm a card in a gallery</CardBody>
             <CardFooter>I have a footer</CardFooter>
         </Card>,
-        <Card isPlain isCompact key="card3">
+        <Card isPlain isCompact key="card3" className="ct-pf-card-inline">
             <CardBody>I'm a card in a gallery</CardBody>
         </Card>,
-        <Card isPlain isCompact key="card4">
+        <Card isPlain isCompact key="card4" className="ct-pf-card-inline">
             <CardTitle>I have a header too</CardTitle>
             <CardBody>I'm a card in a gallery</CardBody>
         </Card>,
-        <Card isPlain key="card5">
+        <Card isPlain key="card5" className="ct-pf-card-inline">
             <CardHeader actions={{
                 actions: <><input type="checkbox" />
                     <Button className="btn">click</Button></>,

--- a/pkg/selinux/setroubleshoot-view.jsx
+++ b/pkg/selinux/setroubleshoot-view.jsx
@@ -409,7 +409,7 @@ export class SETroubleshootPage extends React.Component {
                 : null
         );
         const troubleshooting = (
-            <Card isPlain>
+            <Card isPlain className="ct-pf-card-inline">
                 <CardHeader actions={{ actions }}>
                     <CardTitle component="h2">{title}</CardTitle>
                 </CardHeader>

--- a/pkg/sosreport/sosreport.jsx
+++ b/pkg/sosreport/sosreport.jsx
@@ -494,7 +494,7 @@ const SOSBody = () => {
 
     return (
         <PageSection hasBodyWrapper={false}>
-            <Card isPlain className="ct-card">
+            <Card isPlain className="ct-card ct-pf-card-inline">
                 <CardHeader actions={{
                     actions: <Button id="create-button" variant="primary" onClick={run_report}>
                         {_("Run report")}

--- a/pkg/storaged/legacy-vdo/legacy-vdo.jsx
+++ b/pkg/storaged/legacy-vdo/legacy-vdo.jsx
@@ -221,7 +221,7 @@ class VDODetails extends React.Component {
 
         if (vdo.broken) {
             return (
-                <Card isPlain>
+                <Card isPlain className="ct-pf-card-inline">
                     <Alert variant='danger' isInline
                            title={_("The creation of this VDO device did not finish and the device can't be used.")}
                            actionClose={<StorageButton onClick={force_delete}>

--- a/pkg/storaged/overview/overview.jsx
+++ b/pkg/storaged/overview/overview.jsx
@@ -177,7 +177,7 @@ const OverviewCard = ({ card, plot_state }) => {
         <Stack hasGutter>
             { !client.in_anaconda_mode() &&
             <StackItem>
-                <Card isPlain>
+                <Card isPlain className="ct-pf-card-inline">
                     <CardBody>
                         <StoragePlots plot_state={plot_state} />
                     </CardBody>

--- a/pkg/storaged/pages.jsx
+++ b/pkg/storaged/pages.jsx
@@ -597,7 +597,7 @@ export const PageTable = ({ emptyCaption, aria_label, pages, crossrefs, sorted, 
         if (narrow) {
             rows.push(
                 <Card isPlain key={key}
-                      className={"ct-small-table-card" +
+                      className={"ct-pf-card-inline ct-small-table-card" +
                                  (is_new ? " ct-new-item" : "")}
                       data-test-row-name={page.name}
                       data-test-row-location={location?.label || location}>
@@ -807,7 +807,7 @@ const StorageBreadcrumb = ({ page }) => {
 
 export const StorageCard = ({ card, alert, alerts, actions, children }) => {
     return (
-        <Card isPlain={card.page_location && card.page_location.length == 0} data-test-card-title={card.title}>
+        <Card isPlain={card.page_location && card.page_location.length == 0} data-test-card-title={card.title} className="ct-pf-card-inline">
             { (client.in_anaconda_mode() && card.page.parent && !card.next) &&
             <CardBody>
                 <StorageBreadcrumb page={card.page} />

--- a/pkg/systemd/hwinfo.jsx
+++ b/pkg/systemd/hwinfo.jsx
@@ -314,7 +314,7 @@ const HardwareInfo = ({ info }) => {
             </PageBreadcrumb>
             <PageSection hasBodyWrapper={false}>
                 <Gallery hasGutter>
-                    <Card isPlain>
+                    <Card isPlain className='ct-pf-card-inline'>
                         <CardHeader>
                             <CardTitle component="h2">{_("System information")}</CardTitle>
                         </CardHeader>
@@ -325,7 +325,7 @@ const HardwareInfo = ({ info }) => {
                                             : undefined } />
                         </CardBody>
                     </Card>
-                    <Card isPlain id="pci-listing">
+                    <Card isPlain id="pci-listing" className='ct-pf-card-inline'>
                         <CardHeader>
                             <CardTitle component="h2">{_("PCI")}</CardTitle>
                         </CardHeader>
@@ -333,7 +333,7 @@ const HardwareInfo = ({ info }) => {
                             { pci }
                         </CardBody>
                     </Card>
-                    <Card isPlain id="memory-listing">
+                    <Card isPlain id="memory-listing" className='ct-pf-card-inline'>
                         <CardHeader>
                             <CardTitle component="h2">{_("Memory")}</CardTitle>
                         </CardHeader>

--- a/pkg/systemd/logDetails.jsx
+++ b/pkg/systemd/logDetails.jsx
@@ -54,7 +54,7 @@ const LogDetails = ({ entry }) => {
 
     return (
         <GalleryItem>
-            <Card isPlain>
+            <Card isPlain className='ct-pf-card-inline'>
                 <CardHeader actions={{ actions }}>
                     <h2 id="entry-heading">{id}</h2>
                 </CardHeader>

--- a/pkg/systemd/service-details.jsx
+++ b/pkg/systemd/service-details.jsx
@@ -618,7 +618,7 @@ export class ServiceDetails extends React.Component {
             });
 
         return (
-            <Card isPlain id="service-details-unit" className="ct-card">
+            <Card isPlain id="service-details-unit" className="ct-card ct-pf-card-inline">
                 { this.state.showDeleteDialog &&
                 <DeleteModal
                     name={this.props.unit.Description}

--- a/pkg/systemd/services.jsx
+++ b/pkg/systemd/services.jsx
@@ -706,7 +706,7 @@ class ServicesPageBody extends React.Component {
 
         return (
             <PageSection hasBodyWrapper={false}>
-                <Card isPlain isCompact>
+                <Card isPlain isCompact className='ct-pf-card-inline'>
                     <CardHeader id='services-card-header'>
                         <ServicesPageFilters activeStateDropdownOptions={activeStateDropdownOptions}
                                             fileStateDropdownOptions={fileStateDropdownOptions}

--- a/pkg/users/account-details.js
+++ b/pkg/users/account-details.js
@@ -239,7 +239,7 @@ export function AccountDetails({ account, groups, isLoading, current_user, shell
             </PageBreadcrumb>
             <PageSection hasBodyWrapper={false}>
                 <Gallery hasGutter>
-                    <Card isPlain className="account-details" id="account-details">
+                    <Card isPlain className="account-details ct-pf-card-inline" id="account-details">
                         <CardHeader actions={{ actions }}>
                             <CardTitle id="account-title" component="h2">{title_name}</CardTitle>
                         </CardHeader>

--- a/pkg/users/account-logs-panel.jsx
+++ b/pkg/users/account-logs-panel.jsx
@@ -69,7 +69,7 @@ export function AccountLogs({ name }) {
     }, [name]);
 
     return (
-        <Card isPlain id="account-logs">
+        <Card isPlain id="account-logs" className='ct-pf-card-inline'>
             <CardTitle component="h2">{_("Login history")}</CardTitle>
             <CardBody className="contains-list">
                 <ListingTable variant="compact" aria-label={ _("Login history list") }

--- a/pkg/users/accounts-list.js
+++ b/pkg/users/accounts-list.js
@@ -443,7 +443,7 @@ const AccountsList = ({ accounts, current_user, groups, min_uid, max_uid, shells
     );
 
     return (
-        <Card isPlain className="ct-card">
+        <Card isPlain className="ct-card ct-pf-card-inline">
             <CardHeader actions={{ actions: tableToolbar }}>
                 <CardTitle component="h2">{_("Accounts")}</CardTitle>
             </CardHeader>

--- a/pkg/users/authorized-keys-panel.js
+++ b/pkg/users/authorized-keys-panel.js
@@ -114,7 +114,7 @@ export function AuthorizedKeys({ name, home, allow_mods }) {
     );
 
     return (
-        <Card isPlain id="account-authorized-keys">
+        <Card isPlain id="account-authorized-keys" className='ct-pf-card-inline'>
             <CardHeader actions={{ actions }}>
                 <CardTitle component="h2">{_("Authorized public SSH keys")}</CardTitle>
             </CardHeader>


### PR DESCRIPTION
Creates a new inline modifier for PF cards to make cards look like they
aren't cards. Keeps the spacing and features of cards but without it
looking like one.

This is still a temp fix for finding a better solution, but now it
should no longer break other dependencies where this is not wanted when
plain PF cards are used.

Related-to: https://github.com/cockpit-project/cockpit-files/pull/1234
Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
