### PR TITLE
git: Prevent editor popup on `tools/node_modules`

### DIFF
--- a/test/common/git-utils.sh
+++ b/test/common/git-utils.sh
@@ -71,7 +71,7 @@ fetch_sha_to_cache() {
         message FETCH "${SUBDIR}  [ref: ${sha}]"
         git_cache fetch --no-tags ${quiet} origin "${sha}"
         # tag it to keep it from being GC'd.
-        git_cache tag "sha-${sha}" "${sha}"
+        git_cache tag "sha-${sha}" "${sha}" "--no-sign"
     fi
 }
 


### PR DESCRIPTION
Hopefully this takes care of the editor popup I get from time to time
when executing stuff like `make vm` in cockpit-files or other commands
that execute functions in `node_modules`.

It's been an issue with git config `tag.gpgsign=true` as that by
default makes all tags, commits, and otherwise not inline to make it
possible to sign the content.

Not successfully tested as when it gets triggered once then the following calls work as expected..

Fixes: #22870
Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
