### PR TITLE
test: workaround ubuntu-2404 journald going away

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -507,6 +507,10 @@ class TestHistoryMetrics(testlib.MachineCase):
         except AssertionError:
             self.assertIn(f"until=2021-3-8%2010%3A{load_minute + 1}%3A", url)
 
+        # Workaround journald crash? on ubuntu 2404.
+        if m.image == "ubuntu-2404":
+            b.logout()
+
     @testlib.nondestructive
     def testNoDataEnable(self):
         b = self.browser


### PR DESCRIPTION
For unknown reasons this specific test fails at teardown calling `journalctl --sync` with:

Failed to connect to /run/systemd/journal/io.systemd.journal: Connection refused.


Created https://github.com/cockpit-project/cockpit/issues/22705 to track this