### PR TITLE
flathub: Release token for flathub PR creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
     needs: source
     environment: flathub
     env:
-      COCKPITUOUS_TOKEN: ${{ secrets.COCKPITUOUS_TOKEN }}
+      COCKPITUOUS_RELEASE_TOKEN: ${{ secrets.COCKPITUOUS_RELEASE_TOKEN }}
     permissions: {}
     runs-on: ubuntu-latest
     steps:
@@ -136,7 +136,7 @@ jobs:
           git show
           git push git@github.com:cockpit-project/org.cockpit_project.CockpitClient HEAD
 
-          echo ${{ env.COCKPITUOUS_TOKEN }} >> auth.txt
+          echo ${{ env.COCKPITUOUS_RELEASE_TOKEN }} >> auth.txt
           gh auth login --with-token < auth.txt
 
           gh pr create \


### PR DESCRIPTION
The Cockpituous token we have doesn't have all the required scopes
needed to create PRs from our repo to the flathub PR. We mentioned that
the token is used in a few places where it is possible that the key
could be linked.

Since we require more permissions to be able to create a PR from
Cockpit's repo to flathub's Cockpit Client repo we need a new token
with permissions:
- `repo`,
- `read:org`, and
- `gist`

Once done and this is merged to main we should hopefully get automated
PR creations from Cockpit to Flathub org.

Related-to: https://github.com/cockpit-project/cockpit/actions/runs/19295842838/job/55177626160
See-also: https://cli.github.com/manual/gh_auth_login
Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
