### PR TITLE
css: Replace wrap override with PF modifier

### DIFF
--- a/pkg/apps/application.jsx
+++ b/pkg/apps/application.jsx
@@ -114,7 +114,7 @@ export const Application = ({ metainfo_db, id, progress, action }) => {
 
         return (
             <Card isPlain>
-                <CardHeader actions={{
+                <CardHeader hasWrap actions={{
                     actions: <>{progress_or_launch}<ActionButton comp={comp} progress={progress} action={action} /></>,
                 }}>
                     <CardTitle>

--- a/pkg/lib/cockpit-components-logs-panel.jsx
+++ b/pkg/lib/cockpit-components-logs-panel.jsx
@@ -148,7 +148,7 @@ export class LogsPanel extends React.Component {
 
         return (
             <Card isPlain className="cockpit-log-panel">
-                <CardHeader actions={{ actions }}>
+                <CardHeader hasWrap actions={{ actions }}>
                     <CardTitle>{this.props.title}</CardTitle>
                 </CardHeader>
                 <CardBody className={(!this.state.logs.length && this.props.emptyMessage.length) ? "empty-message" : "contains-list"}>

--- a/pkg/lib/cockpit-components-modifications.jsx
+++ b/pkg/lib/cockpit-components-modifications.jsx
@@ -135,6 +135,11 @@ export const Modifications = ({ entries, failed, permitted, title, shell, ansibl
         </DataListItem>;
     }
 
+    const actions = !emptyRow &&
+        <Button variant="secondary" onClick={() => setShowDialog(true)}>
+            {_("View automation script")}
+        </Button>
+
     return (
         <>
             { showDialog &&
@@ -142,13 +147,8 @@ export const Modifications = ({ entries, failed, permitted, title, shell, ansibl
                 onClose={() => setShowDialog(false)} />
             }
             <Card isPlain className="modifications-table">
-                <CardHeader>
+                <CardHeader actions={{ actions }}>
                     <CardTitle component="h2">{title}</CardTitle>
-                    { !emptyRow &&
-                        <Button variant="secondary" onClick={() => setShowDialog(true)}>
-                            {_("View automation script")}
-                        </Button>
-                    }
                 </CardHeader>
                 <CardBody className="contains-list">
                     <DataList aria-label={title} isCompact>

--- a/pkg/lib/patternfly/patternfly-6-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-6-overrides.scss
@@ -77,39 +77,14 @@ $phone: 767px;
 
 
 .pf-v6-c-card {
-  // FIXME: Using an expandable content within a card would cause the card to be scrollable while nothing
-  // would be in view. Makes it look like there is something to scroll to when there isn't anything.
-  // PF deliberately makes expandable `[hidden]` content have `display: revert` which would make them have
-  // `display: block` or whatever is default from the browser. They do this to make animations work.
-  // Until fixed upstream we revert their `display: revert` rule.
-  // https://github.com/patternfly/patternfly/issues/7746
-  .pf-v6-c-expandable-section__content:where([hidden]) {
-    display: none;
-  }
-
-  // https://github.com/patternfly/patternfly/issues/3959
-  // TODO @Venefilyn: Change so we use .pf-m-no-offset, then remove this
-  // --pf-v6-c-card__header-toggle--MarginTop: 0;
-
-  .pf-v6-c-card__header:not(.ct-card-expandable-header),
-  .pf-v6-c-card__header:not(.ct-card-expandable-header) .pf-v6-c-card__header-main {
-    // upstream fix (pending): https://github.com/patternfly/patternfly/pull/3714
-    display: flex;
-    flex-wrap: wrap;
-    row-gap: var(--pf-t--global--spacer--sm);
-    justify-content: space-between;
-  }
-
+  // HACK: We change the size of our card headers so our card actions are not aligned as it should
+  // Unsetting margin makes the title aligned with the buttons
   .pf-v6-c-card__header:not(.ct-card-expandable-header) {
     > .pf-v6-c-card__actions {
-      flex-wrap: wrap;
-      row-gap: var(--pf-t--global--spacer--sm);
-
       // PF4 CardActions act up when using buttons while the title is large of font
       // https://github.com/patternfly/patternfly/issues/3713
       // https://github.com/patternfly/patternfly/issues/4362
       margin: unset;
-      padding-inline: var(--pf-v6-c-card__actions--PaddingLeft) unset;
     }
   }
 }

--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -201,7 +201,7 @@ function ZoneSection(props) {
     ];
 
     return <Card isPlain className="zone-section" data-id={props.zone.id}>
-        <CardHeader actions={{ actions }} className="zone-section-heading">
+        <CardHeader hasWrap actions={{ actions }} className="zone-section-heading">
             <Flex alignItems={{ default: 'alignSelfBaseline' }} spaceItems={{ default: 'spaceItemsXl' }}>
                 <CardTitle component="h2">
                     { cockpit.format(_("$0 zone"), upperCaseFirstLetter(props.zone.name || props.zone.id)) }

--- a/pkg/networkmanager/network-interface-members.jsx
+++ b/pkg/networkmanager/network-interface-members.jsx
@@ -182,7 +182,7 @@ export const NetworkInterfaceMembers = ({
 
     return (
         <Card isPlain id="network-interface-members" className="network-interface-members">
-            <CardHeader actions={{ actions: add_btn }}>
+            <CardHeader hasWrap actions={{ actions: add_btn }}>
                 <CardTitle component="h2">{_("Interface members")}</CardTitle>
             </CardHeader>
             <ListingTable aria-label={_("Interface members")}

--- a/pkg/networkmanager/network-interface.jsx
+++ b/pkg/networkmanager/network-interface.jsx
@@ -1042,7 +1042,7 @@ export const NetworkInterfacePage = ({
 
         return (
             <Card isPlain id="network-interface-wifi-networks">
-                <CardHeader actions={{
+                <CardHeader hasWrap actions={{
                     actions: (
                         <Flex>
                             {dev.visibleSsids.length >= 3 && (
@@ -1228,7 +1228,7 @@ export const NetworkInterfacePage = ({
             <PageSection hasBodyWrapper={false}>
                 <Gallery hasGutter>
                     <Card isPlain className="network-interface-details">
-                        <CardHeader actions={{
+                        <CardHeader hasWrap actions={{
                             actions: (
                                 <>
                                     {isDeletable && isManaged &&

--- a/pkg/networkmanager/network-main.jsx
+++ b/pkg/networkmanager/network-main.jsx
@@ -169,7 +169,7 @@ export const NetworkPage = ({ privileged, operationInProgress, usage_monitor, pl
             <PageSection hasBodyWrapper={false}>
                 <Gallery hasGutter>
                     {firewall.installed && <Card isPlain id="networking-firewall-summary">
-                        <CardHeader actions={{
+                        <CardHeader hasWrap actions={{
                             actions: <Button variant="secondary" id="networking-firewall-link"
                                         component="a"
                                         onClick={() => cockpit.jump("/network/firewall", cockpit.transport.host)}>
@@ -191,7 +191,7 @@ export const NetworkPage = ({ privileged, operationInProgress, usage_monitor, pl
                         </CardBody>
                     </Card>}
                     <Card isPlain id="networking-interfaces">
-                        <CardHeader actions={{ actions }}>
+                        <CardHeader hasWrap actions={{ actions }}>
                             <CardTitle component="h2">{_("Interfaces")}</CardTitle>
                         </CardHeader>
                         <ListingTable aria-label={_("Managed interfaces")}

--- a/pkg/networkmanager/networking.scss
+++ b/pkg/networkmanager/networking.scss
@@ -64,6 +64,7 @@ th {
     display: grid;
     grid-auto-flow: column;
     gap: var(--pf-t--global--spacer--md);
+    justify-content: start;
   }
 
   &-delete {

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -941,7 +941,7 @@ class CardsPage extends React.Component {
         return cardContents.map(card => {
             return (
                 <Card key={card.id} className={card.className} id={card.id}>
-                    <CardHeader actions={{ actions: card.actions }}>
+                    <CardHeader hasWrap actions={{ actions: card.actions }}>
                         <CardTitle component="h2">{card.title}</CardTitle>
                     </CardHeader>
                     <CardBody className={card.containsList ? "contains-list" : null}>

--- a/pkg/playground/react-demo-cards.jsx
+++ b/pkg/playground/react-demo-cards.jsx
@@ -27,7 +27,7 @@ const CardsDemo = () => {
             <CardBody>I'm a card in a gallery</CardBody>
         </Card>,
         <Card isPlain key="card5">
-            <CardHeader actions={{
+            <CardHeader hasWrap actions={{
                 actions: <><input type="checkbox" />
                     <Button className="btn">click</Button></>,
             }} />

--- a/pkg/selinux/setroubleshoot-view.jsx
+++ b/pkg/selinux/setroubleshoot-view.jsx
@@ -397,7 +397,7 @@ export class SETroubleshootPage extends React.Component {
         );
         const troubleshooting = (
             <Card isPlain>
-                <CardHeader actions={{ actions }}>
+                <CardHeader hasWrap actions={{ actions }}>
                     <CardTitle component="h2">{title}</CardTitle>
                 </CardHeader>
                 <CardBody className="contains-list">

--- a/pkg/sosreport/sosreport.jsx
+++ b/pkg/sosreport/sosreport.jsx
@@ -481,7 +481,7 @@ const SOSBody = () => {
     return (
         <PageSection hasBodyWrapper={false}>
             <Card isPlain className="ct-card">
-                <CardHeader actions={{
+                <CardHeader hasWrap actions={{
                     actions: <Button id="create-button" variant="primary" onClick={run_report}>
                         {_("Run report")}
                     </Button>,

--- a/pkg/storaged/crypto/keyslots.jsx
+++ b/pkg/storaged/crypto/keyslots.jsx
@@ -770,7 +770,7 @@ export class CryptoKeyslots extends React.Component {
 
         return (
             <>
-                <CardHeader actions={{
+                <CardHeader hasWrap actions={{
                     actions: <>
                         <span className="key-slot-panel-remaining">
                             { remaining < 6 ? (remaining ? cockpit.format(cockpit.ngettext("$0 slot remains", "$0 slots remain", remaining), remaining) : _("No available slots")) : null }

--- a/pkg/storaged/pages.jsx
+++ b/pkg/storaged/pages.jsx
@@ -799,7 +799,7 @@ export const StorageCard = ({ card, alert, alerts, actions, children }) => {
                 <StorageBreadcrumb page={card.page} />
             </CardBody>
             }
-            <CardHeader actions={{ actions: actions || <Actions actions={card.actions} /> }}>
+            <CardHeader hasWrap actions={{ actions: actions || <Actions actions={card.actions} /> }}>
                 <CardTitle>{card.title}</CardTitle>
             </CardHeader>
             {(alert || (alerts && alerts.length > 0)) && <CardBody><AlertGroup>{alert}{alerts}</AlertGroup></CardBody>}

--- a/pkg/systemd/logDetails.jsx
+++ b/pkg/systemd/logDetails.jsx
@@ -41,7 +41,7 @@ const LogDetails = ({ entry }) => {
     return (
         <GalleryItem>
             <Card isPlain>
-                <CardHeader actions={{ actions }}>
+                <CardHeader hasWrap actions={{ actions }}>
                     <h2 id="entry-heading">{id}</h2>
                 </CardHeader>
                 <CardTitle>{journal.printable(entry.MESSAGE, "MESSAGE")}</CardTitle>

--- a/pkg/users/account-details.js
+++ b/pkg/users/account-details.js
@@ -226,7 +226,7 @@ export function AccountDetails({ account, groups, isLoading, current_user, shell
             <PageSection hasBodyWrapper={false}>
                 <Gallery hasGutter>
                     <Card isPlain className="account-details" id="account-details">
-                        <CardHeader actions={{ actions }}>
+                        <CardHeader hasWrap actions={{ actions }}>
                             <CardTitle id="account-title" component="h2">{title_name}</CardTitle>
                         </CardHeader>
                         <CardBody>

--- a/pkg/users/accounts-list.js
+++ b/pkg/users/accounts-list.js
@@ -286,7 +286,7 @@ const GroupsList = ({ groups, accounts, isExpanded, setIsExpanded, min_gid, max_
 
     return (
         <Card className="ct-card card-groups" isExpanded={isExpanded}>
-            <CardHeader actions={{ actions: tableToolbar, hasNoOffset: true }}
+            <CardHeader hasWrap actions={{ actions: tableToolbar, hasNoOffset: true }}
                 className="ct-card-expandable-header"
                 onExpand={() => setIsExpanded(!isExpanded)}
                 toggleButtonProps={{
@@ -419,7 +419,7 @@ const AccountsList = ({ accounts, current_user, groups, min_uid, max_uid, shells
 
     return (
         <Card isPlain className="ct-card">
-            <CardHeader actions={{ actions: tableToolbar }}>
+            <CardHeader hasWrap actions={{ actions: tableToolbar }}>
                 <CardTitle component="h2">{_("Accounts")}</CardTitle>
             </CardHeader>
             <ListingTable columns={columns}

--- a/pkg/users/authorized-keys-panel.js
+++ b/pkg/users/authorized-keys-panel.js
@@ -101,7 +101,7 @@ export function AuthorizedKeys({ name, home, allow_mods }) {
 
     return (
         <Card isPlain id="account-authorized-keys">
-            <CardHeader actions={{ actions }}>
+            <CardHeader hasWrap actions={{ actions }}>
                 <CardTitle component="h2">{_("Authorized public SSH keys")}</CardTitle>
             </CardHeader>
             <ListingTable


### PR DESCRIPTION
A while back PatternFly added `.pf-m-wrap` modifier to Card headers and
later added it to PF React CardHeaders with an `hasWrap` property. Cards
that use CardHeaders and has actions now have the `hasWrap` property
added while the PF6 override we created was removed.

There should be no to little visual changes happening because of this
PR, however some padding might change.

This also removes an override added to fix a bug in cards where
expandable content could cause scrollbar to appear pre-emptively.

Fixes: https://github.com/cockpit-project/cockpit/issues/22992
Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
