### PR TITLE
ci: Revamp release workflow

### DIFF
--- a/.github/actions/get-release-assets/action.yml
+++ b/.github/actions/get-release-assets/action.yml
@@ -1,0 +1,62 @@
+name: 'Get release assets'
+description: 'Download and show Cockpit release tarball'
+inputs:
+  release:  # id of input
+    description: 'Release tag to fetch from'
+    required: false
+  checksum:
+    description: 'Checksum to verify tarball against'
+    required: false
+  path:
+    description: 'Cockpit repo is needed and if within a different path we need to go there'
+    required: false
+    default: '.'
+outputs:
+  tarball:
+    description: "Cockpit tarball"
+    value: ${{ steps.setup.outputs.filename }}
+  tarball_checksum:
+    description: "The second output string"
+    value: ${{ steps.download_tarball.outputs.checksum }}
+runs:
+  using: "composite"
+  steps:
+    - id: setup
+      name: Setup file
+      shell: bash
+      if: success()
+      env:
+        RELEASE: ${{ inputs.release }}
+        COCKPIT_PATH: ${{ inputs.path }}
+      run: |
+        set -x
+
+        cd ${{ inputs.path }}
+
+        {
+          echo "filename=cockpit-${RELEASE}.tar.xz"
+          echo "download=${{ github.server_url }}/${{ github.repository }}/releases/download/${RELEASE}/cockpit-${RELEASE}.tar.xz"
+        } >> "$GITHUB_OUTPUT"
+
+    - id: download_tarball
+      if: success()
+      name: Download source release
+      shell: bash
+      run: |
+        set -x
+
+        cd ${{ inputs.path }}
+
+        curl -L -o '${{ steps.setup.outputs.filename }}' '${{ steps.setup.outputs.download }}'
+
+        echo "checksum=$(sha256sum ${{ steps.setup.outputs.filename }} | cut -d ' ' -f 1)" >> "$GITHUB_OUTPUT"
+
+    - name: Verify checksum
+      if: success() && inputs.checksum
+      shell: bash
+      run: |
+        set -x
+
+        cd ${{ inputs.path }}
+
+        echo '${{ inputs.checksum }} ${{ steps.setup.outputs.filename }}' | sha256sum -c

--- a/.github/workflows/node-cache.yml
+++ b/.github/workflows/node-cache.yml
@@ -1,0 +1,38 @@
+name: Push node cache
+on:
+  # Trigger for other workflows
+  workflow_call:
+  # Runs that are triggered manually
+  workflow_dispatch:
+
+jobs:
+  node-cache:
+    # doesn't depend on it, but let's make sure the build passes before we do this
+    runs-on: ubuntu-latest
+    environment: node-cache
+    # done via deploy key, token needs no write permissions at all
+    permissions: {}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v6
+
+      - name: Set up git
+        run: |
+            git config user.name "GitHub Workflow"
+            git config user.email "cockpituous@cockpit-project.org"
+
+      - name: Tag node-cache
+        run: |
+          set -eux
+          # this is a shared repo, prefix with project name
+          TAG="${GITHUB_REPOSITORY#*/}-$(basename $GITHUB_REF)"
+          tools/node-modules checkout
+          cd node_modules
+          git tag "$TAG"
+          git remote add cache "ssh://git@github.com/${GITHUB_REPOSITORY%/*}/node-cache"
+          eval $(ssh-agent)
+          ssh-add - <<< '${{ secrets.DEPLOY_KEY }}'
+          # make this idempotent: delete an existing tag
+          git push cache :"$TAG" || true
+          git push cache tag "$TAG"
+          ssh-add -D

--- a/.github/workflows/release-flathub.yml
+++ b/.github/workflows/release-flathub.yml
@@ -1,0 +1,118 @@
+name: Release on flathub
+on:
+  # Trigger for other workflows
+  workflow_call:
+    inputs:
+      release_tag:
+        description: 'What release to take source file from.'
+        required: true
+        type: string
+      use_existing_branch:
+        description: 'Use existing branch (do not create a tag branch).'
+        required: false
+        type: boolean
+        default: false
+      checksum:
+        description: 'Checksum to verify against'
+        required: false
+        type: string
+  # Runs that are triggered manually
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'What release to take source file from.'
+        required: true
+        type: string
+      use_existing_branch:
+        description: 'Use existing branch (do not create a tag branch).'
+        required: false
+        type: boolean
+        default: false
+      checksum:
+        description: 'Checksum to verify against'
+        required: false
+        type: string
+
+jobs:
+  flathub:
+    environment: flathub
+    env:
+      COCKPITUOUS_TOKEN: ${{ secrets.COCKPITUOUS_TOKEN }}
+    permissions: {}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source repository
+        uses: actions/checkout@v6
+        with:
+          path: src
+          fetch-depth: 0
+
+      - name: Get release assets
+        id: release_assets
+        uses: ./src/.github/actions/get-release-assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          path: src
+          release: ${{ inputs.release_tag }}
+          checksum: ${{ inputs.checksum }}
+
+      - name: Checkout flathub repository
+        uses: actions/checkout@v6
+        with:
+          path: flathub
+          repository: flathub/org.cockpit_project.CockpitClient
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
+          # this is needed so we can push to a different repository
+          fetch-depth: 0
+      - name: Get tag body
+        id: tag
+        run: |
+          set -x
+          cd src
+          echo "body=$(git for-each-ref --format='%(contents:body)' refs/tags/${{ inputs.release_tag }} | jq --raw-input --compact-output --slurp)" >> "$GITHUB_OUTPUT"
+
+      - name: Configure flathub git defaults
+        run: |
+          git config --global user.name "GitHub Workflow"
+          git config --global user.email "cockpituous@cockpit-project.org"
+
+          cd flathub
+          git remote rename origin upstream
+          git remote add origin git@github.com:cockpit-project/org.cockpit_project
+
+      - name: Create flathub branch
+        if: ${{ inputs.use_existing_branch == false }}
+        env:
+          # Construct the download URL
+          DOWNLOAD: ${{ github.server_url }}/${{ github.repository }}/releases/download/${{ inputs.release_tag }}/cockpit-${{ inputs.release_tag }}.tar.xz
+          CHECKSUM: ${{ steps.release_assets.outputs.tarball_checksum }}
+          TAG_BODY: ${{ fromJson(steps.tag.outputs.body) }}
+        run: |
+          set -x
+
+          cd flathub
+          git checkout -b "${{ inputs.release_tag }}"
+          printf '%s\n' "${TAG_BODY}" | ../src/containers/flatpak/add-release \
+             org.cockpit_project.CockpitClient.releases.xml \
+             "${{ inputs.release_tag }}" \
+             "$(date +%Y-%m-%d)"
+          git add "$(../src/containers/flatpak/prepare --packages=upstream --sha256="${CHECKSUM}" "${DOWNLOAD}")"
+          git add org.cockpit_project.CockpitClient.packages.json
+          git add org.cockpit_project.CockpitClient.releases.xml
+          git commit -m "Update to version ${{ inputs.release_tag }}"
+          git show
+          git push origin HEAD
+
+      - name: Create flathub PR
+        run: |
+          cd flathub
+
+          echo ${{ env.COCKPITUOUS_TOKEN }} >> auth.txt
+          gh auth login --with-token < auth.txt
+
+          gh pr create \
+            --title "Update to version ${{ inputs.release_tag }}" \
+            --body "" \
+            --head cockpit-project:${{ inputs.release_tag }} \
+            --repo flathub/org.cockpit_project.CockpitClient

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   source:
     runs-on: ubuntu-latest
+    outputs:
+      checksum: ${{ steps.publish.outputs.checksum }}
     permissions:
       # create GitHub release
       contents: write
@@ -40,7 +42,7 @@ jobs:
             ${REPO_NAME}-${TAG_VERSION}.tar.xz \
             ${REPO_NAME}-node-${TAG_VERSION}.tar.xz
 
-          # Set outputs for downstream jobs
+          # Set outputs for downstream jobs if they can use it
           {
             echo "filename=${REPO_NAME}-${TAG_VERSION}.tar.xz"
             echo "download=${{ github.server_url }}/${{ github.repository }}/releases/download/${TAG_VERSION}/${REPO_NAME}-${TAG_VERSION}.tar.xz"
@@ -50,108 +52,19 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
-    outputs:
-      filename: ${{ steps.publish.outputs.filename }}
-      checksum: ${{ steps.publish.outputs.checksum }}
-      download: ${{ steps.publish.outputs.download }}
-      body: ${{ steps.publish.outputs.body }}
-
   guide:
     needs: source
-    environment: website
-    permissions: {}
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/cockpit-project/tasks:latest
-      options: --user root
-    steps:
-      - name: Checkout website repository
-        uses: actions/checkout@v6
-        with:
-          path: website
-          repository: cockpit-project/cockpit-project.github.io
-          ssh-key: ${{ secrets.DEPLOY_KEY }}
-
-      - name: Download source release
-        run: curl -L -o '${{ needs.source.outputs.filename }}' '${{ needs.source.outputs.download }}'
-
-      - name: Verify checksum
-        run: echo '${{ needs.source.outputs.checksum }} ${{ needs.source.outputs.filename }}' | sha256sum -c
-
-      - name: Extract guide from release tarball
-        run: |
-          mkdir source
-          tar --directory source --extract --strip-components=1 --file '${{ needs.source.outputs.filename }}'
-
-      - name: Update the website
-        run: |
-          rm -rf website/guide/latest
-          cp -rT source/doc/output/html website/guide/latest
-
-          git config --global user.name "GitHub Workflow"
-          git config --global user.email "cockpituous@cockpit-project.org"
-
-          cd website
-          git add guide/
-          git commit --message='Update guide to version ${{ github.ref_name }}'
-          git show --stat
-          git push origin main
-
+    uses: ./.github/workflows/update-guide.yml
+    with:
+      release_tag: ${{ github.ref_name }}
+      checksum: ${{ needs.source.outputs.checksum }}
 
   flathub:
     needs: source
-    environment: flathub
-    env:
-      COCKPITUOUS_TOKEN: ${{ secrets.COCKPITUOUS_TOKEN }}
-    permissions: {}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout source repository
-        uses: actions/checkout@v6
-        with:
-          path: src
-
-      - name: Checkout flathub repository
-        uses: actions/checkout@v6
-        with:
-          path: flathub
-          repository: flathub/org.cockpit_project.CockpitClient
-          ssh-key: ${{ secrets.DEPLOY_KEY }}
-          # this is needed so we can push to a different repository
-          fetch-depth: 0
-
-      - name: Update flathub repository
-        env:
-          DOWNLOAD: ${{ needs.source.outputs.download }}
-          CHECKSUM: ${{ needs.source.outputs.checksum }}
-          TAG_BODY: ${{ needs.source.outputs.body }}
-        run: |
-          set -x
-
-          git config --global user.name "GitHub Workflow"
-          git config --global user.email "cockpituous@cockpit-project.org"
-
-          cd flathub
-          git checkout -b "${{ github.ref_name }}"
-          printf '%s\n' "${TAG_BODY}" | ../src/containers/flatpak/add-release \
-             org.cockpit_project.CockpitClient.releases.xml \
-             "${{ github.ref_name }}" \
-             "$(date +%Y-%m-%d)"
-          git add "$(../src/containers/flatpak/prepare --packages=upstream --sha256="${CHECKSUM}" "${DOWNLOAD}")"
-          git add org.cockpit_project.CockpitClient.packages.json
-          git add org.cockpit_project.CockpitClient.releases.xml
-          git commit -m "Update to version ${{ github.ref_name }}"
-          git show
-          git push git@github.com:cockpit-project/org.cockpit_project.CockpitClient HEAD
-
-          echo ${{ env.COCKPITUOUS_TOKEN }} >> auth.txt
-          gh auth login --with-token < auth.txt
-
-          gh pr create \
-            --fill \
-            -H cockpit-project:${{ github.ref_name }} \
-            -R flathub/org.cockpit_project.CockpitClient
-
+    uses: ./.github/workflows/release-flathub.yml
+    with:
+      release_tag: ${{ github.ref_name }}
+      checksum: ${{ needs.source.outputs.checksum }}
 
   node-cache:
     # doesn't depend on it, but let's make sure the build passes before we do this
@@ -183,4 +96,5 @@ jobs:
           # make this idempotent: delete an existing tag
           git push cache :"$TAG" || true
           git push cache tag "$TAG"
+          ssh-add -D
           ssh-add -D

--- a/.github/workflows/update-guide.yml
+++ b/.github/workflows/update-guide.yml
@@ -1,0 +1,74 @@
+name: Update guide from release
+on:
+  # Trigger for other workflows
+  workflow_call:
+    inputs:
+      release_tag:
+        description: 'What release to take source file from.'
+        required: true
+        type: string
+      checksum:
+        description: 'Checksum to verify against'
+        required: false
+        type: string
+  # Runs that are triggered manually
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'What release to take source file from.'
+        required: true
+        type: string
+      checksum:
+        description: 'Checksum to verify against'
+        required: false
+        type: string
+
+jobs:
+  guide:
+    environment: website
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/cockpit-project/tasks:latest
+      options: --user root
+    steps:
+      - name: Checkout website repository
+        uses: actions/checkout@v6
+        with:
+          path: website
+          repository: cockpit-project/cockpit-project.github.io
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
+
+      - name: Checkout Cockpit repository
+        uses: actions/checkout@v6
+        with:
+          path: src
+          fetch-depth: 0
+
+      - name: Get release assets
+        id: release_assets
+        uses: ./src/.github/actions/get-release-assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          path: src
+          release: ${{ inputs.release_tag }}
+          checksum: ${{ inputs.checksum }}
+
+      - name: Extract guide from release tarball
+        run: |
+          mkdir source
+          tar --directory source --extract --strip-components=1 --file 'src/${{ steps.release_assets.outputs.tarball }}'
+
+      - name: Update the website
+        run: |
+          rm -rf website/guide/latest
+          cp -rT source/doc/output/html website/guide/latest
+
+          git config --global user.name "GitHub Workflow"
+          git config --global user.email "cockpituous@cockpit-project.org"
+
+          cd website
+          git add guide/
+          git commit --message='Update guide to version ${{ github.ref_name }}'
+          git show --stat
+          git push origin main


### PR DESCRIPTION
This revamps the release workflow to be manually triggered if something goes bad without having to create a new release

Coincidentally, this made it possible to experiment with the flathub PR creation which now works as it should. I've created a secret env within `cockpit-project/cockpit` already so the workflow should function when merged.
https://github.com/Venefilyn/cockpit/actions/runs/19749612709/job/56590267873

Successful run here with some things were commented out to prevent accidental pushes to cockpit-project, hence failing `node-cache`
https://github.com/Venefilyn/cockpit/actions/runs/20852299144

And for working flathub workflow you can see that here
https://github.com/Venefilyn/cockpit/actions/runs/19747486121/job/56584524019

Dependencies:
 - [x] PR #22693 
 - [x] Adjust guide workflow to tarballs containing built guide (preferably in separate PR)
 - [x] Rebase this