### PR TITLE
debian: Drop obsolete docbook-xsl build dependency

### DIFF
--- a/tools/debian/control
+++ b/tools/debian/control
@@ -5,7 +5,6 @@ Maintainer: Cockpit <cockpit@cockpit-project.org>
 Build-Depends: asciidoctor,
                debhelper-compat (= 13),
                dh-python,
-               docbook-xsl,
                gettext (>= 0.21),
                glib-networking,
                libcrypt-dev,


### PR DESCRIPTION
Using asciidoctor now.