### PR TITLE
networkmanager: Signal cockpit_has_modal for NetworkModal dialogs

### DIFF
--- a/pkg/networkmanager/dialogs-common.jsx
+++ b/pkg/networkmanager/dialogs-common.jsx
@@ -126,6 +126,11 @@ export const Name = ({ idPrefix, iface, setIface }) => {
 export const NetworkModal = ({ dialogError, help, idPrefix, title, onSubmit, children, isFormHorizontal, isCreateDialog, submitDisabled = false }) => {
     const Dialogs = useDialogs();
 
+    useEffect(() => {
+        window.sessionStorage.setItem("cockpit_has_modal", true);
+        return () => window.sessionStorage.setItem("cockpit_has_modal", false);
+    }, []);
+
     return (
         <Modal id={idPrefix + "-dialog"} position="top" variant="medium"
             isOpen


### PR DESCRIPTION
Set sessionStorage cockpit_has_modal on mount/unmount of NetworkModal, matching the existing behavior in cockpit-components-dialog.jsx. This allows embedding applications (like Anaconda Web UI) to detect when a network dialog is open and show a backdrop scrim.

We probably need also to update WiFi configuration to provide the event.