### PR TITLE
Skip Anaconda storage tests on Debian/Ubuntu/Arch

### DIFF
--- a/test/verify/check-storage-anaconda
+++ b/test/verify/check-storage-anaconda
@@ -26,6 +26,7 @@ import testlib
 
 @testlib.nondestructive
 @testlib.skipOstree("No /sysroot and directory cannot be created on read-only filesystem")
+@testlib.skipImage("Not relevant for Anaconda", "debian-*", "ubuntu-*", "arch")
 class TestStorageAnaconda(storagelib.StorageCase):
 
     def enterAnacondaMode(self, config):


### PR DESCRIPTION
They are rather expensive, and totally not relevant outside of Fedora/RHEL.