### PR TITLE
packit: Exclusively use branch aliases

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -108,20 +108,15 @@ jobs:
     actions: *official_release_actions
 
     dist_git_branches:
-      - fedora-development
-      - fedora-43
-      - fedora-44
+      - fedora-all
 
   - job: koji_build
     trigger: commit
     dist_git_branches:
-      - fedora-development
-      - fedora-43
-      - fedora-44
+      - fedora-all
 
   - job: bodhi_update
     trigger: commit
     dist_git_branches:
       # rawhide updates are created automatically
-      - fedora-43
-      - fedora-44
+      - fedora-branched


### PR DESCRIPTION
Instead of updating Fedora version branch frequently we should rely on
aliases to automate this and reduce human error factor.

As of this commit `fedora-all` resolves to
- `fedora-42`
- `fedora-43`
- `fedora-44`
- `fedora-rawhide`

With `fedora-branched` it resolves to
- `fedora-42`
- `fedora-43`
- `fedora-44`

Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
