### PR TITLE
sosreport: introduce manifest condition for Arch Linux

### DIFF
--- a/pkg/sosreport/manifest.json
+++ b/pkg/sosreport/manifest.json
@@ -1,4 +1,7 @@
 {
+    "conditions": [
+	{"any": [{"path-exists": "/usr/bin/sos"}, {"path-exists": "/usr/sbin/sos"}]}
+    ],
     "tools": {
         "index": {
             "label": "Diagnostic reports",


### PR DESCRIPTION
Arch Linux has no sos-report so when beibooting into an Arch Linux machine showing the sos report page is not useful.