### PR TITLE
build: Silence if-function deprecation from PF6

### DIFF
--- a/build.js
+++ b/build.js
@@ -157,6 +157,9 @@ async function build() {
             loadPaths: [...nodePaths, 'node_modules'],
             filter: /\.scss/,
             quietDeps: true,
+            silenceDeprecations: [
+                "if-function" // https://github.com/patternfly/patternfly/issues/8077
+            ]
         })
     ];
 


### PR DESCRIPTION
Patternfly v6 uses Sass if-functions which has been deprecated in favor
of pure CSS if-functions. However, we need to wait for Patternfly to
move to this and can't do much ourselves.

Ignoring the warnings produced is not super ideal as it catches more
than just Patternfly, but given that we don't use Sass if-functions we
should be fine.

Related-to: https://github.com/patternfly/patternfly/issues/8077
Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
