### PR TITLE
lib: Use browser context menu on shift

### DIFF
--- a/pkg/lib/cockpit-components-context-menu.tsx
+++ b/pkg/lib/cockpit-components-context-menu.tsx
@@ -26,6 +26,13 @@ export const ContextMenu = ({ parentId, children } : {
 
     React.useEffect(() => {
         const _handleContextMenu = (event: MouseEvent) => {
+            /* In Firefox they explicitly prevent us from interrupting when holding shift while
+             * right-clicking for context. Lets make it default for all browsers so they can inspect et. al.
+             */
+            if (event.shiftKey) {
+                setVisible(false);
+                return;
+            }
             event.preventDefault();
 
             setVisible(true);


### PR DESCRIPTION
With Firefox explicitly preventing pages from interrupting the browser
context menu while holding shift we should adopt that to all browsers.

This is a quality of life thing where users will now be able to access
inspect or any other extension-related context menu items that was
otherwise difficult for them to do.

Fixes: https://github.com/cockpit-project/cockpit/issues/22919
See-also: https://developer.mozilla.org/en-US/docs/Web/API/Element/contextmenu_event
Signed-off-by: Freya Gustavsson <freya@venefilyn.se>

## Use browser's context menu when holding `Shift`

To help with accessibility and user-specific items in your browser context menu we now follow the behavior seen in Firefox. Holding `Shift` key while right-clicking will now skip our own context menu and instead use the default behavior of your browser. Note that while Cockpit Files uses the Cockpit context menu it did not get the update before this release, but is scheduled for next release.

<img width="904" height="611" alt="Terminal page showing the shell 'spytec@vm1' with the Firefox context menu popup visible. In it are grayed out items 'Undo, Redo', followed by 'Cut, Copy, Paste', then grayed out 'Delete, Select All', then 'This Frame' with an right-pointing caret on the right of the row." src="https://github.com/user-attachments/assets/b425119d-e8e0-4d7e-ac53-b3c3ca9e174b" />
