### PR TITLE
test: Wait for memory to disappear

### DIFF
--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -305,6 +305,7 @@ WantedBy=default.target
                                    ["Start", "Clear 'Failed to start'", "Disallow running (mask)", "Pin unit"],
                                    enabled=True)
         if not user:
+            b.wait_not_present("#memory")
             b.assert_pixels("#service-details-unit", "details-test-fail",
                             # in medium layout we sometimes get a scrollbar depending on how many test-fail logs exist
                             skip_layouts=["medium"],


### PR DESCRIPTION
Flaky pixel tests can occur where memory still shows on a disabled
service. Waiting on the memory to disappear before taking pixel tests
will ensure pixel tests match.

Fixes: https://github.com/cockpit-project/cockpit/issues/23030
Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
