### PR TITLE
lib: Make sure that event listeners are registered on time

### DIFF
--- a/pkg/lib/hooks.ts
+++ b/pkg/lib/hooks.ts
@@ -301,7 +301,7 @@ export function useEvent<EM extends cockpit.EventMap, E extends keyof EM>(obj: c
 
     const [, forceUpdate] = useReducer(x => x + 1, 0);
 
-    useEffect(() => {
+    function addListener() {
         function update(...args: Parameters<cockpit.EventListener<EM[E]>>) {
             if (handler)
                 handler(...args);
@@ -310,7 +310,12 @@ export function useEvent<EM extends cockpit.EventMap, E extends keyof EM>(obj: c
 
         obj?.addEventListener(event, update);
         return () => obj?.removeEventListener(event, update);
-    }, [obj, event, handler]);
+    }
+
+    useObject(
+        addListener,
+        removeListener => removeListener(),
+        [obj, event, handler]);
 }
 
 /* Same as useEvent, but for our own EventEmitter.
@@ -318,9 +323,10 @@ export function useEvent<EM extends cockpit.EventMap, E extends keyof EM>(obj: c
 export function useOn<EM extends { [E in keyof EM]: (...args: never[]) => void }, E extends keyof EM>(object: EventEmitter<EM> | null, event: E): void {
     const [, forceUpdate] = useReducer(x => x + 1, 0);
 
-    useEffect(() => {
-        return object?.on(event, forceUpdate as EM[E]);
-    }, [object, event]);
+    useObject(
+        () => object?.on(event, forceUpdate as EM[E]),
+        off => off && off(),
+        [object, event]);
 }
 
 /* - useInit(func, deps, comps)

--- a/pkg/shell/state.tsx
+++ b/pkg/shell/state.tsx
@@ -185,9 +185,7 @@ export class ShellState extends EventEmitter<ShellStateEvents> {
             const watchdog_problem = options.problem as string || "disconnected";
             console.warn("transport closed: " + watchdog_problem);
             this.problem = watchdog_problem;
-            // We might get here real early, before events seem to
-            // work. Let's push the update processing to the event loop.
-            setTimeout(() => this.update(), 0);
+            this.update();
         });
 
         const old_onerror = window.onerror;


### PR DESCRIPTION
Our useEvent and useOn hooks should register their event listeners immediately when they are called, not some time later whenever useEffect runs its function.  Otherwise, we might lose events.

This used to happen in the specific case of the connection watchdog in the Shell when the WebSocket could not be opened in Firefox.  The watchdog triggered after a call to useOn but before the useEffect hook.  would have actually run the code for adding the listener.  The result was that the Shell did not render and would not show the "early failure" message.

The useObject hook is suitable for preventing this, and we can remove the (not fully effective) workaround in the Shell.