### PR TITLE
storaged: switch to JSON.stringify() for tang

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "dequal": "2.0.3",
     "gettext-parser": "9.0.1",
     "ipaddr.js": "2.3.0",
-    "json-stable-stringify-without-jsonify": "1.0.1",
     "prop-types": "15.8.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/pkg/storaged/crypto/tang.jsx
+++ b/pkg/storaged/crypto/tang.jsx
@@ -25,8 +25,6 @@ import { Content, ContentVariants } from "@patternfly/react-core/dist/esm/compon
 
 import { useInit } from "hooks";
 
-import stable_stringify from "json-stable-stringify-without-jsonify";
-
 const _ = cockpit.gettext;
 
 async function digest(text, hash) {
@@ -87,20 +85,21 @@ async function compute_thp(jwk) {
     if (!REQUIRED_ATTRS[jwk.kty])
         return cockpit.format("(unknown keytype $0)", jwk.kty);
 
-    const req = REQUIRED_ATTRS[jwk.kty];
+    const req = REQUIRED_ATTRS[jwk.kty].sort();
     const norm = { };
     req.forEach(k => { if (k in jwk) norm[k] = jwk[k]; });
 
     const hashes = {};
     try {
-        const sha256 = jwk_b64_encode(await digest(stable_stringify(norm), "SHA-256"));
+        console.log(JSON.stringify(norm));
+        const sha256 = jwk_b64_encode(await digest(JSON.stringify(norm), "SHA-256"));
         hashes.sha256 = sha256;
     } catch (err) {
         console.warn("Unable to create a sha256 hash", err);
     }
 
     try {
-        const sha1 = jwk_b64_encode(await digest(stable_stringify(norm), "SHA-1"));
+        const sha1 = jwk_b64_encode(await digest(JSON.stringify(norm), "SHA-1"));
         hashes.sha1 = sha1;
     } catch (err) {
         console.warn("Unable to create a sha1 hash", err);


### PR DESCRIPTION
JSON.stringify() does not order keys when stringify(), however if you provide the same order without nested keys the order is retained.

Our stringified output is always the same as we always create the `norm` object with the same order of keys. However to show the same hash output as `tang-show-keys` we have to order the keys alphabetically. This allows us to drop the external node module
`json-stable-stringify-without-jsonify`.