### PR TITLE
kdump(arch): Add information about missing support

### DIFF
--- a/pkg/kdump/kdump-view.jsx
+++ b/pkg/kdump/kdump-view.jsx
@@ -583,6 +583,12 @@ ${enableCrashKernel}
                         </>
                     );
                 }
+            } else if (this.state.os_release.NAME?.includes('Arch')) {
+                alertMessage = _("kdump is not supported on Arch Linux.");
+                alertDetail = fmt_to_fragments(
+                    _("kexec is not supported on Arch. $0 provides more information."),
+                    <a href="https://github.com/cockpit-project/cockpit/issues/21006#issuecomment-2350036816">GitHub issue #21006</a>,
+                );
             } else {
                 alertMessage = _("Kdump service is not installed.");
                 alertDetail = fmt_to_fragments(


### PR DESCRIPTION
After finding out that the kdump-tools package is actually installed and that the problem is more Arch-related (#21006), I added this small notice to the view to prevent further confusion of other users.

## Still unsure

I'm not sure whether just checking for `Arch` is sufficient or if the substring should be expanded to `Arch Linux`. The `/etc/os-release` for reference is:

```
NAME="Arch Linux"
PRETTY_NAME="Arch Linux"
ID=arch
BUILD_ID=rolling
ANSI_COLOR="38;2;23;147;209"
HOME_URL="https://archlinux.org/"
DOCUMENTATION_URL="https://wiki.archlinux.org/"
SUPPORT_URL="https://bbs.archlinux.org/"
BUG_REPORT_URL="https://gitlab.archlinux.org/groups/archlinux/-/issues"
PRIVACY_POLICY_URL="https://terms.archlinux.org/docs/privacy-policy/"
LOGO=archlinux-logo
```

## Screenshot

<img width="750" height="504" alt="Screenshot of the change on a running Arch Linux system. It now links to the GitHub issue I mentioned earlier when visiting the kdump subpage." src="https://github.com/user-attachments/assets/f8f77d56-2796-4bd7-aa36-7afd0cef4c8b" />
