### PR TITLE
test: Fix ws container Python sitelib path for Fedora version desyncs

### DIFF
--- a/test/ws-container.install
+++ b/test/ws-container.install
@@ -16,6 +16,19 @@ system
 for rpm in ws bridge $PACKAGES; do
     rpm2cpio /var/tmp/cockpit-$rpm-*.rpm | cpio -i --make-directories --directory=/var/tmp/install
 done
+
+# Sometimes the actual quay.io/cockpit/ws Fedora version lags behind containers/ws/Containerfile, i.e. in between
+# moving the latter to a new Fedora version, and releasing Cockpit and landing it in Fedora. Then the Python version
+# in the rpms does not match the actual Python version in the container. So remove any traces of the old Python
+# deployment first, unpack the new rpms, and move our Python module into place.
+ws_pyver=$(podman run --rm --entrypoint /usr/bin/python3 quay.io/cockpit/ws -c \
+           'import sys; print("%d.%d" % sys.version_info[:2])')
+ws_sitelib="/var/tmp/install/usr/lib/python${ws_pyver}"
+if ! [ -d "$ws_sitelib" ]; then
+    echo "Adjusting Python module location to $ws_sitelib" >&2
+    mv --verbose /var/tmp/install/usr/lib/python3.* "$ws_sitelib" >&2
+fi
+
 podman run --name build-cockpit -i \
     -v /var/tmp/:/run/build:Z \
     quay.io/cockpit/ws sh -exc '


### PR DESCRIPTION
We recently switched the ws container to Fedora 43 (commit 92c4634277ee), but we haven't released Cockpit yet and rebuilt the official container. So on our images, the container is still Fedora 42.

We already had a hack in the past (commit 8ea9eaccf9edad86d), but it was version specific and even detrimental, so we reverted it (commit 7b48ee792b77cb9).

Generalize the idea, and do actual version detection.

---

Stumbled over this in https://github.com/cockpit-project/cockpit/pull/22373#issuecomment-3766994956 when I thought "where the heck is my code going??".. 

Now it works properly, `test/image-prepare -qv --container rhel-8-10` shows

> Adjusting Python module location to /var/tmp/install/usr/lib/python3.13
> renamed '/var/tmp/install/usr/lib/python3.14' -> '/var/tmp/install/usr/lib/python3.13'
