### PR TITLE
test: Use VirtMachine.boot() API

### DIFF
--- a/test/ARCHITECTURE.md
+++ b/test/ARCHITECTURE.md
@@ -94,8 +94,7 @@ sequenceDiagram
 
     test->>test: test_main()
     test->>test: setUp()
-    test->>machine: start()
-    test->>machine: wait_boot()
+    test->>machine: boot()
     test->>browser: __init__()
     test->>test: setup non-destructive setup
     test->>test: run test

--- a/test/image-prepare
+++ b/test/image-prepare
@@ -42,8 +42,7 @@ def create_machine(image: str) -> Iterator[machine_virtual.VirtMachine]:
     network = machine_virtual.VirtNetwork(image=image)
     machine = machine_virtual.VirtMachine(image=image, networking=network.host(restrict=True))
     try:
-        machine.start()
-        machine.wait_boot()
+        machine.boot()
         yield machine
     finally:
         machine.stop()

--- a/test/verify/check-bots-api
+++ b/test/verify/check-bots-api
@@ -36,8 +36,7 @@ class TestImageCustomize(unittest.TestCase):
         with testvm.Timeout(seconds=300, error_message="Timed out waiting for image to run"):
             network = testvm.VirtNetwork(0, image=image)
             machine = testvm.VirtMachine(image=image, networking=network.host(), memory_mb=512)
-            machine.start()
-            machine.wait_boot()
+            machine.boot()
             out = machine.execute('cat /var/custom-test')
             machine.stop()
         self.assertEqual(out, "hello\n")


### PR DESCRIPTION
Use the new API [1] to benefit from the nested KVM auto-retries in [2].

Keep the explicit start()/wait_boot() in testlib.py, as provisioned
machines should boot in parallel, and it already auto-retries failed VM
boots (although more noisily).

[1] https://github.com/cockpit-project/bots/commit/6b948eed
[2] https://github.com/cockpit-project/bots/commit/2c695f9d
