### PR TITLE
doc: add container port configuration to listen guide

### DIFF
--- a/containers/ws/README.md
+++ b/containers/ws/README.md
@@ -90,6 +90,11 @@ host with SSH.
 podman run -d --name cockpit-bastion -p 9090:9090 quay.io/cockpit/ws
 ```
 
+To change the port, adjust the `-p HOST_PORT:9090` argument, for example
+`-p 443:9090`. See the
+[podman-run documentation](https://docs.podman.io/en/latest/markdown/podman-run.1.html)
+for details.
+
 This mode is suitable for deploying to e.g. Kubernetes or similar environments
 where you cannot have or want privileged containers. In this "bastion host
 mode", you can get a Cockpit for servers in your data center without opening an

--- a/doc/guide/pages/listen.adoc
+++ b/doc/guide/pages/listen.adoc
@@ -97,3 +97,41 @@ last options specify the desired TCP port.
 $ sudo firewall-cmd [--zone=ZONE] --add-port=443/tcp
 $ sudo firewall-cmd --permanent [--zone=ZONE] --add-port=443/tcp
 ....
+
+[[listen-container]]
+== Cockpit Container (podman/ws)
+
+If Cockpit is deployed via the
+https://quay.io/repository/cockpit/ws[`+quay.io/cockpit/ws+`] container,
+no `+cockpit.socket+` systemd unit is created. The socket drop-in method
+described above does not apply in this case.
+
+=== Unprivileged bastion container
+
+The recommended way to run the `+cockpit/ws+` container is in
+unprivileged bastion mode. To change the port, adjust the `+-p+` flag in
+the `+podman run+` command:
+
+....
+$ podman run -d --name cockpit-bastion -p 443:443 quay.io/cockpit/ws
+....
+
+=== Privileged container
+
+If you are using the privileged `+runlabel+` mode, append the `+-p+`
+option to change the port:
+
+....
+$ sudo podman container runlabel --name cockpit-ws RUN quay.io/cockpit/ws -- -p 443
+....
+
+To inspect the full `+RUN+` label command before customizing it:
+
+....
+$ sudo podman container runlabel --display RUN quay.io/cockpit/ws
+....
+
+NOTE: The privileged `+runlabel+` deployment is considered legacy. The
+unprivileged bastion container mode is recommended for new deployments.
+See the https://quay.io/repository/cockpit/ws[`+cockpit/ws+` container
+page] for full deployment documentation.


### PR DESCRIPTION
## What does this PR do?
Adds a new section to the TCP Port and Address guide explaining how 
to change the port when running Cockpit via the cockpit/ws container, 
where no cockpit.socket systemd unit is created.

## Why?
Fixes #22503

The existing listen guide only documented the systemd socket drop-in 
method, which does not apply to containerized deployments on Fedora 
CoreOS or similar container hosts.

## Changes
- Added `[[listen-container]]` section after the Firewalld section
- Covers unprivileged bastion mode (recommended) first
- Covers privileged runlabel mode briefly  
- Includes a NOTE recommending unprivileged mode for new deployments
- Links to the quay.io/cockpit/ws container page for full docs