### PR TITLE
tools: require /usr/bin/node as buildrequires for Fedora rawhidu

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -119,6 +119,7 @@ BuildRequires: gdb
 
 %if 0%{?rebuild_bundle}
 BuildRequires: nodejs
+BuildRequires: %{_bindir}/node
 BuildRequires: nodejs-esbuild
 %endif
 


### PR DESCRIPTION
Depend on the binary as rawhide transitioned into providing `nodejs` via a `nodejs-bin`.

https://fedoraproject.org/wiki/Changes/NodejsAlternativesSystem