### PR TITLE
workflows: Adjust "guide" release job for pre-built docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,20 +78,15 @@ jobs:
       - name: Verify checksum
         run: echo '${{ needs.source.outputs.checksum }} ${{ needs.source.outputs.filename }}' | sha256sum -c
 
-      - name: Build guide
+      - name: Extract guide from release tarball
         run: |
-          mkdir source build
+          mkdir source
           tar --directory source --extract --strip-components=1 --file '${{ needs.source.outputs.filename }}'
-          (
-              cd build
-              ../source/configure
-              make render-docs
-          )
 
       - name: Update the website
         run: |
           rm -rf website/guide/latest
-          mv -Tv build/doc/output/html website/guide/latest
+          cp -rT source/doc/output/html website/guide/latest
 
           # Add frontmatter for Jekyll
           find website/guide/latest -name '*.html' -exec sed -i '


### PR DESCRIPTION
The previous version was failing as asciidoc wasn't installed in that environment. Since 6a0da46280c we have pre-built documentation in the release tarballs, so we don't have to build it any more. Just extract it.

https://issues.redhat.com/browse/COCKPIT-1375

----

[Tested on my fork](https://github.com/martinpitt/cockpit/actions/runs/20818274546/job/59799782378#step:7:43), it shows that it correctly updated the *html files, and then failed as expected on permission error, as my fork can't deploy to official GH pages.