### PR TITLE
tls: Fix non-blocking poll() loop

### DIFF
--- a/src/tls/connection.c
+++ b/src/tls/connection.c
@@ -663,7 +663,7 @@ connection_thread_loop (Connection *self)
       ws_revents = calculate_revents (&self->ws_to_client_buffer, &self->client_to_ws_buffer);
 
       if (self->tls && buffer_can_read (&self->client_to_ws_buffer))
-        client_revents |= POLLIN * gnutls_record_check_pending (self->tls);
+        client_revents |= POLLIN * (gnutls_record_check_pending (self->tls) != 0);
 
       debug (POLL, "poll | client %d/x%x/x%x | ws %d/x%x/x%x |",
              self->client_fd, client_events, client_revents,


### PR DESCRIPTION
The call to gnutls_record_check_pending returns the number of pending bytes, not a 0 or 1 boolean indication.

Multiplying that by POLLIN gives random numbers and if that number is != 0 but doesn't have POLLIN set, we poll with a zero timeout but don't read from the tls pipe. Thus gnutls_record_check_pending keeps returning the same non-zero number and we loop with a zero poll timeout until something else happens that maybe causes us to make progress.

Fixes #22274