### PR TITLE
ws: Excise broken https check

### DIFF
--- a/src/websocket/test-websocket.c
+++ b/src/websocket/test-websocket.c
@@ -477,7 +477,7 @@ setup_pair (Test *test,
 
   cockpit_socket_streampair (&ioc, &ios);
 
-  test->server = web_socket_server_new_for_stream ("ws://localhost/unix", NULL, NULL, ios, NULL, NULL);
+  test->server = web_socket_server_new_for_stream (NULL, NULL, ios, NULL, NULL);
   test->client =  web_socket_client_new_for_stream ("ws://localhost/unix", NULL, NULL, ioc);
 
   g_signal_connect (test->server, "error", G_CALLBACK (on_error_not_reached), NULL);
@@ -1237,8 +1237,7 @@ test_handshake_with_buffer_and_headers (void)
   input = g_byte_array_new ();
   g_byte_array_append (input, (guchar *)buffer + (in1 + in2), count - (in1 + in2));
 
-  server = web_socket_server_new_for_stream ("ws://localhost/unix", NULL,
-                                             NULL, ios, headers, input);
+  server = web_socket_server_new_for_stream (NULL, NULL, ios, headers, input);
   g_signal_connect (server, "error", G_CALLBACK (on_error_not_reached), NULL);
 
   WAIT_UNTIL (web_socket_connection_get_ready_state (server) != WEB_SOCKET_STATE_CONNECTING);

--- a/src/websocket/websocketserver.c
+++ b/src/websocket/websocketserver.c
@@ -243,7 +243,6 @@ parse_handshake_request (WebSocketServer *self,
   gboolean valid;
   gssize in1, in2;
   gssize consumed;
-  const gchar *url;
 
   /* Headers already passed from caller */
   if (self->request_headers)
@@ -251,11 +250,6 @@ parse_handshake_request (WebSocketServer *self,
       headers = self->request_headers;
       self->request_headers = NULL;
       method = g_strdup ("GET");
-
-      url = web_socket_connection_get_url (conn);
-      if (!_web_socket_util_parse_url (url, NULL, NULL, &resource, NULL))
-        resource = g_strdup ("/");
-
       consumed = 0;
     }
   else
@@ -292,7 +286,7 @@ parse_handshake_request (WebSocketServer *self,
 
   if (!g_str_equal (method, "GET"))
     {
-      g_message ("received unexpected method: %s %s", method, resource);
+      g_message ("received unexpected method: %s", method);
       valid = FALSE;
     }
   else
@@ -446,7 +440,6 @@ web_socket_server_class_init (WebSocketServerClass *klass)
 
 /**
  * web_socket_server_new_for_stream:
- * @url: the url address of the WebSocket
  * @origins: (allow-none): the origin to expect the client to report
  * @protocols: (allow-none): possible protocols for the client to
  * @io_stream: the IO stream to communicate over
@@ -476,15 +469,13 @@ web_socket_server_class_init (WebSocketServerClass *klass)
  * Returns: (transfer full): a new WebSocket
  */
 WebSocketConnection *
-web_socket_server_new_for_stream (const gchar *url,
-                                  const gchar * const *origins,
+web_socket_server_new_for_stream (const gchar * const *origins,
                                   const gchar * const *protocols,
                                   GIOStream *io_stream,
                                   GHashTable *request_headers,
                                   GByteArray *input_buffer)
 {
   return g_object_new (WEB_SOCKET_TYPE_SERVER,
-                       "url", url,
                        "origins", origins,
                        "protocols", protocols,
                        "io-stream", io_stream,

--- a/src/websocket/websocketserver.h
+++ b/src/websocket/websocketserver.h
@@ -34,8 +34,7 @@ G_BEGIN_DECLS
 
 GType                 web_socket_server_get_type           (void) G_GNUC_CONST;
 
-WebSocketConnection * web_socket_server_new_for_stream     (const gchar *url,
-                                                            const gchar * const *origins,
+WebSocketConnection * web_socket_server_new_for_stream     (const gchar * const *origins,
                                                             const gchar * const *protocols,
                                                             GIOStream *io_stream,
                                                             GHashTable *request_headers,

--- a/src/ws/cockpitwebservice.c
+++ b/src/ws/cockpitwebservice.c
@@ -1310,18 +1310,9 @@ cockpit_web_service_create_socket (const gchar **protocols,
   gchar *allocated = NULL;
   gchar *origin = NULL;
   gchar *defaults[2];
-  gboolean is_https;
-  gchar *url;
 
   const gchar *host = cockpit_web_request_get_host (request);
   const gchar *protocol = cockpit_web_request_get_protocol (request);
-  g_debug("cockpit_web_service_create_socket: host %s, protocol %s", host, protocol);
-  is_https = g_str_equal (protocol, "https") == 0;
-
-  url = g_strdup_printf ("%s://%s%s",
-                         is_https ? "wss" : "ws",
-                         host ? host : "localhost",
-                         cockpit_web_request_get_path (request));
 
   origins = cockpit_conf_strv ("WebService", "Origins", ' ');
   if (origins == NULL)
@@ -1332,12 +1323,11 @@ cockpit_web_service_create_socket (const gchar **protocols,
       origins = (const gchar **)defaults;
     }
 
-  connection = web_socket_server_new_for_stream (url, origins, protocols,
+  connection = web_socket_server_new_for_stream (origins, protocols,
                                                  cockpit_web_request_get_io_stream (request),
                                                  cockpit_web_request_get_headers (request),
                                                  cockpit_web_request_get_buffer (request));
   g_free (allocated);
-  g_free (url);
   g_free (origin);
 
   return connection;

--- a/src/ws/test-server.c
+++ b/src/ws/test-server.c
@@ -556,12 +556,10 @@ on_handle_stream_external (CockpitWebServer *server,
       const gchar *protocols[] = { "cockpit1", NULL };
       const gchar *origins[2] = { NULL, NULL };
       WebSocketConnection *ws = NULL;
-      gchar *url;
 
-      url = g_strdup_printf ("ws://localhost:%u%s", server_port, path);
       origins[0] = g_strdup_printf ("http://localhost:%u", server_port);
 
-      ws = web_socket_server_new_for_stream (url, (const gchar **)origins,
+      ws = web_socket_server_new_for_stream ((const gchar **)origins,
                                              protocols, io_stream, headers, input);
 
       g_signal_connect (ws, "message", G_CALLBACK (on_echo_socket_message), NULL);


### PR DESCRIPTION
`cockpit_web_service_create_socket()` previously constructed a WebSocket
URL (like `ws[s]://host/path`) for calling
`web_socket_server_new_for_stream()`. That URL was constructed wrongly
as the `is_https` flag was inverted. However,
`web_socket_server_new_for_stream()` immediately parsed that URL to
extract just the resource path, and ignored the schema, so that bug
never had any actual effect. Also, that path was only used in a single
error log message when the WebSocket handshake received a non-GET
request.

The server independently parses the HTTP request line to get both method
and resource, making the URL parameter redundant. The URL's scheme (ws
vs wss) was never validated or used -- the actual connection security is
determined by the underlying GIOStream, not the URL string.

-----

Spotted completely accidentally while I was debugging #22794. ~How did that ever work? I want to see if it breaks any test case. Not the unit tests at least..~ Initial fix in commit 591d9fc5725b9fb67041b2c4a9416a1abb241b1c was totally green. See below for the analysis.