### PR TITLE
doc: fix broken link and update to most recent RHEL web console docs

### DIFF
--- a/pkg/packagekit/manifest.json
+++ b/pkg/packagekit/manifest.json
@@ -12,7 +12,7 @@
             "docs": [
                 {
                     "label": "Managing software updates",
-                    "url": "https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/managing_systems_using_the_rhel_9_web_console/managing-software-updates-in-the-web-console_system-management-using-the-rhel-9-web-console"
+                    "url": "https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/10/html/managing_systems_in_the_rhel_web_console/getting-started-with-the-rhel-web-console"
                 }
             ],
             "keywords": [

--- a/pkg/shell/manifest.json
+++ b/pkg/shell/manifest.json
@@ -30,7 +30,7 @@
     "docs": [
         {
             "label": "Web Console",
-            "url": "https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/managing_systems_using_the_rhel_9_web_console/index"
+            "url": "https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/10/html/managing_systems_in_the_rhel_web_console/getting-started-with-the-rhel-web-console"
         }
     ],
     "bridges": [

--- a/pkg/systemd/manifest.json
+++ b/pkg/systemd/manifest.json
@@ -12,7 +12,7 @@
             "docs": [
                 {
                     "label": "Configuring system settings",
-                    "url": "https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/managing_systems_using_the_rhel_9_web_console/index"
+                    "url": "https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/10/html/managing_systems_in_the_rhel_web_console/getting-started-with-the-rhel-web-console"
                 }
             ],
             "keywords": [
@@ -35,7 +35,7 @@
             "docs": [
                 {
                     "label": "Managing services",
-                    "url": "https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/managing_systems_using_the_rhel_9_web_console/index"
+                    "url": "https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/10/html/managing_systems_in_the_rhel_web_console/getting-started-with-the-rhel-web-console"
                 }
             ],
             "keywords": [


### PR DESCRIPTION
minor docs change; happened to see this while looking into a different issue

side note, if whoever merges this currently works for RH, tell them not to break their old docs URLs

(also sorry, I would have added no-test label if I could)