### PR TITLE
Convert the login page to CSS

### DIFF
--- a/pkg/static/login.css
+++ b/pkg/static/login.css
@@ -455,20 +455,20 @@ label.checkbox {
   background-color: var(--color-background);
   border-radius: var(--pf-t--global--border--radius--medium);
 
-  .pf-v6-c-alert__icon {
+  & .pf-v6-c-alert__icon {
     grid-column: icon;
   }
 
-  .pf-v6-c-alert__title,
-  .pf-v6-c-alert__description {
+  & .pf-v6-c-alert__title,
+  & .pf-v6-c-alert__description {
     grid-column: content;
   }
 
-  .pf-v6-c-alert__icon {
+  & .pf-v6-c-alert__icon {
     /* vertically align the icon's top edge with the text; https://blog.kizu.dev/cap-height-align/ */
     margin-block-start: calc((1cap - 1ex) / 2);
 
-    svg {
+    & svg {
       display: block;
       block-size: var(--pf-t--global--icon--size--lg);
       inline-size: var(--pf-t--global--icon--size--lg);
@@ -476,11 +476,11 @@ label.checkbox {
     }
   }
 
-  .pf-v6-c-alert__title {
+  & .pf-v6-c-alert__title {
     font-weight: 500;
   }
 
-  p {
+  & p {
     margin: 0;
   }
 
@@ -534,11 +534,11 @@ html body.login-pf {
   inline-size: 100%;
   border-radius: var(--pf-t--global--border--radius--large) var(--pf-t--global--border--radius--large);
 
-  .container-body {
+  & .container-body {
     padding: var(--pf-t--global--spacer--2xl);
   }
 
-  .container-footer {
+  & .container-footer {
     padding-block: var(--pf-t--global--spacer--xl);
     padding-inline: var(--pf-t--global--spacer--2xl);
   }
@@ -670,7 +670,7 @@ html:not(.pf-v6-theme-dark) #login-wait-validating .spinner {
     transform: rotate(90deg);
   }
 
-  path {
+  & path {
     fill: var(--color-text);
   }
 }
@@ -859,11 +859,11 @@ details > summary:hover {
 }
 
 .unsupported-browser {
-  #brand {
+  & #brand {
     display: none;
   }
 
-  ul {
+  & ul {
     display: inline-block;
     text-align: start;
     color: var(--color-text-lighter);
@@ -871,7 +871,7 @@ details > summary:hover {
     margin-inline: 0;
   }
 
-  a {
+  & a {
     font-weight: 700;
   }
 }
@@ -954,7 +954,7 @@ body.login-pf {
     grid-template-columns: 1fr var(--content-width) auto 1fr;
     column-gap: var(--gap);
 
-    #brand img {
+    & #brand img {
       margin: 0;
       text-align: start;
     }
@@ -962,7 +962,7 @@ body.login-pf {
 
   /* Mobile-specific */
   @media (width < 900px) {
-    #badge {
+    & #badge {
       background-position: center;
       margin: 2rem;
     }

--- a/pkg/static/login.js
+++ b/pkg/static/login.js
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
-import "./login.scss";
+import "./login.css";
 
 function debug(...args) {
     if (window.debugging === 'all' || window.debugging?.includes('login'))


### PR DESCRIPTION
The login page is currently written in SASS but since a few years (2023) CSS supports nesting which is one of the main benefits of using SASS.

By moving the login page to plain CSS it makes it easier to work on, removes a build step and makes theming a bit easier. One of the other motivations was that I made cockpit-ws understand a new StaticDir option so it could load an alternative login page for Anaconda, and not having to deal with SCSS.