### PR TITLE
git: Add `configure~` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 #  - patterns to match files in subdirs
 
 # general patterns
+*~
 *.a
 *.gcda
 *.gcno


### PR DESCRIPTION
As part of running `./autogen.sh` I get a `configure~` generated
alongside `configure`. This seems to be an intermittent step and should
be ignored.

For reference, this is ignored by automake itself
https://github.com/autotools-mirror/automake/blob/080b6dbea2acb8005d6a72c52caa71862514d2ce/.gitignore#L1

Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
