### PR TITLE
debian: Stop shipping arch branding symlinks

### DIFF
--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -47,7 +47,7 @@ override_dh_install:
 	install -p -m 644 tools/cockpit.debian.pam debian/tmp/etc/pam.d/cockpit
 
 	# don't ship broken branding symlinks
-	for d in rhel fedora centos opensuse; do rm -r debian/tmp/usr/share/cockpit/branding/$$d; done
+	for d in arch rhel fedora centos opensuse; do rm -r debian/tmp/usr/share/cockpit/branding/$$d; done
 	dpkg-vendor --derives-from ubuntu || rm -r debian/tmp/usr/share/cockpit/branding/ubuntu
 
 	# handled by package maintainer scripts


### PR DESCRIPTION
They are broken in Debian/Ubuntu.

https://bugs.debian.org/1121456