### PR TITLE
tools: update asciidoctor dependency for tumbleweed

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -124,7 +124,7 @@ BuildRequires: nodejs-esbuild
 
 %if !%{defined bundle_docs}
 %if 0%{?suse_version}
-BuildRequires: ruby3.4-rubygem-asciidoctor
+BuildRequires: ruby4.0-rubygem-asciidoctor
 %else
 BuildRequires: asciidoctor
 %endif


### PR DESCRIPTION
Tumbleweed is a rolling release distro so the Ruby dependency updates every now and then. Zypper does not support path based BuildRequires like dnf does.