### PR TITLE
run-tests: Replace static TEST_JOBS with dynamic parallelism, nested kvm failure improvements

### DIFF
--- a/test/ARCHITECTURE.md
+++ b/test/ARCHITECTURE.md
@@ -142,14 +142,14 @@ existing global machine.
 
 ### Test runner
 
-Cockpit uses a custom test runner to run the tests, spread the load over jobs
-and special handling of test failures. The test runner is implemented in Python
-in [test/common/run-tests](./common/run-tests) and expects a list of tests to
-be provided.
+Cockpit uses a custom test runner to run the tests, spread the load across
+parallel instances and special handling of test failures. The test runner is
+implemented in Python in [test/common/run-tests](./common/run-tests) and expects
+a list of tests to be provided.
 
 The provided tests are collected and split up in "destructive" and
-"non-destructive" tests, every test is given a "cost" depending on the amount
-of virtual machines required to run the test for scheduling priority. A default
+"non-destructive" tests, every test calculates its RAM requirements based on the
+amount of virtual machines and browser memory needed to run the test. A default
 timeout is added to every test so hanging tests get killed over time, tests
 which take longer can set a custom timeout using a test decorator.
 
@@ -161,9 +161,9 @@ refactors won't retry a lot of tests.
 
 Having collected the "destructive", "non-destructive" and affected tests a
 scheduling loop is started, if a machine was provided it is used for the
-"non-destructive" tests, "destructive" tests will always spawn a new machine. If no
-machine is provided a pool of global machines is created based on the provided
-`--jobs` and "non-destructive" tests. The test runner will first try to assign all
+"non-destructive" tests, "destructive" tests will always spawn a new machine.
+If no machine is provided a pool of global machines for "non-destructive" tests
+depending on available CPUs and RAM. The test runner will first try to assign all
 "non-destructive" tests on the available global machines and start the tests. 
 
 The scheduling loop periodically inspects all running tests and polls if the

--- a/test/README.md
+++ b/test/README.md
@@ -52,9 +52,9 @@ The cockpit and SSH addresses of the test instance will be printed:
 
     test/verify/check-session -st
 
-You can also run *all* the tests, with some parallelism:
+You can also run *all* the tests, with automatic parallelism:
 
-    test/common/run-tests --test-dir test/verify --jobs 2
+    test/common/run-tests --test-dir test/verify
 
 However, this will take *really* long. You can specify a subset of tests (see
 `--help`); but usually it's better to run individual tests locally, and let the
@@ -178,8 +178,6 @@ You can set these environment variables to configure the test suite:
     [test map](https://github.com/cockpit-project/bots/blob/main/lib/testmap.py)
     for all supported values. "fedora-42" is the default (`TEST_OS_DEFAULT` in
     bots' [constants.py](https://github.com/cockpit-project/bots/blob/main/lib/constants.py)).
-
- * `TEST_JOBS`:  How many tests to run in parallel.  The default is 1.
 
  * `TEST_BROWSER`: What browser should be used for testing. Currently supported
    values are "chromium" and "firefox". "chromium" is the default.

--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -30,6 +30,17 @@ AMPLIFY_TEST_COUNT = 10
 
 # Memory usage constants; measured 2026-01 on Fedora 43 x86_64 with Chromium 143 and Firefox 146
 BROWSER_MEMORY_MB = 550  # Incremental per process (Firefox: 470 MB, Chromium: 319 MB; + margin)
+# browser code/libs shared memory (285 MB measured), and leave some breathing room for OS/buffers
+SYSTEM_RESERVE_GB = 1.0
+
+
+def get_available_memory_gb() -> float:
+    # Format: "MemAvailable:    12345678 kB"
+    with open('/proc/meminfo', 'r') as f:
+        for line in f:
+            if line.startswith('MemAvailable:'):
+                return int(line.split()[1]) / (1024 * 1024)
+    raise RuntimeError("MemAvailable not found in /proc/meminfo")
 
 
 @dataclass
@@ -39,7 +50,6 @@ class CliOpts(testlib.TestlibArgs):
     browser: str | None
     debug: bool
     exclude: Sequence[str]
-    jobs: int
     machine: str | None
     no_retry_fail: bool
     nondestructive: bool
@@ -486,12 +496,26 @@ def run(opts: CliOpts, image: str) -> int:
 
     running_tests: list[Test] = []
     global_machines: list[GlobalMachine] = []
+    test_slots: int = 0  # how many tests can we run in parallel
 
     if not opts.machine:
         # Create appropriate number of nondestructive machines; prioritize the nondestructive tests, to get
         # them out of the way as fast as possible, then let the destructive ones start as soon as
-        # a given nondestructive runner is done.
-        num_global = min(nondestructive_tests_len, opts.jobs)
+        # a given nondestructive runner is done. Limit by available RAM and CPU.
+        available_ram_gb = get_available_memory_gb() - SYSTEM_RESERVE_GB
+        global_machine_ram_gb = (opts.nondestructive_memory_mb + BROWSER_MEMORY_MB) / 1024.0
+        max_global_by_ram = int(available_ram_gb / global_machine_ram_gb)
+        if max_global_by_ram == 0:
+            sys.exit(f"Need {global_machine_ram_gb:.1f} GB per test, but only {available_ram_gb:.1f} GB available")
+
+        max_global_by_cpu = max((os.cpu_count() or 0) // 2, 1)
+        test_slots = min(max_global_by_ram, max_global_by_cpu)
+
+        num_global = min(nondestructive_tests_len, test_slots)
+        logging.debug("ND capacity: %.1f GB available, %.1f GB/slot, "
+                      "max %d by RAM, max %d by CPU, %d tests → starting %d slots",
+                      available_ram_gb, global_machine_ram_gb,
+                      max_global_by_ram, max_global_by_cpu, nondestructive_tests_len, num_global)
 
         for _ in range(num_global):
             global_machines.append(
@@ -565,30 +589,33 @@ def run(opts: CliOpts, image: str) -> int:
 
                     made_progress = True
 
-        def running_ram_gb() -> float:
-            return sum(test.ram_gb for test in running_tests)
-
-        # Each "job" represents capacity for one VM + browser
-        job_capacity_gb = (DEFAULT_MACHINE_MEMORY_MB + BROWSER_MEMORY_MB) / 1024.0
-        total_capacity_gb = opts.jobs * job_capacity_gb
+        # Schedule destructive tests if we have enough RAM, and also don't exceed the parallelism capacity
+        running_destructive_tests = len([t for t in running_tests if not t.nondestructive])
+        available_ram_gb = get_available_memory_gb() - SYSTEM_RESERVE_GB
 
         # Start destructive tests one at a time to avoid VM boot storms
-        # Only start if we have capacity based on RAM (or if idle to avoid deadlock)
-        if destructive_tests and (
-            running_ram_gb() + destructive_tests[0].ram_gb <= total_capacity_gb or len(running_tests) == 0
-        ):
-            test = destructive_tests.pop(0)
-            logging.debug(
-                "%d running tests using %.1f GB, starting next destructive test %s",
-                len(running_tests),
-                running_ram_gb(),
-                test,
-            )
-            test.start()
-            running_tests.append(test)
-            made_progress = True
-            # Avoid VM boot storms; unreliable especially with nested KVM. This should be enough time to let VMs boot
-            time.sleep(15)
+        if destructive_tests:
+            next_test = destructive_tests[0]
+
+            # Check if we have a free slot
+            running_global_machines = len([m for m in global_machines if m.machine is not None])
+            assert test_slots
+            max_destructive = test_slots - running_global_machines
+            if running_destructive_tests >= max_destructive:
+                logging.debug("NOT starting %s: no free slots (max %d), already running %d destructive and %d global ND machines",
+                              next_test, max_destructive, running_destructive_tests, running_global_machines)
+            # Check available RAM
+            elif next_test.ram_gb > available_ram_gb:
+                logging.debug("NOT starting %s: insufficient RAM (needs %.1f GB, only %.1f GB available)",
+                              next_test, next_test.ram_gb, available_ram_gb)
+            else:
+                test = destructive_tests.pop(0)
+                logging.debug("starting %s", test)
+                test.start()
+                running_tests.append(test)
+                made_progress = True
+                # Avoid VM boot storms; unreliable especially with nested KVM. This should be enough time to let VMs boot
+                time.sleep(15)
 
         # are we done?
         if not running_tests:
@@ -628,9 +655,6 @@ def run(opts: CliOpts, image: str) -> int:
 
 def main() -> int:
     parser = testlib.arg_parser(enable_sit=False)
-    parser.add_argument(
-        "-j", "--jobs", type=int, default=int(os.environ.get("TEST_JOBS", 1)), help="Number of concurrent jobs"
-    )
     parser.add_argument("--debug", action="store_true", help="Enable verbose debug logging")
     parser.add_argument("--thorough", action="store_true", help="Thorough mode, no skipping known issues")
     parser.add_argument("-n", "--nondestructive", action="store_true", help="Only consider @nondestructive tests")
@@ -688,8 +712,6 @@ def main() -> int:
         logging.basicConfig(level=logging.DEBUG, format='%(levelname)s:run-tests:%(message)s')
 
     if opts.machine:
-        if opts.jobs > 1:
-            parser.error("--machine cannot be used with concurrent jobs")
         if not opts.browser:
             parser.error("--browser must be specified together with --machine")
         opts.nondestructive = True

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -94,7 +94,6 @@ opts.trace = False
 opts.attachments = None
 opts.revision = None
 opts.address = None
-opts.jobs = 1
 opts.fetch = True
 opts.coverage = False
 

--- a/test/run
+++ b/test/run
@@ -78,4 +78,4 @@ if [ -n "$TEST_SCENARIO" ] && [ -z "$RUN_OPTS" ]; then
 fi
 
 test/image-prepare --verbose ${PREPARE_OPTS} "$TEST_OS"
-test/common/run-tests --jobs ${TEST_JOBS:-1} --test-dir test/verify --track-naughties ${RUN_OPTS}
+test/common/run-tests --test-dir test/verify --track-naughties ${RUN_OPTS}

--- a/test/verify/check-testlib
+++ b/test/verify/check-testlib
@@ -87,13 +87,6 @@ class TestRunTest(testlib.MachineCase):
         self.assertRegex(out, b"\nok .* TestNondestructiveExample.testTwo")
         self.assertIn(b"TESTS PASSED", out)
 
-        # can't be called with concurrency
-        p = subprocess.Popen([run_tests, "--test-dir", EXAMPLE_DIR, "--machine", "1.2.3.4:56", "--browser", "1.2.3.4:67", "-j2"],
-                             stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
-        (out, err) = p.communicate()
-        self.assertGreaterEqual(p.returncode, 1)
-        self.assertIn(b"--machine cannot be used with concurrent jobs", err)
-
         # implies --nondestructive
         out = subprocess.check_output([run_tests, "--test-dir", EXAMPLE_DIR, "--machine", "1.2.3.4:56", "--browser", "1.2.3.4:67",
                                        "TestExample.testBasic"], env=env)


### PR DESCRIPTION
This addresses [this mess](https://logs-cockpit.apps.ocp.cloud.ci.centos.org/pull-22373-08af2109-20260109-101120-fedora-43-devel/log.html) from #22373. We are seeing [these problems](https://logs-cockpit.apps.ocp.cloud.ci.centos.org/pull-22749-c22adaf9-20260111-042848-fedora-43-devel/log.html) even in PRs *without* affected "expensive" tests.

See all the experiments below. The details are in the commit messages, and the TL/DR is: nested kvm sucks and is unpredictable, we have to deal with failed VM boots. This series tries to avoid parallel ones, which seems to help quite a lot at least.

https://issues.redhat.com/browse/COCKPIT-1391
