### PR TITLE
cockpit-desktop: clarify error when cockpit-bridge is missing

### DIFF
--- a/src/ws/cockpit-desktop.in
+++ b/src/ws/cockpit-desktop.in
@@ -118,6 +118,13 @@ esac
 detect_browser
 
 # start the bridge; this needs to run in the normal user session/namespace
+echo "cockpit-desktop: attempting to start cockpit-bridge locally"
+
+if ! command -v cockpit-bridge >/dev/null 2>&1; then
+    echo "cockpit-desktop: error: cockpit-bridge was not found."
+    echo "cockpit-desktop: please install the cockpit package or ensure cockpit-bridge is in your PATH."
+fi
+
 coproc ${2:+ssh "$2"} cockpit-bridge
 trap "kill $COPROC_PID; wait $COPROC_PID || true" EXIT INT QUIT PIPE
 


### PR DESCRIPTION
### What this PR does
Improves the user-facing error message when cockpit-bridge is not found and adds a brief explanation before attempting to start it.

### Why
Previously, the root cause was obscured by unrelated terminal output, which made the failure confusing for users.

### Testing
Manually verified the messaging when cockpit-bridge is not installed.

Fixes #20766