### PR TITLE
tests: give +256MB RAM to machines in TestSuperuserDashboard.test

### DIFF
--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -414,8 +414,8 @@ session include system-auth
 @testlib.skipBeiboot("host switching disabled in beiboot mode")
 class TestSuperuserDashboard(testlib.MachineCase):
     provision = {
-        "machine1": {"address": "10.111.113.1/20", "memory_mb": 512},
-        "machine2": {"address": "10.111.113.2/20", "memory_mb": 512},
+        "machine1": {"address": "10.111.113.1/20", "memory_mb": 768},
+        "machine2": {"address": "10.111.113.2/20", "memory_mb": 768},
     }
 
     def test(self):


### PR DESCRIPTION
This test fails on rhel-10-2 image refresh as it has not enough RAM.
https://github.com/cockpit-project/bots/pull/8491