### PR TITLE
packit: disable s390x copr_builds

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -67,11 +67,12 @@ jobs:
     targets: *test_targets
 
   # run extra build/unit tests on some interesting architectures
-  - job: copr_build
-    trigger: pull_request
-    targets:
-      # big-endian
-      - fedora-latest-stable-s390x
+  # https://github.com/fedora-copr/copr/issues/4219
+  # - job: copr_build
+  #   trigger: pull_request
+  #   targets:
+  #     # big-endian
+  #     - fedora-latest-stable-s390x
 
   # for cross-project testing
   - job: copr_build


### PR DESCRIPTION
The s390x builders are down due the deprecation of the cloud infrastructure and there is no indication it will be back up soon.

See https://github.com/fedora-copr/copr/issues/4219

---

This drops the forever spinning fedora s390x status on pull requests.