### PR TITLE
doc: Add cockpit-version to AsciiDoctor

### DIFF
--- a/doc/guide/Makefile-guide.am
+++ b/doc/guide/Makefile-guide.am
@@ -143,6 +143,7 @@ GUIDE_PAGES_INST = \
 noinst_DATA += $(GUIDE_PAGES_INST)
 
 GUIDE_ASCIIDOC_ARGS = \
+	-a cockpit-version=$(VERSION) \
 	-a toc=left \
 	-a toclevels=3 \
 	-a webfonts! \


### PR DESCRIPTION
Regressed during migration from DocBook to AsciiDoc, version should now
show up correctly in the documentation pages themselves.

Fixes: https://github.com/cockpit-project/cockpit/issues/22671
Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
