### PR TITLE
test: disable SELinux in the daily scenario

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -2662,6 +2662,13 @@ def skipBeiboot(reason: str) -> Callable[[_FT], _FT]:
     return lambda testEntity: testEntity
 
 
+def skipDaily(reason: str) -> Callable[[_FT], _FT]:
+    """Decorator for skipping a test with fedora-*/nightly"""
+    if "daily" in os.getenv("TEST_SCENARIO", ""):
+        return unittest.skip(f"{testvm.DEFAULT_IMAGE}: {reason}")
+    return lambda testEntity: testEntity
+
+
 def nondestructive(testEntity: _T) -> _T:
     """Tests decorated as nondestructive will all run against the same VM
 

--- a/test/verify/check-selinux
+++ b/test/verify/check-selinux
@@ -48,6 +48,8 @@ mv -f ~/.ssh/authorized_keys.test-avc ~/.ssh/authorized_keys
 """
 
 
+# https://github.com/fedora-selinux/selinux-policy/issues/2947
+@testlib.skipDaily("nightly has selinux set to permissive")
 class TestSelinux(testlib.MachineCase):
     provision = {
         "0": {},
@@ -296,6 +298,8 @@ class TestSelinux(testlib.MachineCase):
         b.wait_text("ul[aria-label='System modifications']", "The logged in user is not permitted to view system modifications")
 
 
+# https://github.com/fedora-selinux/selinux-policy/issues/2947
+@testlib.skipDaily("nightly has selinux set to permissive")
 @testlib.skipImage("No cockpit-selinux", "debian-*", "ubuntu-*", "arch")
 @testlib.skipOstree("No cockpit-selinux")
 @testlib.nondestructive

--- a/test/vm.daily
+++ b/test/vm.daily
@@ -16,4 +16,7 @@ echo "https://download.opensuse.org/repositories/system:systemd/${fedora_release
 dnf config-manager addrepo --from-repofile="https://download.opensuse.org/repositories/system:systemd/${fedora_release}/system:systemd.repo"
 dnf -y update --repo=system_systemd --setopt=install_weak_deps=False
 
+# https://github.com/fedora-selinux/selinux-policy/issues/2947
+sed -i 's/SELINUX=enforcing/SELINUX=permissive/g' /etc/selinux/config
+
 /var/lib/download-package-sets.sh


### PR DESCRIPTION
We test against systemd/main which is not made for Fedora's selinux-policy. This generally doesn't cause issues but when systemd changes behaviour in what files it wants to create this can cause breakage.