### PR TITLE
tools: disable doc generation in packit

### DIFF
--- a/tools/make-dist
+++ b/tools/make-dist
@@ -44,6 +44,7 @@ else
     ../../configure \
         CPPFLAGS=-I../../tools/mock-build-env \
         PKG_CONFIG_PATH=../../tools/mock-build-env \
+        --disable-doc \
         --enable-prefix-only \
         > /dev/null
 fi


### PR DESCRIPTION
  When proposing a new release downstream `post-upstream-clone` runs which
  creates a dist tarball with `tools/make-dist`. At this point we don't
  have asciidoctor nor asciidoc installed so this always fails.

  This is an packit issue as it should not really create an archive as it
  uses Source* for uploading the release tarballs to the lookaside cache.

---

As we started merging other stuff, I'll need to do this in a separate branch and tag 355.1