### PR TITLE
spec: improve asciidoctor builddep resolving

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -124,7 +124,7 @@ BuildRequires: nodejs-esbuild
 
 %if !%{defined bundle_docs}
 %if 0%{?suse_version}
-BuildRequires: /usr/bin/asciidoctor
+BuildRequires: rubygem(asciidoctor)
 %else
 BuildRequires: asciidoctor
 %endif


### PR DESCRIPTION
/usr/bin/asciidoctor does resolve when using dnf however under zypper or subsequently building in obs this fails. It seems the more correct way of handling this is through rubygem(asciidoctor) which works under both package managers