### PR TITLE
systemd: Keep servcices filter state only in the URL

### DIFF
--- a/pkg/systemd/services-list.jsx
+++ b/pkg/systemd/services-list.jsx
@@ -32,7 +32,7 @@ import cockpit from "cockpit";
 
 const _ = cockpit.gettext;
 
-export const ServicesList = ({ units, isTimer, filtersRef }) => {
+export const ServicesList = ({ units, isTimer, onClearAllFilters }) => {
     let columns;
     if (!isTimer) {
         columns = [
@@ -55,7 +55,7 @@ export const ServicesList = ({ units, isTimer, filtersRef }) => {
                       rows={ units.map(unit => getServicesRow({ key: unit[0], isTimer, shortId: unit[0], ...unit[1] })) }
                       emptyComponent={<EmptyStatePanel icon={SearchIcon}
                                                        paragraph={_("No results match the filter criteria. Clear all filters to show results.")}
-                                                       action={<Button id="clear-all-filters" onClick={() => { filtersRef.current() }} isInline variant='link'>{_("Clear all filters")}</Button>}
+                                                       action={<Button id="clear-all-filters" onClick={onClearAllFilters} isInline variant='link'>{_("Clear all filters")}</Button>}
                                                        title={_("No matching results")} /> }
                       className="services-list" />
     );


### PR DESCRIPTION
Instead of also putting it into the React state and then synchronizing the two places labouriously via useEffect hooks. This is much simpler and avoids spurious calls to cockpit.location.go.

We also simplify the onClearAllFilters logic by defining it further up and passing it down into the components that need it, instead of passing it up via useRef hook.

Also, use cockpit.location.replace instead of c.l.go to avoid adding entries to the browsing history for each key press.

The useEffect hooks had dubious dependencies. It's not clear whether or not functions like setCurrentTextFilter are a new object on every render.