### PR TITLE
test: Add helper function for system admin user

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -2534,6 +2534,10 @@ class MachineCase(unittest.TestCase):
         if not self.machine.ws_container and self.file_exists(disallowed_conf):
             self.sed_file('/root/d', disallowed_conf)
 
+    def get_sudo_user(self) -> str:
+        # In (open)SUSE images, superuser access always requires the root password
+        return "root" if "suse" in self.image else "admin"
+
     def reboot(self, timeout_sec: int | None = None) -> None:
         self.allow_restart_journal_messages()
         if timeout_sec is None:

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -58,7 +58,8 @@ class TestSuperuser(testlib.MachineCase):
         b.wait_text(".pf-v6-c-modal-box__title-text", "Switch to administrative access")
         if "ubuntu" not in m.image and "debian" not in m.image:
             b.wait_in_text(".pf-v6-c-modal-box", "We trust you have received the usual lecture")
-        b.wait_in_text(".pf-v6-c-modal-box", "Password for admin:")
+        user = self.get_sudo_user()
+        b.wait_in_text(".pf-v6-c-modal-box", f"Password for {user}:")
         b.set_input_text(".pf-v6-c-modal-box input", "foobar")
         b.focus(".pf-v6-c-modal-box button:contains('Cancel')")
         b.assert_pixels(".pf-v6-c-modal-box", "superuser-modal",
@@ -143,7 +144,8 @@ session include system-auth
 
         b.open_superuser_dialog()
         b.wait_text(".pf-v6-c-modal-box__title-text", "Switch to administrative access")
-        b.wait_in_text(".pf-v6-c-modal-box", "Password for admin:")
+        user = self.get_sudo_user()
+        b.wait_in_text(".pf-v6-c-modal-box", f"Password for {user}:")
         # Let the dialog sit there for 45 seconds, to test that this doesn't trigger a D-Bus timeout.
         time.sleep(45)
         b.set_input_text(".pf-v6-c-modal-box input", "foobar")
@@ -160,17 +162,17 @@ session include system-auth
         # Log in with limited access
         self.login_and_go(superuser=False)
         b.check_superuser_indicator("Limited access")
-
+        user = self.get_sudo_user()
         b.open_superuser_dialog()
         b.wait_text(".pf-v6-c-modal-box__title-text", "Switch to administrative access")
-        b.wait_in_text(".pf-v6-c-modal-box", "Password for admin:")
+        b.wait_in_text(".pf-v6-c-modal-box", f"Password for {user}:")
         b.set_input_text(".pf-v6-c-modal-box input", "wrong")
         b.click(".pf-v6-c-modal-box button:contains('Authenticate')")
-        b.wait_in_text(".pf-v6-c-modal-box", "Password for admin:")
+        b.wait_in_text(".pf-v6-c-modal-box", f"Password for {user}:")
         b.wait_in_text(".pf-v6-c-modal-box", "Sorry, try again")
         b.set_input_text(".pf-v6-c-modal-box input", "wronger")
         b.click(".pf-v6-c-modal-box button:contains('Authenticate')")
-        b.wait_in_text(".pf-v6-c-modal-box", "Password for admin:")
+        b.wait_in_text(".pf-v6-c-modal-box", f"Password for {user}:")
         b.wait_in_text(".pf-v6-c-modal-box", "Sorry, try again")
         b.set_input_text(".pf-v6-c-modal-box input", "wrongest")
         b.click(".pf-v6-c-modal-box button:contains('Authenticate')")
@@ -194,6 +196,7 @@ session include system-auth
         m.execute(f"gpasswd -d admin {m.get_admin_group()}")
 
         self.login_and_go()
+        user = self.get_sudo_user()
         b.check_superuser_indicator("Limited access")
 
         b.open_superuser_dialog()
@@ -207,11 +210,10 @@ session include system-auth
 
         # no stray/hanging sudo process
         testlib.wait(lambda: "sudo" not in m.execute("loginctl --lines=0 user-status admin"), tries=5)
-
         # cancelling auth dialog stops sudo
         b.open_superuser_dialog()
         b.wait_in_text(".pf-v6-c-modal-box", "Switch to administrative access")
-        b.wait_in_text(".pf-v6-c-modal-box", "Password for admin")
+        b.wait_in_text(".pf-v6-c-modal-box", f"Password for {user}")
         status = m.execute("loginctl --lines=0 user-status admin")
         self.assertIn("sudo", status)
         if not m.ws_container:
@@ -224,7 +226,7 @@ session include system-auth
 
         # logging out cleans up pending sudo auth; user should either go to "State: closing" or disappear completely
         b.open_superuser_dialog()
-        b.wait_in_text(".pf-v6-c-modal-box", "Password for admin")
+        b.wait_in_text(".pf-v6-c-modal-box", f"Password for {user}")
         if not m.ws_container:
             self.assertIn("cockpit-askpass", m.execute("loginctl --lines=0 user-status admin"))
         b.click(".pf-v6-c-modal-box button:contains('Cancel')")
@@ -430,11 +432,12 @@ session include system-auth
 
         # Run the regular sudo method, which should work as always
         b.open_superuser_dialog()
+        user = self.get_sudo_user()
         b.wait_text(".pf-v6-c-modal-box__title-text", "Switch to administrative access")
         b.set_val(".pf-v6-c-modal-box select", "Sudo")
         b.wait_in_text(".pf-v6-c-modal-box select", "Sudo")
         b.click(".pf-v6-c-modal-box button:contains('Authenticate')")
-        b.wait_in_text(".pf-v6-c-modal-box", "Password for admin:")
+        b.wait_in_text(".pf-v6-c-modal-box", f"Password for {user}:")
         b.set_input_text(".pf-v6-c-modal-box input", "foobar")
         b.click(".pf-v6-c-modal-box button:contains('Authenticate')")
         b.wait_not_present(".pf-v6-c-modal-box")
@@ -444,10 +447,11 @@ session include system-auth
         b = self.browser
 
         self.login_and_go("/system", superuser=False)
+        user = self.get_sudo_user()
         b.wait_in_text(".ct-limited-access-alert", "Web console is running in limited access mode.")
         b.click(".ct-limited-access-alert button")
         b.wait_text(".pf-v6-c-modal-box__title-text", "Switch to administrative access")
-        b.wait_in_text(".pf-v6-c-modal-box", "Password for admin:")
+        b.wait_in_text(".pf-v6-c-modal-box", f"Password for {user}:")
         b.set_input_text(".pf-v6-c-modal-box input", "foobar")
         b.click(".pf-v6-c-modal-box button:contains('Authenticate')")
         b.wait_not_present(".pf-v6-c-modal-box")

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -875,7 +875,6 @@ class TestSystemInfoTime(packagelib.PackageCase):
         b.click(f"#change_systime button:contains('{mode}')")
         b.wait_in_text("#system_information_change_systime #change_systime_btn", mode)
 
-    @testlib.skipImage("TODO: fix for OpenSUSE", "opensuse-tumbleweed")
     def testTime(self):
         m = self.machine
         b = self.browser
@@ -902,10 +901,11 @@ class TestSystemInfoTime(packagelib.PackageCase):
         b.wait_visible('#system_information_systime_button[disabled]')
 
         # Gain admin access
+        user = self.get_sudo_user()
         b.wait_in_text(".ct-limited-access-alert", "Web console is running in limited access mode.")
         b.click(".ct-limited-access-alert button")
         b.wait_text(".pf-v6-c-modal-box__title-text", "Switch to administrative access")
-        b.wait_in_text(".pf-v6-c-modal-box", "Password for admin:")
+        b.wait_in_text(".pf-v6-c-modal-box", f"Password for {user}:")
         b.set_input_text(".pf-v6-c-modal-box input", "foobar")
         b.click(".pf-v6-c-modal-box button:contains('Authenticate')")
         b.wait_not_present(".pf-v6-c-modal-box")


### PR DESCRIPTION
on opensuse, sudo does not ask for the current user's password it instead asks for the root password. This adds a function to get which user will be prompted for sudo access and (`get_sudo_user`) and updates checks for `Password for admin:` to check for the expected user