### PR TITLE
pyproject: add minimal ty configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,6 +165,9 @@ mark-parentheses = false
 [tool.ruff.lint.isort]
 known-first-party = ["cockpit"]
 
+[tool.ty.environment]
+extra-paths = ["src", "test/common", "bots"]
+
 [tool.pytest.ini_options]
 addopts = ['--strict-markers']  # cf. https://github.com/cockpit-project/cockpit/pull/18584#issuecomment-1490243994
 pythonpath = ["src", "test/common", "bots"]


### PR DESCRIPTION
ty is a new Python type checker implemented in Rust, its quite a bit faster then mypy but still experimental.

---

I didn't copy our full mypy unresolved imports list as its quite a lot but this is already interesting enough to compare with mypy I'd say.