### PR TITLE
kdump: Hide page on Arch

### DIFF
--- a/pkg/kdump/manifest.json
+++ b/pkg/kdump/manifest.json
@@ -1,6 +1,7 @@
 {
     "conditions": [
-        {"path-exists": "/usr/sbin/kexec"}
+        {"path-exists": "/usr/sbin/kexec"},
+        {"path-not-exists": "/etc/arch-release"}
     ],
     "tools": {
         "index": {

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -94,6 +94,7 @@ class KdumpHelpers(testlib.MachineCase):
 
 
 @testlib.skipOstree("kexec-tools not installed")
+# Kdump page is hidden on Arch as it lacks the necessary kdump packages and grub infra
 @testlib.skipImage("kexec-tools not installed", "debian-*", "ubuntu-*", "arch")
 @testlib.skipImage("kdump not compatible with separate /var btrfs subvolume https://bugzilla.redhat.com/show_bug.cgi?id=2270423", "fedora-*")
 @testlib.timeout(900)

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -885,6 +885,14 @@ OnCalendar=daily
             b.click(f"#nav-system .nav-item a[href='{href}']")
             b.wait_visible(f"iframe.container-frame[name='cockpit1:localhost{href}'][data-loaded]")
 
+        # Same skips as in test/verify/check-kdump
+        img = self.machine.image
+        expect_kdump = (img != "arch" and
+                        not img.startswith("debian") and
+                        not img.startswith("ubuntu") and
+                        "coreos" not in img)  # does show up on bootc
+        self.check_system_menu("Kernel dump", present=expect_kdump)
+
         # logging out too fast, some D-Bus services get disconnected
         self.allow_restart_journal_messages()
 

--- a/tools/arch/PKGBUILD
+++ b/tools/arch/PKGBUILD
@@ -70,6 +70,10 @@ package_cockpit() {
          "$pkgdir"/usr/lib/cockpit/cockpit-pcp \
          "$pkgdir"/var/lib/pcp
 
+  # Arch lacks the necessary kdump packages and grub infra
+  rm -rf "$pkgdir"/usr/share/cockpit/kdump \
+         "$pkgdir"/usr/share/metainfo/org.cockpit_project.cockpit_kdump.metainfo.xml
+
   # Disallow root login by default
   printf "# List of users which are not allowed to login to Cockpit\nroot\n" > "$pkgdir"/etc/cockpit/disallowed-users
   chmod 644 "$pkgdir"/etc/cockpit/disallowed-users


### PR DESCRIPTION
Arch Linux does not currently support kdump. There is no kexec-tools equivalent. [1] sounds promising, but it's not currently integrated into Arch.

Stop packaging the kdump page, and also add a manifest condition so that it doesn't appear in beiboot/ws-container/Client scenarios.

[1] https://blogs.igalia.com/gpiccoli/2024/07/presenting-kdumpst-or-how-to-collect-kernel-crash-logs-on-arch-linux/

Fixes #21106

----

This is an alternative to #22713. @nachtjasmin what do you think?

Closes #22713