### PR TITLE
workflows: extend changes triggering anaconda webui tests

### DIFF
--- a/.github/workflows/trigger-anaconda.yml
+++ b/.github/workflows/trigger-anaconda.yml
@@ -13,6 +13,7 @@ on:
     paths:
       - src/cockpit/**
       - pkg/storaged/**
+      - pkg/networkmanager/**
 jobs:
   trigger:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We might want to get more granular in the future, for example run cockpit-network and cockpit-storage tests but it is out of scope of the addressed issue.

Related Anaconda PR: https://github.com/rhinstaller/anaconda-webui/pull/1187

Resolves: INSTALLER-4625