### PR TITLE
workflows: Fix guide/flathub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,8 @@ jobs:
       - name: Build release
         run: tools/release '${{ github.server_url }}/${{ github.repository }}' '${{ github.ref_name }}'
 
-      - name: Create a release
+      - id: publish
+        name: Create a release
         run: |
           set -x
 
@@ -38,6 +39,16 @@ jobs:
             ${TAG_VERSION} \
             ${REPO_NAME}-${TAG_VERSION}.tar.xz \
             ${REPO_NAME}-node-${TAG_VERSION}.tar.xz
+
+          # Set outputs for downstream jobs
+          {
+            echo "filename=${REPO_NAME}-${TAG_VERSION}.tar.xz"
+            echo "download=${{ github.server_url }}/${{ github.repository }}/releases/download/${TAG_VERSION}/${REPO_NAME}-${TAG_VERSION}.tar.xz"
+            echo "checksum=$(sha256sum ${REPO_NAME}-${TAG_VERSION}.tar.xz | cut -d ' ' -f 1)"
+            echo "body<<EOF"
+            cat release-note.txt
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
     outputs:
       filename: ${{ steps.publish.outputs.filename }}


### PR DESCRIPTION
Commit cc7444fab6a moved the main tarball release away from cockpit-project/action-release to `gh release`. But that stopped setting the `steps.publish.outputs.*` variables that the downstream jobs need. Compute these and put them back.

----

This broke both the [guide](https://github.com/cockpit-project/cockpit/actions/runs/20779597053/job/59673833557) and the [flathub](https://github.com/cockpit-project/cockpit/actions/runs/20779597053/job/59673833550) release jobs for today's 354. I tested this on my fork with release 999, and the [run gets over these initial bugs](https://github.com/martinpitt/cockpit/actions/runs/20785733841). [flathub fails late](https://github.com/martinpitt/cockpit/actions/runs/20785733841/job/59694911128) on a permission error, which is expected from my fork. [guide](https://github.com/martinpitt/cockpit/actions/runs/20785733841/job/59694911060) fails on a build system bug, this step apparently was never tested. But after PR #22693 we'll have to change this anyway, as we'll have pre-built docs in the release tarball and don't have to rebuild them in the `guide` job.