### PR TITLE
flatpak: Bump Gnome runtime to v49

### DIFF
--- a/containers/flatpak/prepare
+++ b/containers/flatpak/prepare
@@ -86,7 +86,7 @@ def create_manifest(
     return {
         'app-id': FLATPAK_ID,
         'runtime': 'org.gnome.Platform',
-        'runtime-version': '48',
+        'runtime-version': '49',
         'sdk': 'org.gnome.Sdk',
         'command': 'cockpit-client',
         'rename-icon': 'cockpit-client',


### PR DESCRIPTION
Bumps to the latest stable release

See-also: https://release.gnome.org/calendar/
Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
