### PR TITLE
tmpfiles: don't overwrite the symlink if it exists

### DIFF
--- a/src/systemd/tmpfiles.d/cockpit-ws.conf.in
+++ b/src/systemd/tmpfiles.d/cockpit-ws.conf.in
@@ -1,3 +1,3 @@
 C /run/cockpit/inactive.issue 0640 root @admin_group@ - @datadir@/@PACKAGE@/issue/inactive.issue
 f /run/cockpit/active.issue   0640 root @admin_group@ -
-L+ /run/cockpit/issue - - - - inactive.issue
+L /run/cockpit/issue - - - - inactive.issue


### PR DESCRIPTION
There's a race-condition where `cockpit.socket` and its `ExecPost=` and `systemd-tmpfiles-setup.service` will run at the same, undetermined, time.

That is, because, there's no explicit ordering between the `sockets.target` and correspondingly `cockpit.socket` and  the `sysinit.target` and correspondingly `systemd-tmpfiles-setup.service`.

The result is that tmpfiles will some times overwrite the symlink created by the socket.

There's really no need for tmpfiles to override that symlink if it exists, so just remove the `+`, and leave it at `L` - "Create a symlink if it does not exist yet".