### PR TITLE
src: Add compact JSON to Printer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ module = [
     'cockpit.channels.pcp',
     'cockpit.channels.stream',
     'cockpit.channels.trivial',
+    'cockpit.misc.print',
     'cockpit.jsonutil',
     'cockpit.packages',
     'cockpit.peer',

--- a/src/cockpit/misc/print.py
+++ b/src/cockpit/misc/print.py
@@ -12,16 +12,20 @@ import readline  # noqa: F401, side-effecting import
 import shlex
 import sys
 import time
-from typing import Any, BinaryIO, Iterable, Optional
+from typing import Any, BinaryIO, Iterable, Literal, Optional
+
+ViewType = Literal['compact', 'pretty']
 
 
 class Printer:
     output: BinaryIO
+    view_type: ViewType
     last_channel: int
 
-    def __init__(self, output=None):
+    def __init__(self, output: Any = None, view_type: ViewType = "compact"):
         self.last_channel = 0
         self.output = output or sys.stdout.buffer
+        self.view_type = view_type
 
     def data(self, channel: str, /, data: bytes) -> None:
         """Send raw data (byte string) on a channel"""
@@ -30,9 +34,18 @@ class Printer:
         self.output.write(frame)
         self.output.flush()
 
-    def json(self, channel: str, /, **kwargs: object) -> None:
+    def json(
+        self, channel: str, /, **kwargs: object
+    ) -> None:
         """Send a json message (built from **kwargs) on a channel"""
-        self.data(channel, json.dumps(kwargs, indent=2).encode() + b'\n')
+        # FIXME: Cockpit's `session-utils.c#get_authorize_key` expect JSON to
+        # be compact otherwise parsed values will be broken.
+        params: Any = {"separators": None, "indent": None}
+        if self.view_type == "compact":
+            params["separators"] = (',', ':')
+        elif self.view_type == "pretty":
+            params["indent"] = 4
+        self.data(channel, json.dumps(kwargs, **params).encode() + b'\n')
 
     def control(self, command: str, **kwargs: Any) -> None:
         """Send a control message, build from **kwargs"""
@@ -180,6 +193,7 @@ def main() -> None:
                         help="Don't for [Enter] after printing, before exit")
     parser.add_argument('--no-init', action='store_true',
                         help="Don't send an init message")
+    parser.add_argument('--pretty', action='store_true', help="Enable pretty printing for JSON output.")
     parser.add_argument('command', nargs='*', default=['-'],
                         help="The command to invoke: try 'help'")
     args = parser.parse_args()
@@ -191,7 +205,8 @@ def main() -> None:
     output = open(os.dup(1), 'wb')
     os.dup2(os.open('/dev/tty', os.O_WRONLY), 1)
 
-    printer = Printer(output)
+    view_type: ViewType = "pretty" if args.pretty else "compact"
+    printer = Printer(output=output, view_type=view_type)
 
     need_init = not args.no_init
 

--- a/src/cockpit/misc/print.py
+++ b/src/cockpit/misc/print.py
@@ -92,7 +92,7 @@ class Printer:
         if headers is not None:
             our_headers.update(headers)
         # mypy is right: kwargs could include  `done` or `method`, but codifying that is really awkward
-        self.http(path, internal='packages', channel=channel, headers=our_headers, **kwargs)  # type: ignore[arg-type]
+        self.http(path, internal='packages', channel=channel, headers=our_headers, **kwargs)
 
     def spawn(self, *args: str, channel: Optional[str] = None, **kwargs: object) -> None:
         """Open a stream channel with a spawned command"""


### PR DESCRIPTION
By default the printer now outputs compact JSON which is more aligned
with what is expected of Cockpit. When using `control` it will now print
it compact by default.

Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
