### PR TITLE
test: Drop cryptsetup "lots of memory" workaround

### DIFF
--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -691,10 +691,9 @@ def main() -> int:
     parser.add_argument(
         "--nondestructive-cpus", type=int, default=None, help="Number of CPUs for nondestructive test global machines"
     )
-    # provide enough RAM for cryptsetup's PBKDF, as long as that is not configurable:
-    # https://bugzilla.redhat.com/show_bug.cgi?id=1881829
     parser.add_argument(
-        "--nondestructive-memory-mb", type=int, default=1400, help="RAM size for nondestructive test global machines"
+        "--nondestructive-memory-mb", type=int, default=DEFAULT_MACHINE_MEMORY_MB,
+        help="RAM size for nondestructive test global machines (default: %(default)s MB)",
     )
     parser.add_argument(
         "--base",
@@ -728,6 +727,11 @@ def main() -> int:
     image = testvm.DEFAULT_IMAGE
     testvm.DEFAULT_IMAGE = image
     os.environ["TEST_OS"] = image
+
+    # on RHEL 8, provide enough RAM for cryptsetup's PBKDF (https://issues.redhat.com/browse/RHEL-8258)
+    # On any newer OS, cryptsetup gets along with less RAM
+    if image.startswith("rhel-8") and opts.nondestructive_memory_mb == DEFAULT_MACHINE_MEMORY_MB:
+        opts.nondestructive_memory_mb = 1400
 
     # Make sure tests can make relative imports
     sys.path.append(os.path.realpath(opts.test_dir))

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -18,6 +18,7 @@
 # along with Cockpit; If not, see <https://www.gnu.org/licenses/>.
 
 import json
+import os
 import subprocess
 
 import packagelib
@@ -349,9 +350,10 @@ class TestStorageLuks(storagelib.StorageCase):
 
 class TestStorageLuksDestructive(storagelib.StorageCase):
 
-    # LUKS uses memory hard PBKDF, 1 GiB is not enough; see https://bugzilla.redhat.com/show_bug.cgi?id=1881829
+    # on RHEL 8, provide enough RAM for cryptsetup's PBKDF (https://issues.redhat.com/browse/RHEL-8258)
+    # On any newer OS, cryptsetup gets along with less RAM
     provision = {
-        "0": {"memory_mb": 1536}
+        "0": {"memory_mb": 1400 if os.environ.get("TEST_OS", "").startswith("rhel-8-") else None}
     }
 
     def testLuks1Slots(self):

--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <https://www.gnu.org/licenses/>.
 
+import os
 import unittest
 
 import storagelib
@@ -25,9 +26,10 @@ import testlib
 
 class TestStorageResize(storagelib.StorageCase):
 
-    # LUKS uses memory hard PBKDF, 1 GiB is not enough; see https://bugzilla.redhat.com/show_bug.cgi?id=1881829
+    # on RHEL 8, provide enough RAM for cryptsetup's PBKDF (https://issues.redhat.com/browse/RHEL-8258)
+    # On any newer OS, cryptsetup gets along with less RAM
     provision = {
-        "0": {"memory_mb": 1536}
+        "0": {"memory_mb": 1400 if os.environ.get("TEST_OS", "").startswith("rhel-8-") else None}
     }
 
     def checkResize(self, fsys, crypto, can_shrink, can_grow, shrink_needs_unmount=None, grow_needs_unmount=None):

--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -584,11 +584,6 @@ systemctl restart stratisd
 @testlib.skipImage("stratis not installed", "*-bootc")
 @testlib.skipImage("commit 817c957899a4 removed Statis 2 support", "rhel-8-*")
 class TestStorageStratisReboot(storagelib.StorageCase):
-    # LUKS uses memory hard PBKDF, 1 GiB is not enough; see https://bugzilla.redhat.com/show_bug.cgi?id=1881829
-    provision = {
-        "0": {"memory_mb": 1536}
-    }
-
     def setUp(self):
         super().setUp()
         exe = self.machine.execute


### PR DESCRIPTION
That bugzilla bug (since then moved to [1]) actually got fixed long ago. Current cryptsetup in RHEL 9 and newer works fine on machines with 1 GB or even less. Thus drop the special RAM requirements. This should even make the tests faster, as it then uses a less expensive PBKDF.

Only keep the hacks for RHEL 8, they are easy to grep for now (`rhel-8`).


[1] https://issues.redhat.com/browse/RHEL-8258

----

Spotted here: https://github.com/cockpit-project/cockpit/pull/22748#discussion_r2693762225