### PR TITLE
test: fix firefox test check-shell-keys flake

### DIFF
--- a/test/verify/check-shell-keys
+++ b/test/verify/check-shell-keys
@@ -66,12 +66,13 @@ class TestKeys(testlib.MachineCase):
 
         # add good
         add_key(KEY, FP_SHA256, "test-name")
+        b.wait_count("#account-authorized-keys-list tr", 1)
 
         # remove key on mobile, on mobile we show a kebab menu
         b.set_layout("mobile")
         b.click("#account-authorized-keys button.pf-v6-c-menu-toggle")
         b.click("button.pf-v6-c-menu__item")
-        b.wait_count("#account-authorized-keys-list tr", 1)
+        b.wait_count("#account-authorized-keys-list tr", 0)
         b.set_layout("desktop")
 
         # add good


### PR DESCRIPTION
The test removals an authorized key but then asserts the total amount of keys are 1 instead of 0. This flakes on retries in Firefox but succeeds in Chromium.