### PR TITLE
client: Add "vcs-browser" URL to appstream metainfo

### DIFF
--- a/src/client/org.cockpit_project.CockpitClient.metainfo.xml
+++ b/src/client/org.cockpit_project.CockpitClient.metainfo.xml
@@ -65,4 +65,5 @@
   <url type="bugtracker">https://github.com/cockpit-project/cockpit/issues</url>
   <url type="help">https://cockpit-project.org/documentation.html</url>
   <url type="translate">https://translate.fedoraproject.org/projects/cockpit</url>
+  <url type="vcs-browser">https://github.com/cockpit-project/cockpit/tree/main/src/client</url>
 </component>


### PR DESCRIPTION
Fixes https://github.com/flathub/org.cockpit_project.CockpitClient/issues/79