### PR TITLE
build: Fix inconsistent NODE_CACHE path

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -63,10 +63,10 @@ $(distdir)/configure: $(distdir)/version.m4
 
 # Various downstream packaging assets
 
-NODE_CACHE = cockpit-node-$(VERSION).tar.xz
+NODE_CACHE = $(CURDIR)/cockpit-node-$(VERSION).tar.xz
 
 $(NODE_CACHE): $(srcdir)/package-lock.json
-	$(AM_V_GEN) $(srcdir)/tools/node-modules runtime-tar $(CURDIR)/$(NODE_CACHE)
+	$(AM_V_GEN) $(srcdir)/tools/node-modules runtime-tar $(NODE_CACHE)
 
 dist-hook: $(distdir)/tools/debian/copyright
 # when building from a git checkout, we need to generate the copyright file


### PR DESCRIPTION
We want NODE_CACHE to be a built file in the build dir. So declare that properly and use it at face value, instead of mangling the path in the `node-modules runtime-tar` output argument.

This fixes tools/make-dist if the project root already contains the tarballs. That happens when a previous `packit propose-downstream` already ran and moved the tarballs to the project root.

Fixes #22675