### PR TITLE
test: disable signature verification globally for pacman

### DIFF
--- a/test/common/packagelib.py
+++ b/test/common/packagelib.py
@@ -101,6 +101,7 @@ class PackageCase(MachineCase):
 [options]
 Architecture = auto
 HoldPkg     = pacman glibc
+SigLevel = Never
 
 [empty]
 SigLevel = Never


### PR DESCRIPTION
A newer pacman 7.1 release now enforces signature validation by default, making `pacman -U` fail on missing signatures. For testing we don't want/need signatures so disable them globally.