### PR TITLE
containers/ws: Move to Fedora 43

### DIFF
--- a/containers/ws/Containerfile
+++ b/containers/ws/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:42 AS builder
+FROM registry.fedoraproject.org/fedora:43 AS builder
 LABEL maintainer="cockpit-devel@lists.fedorahosted.org"
 LABEL VERSION=main
 


### PR DESCRIPTION
Validated with
```
podman build -t localhost/ws containers/ws
podman run -d --name cockpit-bastion -p 9090:9090 localhost/ws
```

and logging in on https://localhost:9090/=host.containers.internal/