### PR TITLE
packit: Use upstream repo as fallback

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -98,8 +98,8 @@ jobs:
           bash -exc '
           # for debugging of official runs, CLI is different from packit service
           env | grep PACKIT
-          tar -xJf "${PACKIT_DOWNSTREAM_REPO}/cockpit-${PACKIT_PROJECT_VERSION}.tar.xz" "cockpit-*/runtime-npm-modules.txt" --strip-components=1
-          tools/fix-spec "${PACKIT_DOWNSTREAM_REPO}/cockpit.spec" "${PACKIT_PROJECT_VERSION}"
+          tar -xJf "${PACKIT_DOWNSTREAM_REPO:-${PACKIT_UPSTREAM_REPO}}/cockpit-${PACKIT_PROJECT_VERSION}.tar.xz" "cockpit-*/runtime-npm-modules.txt" --strip-components=1
+          tools/fix-spec "${PACKIT_DOWNSTREAM_REPO:-${PACKIT_UPSTREAM_REPO}}/cockpit.spec" "${PACKIT_PROJECT_VERSION}"
           '
 
   - job: propose_downstream


### PR DESCRIPTION
When we publish our packages we currently use the
`PACKIT_DOWNSTREAM_REPO` envvar. This is not defined when we are
publishing to Copr and instead we should use `PACKIT_UPSTREAM_REPO`
envvar.

Changing it to use downstream repo by default and fallback to upstream
repo fixes this issue.

Fixes: https://github.com/cockpit-project/cockpit/issues/22883
Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
