### PR TITLE
common: resolve initialization discards ‘const’ qualifier from pointe…

### DIFF
--- a/src/common/cockpitbase64.c
+++ b/src/common/cockpitbase64.c
@@ -70,7 +70,7 @@ cockpit_base64_pton (const char *src,
                      size_t targsize)
 {
   int tarindex, state, ch;
-  char *pos;
+  const char *pos;
   const char *end;
 
   state = 0;


### PR DESCRIPTION
…r target type

In C23 strchr is now implemented different from the POSIX definition and has two forms:

char       *strchr(char *s, int c);
const char *strchr(const char *s, int c);

Base64 is passed as const, so the return value should also be const.