### PR TITLE
test: Stabilize memory usage tests

### DIFF
--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -683,7 +683,7 @@ fi
             m.execute("while [ ! -e /tmp/hogged ]; do sleep 1; done")
             # bars update every 5s
             time.sleep(8)
-            testlib.wait(lambda: progressValue(2) >= initial_usage + 10)
+            testlib.wait(lambda: progressValue(2) != initial_usage)
             hog_usage = progressValue(2)
         finally:
             m.execute("kill %d" % mem_hog)


### PR DESCRIPTION
We currently test that we both go up in usage and then go down in
usage. As we are just checking that the metrics works and not that the
process we created is allocating X amount more we can simplify this a
bit to make it more reliable.

Instead of allocating 200 MB and hoping the memory is at least 100 MB
more than it was before, we should instead wait until memory changed and
then kill the process to clear up memory. That way we can be more sure
that we had a memory change that is being reflected on the UI.

As it is not exact science, this can still have failures. But it should
be less frequently failing.

Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
