### PR TITLE
lib: handle CPU model names parsing on LoongArch

### DIFF
--- a/pkg/lib/machine-info.js
+++ b/pkg/lib/machine-info.js
@@ -44,6 +44,8 @@ export const cpu_ram_info = () =>
                     model_match = text.match(/^cpu\s*:\s*(.*)$/m); // PowerPC
                 if (!model_match)
                     model_match = text.match(/^vendor_id\s*:\s*(.*)$/m); // s390x
+                if (!model_match)
+                    model_match = text.match(/^Model Name\s*:\s*(.*)$/m); // LoongArch
                 if (model_match)
                     info.cpu_model = model_match[1];
 


### PR DESCRIPTION
On LoongArch hosts, /proc/cpuinfo lists CPU model names under the field "Model Name:", as follows (Loongson 3C6000/D):

```
processor               : 127
package                 : 1
core                    : 63
global_id               : 127
CPU Family              : Loongson-64bit
Model Name              : Loongson-3C6000/D
PRID                    : LA664 (0014d010)
CPU Revision            : 0x10
FPU Revision            : 0x00
CPU MHz                 : 2100.00
BogoMIPS                : 4200.00
TLB Entries             : 2112
Address Sizes           : 48 bits physical, 48 bits virtual
ISA                     : loongarch32r loongarch32s loongarch64
Features                : cpucfg lam ual fpu lsx lasx crc32 complex crypto ptw lspw lvz lbt_x86 lbt_arm lbt_mips
Hardware Watchpoint     : yes, iwatch count: 8, dwatch count: 4
```

Add "Model Name:" fallback to fix CPU model display on LoongArch.