### PR TITLE
selinux: allow cockpit-ws to get attributes of pidfs

### DIFF
--- a/selinux/cockpit.te
+++ b/selinux/cockpit.te
@@ -230,6 +230,7 @@ optional_policy(`
         type pidfs_t;
     ')
     allow cockpit_session_t pidfs_t:filesystem getattr;
+    allow cockpit_ws_t pidfs_t:filesystem getattr;
 ')
 
 #########################################################


### PR DESCRIPTION
Addresses the following AVC denial introduced by systemd 260: avc:  denied  { getattr } for  pid=16530 comm="cockpit-ws" name="/" dev="pidfs" ino=1 scontext=system_u:system_r:cockpit_ws_t:s0 tcontext=system_u:object_r:pidfs_t:s0 tclass=filesystem permissive=0

systemd 260 refactored internal code to use pidfs in most places which is the likely cause of the new violation.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2449605

---

For reference see https://bugzilla.redhat.com/show_bug.cgi?id=2417839