### PR TITLE
cockpit: transports: clamp pty window size

### DIFF
--- a/pkg/base1/test-spawn-proc.js
+++ b/pkg/base1/test-spawn-proc.js
@@ -182,6 +182,23 @@ QUnit.test("pty window size", async assert => {
     assert.equal(await proc, '77\r\n88\r\n', 'Correct rows and columns');
 });
 
+QUnit.test("pty window size limits", async assert => {
+    let proc = cockpit.spawn(['stty', 'size'], {
+        pty: true,
+        environ: ["TERM=vt100"],
+        window: { rows: -1, cols: 65538 }
+    });
+    assert.equal(await proc, '0 65535\r\n', 'Clamps to 0x65535');
+
+    proc = cockpit.spawn(['stty', 'size'], {
+        pty: true,
+        environ: ["TERM=vt100"],
+        // HACK: tput fallback to 80 if cols are 0
+        window: { rows: 65538, cols: 0 }
+    });
+    assert.equal(await proc, '65535 0\r\n', 'Clamps to 65538x0');
+});
+
 QUnit.test("stream large output", async assert => {
     let lastblock = null;
     const resp = await cockpit.spawn(["seq", "10000000"])

--- a/src/cockpit/transports.py
+++ b/src/cockpit/transports.py
@@ -387,7 +387,9 @@ class SubprocessTransport(_Transport, asyncio.SubprocessTransport):
 
     def set_window_size(self, size: WindowSize) -> None:
         assert self._pty_fd is not None
-        fcntl.ioctl(self._pty_fd, termios.TIOCSWINSZ, struct.pack('2H4x', size.rows, size.cols))
+        rows = max(0, min(size.rows, 2**16 - 1))
+        cols = max(0, min(size.cols, 2**16 - 1))
+        fcntl.ioctl(self._pty_fd, termios.TIOCSWINSZ, struct.pack('2H4x', rows, cols))
 
     def can_write_eof(self) -> bool:
         assert self._process is not None


### PR DESCRIPTION
Prevent cockpit-bridge from crashing by clamping the minimum and maximum size of the terminal window. Clamping to a minimum size of 1,1 would likely render the terminal page useless so instead clamp a "known good" size of 24x80 while leaving the maximum size as large as accepted by TIOCSWINSZ.

Closes: #22898

---

I'm convinced we do something but maybe as alternative we should throw a ChannelError and ignore the request?

