### PR TITLE
tools: use path based buildrequires for opensuse

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -124,7 +124,7 @@ BuildRequires: nodejs-esbuild
 
 %if !%{defined bundle_docs}
 %if 0%{?suse_version}
-BuildRequires: ruby4.0-rubygem-asciidoctor
+BuildRequires: /usr/bin/asciidoctor
 %else
 BuildRequires: asciidoctor
 %endif


### PR DESCRIPTION
zypper does not supported path based installing of packages but `BuildRequires` does, circumventing unneeded churn of updating the spec file for every new Ruby version

---

See https://github.com/cockpit-project/cockpit/pull/22768#issuecomment-3759829622