### PR TITLE
spec: Add nodejs-devel BuildRequires for Fedora

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -118,6 +118,7 @@ BuildRequires: gdb
 
 %if %{defined rebuild_bundle}
 BuildRequires: nodejs
+BuildRequires: nodejs-devel
 BuildRequires: nodejs-esbuild
 %endif
 


### PR DESCRIPTION
This isn't strictly necessary, but the policy mandates it: https://docs.fedoraproject.org/en-US/packaging-guidelines/Node.js/#_buildrequires

----

We [currently install it into our test images](https://github.com/cockpit-project/bots/blob/eae416ffcdad00c1916f046b9c84addc2320262e/images/scripts/lib/build-deps.sh#L67), so let's make that official.