### PR TITLE
test: set useradd defaults on suse images

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1065,6 +1065,10 @@ class Browser:
         self.open(href, tls=tls)
 
         self.try_login(user=user, password=password, superuser=superuser, legacy_authorized=legacy_authorized)
+        # HACK: opensuse images, superuser password is root password,
+        # if superuser = True and user, password are set call become_superuser()
+        if superuser and user and password and "suse" in self.machine.image:
+            self.become_superuser()
 
         self.wait_visible('#content')
         if path:

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -2374,22 +2374,32 @@ class MachineCase(unittest.TestCase):
                 break
             time.sleep(3)
 
-    def sed_file(self, expr: str, path: str, apply_change_action: str | None = None) -> None:
+    def sed_file(self, expr: str, path: str, apply_change_action: str | None = None, absent_content: str | None = None) -> None:
         """sed a file on primary machine
 
         This is safe for @nondestructive tests, the file will be restored during cleanup.
 
         The optional apply_change_action will be run both after sedding and after restoring the file.
+
+        The optional absent_content will create a file in path with the specified contents should the file not exist
         """
         m = self.machine
-        m.execute(f"sed -i.cockpittest '{expr}' {path}")
+        was_absent = False
+        if absent_content and not self.file_exists(path):
+            m.write(path, absent_content)
+            was_absent = True
+        else:
+            m.execute(f"sed -i.cockpittest '{expr}' {path}")
         if apply_change_action:
             m.execute(apply_change_action)
 
         if self.is_nondestructive():
             if apply_change_action:
                 self.addCleanup(m.execute, apply_change_action)
-            self.addCleanup(m.execute, f"mv {path}.cockpittest {path}")
+            if was_absent:
+                self.addCleanup(m.execute, f"rm {path}")
+            else:
+                self.addCleanup(m.execute, f"mv {path}.cockpittest {path}")
 
     def file_exists(self, path: str) -> bool:
         """Check if file exists on test machine"""

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -276,7 +276,6 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
             verify_correct(has_last=True, n_fail=0)
 
     @testlib.skipImage("Arch Linux has no pwquality by default", "arch")
-    @testlib.skipImage("TODO: fix for OpenSUSE", "opensuse-tumbleweed")
     def testExpired(self):
         m = self.machine
         b = self.browser
@@ -297,7 +296,8 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
         # test steps below assume a pam_pwquality config with retry > 1; on some images authselect drops that setting
         if not m.image.startswith('debian') and not m.image.startswith('ubuntu') and not m.image.startswith("arch"):
-            self.sed_file("/password.*requisite.*pam_pwquality/ s/$/ retry=3/", "/etc/pam.d/password-auth")
+            self.sed_file("/password.*requisite.*pam_pwquality/ s/$/ retry=3/",
+                          "/etc/pam.d/common-password-pc" if "suse" in m.image else "/etc/pam.d/password-auth")
 
         m.execute("chage -d 0 admin")
         m.start_cockpit()

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -95,7 +95,6 @@ def createUser(
 
 
 @testlib.nondestructive
-@testlib.skipImage("TODO: fix for OpenSUSE", "opensuse-tumbleweed")
 class TestAccounts(testlib.MachineCase):
 
     def testBasic(self) -> None:
@@ -216,7 +215,8 @@ class TestAccounts(testlib.MachineCase):
         b.wait_visible("#accounts-create")
 
         # Create a user from the UI
-        self.sed_file('s@^SHELL=.*$@SHELL=/bin/true@', '/etc/default/useradd')
+        self.sed_file('s@^SHELL=.*$@SHELL=/bin/true@', '/etc/default/useradd', absent_content="SHELL=/bin/true")
+
         b.click('#accounts-create')
         b.wait_visible('#accounts-create-dialog')
         b.set_input_text('#accounts-create-user-name', "Berta")
@@ -459,7 +459,7 @@ class TestAccounts(testlib.MachineCase):
 
         self.login_and_go("/users")
         # Create a locked user with weak password
-        self.sed_file('s/^SHELL=.*$/SHELL=/', '/etc/default/useradd')
+        self.sed_file('s/^SHELL=.*$/SHELL=/', '/etc/default/useradd', absent_content="SHELL=")
         self.allow_journal_messages(".*required to change your password immediately.*")
         self.allow_journal_messages(".*user account or password has expired.*")
 

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -1331,7 +1331,9 @@ class TestAccounts(testlib.MachineCase):
         self.assertNotIn("titan", m.execute("getent group"))
 
         # Rename and delete actions are available only for user created groups
-        b.wait_not_present(f"#groups-list tbody tr[data-row-id='{m.get_admin_group()}'] button.pf-v6-c-menu-toggle")
+        # Don't check on opensuse, since opensuse doesn't prevent this
+        if "suse" not in m.image:
+            b.wait_not_present(f"#groups-list tbody tr[data-row-id='{m.get_admin_group()}'] button.pf-v6-c-menu-toggle")
 
     def testChangeShell(self) -> None:
         b = self.browser

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -282,6 +282,11 @@ class TestAccounts(testlib.MachineCase):
 
         b.logout()
         b.login_and_go("/users")
+
+        # in suse images, Administrative requires root to be unlocked
+        if "suse" in m.image:
+            m.execute("usermod root --unlock")
+
         createUser(
             browser=b,
             machine=m,

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -574,7 +574,13 @@ class TestAccounts(testlib.MachineCase):
 
         # Login as jussi and change role admin for itself
         b.logout()
-        b.login_and_go("/users", user="jussi", password="bar")
+        if "suse" in m.image:
+            # on suse images, you cannot use login_and_go hackery to automatigically get admin rights
+            # when the user doesn't have the same password as root
+            b.login_and_go("/users", user="jussi", password="bar", superuser=False)
+            b.become_superuser()
+        else:
+            b.login_and_go("/users", user="jussi", password="bar")
 
         # There is only one badge and it is for jussi
         b.wait_text('#current-account-badge', 'Your account')
@@ -650,7 +656,13 @@ class TestAccounts(testlib.MachineCase):
         m.execute('echo "damaged:x:1234:1234:Damaged" >> /etc/passwd')
 
         # Logout and login with the new password
-        b.relogin(path="/users", user="jussi", password=good_password_2)
+        if "suse" in m.image:
+            # on suse images, you cannot use login_and_go hackery to automatigically get admin rights
+            # when the user doesn't have the same password as root
+            b.relogin(path="/users", user="jussi", password=good_password_2, superuser=False)
+            b.become_superuser()
+        else:
+            b.relogin(path="/users", user="jussi", password=good_password_2)
 
         b.go("/users")
         b.enter_page("/users")
@@ -1104,6 +1116,7 @@ class TestAccounts(testlib.MachineCase):
         b.wait_not_present("#password-expiration")
 
         b.logout()
+
         # HACK: https://github.com/cockpit-project/cockpit/issues/20262
         self.login_and_go("/users#/scruffy", user="scruffy", superuser=False)
         b.wait_text("#account-user-name", "scruffy")

--- a/tools/cockpit.suse.pam
+++ b/tools/cockpit.suse.pam
@@ -2,10 +2,12 @@
 auth substack common-auth
 # List of users to deny access to Cockpit, by default root is included.
 auth    required pam_listfile.so item=user sense=deny file=/etc/cockpit/disallowed-users onerr=succeed
+auth    include postlogin-auth
 account required pam_nologin.so
 account include common-account
 password include common-password
 session required pam_loginuid.so
 session optional pam_keyinit.so force revoke
 session include common-session
+session include postlogin-session
 auth [user_unknown=ignore success=ok] pam_oath.so usersfile=${HOME}/.pam_oath_usersfile no_usersfile_okay window=20 digits=6


### PR DESCRIPTION
useradd doesn't have defaults on opensuse, instead we need to use `self.write_file` to create the default files instead of sedding the defaults

depends on: https://github.com/cockpit-project/bots/pull/9368