### PR TITLE
test: Skip currently failing opensuse-tumbleweed/other tests

### DIFF
--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -12,6 +12,7 @@ import testlib
 
 
 @testlib.skipWsContainer("Not supported")
+@testlib.skipImage("TODO: fix for OpenSUSE", "opensuse-tumbleweed")
 @testlib.nondestructive
 class TestApps(packagelib.PackageCase):
 

--- a/test/verify/check-client
+++ b/test/verify/check-client
@@ -10,6 +10,7 @@ import testlib
 
 # enable this once our cockpit/ws container can beiboot
 @testlib.skipWsContainer("client setup does not work with ws container")
+@testlib.skipImage("TODO: fix for OpenSUSE", "opensuse-tumbleweed")
 class TestClient(testlib.MachineCase):
 
     provision = {

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -1509,6 +1509,7 @@ Command={self.libexecdir}/cockpit-session
         self.assertIn('sudo', bridge_names)
 
 
+@testlib.skipImage("TODO: fix for OpenSUSE", "opensuse-tumbleweed")
 class TestReverseProxy(testlib.MachineCase):
 
     provision = {

--- a/test/verify/check-loopback
+++ b/test/verify/check-loopback
@@ -9,6 +9,7 @@ import testlib
 
 
 @testlib.skipWsContainer("cockpit/ws always uses loopback")
+@testlib.skipImage("TODO: fix for OpenSUSE", "opensuse-tumbleweed")
 @testlib.nondestructive
 class TestLoopback(testlib.MachineCase):
 

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -605,6 +605,7 @@ class TestHistoryMetrics(testlib.MachineCase):
         self.assertEqual(m.execute("systemctl is-enabled pmlogger").strip(), "enabled")
 
     @testlib.nondestructive
+    @testlib.skipImage("TODO: fix for OpenSUSE", "opensuse-tumbleweed")
     def testPmProxySettings(self, customRedisService=None):
         b = self.browser
         m = self.machine
@@ -1033,6 +1034,7 @@ class TestCurrentMetrics(testlib.MachineCase):
             b.enter_page("/system/services")
             b.wait_in_text(".service-name", "/usr/bin/dd if=/dev/urandom of=/dev/null")
 
+    @testlib.skipImage("TODO: fix for OpenSUSE", "opensuse-tumbleweed")
     def testMemory(self):
         b = self.browser
         m = self.machine
@@ -1313,6 +1315,7 @@ BEGIN {{
 
 @testlib.skipImage("TODO: Arch Linux packagekit support", "arch")
 @testlib.skipImage("image has pcp installed, but cannot be removed", "*-bootc")
+@testlib.skipImage("TODO: fix for OpenSUSE", "opensuse-tumbleweed")
 class TestMetricsPackages(packagelib.PackageCase):
     pcp_dialog_selector = "#pcp-settings-modal"
 
@@ -1491,6 +1494,7 @@ class TestMultiCPU(testlib.MachineCase):
 
 
 @testlib.skipOstree("no PCP support")
+@testlib.skipImage("TODO: fix for OpenSUSE", "opensuse-tumbleweed")
 class TestGrafanaClient(testlib.MachineCase):
 
     provision = {

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1240,6 +1240,7 @@ ExecStart=/usr/local/bin/{packageName}
 
 @testlib.skipImage("TODO: Arch Linux has no cockpit-ws package, it's in cockpit", "arch")
 @testlib.skipWsContainer("no cockpit-ws package with cockpit/ws container")
+@testlib.skipImage("TODO: fix for OpenSUSE", "opensuse-tumbleweed")
 class TestWsUpdate(NoSubManCase):
     def testBasic(self):
         # The main case for this is that cockpit-ws itself gets upgraded, which
@@ -1305,6 +1306,7 @@ class TestWsUpdate(NoSubManCase):
 
 
 @testlib.skipImage("kpatch is not available", *OSesWithoutKpatch)
+@testlib.skipImage("TODO: fix for OpenSUSE", "opensuse-tumbleweed")
 class TestKpatchInstall(NoSubManCase):
     def testBasic(self):
         b = self.browser
@@ -1836,6 +1838,7 @@ WantedBy=basic.target
 
 
 @testlib.skipOstree("Image uses OSTree")
+@testlib.skipImage("TODO: fix for OpenSUSE", "opensuse-tumbleweed")
 @testlib.nondestructive
 class TestInstallDialog(NoSubManCase):
 

--- a/test/verify/check-reauthorize
+++ b/test/verify/check-reauthorize
@@ -69,6 +69,7 @@ class TestReauthorize(testlib.MachineCase):
         b.leave_page()
         b.check_superuser_indicator("")
 
+    @testlib.skipImage("TODO: fix for OpenSUSE", "opensuse-tumbleweed")
     def testSudo(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-selinux
+++ b/test/verify/check-selinux
@@ -44,7 +44,7 @@ class TestSelinux(testlib.MachineCase):
         "ansible_machine": {"image": TEST_OS_DEFAULT}
     }
 
-    @testlib.skipImage("No setroubleshoot", "debian-*", "ubuntu-*", "arch")
+    @testlib.skipImage("No setroubleshoot", "debian-*", "ubuntu-*", "arch", "opensuse-tumbleweed")
     @testlib.skipOstree("No setroubleshoot")
     @testlib.skipBrowser("Firefox fails to recognize 'clipboard-read' permission", "firefox")
     def testTroubleshootAlerts(self):
@@ -294,7 +294,7 @@ class TestSelinux(testlib.MachineCase):
 
 # https://github.com/fedora-selinux/selinux-policy/issues/2947
 @testlib.skipDaily("nightly has selinux set to permissive")
-@testlib.skipImage("No cockpit-selinux", "debian-*", "ubuntu-*", "arch")
+@testlib.skipImage("No cockpit-selinux", "debian-*", "ubuntu-*", "arch", "opensuse-tumbleweed")
 @testlib.skipOstree("No cockpit-selinux")
 @testlib.nondestructive
 class TestSelinuxEnforcing(testlib.MachineCase):

--- a/test/verify/check-session
+++ b/test/verify/check-session
@@ -11,6 +11,7 @@ import testlib
 @testlib.nondestructive
 class TestSession(testlib.MachineCase):
 
+    @testlib.skipImage("TODO: fix for OpenSUSE", "opensuse-tumbleweed")
     def testBasic(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-shell-keys
+++ b/test/verify/check-shell-keys
@@ -137,6 +137,7 @@ class TestKeys(testlib.MachineCase):
 
     # Possible workaround - ssh as `admin` and just do `m.execute()`
     @testlib.skipBrowser("Firefox cannot do `cockpit.spawn`", "firefox")
+    @testlib.skipImage("TODO: fix for OpenSUSE", "opensuse-tumbleweed")
     def testPrivateKeys(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-shell-menu
+++ b/test/verify/check-shell-menu
@@ -143,6 +143,7 @@ class TestMenu(testlib.MachineCase):
         b.wait_visible("#login-info-message")
         b.wait_text("#login-info-message", "You have been logged out due to inactivity.")
 
+    @testlib.skipImage("TODO: fix for OpenSUSE", "opensuse-tumbleweed")
     def testKeyboardNavigation(self):
         b = self.browser
         self.login_and_go()

--- a/test/verify/check-sosreport
+++ b/test/verify/check-sosreport
@@ -13,7 +13,7 @@ import testlib
 
 
 @testlib.skipOstree("No sosreport")
-@testlib.skipImage("No sosreport", "arch")
+@testlib.skipImage("No sosreport", "arch", "opensuse-tumbleweed")
 @testlib.nondestructive
 class TestSOS(testlib.MachineCase):
 

--- a/test/verify/check-ssh-api
+++ b/test/verify/check-ssh-api
@@ -30,6 +30,7 @@ class TestSshDialog(testlib.MachineCase):
         self.machine.execute("pkill -ef [s]sh.*ferny.*127.0.0.1")
 
     @testlib.skipImage("FIXME: Assertion failed: UnknownHostDialog needs a host-key and host-fingerprint in error", "rhel-8-10")
+    @testlib.skipImage("TODO: fix for OpenSUSE", "opensuse-tumbleweed")
     def testPassword(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -26,7 +26,7 @@ class TestLogin(testlib.MachineCase):
             b.click("#hosts-sel button")
             b.set_layout("desktop")
 
-    # @testlib.skipBeiboot("no local cockpit PAM config in beiboot mode")
+    @testlib.skipImage("TODO: fix for OpenSUSE", "opensuse-tumbleweed")
     def testBasic(self):
         m = self.machine
         b = self.browser
@@ -212,6 +212,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
                                     "noise-rc-.*")
 
     @testlib.skipWsContainer("logs in via ssh, not cockpit-session")
+    @testlib.skipImage("TODO: fix for OpenSUSE", "opensuse-tumbleweed")
     def testLogging(self):
         m = self.machine
         b = self.browser
@@ -270,6 +271,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         verify_correct(has_last=True, n_fail=0)
 
     @testlib.skipImage("Arch Linux has no pwquality by default", "arch")
+    @testlib.skipImage("TODO: fix for OpenSUSE", "opensuse-tumbleweed")
     def testExpired(self):
         m = self.machine
         b = self.browser
@@ -378,6 +380,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         self.allow_restart_journal_messages()
 
     @testlib.skipWsContainer("mock-pam-conv not installed")
+    @testlib.skipImage("TODO: fix for OpenSUSE", "opensuse-tumbleweed")
     def testConversation(self):
         m = self.machine
         b = self.browser
@@ -426,7 +429,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
         self.allow_restart_journal_messages()
 
-    @testlib.skipImage("No tlog", "debian-*", "ubuntu-*", "arch")
+    @testlib.skipImage("No tlog", "debian-*", "ubuntu-*", "arch", "opensuse-tumbleweed")
     @testlib.skipOstree("No tlog")
     @testlib.skipImage("FIXME: tlog messes up bridge frame protocol", "rhel-8-10")
     def testSessionRecordingShell(self):
@@ -484,6 +487,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
     @testlib.skipImage("No SELinux", "debian-*", "ubuntu-*", "arch")
     @testlib.skipOstree("No semanage")
+    @testlib.skipImage("TODO: fix for OpenSUSE", "opensuse-tumbleweed")
     def testSELinuxRestrictedUser(self):
         m = self.machine
         b = self.browser
@@ -676,6 +680,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
         m.execute("grep -r faillock /etc/pam.d")
 
+    @testlib.skipImage("TODO: fix for OpenSUSE", "opensuse-tumbleweed")
     def testFaillock(self):
         m = self.machine
         b = self.browser
@@ -772,6 +777,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         self.allow_journal_messages(".*minutes left to unlock.*")
 
     @testlib.skipWsContainer("no local config with cockpit/ws container")
+    @testlib.skipImage("TODO: fix for OpenSUSE", "opensuse-tumbleweed")
     def testAutomaticSudoFaillock(self):
         m = self.machine
         b = self.browser
@@ -810,6 +816,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.logout()
 
     @testlib.skipWsContainer("root logins disabled by default with ssh")
+    @testlib.skipImage("TODO: fix for OpenSUSE", "opensuse-tumbleweed")
     def testPamAccess(self):
         b = self.browser
         m = self.machine
@@ -1039,6 +1046,7 @@ matchrule = <SUBJECT>^DC=LAN,DC=COCKPIT,CN=alice$
 
     # enable this once our cockpit/ws container can beiboot
     @testlib.skipWsContainer("client setup does not work with ws container")
+    @testlib.skipImage("TODO: fix for OpenSUSE", "opensuse-tumbleweed")
     def testSSH(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -56,6 +56,7 @@ class TestSystemInfo(testlib.MachineCase):
         # Switching into and out of FIPS mode is not supported anymore in newer OSes.
         self.supportsFIPS = self.machine.image.startswith(("rhel-8", "rhel-9", "centos-9"))
 
+    @testlib.skipImage("TODO: fix for OpenSUSE", "opensuse-tumbleweed")
     def testBasic(self):
         m = self.machine
         b = self.browser
@@ -207,6 +208,7 @@ class TestSystemInfo(testlib.MachineCase):
                                     "sudo: unable to resolve host host1.cockpit.lan: .*")
 
     @testlib.nondestructive
+    @testlib.skipImage("TODO: fix for OpenSUSE", "opensuse-tumbleweed")
     def testMotd(self):
         m = self.machine
         b = self.browser
@@ -744,7 +746,7 @@ fi
         dbus_call = 'busctl get-property org.freedesktop.login1 /org/freedesktop/login1  org.freedesktop.login1.Manager ScheduledShutdown'
         self.assertIn('(st) "" ', m.execute(dbus_call).strip())
 
-    @testlib.skipImage("crypto-policies not available", "debian-*", "ubuntu-*", "arch")
+    @testlib.skipImage("crypto-policies not available", "debian-*", "ubuntu-*", "arch", "opensuse-tumbleweed")
     @testlib.skipOstree("crypto-policies not available")
     def testCryptoPolicies(self):
         m = self.machine
@@ -873,6 +875,7 @@ class TestSystemInfoTime(packagelib.PackageCase):
         b.click(f"#change_systime button:contains('{mode}')")
         b.wait_in_text("#system_information_change_systime #change_systime_btn", mode)
 
+    @testlib.skipImage("TODO: fix for OpenSUSE", "opensuse-tumbleweed")
     def testTime(self):
         m = self.machine
         b = self.browser
@@ -958,6 +961,7 @@ class TestSystemInfoTime(packagelib.PackageCase):
         self.assertIn("EEST 2050\n", m.execute("date"))
 
     @testlib.skipImage("timesyncd not available", "rhel*", "centos-*")
+    @testlib.skipImage("TODO: fix for OpenSUSE", "opensuse-tumbleweed")
     def testTimeServersTimesyncd(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -1133,6 +1133,7 @@ class TestKerberos(testlib.MachineCase):
 
 
 @testlib.skipImage("No realmd available", "arch")
+@testlib.skipImage("TODO: fix for OpenSUSE", "opensuse-tumbleweed")
 @testlib.skipOstree("Package (un)install does not work on OSTree")
 class TestPackageInstall(packagelib.PackageCase):
 

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -374,6 +374,7 @@ WantedBy=default.target
         b.wait_not_present('#test.service > svg.service-thumbtack-icon-color')
 
     @testlib.nondestructive
+    @testlib.skipImage("TODO: fix for OpenSUSE", "opensuse-tumbleweed")
     def testFilter(self):
         b = self.browser
 
@@ -655,10 +656,12 @@ WantedBy=default.target
             b.click(".pf-v6-c-breadcrumb a:contains('Services')")
 
     @testlib.nondestructive
+    @testlib.skipImage("TODO: fix for OpenSUSE", "opensuse-tumbleweed")
     def testServiceMetrics(self):
         self._testServiceMetrics(user=False)
 
     @testlib.nondestructive
+    @testlib.skipImage("TODO: fix for OpenSUSE", "opensuse-tumbleweed")
     def testServiceMetricsSession(self):
         self._testServiceMetrics(user=True)
 

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -94,6 +94,7 @@ def createUser(
 
 
 @testlib.nondestructive
+@testlib.skipImage("TODO: fix for OpenSUSE", "opensuse-tumbleweed")
 class TestAccounts(testlib.MachineCase):
 
     def testBasic(self):


### PR DESCRIPTION
This establishes a baseline for introducing opensuse-tumbleweed into our CI. We'll start with the  `/ohter` scenario. There are currently 111 passing and 47 failing tests. A few of them are obvious, like crypto-policies and setroubleshoot not being available on Tumbleweed, adjust their skips accordingly. For the rest, just mass-skip them with "TODO: fix for OpenSUSE", which is easy enough to grep.

After that, we can enable them step by step with actual fixes. E.g. large swaths of functionality is broken due to PackageKit.

----

FYI @Lunarequest @Nykseli 

[This run](https://logs-cockpit.apps.ocp.cloud.ci.centos.org/pull-22901-e17003df-20260219-085349-opensuse-tumbleweed-other/log.html) was the first ever that we ran on our CI in years, triggered in #22901. Let's land this first to avoid regressions in the future, then enable this, and make the other pending PRs green!