### PR TITLE
test: disable packagekit preloading to prevent udisks oom

### DIFF
--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -603,6 +603,9 @@ class TestStorageMountingLUKS(storagelib.StorageCase):
         m = self.machine
         b = self.browser
 
+        # Disable pre-loading packagekit, otherwise udisks oom's.
+        self.disable_preload("packagekit")
+
         self.login_and_go("/storage")
 
         # Add a disk and make two partitions on it, one on self.mnt_dir/foo


### PR DESCRIPTION
On our RHEL gating this started to fail because udisks oom's, prevent this by not starting packagekitd.

---

The gating failure can be seen here https://gitlab.com/redhat/centos-stream/rpms/cockpit/-/merge_requests/142