### PR TITLE
packit: Fix copr_build job

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -86,18 +86,22 @@ jobs:
     project: "cockpit-preview"
     preserve_project: True
     actions:
-      # same as the global one, but specifying actions: does not inherit
-      post-upstream-clone:
-        # build patched spec
-        - tools/node-modules make_package_lock_json
-        - cp tools/cockpit.spec .
-        # packit will compute and set the version by itself
-        - tools/fix-spec ./cockpit.spec 0
       # HACK: tarball for releases (copr_build, koji, etc.), copying spec's Source0 and Source1; this
       # really should be the default, see https://github.com/packit/packit-service/issues/1505
+      # packit will compute and set the version by itself; but we want to NPM_PROVIDES
+      post-upstream-clone:
+        - |
+          bash -exc '
+          curl -L --fail -O https://github.com/cockpit-project/cockpit/releases/download/${PACKIT_PROJECT_VERSION}/${PACKIT_PROJECT_NAME_VERSION}.tar.xz
+          curl -L --fail -O https://github.com/cockpit-project/cockpit/releases/download/${PACKIT_PROJECT_VERSION}/cockpit-node-${PACKIT_PROJECT_VERSION}.tar.xz
+          tar -xJf ${PACKIT_PROJECT_NAME_VERSION}.tar.xz ${PACKIT_PROJECT_NAME_VERSION}/runtime-npm-modules.txt ${PACKIT_PROJECT_NAME_VERSION}/tools/cockpit.spec --strip-components=1
+          tools/fix-spec ./tools/cockpit.spec 0
+          cp tools/cockpit.spec .
+          '
+      # same as the global one, but specifying actions: does not inherit
+      # packit needs local file names, not URLs
       fix-spec-file:
-        - 'sh -exc "curl -L --fail -O https://github.com/cockpit-project/cockpit/releases/download/${PACKIT_PROJECT_VERSION}/${PACKIT_PROJECT_NAME_VERSION}.tar.xz"'
-        - 'sh -exc "curl -L --fail -O https://github.com/cockpit-project/cockpit/releases/download/${PACKIT_PROJECT_VERSION}/cockpit-node-${PACKIT_PROJECT_VERSION}.tar.xz"'
+        - sed -i 's|^\(Source[0-9]*:\s*\).*\/|\1|' cockpit.spec
 
   - job: propose_downstream
     trigger: release


### PR DESCRIPTION
Our cockpit-preview COPR packit source build has failed since version 352 since the reorganization of our build system for the -node tarball. `tools/fix-spec` now requires `runtime-npm-modules.txt` to be present, so adjust the tarball extraction accordingly.

While we are at it, also move the tarball downloads from fix-spec-file into post-upstream-clone, which fits better. Now both the global and the local `fix-spec-file:` rules are actually the same.

----

See the [recent COPR srpm build failures](https://copr.fedorainfracloud.org/coprs/g/cockpit/cockpit-preview/builds/), with [logs like this](https://download.copr.fedorainfracloud.org/results/@cockpit/cockpit-preview/srpm-builds/09981434/builder-live.log.gz):

```
2026-01-07 11:17:38.294 commands.py       DEBUG  Command: tools/fix-spec ./cockpit.spec 0
2026-01-07 11:17:38.299 logging.py        INFO   awk: fatal: cannot open file `/tmp/tmpa7lbqjg2/runtime-npm-modules.txt' for reading: No such file or directory
2026-01-07 11:17:38.299 commands.py       ERROR  Command 'tools/fix-spec ./cockpit.spec 0' failed.
2026-01-07 11:17:38.299 commands.py       DEBUG  Command stderr: awk: fatal: cannot open file `/tmp/tmpa7lbqjg2/runtime-npm-modules.txt' for reading: No such file or directory
```

The command from that log can be reproduced locally with
```sh
PACKIT_PROJECT_VERSION=354 PACKIT_PROJECT_NAME_VERSION=cockpit-354 packit -d prepare-sources --result-dir /tmp/res --ref 354 --job-config-index 5 --no-update-release --merged-ref '354' --no-create-symlinks https://github.com/cockpit-project/cockpit
```

For testing this fix, omit the `--ref` and `--merged-ref` options and run from the local checkout instead of a git URL:
```sh
rm -rf /tmp/res; PACKIT_PROJECT_VERSION=354 PACKIT_PROJECT_NAME_VERSION=cockpit-354 packit -d prepare-sources --result-dir /tmp/res --job-config-index 5 --no-update-release --no-create-symlinks .
```

this works fine, /tmp/res/cockpit.spec has correct Version and `Provides: bundled(npm(...))`.