### PR TITLE
test: reduce memory requirement for reverse proxy tests

### DIFF
--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -1391,7 +1391,7 @@ Command={self.libexecdir}/cockpit-session
 class TestReverseProxy(testlib.MachineCase):
 
     provision = {
-        "0": {"forward": {"443": 8443}}
+        "0": {"forward": {"443": 8443}, "memory_mb": 768}
     }
 
     def setUp(self):


### PR DESCRIPTION
These are only ran on Fedora as that image has nginx installed.

Before:
```
               total        used        free      shared  buff/cache   available
Mem:            1073         457         428           1         324         615
```
After:
```
               total        used        free      shared  buff/cache   available
Mem:             696         404          74           1         321         292
```