### PR TITLE
test: Make the load-hog unit produce load more reliably

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -855,7 +855,7 @@ class TestCurrentMetrics(testlib.MachineCase):
         b.wait(lambda: float(b.text("#load-avg .pf-v6-l-flex div:first-child").split()[-1].rstrip(',')) < 5)
 
         m.execute("systemd-run --collect --slice cockpittest --unit load-hog sh -ec "
-                  "  'for i in `seq 500`; do dd if=/dev/urandom of=/dev/zero bs=100K count=500 status=none & done'")
+                  "  'for i in `seq 50`; do dd if=/dev/urandom of=/dev/zero bs=100K status=none & done; sleep infinity'")
         try:
             with b.wait_timeout(120):
                 b.wait(lambda: float(b.text("#load-avg .pf-v6-l-flex div:first-child").split()[-1].rstrip(',')) > 15)


### PR DESCRIPTION
The test was spawning 500 copies of "dd" but the whole systemd unit would deactive itself once all the spawning was done. This did produce a significant load spike since the spawning itself took a long enough time, but only for a couple of seconds. The average sometimes missed that spike.

Instead, let's just spawn a smaller number of "dd"s and let them run forever, and also keep the unit active forever. Then we can wait for the load average to rise without hurry.

The smaller number of "dd"s also helps when "dd" comes from uutils: That version takes about 3 times as much RAM as the traditional coreutils version, and spawning 500 of them would produce aborts and core dumps and all kinds of chaos and would sometimes produce an error in the shell itself that does all the spawning, which would cut the load spike short.