### PR TITLE
dependabot: ignore major xterm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,6 +47,10 @@ updates:
       - dependency-name: "*react*"
         update-types: ["version-update:semver-major"]
 
+      # @xterm/addon-canvas is deprecated and requires xterm/xterm 5.x.x
+      - dependency-name: "@xterm/*"
+        update-types: ["version-update:semver-major"]
+
   - package-ecosystem: "github-actions"
     directory: "/"
     open-pull-requests-limit: 3


### PR DESCRIPTION
Closes: #22716

xterm/addon-canvas support was dropped and it requires xterm/xterm 5.x.x