### PR TITLE
sysext: Add Bazzite as Fedora-system

### DIFF
--- a/tools/make-sysext
+++ b/tools/make-sysext
@@ -73,7 +73,7 @@ fi
 case "$ID" in
     # rolling release, no $VERSION_ID
     arch) PAMFILE=tools/arch/cockpit.pam; VERSION_ID=latest ;;
-    fedora|centos|rhel) PAMFILE=tools/cockpit.pam ;;
+    fedora|centos|rhel|bazzite) PAMFILE=tools/cockpit.pam ;;
     debian|ubuntu) PAMFILE=tools/cockpit.debian.pam ;;
     *) echo "Unsupported distribution: $ID"; exit 1 ;;
 esac


### PR DESCRIPTION
To get `make-sysext` to work with my system I need to add Bazzite here
to ensure it installs it correctly, otherwise it shows as unsupported
distro. Bazzite is built upon Fedora and is a bootc-based system.

We could do modifications here to look for `$ID_LIKE` instead, but for
now I just added Bazzite.

See-also: https://github.com/cockpit-project/cockpit/issues/22690
Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
