### PR TITLE
spec: Fix license typo

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -52,7 +52,7 @@
 
 Name:           cockpit
 Summary:        Web Console for Linux servers
-License:        LGPL-2.1-or-later AND GPL-3.0-and-later AND MIT AND CC-BY-SA-3.0 AND BSD-3-Clause
+License:        LGPL-2.1-or-later AND GPL-3.0-or-later AND MIT AND CC-BY-SA-3.0 AND BSD-3-Clause
 URL:            https://cockpit-project.org/
 
 Version:        0


### PR DESCRIPTION
It's spelled "GPL-3.0-or-later", not "*-and-*".

---

Fixes [rpminspect failure](https://artifacts.dev.testing-farm.io/34c9bc0c-f499-4f5a-88ec-d888c8837084/) of yesterday's release.