### PR TITLE
ws: introduce Anaconda PIN configuration mode

### DIFF
--- a/doc/man/pages/cockpit.conf.5.adoc
+++ b/doc/man/pages/cockpit.conf.5.adoc
@@ -113,6 +113,8 @@ ForwardedForHeader = X-Forwarded-For
 *Shell*::
   The relative URL to top level component to display in Cockpit once
   logged in. Defaults to `+/shell/index.html+`
+*Anaconda*::
+  If true, the login page is changed to Anaconda's PIN authentication mode.
 
 == Log
 

--- a/pkg/static/login.js
+++ b/pkg/static/login.js
@@ -626,7 +626,7 @@ function debug(...args) {
         login_machine = id("server-field").value;
         login_data_host = null;
         const user = trim(id("login-user-input").value);
-        if (user === "" && !environment.is_cockpit_client) {
+        if (user === "" && !environment.is_cockpit_client && !environment.is_anaconda) {
             login_failure(_("User name cannot be empty"));
         } else if (need_host() && login_machine === "") {
             login_failure(_("Please specify the host to connect to"));
@@ -728,17 +728,20 @@ function debug(...args) {
 
         hide("#login-wait-validating");
         show("#login");
-        hideToggle("#login-details", environment.is_cockpit_client);
-        hideToggle("#server-field-label", environment.is_cockpit_client);
+        hideToggle("#login-details", environment.is_cockpit_client || environment.is_anaconda);
+        hideToggle("#server-field-label", environment.is_cockpit_client || environment.is_anaconda);
         if (environment.is_cockpit_client) {
             const brand = id("brand");
             brand.textContent = _("Connect to:");
             brand.classList.add("text-brand");
         }
 
-        hideToggle(["#user-group", "#password-group"], form != "login" || environment.is_cockpit_client);
+        hideToggle(["#user-group"], form != "login" || environment.is_cockpit_client || environment.is_anaconda);
+        hideToggle(["#password-group"], form != "login" || environment.is_cockpit_client || !environment.is_anaconda);
         hideToggle("#conversation-group", form != "conversation");
         hideToggle("#hostkey-group", form != "hostkey");
+        if (environment.is_anaconda)
+            document.querySelector("label[for='login-password-input']").textContent = "Pin";
 
         id("login-button-text").textContent = (form == "hostkey") ? _("Accept key and log in") : _("Log in");
         if (form != "login")
@@ -748,7 +751,7 @@ function debug(...args) {
             hide("#option-group");
             expanded = true;
         } else {
-            hideToggle("#option-group", !connectable || form != "login");
+            hideToggle("#option-group", !connectable || form != "login" || environment.is_anaconda);
         }
 
         if (!connectable || form != "login") {
@@ -776,7 +779,12 @@ function debug(...args) {
         /* Show the login screen */
         login_info(message);
         id("server-name").textContent = document.title;
-        login_note(_("Log in with your server user account."));
+        if (!environment.is_anaconda) {
+            login_note(_("Log in with your server user account."));
+        } else {
+            login_note(_("Enter your pin to log in."));
+        }
+
         id("login-user-input").addEventListener("keydown", function(e) {
             login_failure(null);
             clear_info();
@@ -1039,6 +1047,8 @@ function debug(...args) {
                         }
                     } else if (is_conversation) {
                         login_failure(_("Authentication failed"));
+                    } else if (environment.is_anaconda) {
+                        login_failure(_("Authentication failed"), _("Wrong pin"));
                     } else {
                         login_failure(_("Authentication failed"), _("Wrong user name or password"));
                     }

--- a/src/ws/cockpithandlers.c
+++ b/src/ws/cockpithandlers.c
@@ -368,6 +368,9 @@ build_environment (CockpitAuth *auth, GHashTable *request_headers)
         json_object_set_string_member (object, "banner", contents);
     }
 
+  gboolean is_anaconda_mode = cockpit_conf_bool ("WebService", "Anaconda", FALSE);
+  json_object_set_boolean_member (object, "is_anaconda", is_anaconda_mode);
+
   bytes = cockpit_json_write_bytes (object);
   json_object_unref (object);
 


### PR DESCRIPTION
Introduce a cockpit-ws configuration option to change the login page to enable PIN authentication. This form of authentication only renders the password field and changes the text to mention pin login.

Authentication needs to be handled by an external `Command` or UnixPath` for example having this as `cockpit.conf`:

```
[WebService]
Anaconda = true

[Basic]
UnixPath = /run/cockpit/wsinstance/cockpit-pin-auth.sock
```

---

# ws: introduce Anaconda login mode

Enabling `Anaconda = true` in the `WebService` section of `cockpit.conf` changes the login page to enable PIN authentication mode. A user can only login via a secret pin code no user or host can be selected.

Authentication itself should be handled by an external program via the `UnixPath` option in the `Basic` auth section.

<img width="649" height="372" alt="image" src="https://github.com/user-attachments/assets/3510a7f6-0e0e-47f9-a0e3-88440a08aaf1" />
