### PR TITLE
common: Add more base64 unit tests

### DIFF
--- a/src/common/test-base64.c
+++ b/src/common/test-base64.c
@@ -42,6 +42,26 @@
 #include <stdlib.h>
 
 static void
+check_encode_success (const unsigned char *input,
+                      ssize_t input_len,
+                      const char *expected,
+                      ssize_t expected_len)
+{
+  char encoded[8192];
+  int length;
+
+  if (input_len < 0)
+    input_len = strlen ((char *)input);
+  if (expected_len < 0)
+    expected_len = strlen (expected);
+  length = cockpit_base64_ntop (input, input_len, encoded, sizeof (encoded));
+
+  g_assert_cmpint (length, >=, 0);
+  g_assert_cmpint (length, ==, expected_len);
+  g_assert_cmpint (memcmp (encoded, expected, length), ==, 0);
+}
+
+static void
 check_decode_success (const char *input,
                       ssize_t input_len,
                       const unsigned char *expected,
@@ -83,10 +103,22 @@ test_decode_simple (void)
   check_decode_success ("YmxhaAo=", -1, (unsigned char *)"blah\n", -1);
   check_decode_success ("bGVlbGEK", -1, (unsigned char *)"leela\n", -1);
   check_decode_success ("bGVlbG9vCg==", -1, (unsigned char *)"leeloo\n", -1);
+  check_decode_success ("dXNlcgpwYXNzd29yZAo=", -1, (unsigned char *)"user\npassword\n", -1);
+}
 
-  /* Test failure cases with invalid base64 */
+static void
+test_decode_failure (void)
+{
+  unsigned char decoded[8192];
+  int length;
+
+  /* Invalid base64 */
   check_decode_failure ("!!!invalid!!!", -1);
   check_decode_failure ("invalid", -1);
+
+  /* Buffer too small - "blah\n" needs 5 bytes, only 4 provided */
+  length = cockpit_base64_pton ("YmxhaAo=", strlen ("YmxhaAo="), decoded, 4);
+  g_assert_cmpint (length, <, 0);
 }
 
 static void
@@ -190,6 +222,43 @@ test_decode_thawte (void)
   check_decode_success (input, -1, output, sizeof (output));
 }
 
+static void
+test_encode_simple (void)
+{
+  check_encode_success ((unsigned char *)"", 0, "", 0);
+  check_encode_success ((unsigned char *)"1", 1, "MQ==", -1);
+  check_encode_success ((unsigned char *)"blah\n", -1, "YmxhaAo=", -1);
+  check_encode_success ((unsigned char *)"leela\n", -1, "bGVlbGEK", -1);
+  check_encode_success ((unsigned char *)"leeloo\n", -1, "bGVlbG9vCg==", -1);
+  check_encode_success ((unsigned char *)"user\npassword\n", -1, "dXNlcgpwYXNzd29yZAo=", -1);
+}
+
+static void
+test_roundtrip_all_bytes (void)
+{
+  unsigned char input[256];
+  char encoded[8192];
+  unsigned char decoded[8192];
+  int encode_len, decode_len;
+  int i;
+
+  /* Create input with all possible byte values */
+  for (i = 0; i < 256; i++)
+    input[i] = i;
+
+  /* Encode */
+  encode_len = cockpit_base64_ntop (input, sizeof (input), encoded, sizeof (encoded));
+  g_assert_cmpint (encode_len, >=, 0);
+
+  /* Decode */
+  decode_len = cockpit_base64_pton (encoded, encode_len, decoded, sizeof (decoded));
+  g_assert_cmpint (decode_len, >=, 0);
+
+  /* Check round-trip */
+  g_assert_cmpint (decode_len, ==, sizeof (input));
+  g_assert_cmpint (memcmp (input, decoded, sizeof (input)), ==, 0);
+}
+
 int
 main (int argc,
       char *argv[])
@@ -197,7 +266,10 @@ main (int argc,
   cockpit_test_init (&argc, &argv);
 
   g_test_add_func ("/base64/decode-simple", test_decode_simple);
+  g_test_add_func ("/base64/decode-failure", test_decode_failure);
   g_test_add_func ("/base64/decode-thawte", test_decode_thawte);
+  g_test_add_func ("/base64/encode-simple", test_encode_simple);
+  g_test_add_func ("/base64/roundtrip-all-bytes", test_roundtrip_all_bytes);
 
   return g_test_run ();
 }


### PR DESCRIPTION
We previously did not cover the encoding with cockpit_base64_ntop() at all.

Also add a roundtrip test with all byte values, decoding of values with embedded newlines, and decoding with a too small target buffer.