### PR TITLE
login.js: fix a faulty check on X-Conversation challenges

### DIFF
--- a/pkg/static/login.js
+++ b/pkg/static/login.js
@@ -927,7 +927,7 @@ function debug(...args) {
             return null;
 
         const parts = header.split(' ');
-        if (parts[0].toLowerCase() !== 'x-conversation' && parts.length != 3)
+        if (parts[0].toLowerCase() !== 'x-conversation' || parts.length !== 3)
             return null;
 
         const id = parts[1];


### PR DESCRIPTION
This code seems to be expecting a header where:
  - the header has 3 parts; and
  - the first part is 'X-Conversation'

but that's not what the check is doing.  It only returns if both checks fail, which means that the function will continue where:
  - the header has 3 parts; OR
  - the first part is 'X-Conversation'

This means that any three-part header will be accepted (even if it doesn't start with "X-Conversation") and any header starting with "X-Conversation" will be accepted, even if it doesn't have three parts. That last one is a particular problem because the very next thing we do is try to access the 2nd and 3rd parts, which may not even exist.

This bug goes back at least as far as https://github.com/cockpit-project/cockpit/commit/74e58fc8c12a4f3fa0033bbdd3f9be79519d416f ("ws: Support conversations in authentication") before "X-Conversation" was even the name of the challenge (it was "X-Login-Reply" at the time).

We can fix it by changing the `&&` here to a `||`: we want to return if *either* check fails.  Also `!==`, because.