### PR TITLE
Specify full cockpit-bridge path for superuser transient unit

### DIFF
--- a/src/cockpit/superuser.py
+++ b/src/cockpit/superuser.py
@@ -97,7 +97,7 @@ class SuperuserPeer(ConfiguredPeer):
                 ("StandardInputFileDescriptor", {"t": "h", "v": theirs}),
                 ("StandardOutputFileDescriptor", {"t": "h", "v": theirs}),
                 ("StandardErrorFileDescriptor", {"t": "h", "v": stderr}),
-                ("ExecStart", {"t": "a(sasb)", "v": [(args[0], args, False)]}),
+                ("ExecStart", {"t": "a(sasb)", "v": [(shutil.which(args[0]), args, False)]}),
             ],
             [],
         )


### PR DESCRIPTION
Specifies the full path to the `cockpit-bridge` binary when creating the transient unit for superuser privileges, instead of relying on systemd's default PATH to contain cockpit-bridge.

The motivation for this is that, on NixOS, the default systemd PATH is very minimal, instead preferring each service to explicitly include itself in its own PATH:

```
[root@nixos:~]# systemctl show-environment
LANG=en_US.UTF-8
PATH=/nix/store/5j9cg6adv3d2l403fcfklz4lmf9fd0l8-systemd-258.3/bin/
```

And so launching the transient unit fails since it's unable to find the `cockpit-bridge` binary, since it runs in a completely clean environment.

By calling `shutil.which()` on the argument it ensures the path of the binary is resolved on the Python side, before the service is started, instead of relying on systemd to resolve it. (On NixOS `cockpit-bridge` is actually a wrapper that sets up the correct environment including the full `PATH` and `PYTHONPATH` and then executes the real `cockpit-bridge`)