### PR TITLE
test: Remove "memory_mb" provision parameter when less than 1G

### DIFF
--- a/test/verify/check-bots-api
+++ b/test/verify/check-bots-api
@@ -23,7 +23,7 @@ class TestImageCustomize(unittest.TestCase):
     def checkBoot(self, image):
         with testvm.Timeout(seconds=300, error_message="Timed out waiting for image to run"):
             network = testvm.VirtNetwork(0, image=image)
-            machine = testvm.VirtMachine(image=image, networking=network.host(), memory_mb=512)
+            machine = testvm.VirtMachine(image=image, networking=network.host())
             machine.boot()
             out = machine.execute('cat /var/custom-test')
             machine.stop()

--- a/test/verify/check-client
+++ b/test/verify/check-client
@@ -13,8 +13,8 @@ import testlib
 class TestClient(testlib.MachineCase):
 
     provision = {
-        "client": {"address": "10.111.113.1/24", "memory_mb": 660},
-        "target": {"address": "10.111.113.2/24", "memory_mb": 660},
+        "client": {"address": "10.111.113.1/24"},
+        "target": {"address": "10.111.113.2/24"},
     }
 
     def setUp(self):

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -1512,7 +1512,7 @@ Command={self.libexecdir}/cockpit-session
 class TestReverseProxy(testlib.MachineCase):
 
     provision = {
-        "0": {"forward": {"443": 8443}, "memory_mb": 768}
+        "0": {"forward": {"443": 8443}}
     }
 
     def setUp(self):

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -478,7 +478,7 @@ class TestKdumpConfiguration(KdumpHelpers):
 class TestKdumpNFS(KdumpHelpers):
     provision = {
         "0": {"address": "10.111.113.1/24", "memory_mb": 2048, "capture_console": True},
-        "nfs": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/24", "memory_mb": 512}
+        "nfs": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/24"}
     }
 
     def testBasic(self):
@@ -563,9 +563,9 @@ class TestKdumpNFS(KdumpHelpers):
 @testlib.timeout(900)
 class TestKdumpNFSAnsible(KdumpHelpers):
     provision = {
-        "cockpit": {"memory_mb": 512},
+        "cockpit": {},
         "kdump_ansible_machine": {"address": "10.111.113.1/24", "memory_mb": 2048, "capture_console": True},
-        "nfs": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/24", "memory_mb": 512},
+        "nfs": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/24"},
     }
 
     def testBasic(self):
@@ -622,7 +622,7 @@ class TestKdumpNFSAnsible(KdumpHelpers):
 @testlib.timeout(900)
 class TestKdumpAnsible(KdumpHelpers):
     provision = {
-        "cockpit": {"memory_mb": 512},
+        "cockpit": {},
         "kdump_ansible_machine": {"memory_mb": 2048},
     }
 

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1494,9 +1494,9 @@ class TestMultiCPU(testlib.MachineCase):
 class TestGrafanaClient(testlib.MachineCase):
 
     provision = {
-        "0": {"address": "10.111.112.1/20", "dns": "10.111.112.1", "memory_mb": 512},
+        "0": {"address": "10.111.112.1/20", "dns": "10.111.112.1"},
         # forward Grafana port, so that a developer can connect to it with local browser
-        "services": {"image": "services", "forward": {"3000": 3000}, "memory_mb": 1024}
+        "services": {"image": "services", "forward": {"3000": 3000}}
     }
 
     def testBasic(self):

--- a/test/verify/check-networkmanager-bond
+++ b/test/verify/check-networkmanager-bond
@@ -287,8 +287,8 @@ class TestBonding(netlib.NetworkCase):
 
 class TestBondingVirt(netlib.NetworkCase):
     provision = {
-        "machine1": {"address": "10.111.113.1/20", "memory_mb": 512},
-        "machine2": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/20", "dhcp": True, "memory_mb": 512}
+        "machine1": {"address": "10.111.113.1/20"},
+        "machine2": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/20", "dhcp": True}
     }
 
     @testlib.skipImage("Main interface can't be managed", "debian-*", "ubuntu-*")

--- a/test/verify/check-networkmanager-mac
+++ b/test/verify/check-networkmanager-mac
@@ -12,8 +12,8 @@ from lib.constants import TEST_OS_DEFAULT
 
 class TestNetworkingMAC(netlib.NetworkCase):
     provision = {
-        "machine1": {"memory_mb": 512},
-        "machine2": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/20", "dhcp": True, "memory_mb": 512}
+        "machine1": {},
+        "machine2": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/20", "dhcp": True}
     }
 
     def testMac(self):

--- a/test/verify/check-networkmanager-settings
+++ b/test/verify/check-networkmanager-settings
@@ -12,8 +12,8 @@ from lib.constants import TEST_OS_DEFAULT
 
 class TestNetworkingSettings(netlib.NetworkCase):
     provision = {
-        "machine1": {"memory_mb": 512},
-        "machine2": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/20", "dhcp": True, "memory_mb": 512}
+        "machine1": {},
+        "machine2": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/20", "dhcp": True}
     }
 
     def testNoConnectionSettings(self):

--- a/test/verify/check-networkmanager-wireguard
+++ b/test/verify/check-networkmanager-wireguard
@@ -10,8 +10,8 @@ import testlib
 
 class TestWireGuard(packagelib.PackageCase, netlib.NetworkCase):
     provision = {
-        "machine1": {"address": "192.168.100.11/24", "address6": "2001:db8:face::1/64", "memory_mb": 768},
-        "machine2": {"address": "192.168.100.12/24", "address6": "2001:db8:face::2/64", "memory_mb": 512}
+        "machine1": {"address": "192.168.100.11/24", "address6": "2001:db8:face::1/64"},
+        "machine2": {"address": "192.168.100.12/24", "address6": "2001:db8:face::2/64"}
     }
 
     def testVPN(self):

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1346,8 +1346,8 @@ class TestKpatchInstall(NoSubManCase):
 @testlib.skipBeiboot("sub-man-cockpit not contained in cockpit/ws")
 class TestUpdatesSubscriptions(packagelib.PackageCase, submanlib.SubscriptionCase):
     provision = {
-        "0": {"address": "10.111.112.1/20", "dns": "10.111.112.1", "memory_mb": 1024},
-        "services": {"image": "services", "memory_mb": 1024}
+        "0": {"address": "10.111.112.1/20", "dns": "10.111.112.1"},
+        "services": {"image": "services"}
     }
 
     def setUp(self):

--- a/test/verify/check-selinux
+++ b/test/verify/check-selinux
@@ -41,7 +41,7 @@ mv -f ~/.ssh/authorized_keys.test-avc ~/.ssh/authorized_keys
 class TestSelinux(testlib.MachineCase):
     provision = {
         "0": {},
-        "ansible_machine": {"image": TEST_OS_DEFAULT, "memory_mb": 650}
+        "ansible_machine": {"image": TEST_OS_DEFAULT}
     }
 
     @testlib.skipImage("No setroubleshoot", "debian-*", "ubuntu-*", "arch")

--- a/test/verify/check-shell-host-switching
+++ b/test/verify/check-shell-host-switching
@@ -123,9 +123,9 @@ class HostSwitcherHelpers:
 @testlib.skipBeiboot("host switching disabled in beiboot mode")
 class TestHostSwitching(testlib.MachineCase, HostSwitcherHelpers):
     provision = {
-        'machine1': {"address": "10.111.113.1/20", "memory_mb": 512},
-        'machine2': {"address": "10.111.113.2/20", "memory_mb": 512},
-        'machine3': {"address": "10.111.113.3/20", "memory_mb": 512}
+        'machine1': {"address": "10.111.113.1/20"},
+        'machine2': {"address": "10.111.113.2/20"},
+        'machine3': {"address": "10.111.113.3/20"}
     }
 
     def setUp(self):

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -108,9 +108,9 @@ def change_ssh_port(machine, address, sshd_socket, sshd_service, port=None, time
 @testlib.skipBeiboot("host switching disabled in beiboot mode")
 class TestMultiMachineAdd(testlib.MachineCase):
     provision = {
-        "machine1": {"address": "10.111.113.1/20", "memory_mb": 660},
-        "machine2": {"address": "10.111.113.2/20", "memory_mb": 660},
-        "machine3": {"address": "10.111.113.3/20", "memory_mb": 660},
+        "machine1": {"address": "10.111.113.1/20"},
+        "machine2": {"address": "10.111.113.2/20"},
+        "machine3": {"address": "10.111.113.3/20"},
     }
 
     def setUp(self):
@@ -228,9 +228,9 @@ class TestMultiMachineAdd(testlib.MachineCase):
 @testlib.skipBeiboot("host switching disabled in beiboot mode")
 class TestMultiMachine(testlib.MachineCase):
     provision = {
-        "machine1": {"address": "10.111.113.1/20", "memory_mb": 660},
-        "machine2": {"address": "10.111.113.2/20", "memory_mb": 660},
-        "machine3": {"address": "10.111.113.3/20", "memory_mb": 660},
+        "machine1": {"address": "10.111.113.1/20"},
+        "machine2": {"address": "10.111.113.2/20"},
+        "machine3": {"address": "10.111.113.3/20"},
     }
 
     def setUp(self):

--- a/test/verify/check-shell-multi-machine-key
+++ b/test/verify/check-shell-multi-machine-key
@@ -44,8 +44,8 @@ KEY_IDS = [
 @testlib.skipBeiboot("host switching disabled in beiboot mode")
 class TestMultiMachineKeyAuth(testlib.MachineCase):
     provision = {
-        "machine1": {"address": "10.111.113.1/20", "memory_mb": 512},
-        "machine2": {"address": "10.111.113.2/20", "memory_mb": 512},
+        "machine1": {"address": "10.111.113.1/20"},
+        "machine2": {"address": "10.111.113.2/20"},
     }
 
     def load_key(self, name, password):

--- a/test/verify/check-shell-multi-os
+++ b/test/verify/check-shell-multi-os
@@ -11,8 +11,8 @@ import testlib
 @testlib.skipBeiboot("host switching disabled in beiboot mode")
 class TestRHEL8(testlib.MachineCase):
     provision = {
-        "0": {"address": "10.111.113.1/20", "memory_mb": 768},
-        "stock": {"address": "10.111.113.5/20", "image": "rhel-8-10", "memory_mb": 512}
+        "0": {"address": "10.111.113.1/20"},
+        "stock": {"address": "10.111.113.5/20", "image": "rhel-8-10"}
     }
 
     def logout_pf5(self, b):

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -523,8 +523,8 @@ exit 1
 @testlib.skipBeiboot("host switching disabled in beiboot mode")
 class TestSuperuserDashboard(testlib.MachineCase):
     provision = {
-        "machine1": {"address": "10.111.113.1/20", "memory_mb": 768},
-        "machine2": {"address": "10.111.113.2/20", "memory_mb": 768},
+        "machine1": {"address": "10.111.113.1/20"},
+        "machine2": {"address": "10.111.113.2/20"},
     }
 
     def test(self):

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -1119,8 +1119,8 @@ class TestSystemInfoTime(packagelib.PackageCase):
 
 class TestSystemInfoSubscribed(submanlib.SubscriptionCase):
     provision = {
-        "0": {"address": "10.111.112.1/20", "dns": "10.111.112.1", "memory_mb": 1024},
-        "services": {"image": "services", "memory_mb": 1024}
+        "0": {"address": "10.111.112.1/20", "dns": "10.111.112.1"},
+        "services": {"image": "services"}
     }
 
     @testlib.onlyImage("insights-client is only on RHEL", "rhel*")

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -482,7 +482,7 @@ class TestRealms(testlib.MachineCase):
     """Common variables and tests for all supported domain backends"""
 
     provision = {
-        "0": {"address": "10.111.113.1/20", "dns": "10.111.112.100", "memory_mb": 700},
+        "0": {"address": "10.111.113.1/20", "dns": "10.111.112.100"},
         "services": {"image": "services", "memory_mb": 1500}
     }
 
@@ -1006,7 +1006,7 @@ sed -i '/^sudoers:/ s/files sss/sss files/' /etc/nsswitch.conf
 @testlib.no_retry_when_changed
 class TestKerberos(testlib.MachineCase):
     provision = {
-        "0": {"address": "10.111.113.1/20", "dns": "10.111.112.100", "memory_mb": 512},
+        "0": {"address": "10.111.113.1/20", "dns": "10.111.112.100"},
         "services": {"image": "services", "memory_mb": 1500}
     }
 

--- a/test/verify/check-system-shutdown-restart
+++ b/test/verify/check-system-shutdown-restart
@@ -11,8 +11,8 @@ import testlib
 @testlib.skipBeiboot("host switching disabled in beiboot mode")
 class TestShutdownRestart(testlib.MachineCase):
     provision = {
-        "machine1": {"address": "10.111.113.1/20", "memory_mb": 512},
-        "machine2": {"address": "10.111.113.2/20", "memory_mb": 512}
+        "machine1": {"address": "10.111.113.1/20"},
+        "machine2": {"address": "10.111.113.2/20"}
     }
 
     def setUp(self):


### PR DESCRIPTION
Let's not try to use machines with less RAM than the default, which is a little bit more than 1G.  Recent centos-10 images fail to boot with less than 1G.