### PR TITLE
use macro for selinux store in spec

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -473,7 +473,7 @@ SELinux policy module for the cockpit-ws package.
 %{_datadir}/selinux/packages/%{selinuxtype}/%{name}.pp.bz2
 %{_mandir}/man8/%{name}_session_selinux.8cockpit.*
 %{_mandir}/man8/%{name}_ws_selinux.8cockpit.*
-%ghost %{_sharedstatedir}/selinux/%{selinuxtype}/active/modules/200/%{name}
+%ghost %{_selinux_store_path}/%{selinuxtype}/active/modules/200/%{name} 
 
 %pre ws-selinux
 %selinux_relabel_pre -s %{selinuxtype}


### PR DESCRIPTION
This small change adds flexibility based on selinux store path location macro. We plan to move root path from /var/lib/selinux to /etc/selinux in near future and this change prevent breaking build of cockpit package(bsc#1221342).