### PR TITLE
style: Update fail.html to PF6

### DIFF
--- a/src/common/fail.html
+++ b/src/common/fail.html
@@ -5,40 +5,131 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <style>
-       body {
+        :root {
+            --pf-t--global--background--color--secondary--default: #f2f2f2;
+            --pf-v6-c-page__main-container--BackgroundColor: #ffffff;
+            --pf-v6-c-empty-state__icon--Color: #707070;
+            --pf-t--global--text--color--regular: #151515;
+        }
+        :root:where(.pf-v6-theme-dark) {
+            --pf-t--global--background--color--secondary--default: #151515;
+            --pf-v6-c-page__main-container--BackgroundColor: #292929;
+            --pf-v6-c-empty-state__icon--Color: #a3a3a3;
+            --pf-t--global--text--color--regular: #ffffff;
+        }
+        html {
+            height: 100%;
+            display: block;
+        }
+        body {
             margin: 0;
-            font-family: "RedHatDisplay", "Open Sans", Helvetica, Arial, sans-serif;
-            font-size: 12px;
-            line-height: 1.66666667;
-            color: #333333;
-            background-color: #f5f5f5;
+            font-family: "Red Hat Display", "RedHatDisplay", "Noto Sans Arabic", "Noto Sans Hebrew", "Noto Sans JP", "Noto Sans KR", "Noto Sans Malayalam", "Noto Sans SC", "Noto Sans TC", "Noto Sans Thai", Helvetica, Arial, sans-serif;
+            line-height: 1.3;
+            color: var(--pf-t--global--text--color--regular);
+            background: var(--pf-t--global--background--color--secondary--default);
+
         }
         img {
             border: 0;
             vertical-align: middle;
         }
         h1 {
-            font-weight: 300;
-        }
-        p {
-            margin: 0 0 10px;
+            font-size: 1.25rem;
+            font-weight: 500;
         }
         @font-face {
-            font-family: 'RedHatDisplay';
+            font-family: "Red Hat Display";
             font-style: normal;
-            font-weight: 300;
-            src: url('/cockpit/static/fonts/RedHatDisplay-Medium.woff2') format('woff2');
+            font-weight: 400 700;
+            src: url("fonts/RedHatDisplay/RedHatDisplayVF.woff2") format("woff2-variations");
+            font-display: fallback;
         }
         .blank-slate-pf {
             text-align: center;
             padding: 90px 120px;
         }
+        .pf-v6-svg {
+            width: 1em;
+            height: 1em;
+            vertical-align: -0.125em;
+            font-size: 3.5rem;
+            color: var(--pf-v6-c-empty-state__icon--Color);
+            margin-block-end: 1.5rem;
+        }
+        .pf-v6-c-page__main-container {
+            border-radius: 16px;
+            background: var(--pf-v6-c-page__main-container--BackgroundColor);
+            margin-inline: 1.5rem;
+            block-size: 100%;
+        }
     </style>
+    <script>
+        /*
+        * Copyright (C) 2022 Red Hat, Inc.
+        * SPDX-License-Identifier: LGPL-2.1-or-later
+        */
+
+        function debug(...args) {
+            if (window.debugging == "all" || window.debugging?.includes("style")) {
+                console.debug([`cockpit-dark-theme: ${document.documentElement.id}:`, ...args].join(" "));
+            }
+        }
+
+        function changeDarkThemeClass(documentElement, dark_mode) {
+            debug(`Setting cockpit theme to ${dark_mode ? "dark" : "light"}`);
+
+            if (dark_mode) {
+                documentElement.classList.add('pf-v6-theme-dark');
+            } else {
+                documentElement.classList.remove('pf-v6-theme-dark');
+            }
+        }
+
+        function _setDarkMode(_style) {
+            const style = _style || localStorage.getItem('shell:style') || 'auto';
+            let dark_mode;
+            // If a user set's an explicit theme, ignore system changes.
+            if ((window.matchMedia?.('(prefers-color-scheme: dark)').matches && style === "auto") || style === "dark") {
+                dark_mode = true;
+            } else {
+                dark_mode = false;
+            }
+            changeDarkThemeClass(document.documentElement, dark_mode);
+        }
+
+        window.addEventListener("storage", event => {
+            if (event.key === "shell:style") {
+                debug(`Storage element 'shell:style' changed from  ${event.oldValue} to ${event.newValue}`);
+
+                _setDarkMode();
+            }
+        });
+
+        // When changing the theme from the shell switcher the localstorage change will not fire for the same page (aka shell)
+        // so we need to listen for the event on the window object.
+        window.addEventListener("cockpit-style", event => {
+            if (event instanceof CustomEvent) {
+                const style = event.detail.style;
+                debug(`Event received from shell with 'cockpit-style'  ${style}`);
+
+                _setDarkMode(style);
+            }
+        });
+
+        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+            debug(`Operating system theme preference changed to ${window.matchMedia?.('(prefers-color-scheme: dark)').matches ? "dark" : "light"}`);
+            _setDarkMode();
+        });
+
+        _setDarkMode();
+    </script>
 </head>
 <body>
-    <div class="blank-slate-pf">
-        <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADwAAAA8CAYAAAA6/NlyAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAN1wAADdcBQiibeAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAAWGSURBVGiBzZtNaJxFGMd/z2R3YxHbtZa2pqdcPInS9CCUov3QiuhF2hIUjOZrd5NA9VoPuiJSTx6S0s27SVxJ8aOpPSgqpbZVlIIIJirqtRdNpBU3FUqhm53HQzZpPjfvm51J8oeFZd5n5v/8eWbemXfmGcETBgcHt1prm1S1CWgSkUZV3QIkgS0Vs5vAZOV3DRhV1VFr7Wh3d3fRh1/isrFcLrerrq7uKHBMVffW2P4fqjocj8fPtLe3jzty0Y3gfD7/pLX2hIjsB4yLNufAAleste90dXV9W2tjNQkOgmCfqr4lIgdrdSQMROSqtfbNTCZzedVtrKbSwMDAjnK5nBOR51dLXAtU9Yt4PJ5eTVePLDgIgmPAaWBb1LqOURSRV1Op1JkolUILHhkZSRSLxUHgpciu+cX7QCadTpfCGIcSPDQ0dF+pVDonIk/X5Jo/XAaOpNPpmysZrig4l8vtMsZcAB524ZlH/AI8k06nJ6oZVZ1Cent7NxtjvmTjiwV4FLhYKBSS1YyWjXBlzH4FHKrRkY82bdqUamlpuVXNaHh4+N7bt2/ngRdr5LsIPLfcmF42wsVisZ/axaKqV1YSC9DS0nJLVa/UygccZnoWWRJLCu7v728GWh2QIyKJCLb3uOAEOirT5yIsEhwEwTYR6XVEDFAfwdaVYIDTAwMDOxYWLhIsIjlgu0Pi0CKi9IYQ2Gat7VtYOE9wZW181CFpJBHWWpcRBjiWz+efmFswT7CIvO2YEFUN3aWNMVG6fyhYa9+YxzHzJwiCA6q63zUhEcawhwgjIgfnRnluhF93TVZBaBE+IgxgrT0xywEQBMGDwAEfZKq6nmMYABF5amhoqAHuRrgZqPNBFiVqviIMmFKpdAQqglW12RNRpJeWrwgDGGOaAczg4OBWEXnMF1GU1ZPHCKOqewuFQtJYa5twvHu5gCj0GI7SG1YBuXPnzm5jrd3jkSSSCIdr6eXa32NEZLdnktAiPEcYVd1tRKTRJwnr9/GwFBqNqlbdIXCAKIK9Rhi43zB91uMTGynCScPdgy1f2HARVs8kG0mwNUwfVfrERurSk4bpM1qfCCVYVQVwueOxFCY3TIT7+voSeFzxVVA0TJ+8+4TJZrOxEHa+xy+qes0Ao76Jdu7cueLiJpFIPOTbDxEZi6nqqIjfniQiP+bz+Z9VdWoZkzjQ5NWJaYzGYrHYWLlcVvyOn6Sn/bIo0EQiMWY6Ojr+BX5YZ2fWAldbW1snDYCInF1vb9YAZwFiAOVy+VNjzHu4z8ABQETax8fHP8hms3ap56oq+Xz+BeBDH/xAGTgPFYFdXV1/Ad94IqOaWAAR0YmJiU988QOXZw7KZyMqIu/6YqsmNorNamGtPTnzf1ZwKpW6BHzni3S9ICJX5ya0eT9bWm+IyNJnSzAb5c/X1COPEJHPOjs752UVLHorx+PxDuD6mnnlD/+USqXMwsJFgtva2m6o6mtr45M/iEhPT0/P3wvLl5x3M5nMxyIy7Io8m82uOL+HsYmAQiqVGlnqwbIkyWSy01FWDQ0NDa9UE6Sq0tDQ4Crz4BKQXu5h1Q+G3t7ezfX19d8Djzhyxjd+TyQS+1pbW5fd1KjajY4fP/6fMeZZ4DfnrrnHr7FY7HA1sRBi7dzZ2flnLBbbC1xw5pp7XAIeD5M/HTV9OA+8XItnHjAIdDtNH56LDZQgfl1EulOp1PkolVa1y5HL5baLSP96XQEAzsXj8Z62trYbUSvWfMkDyOIgCTUM1u2Sx0IEQXBARE6o6iHcbyKUga9V9WQmk6n5a87pxt2pU6ceiMfjR0SkxcFFrZ9E5IyqjqyU5R4F3nYqC4VCcmpqavYqnrW2UUSSTB/PzhzRzlzDK1K5igeMJhKJsZXm09XifyIP5eSF+BKpAAAAAElFTkSuQmC">
-        <h1>@@message@@</h1>
+    <div class="pf-v6-c-page__main-container">
+        <div class="blank-slate-pf">
+            <svg class="pf-v6-svg" viewBox="0 0 512 512" fill="currentColor" aria-hidden="true" role="img" width="1em" height="1em"><path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"></path></svg>
+            <h1>@@message@@</h1>
+        </div>
     </div>
 </body>
 </html>


### PR DESCRIPTION
Supports dark style now as taken from our codebase elsewhere. File is
still entirely self-contained and needs no external imports apart from
font.

Changes made:
- Font updated to RH Display Variable Font
- Info icon updated to style in PF6
- Info icon changed to SVG from PNG
- Supports dark theme

How it looks in action. Video a bit darker due to HDR related screenrecording bugs

[Kooha-2026-03-16-17-24-04.webm](https://github.com/user-attachments/assets/faa46bd9-f1a4-42d2-aee9-3a49ab2f10b2)

Fixes: https://github.com/cockpit-project/cockpit/issues/23012
Signed-off-by: Freya Gustavsson <freya@venefilyn.se>