### PR TITLE
fix: use console.error for error logging in hooks.ts

### DIFF
--- a/pkg/lib/hooks.ts
+++ b/pkg/lib/hooks.ts
@@ -75,7 +75,7 @@ export function usePageLocation() {
 
 const cockpit_user_promise = cockpit.user();
 let cockpit_user: cockpit.UserInfo | null = null;
-cockpit_user_promise.then(user => { cockpit_user = user }).catch(err => console.log(err));
+cockpit_user_promise.then(user => { cockpit_user = user }).catch(err => console.error(err));
 
 export function useLoggedInUser() {
     const [user, setUser] = useState<cockpit.UserInfo | null>(cockpit_user);


### PR DESCRIPTION
## Summary

Changed `console.log` to `console.error` when logging errors from `cockpit.user()` promise rejection in `pkg/lib/hooks.ts`.

## Rationale

Using `console.error` for error conditions provides better visibility in the browser console (errors are typically highlighted and can be filtered separately) and follows the standard JavaScript convention:
- `console.log` for general informational output
- `console.warn` for warnings
- `console.error` for errors

This is a small but important improvement for debugging purposes, as actual errors will now be properly categorized in browser developer tools.

---

## Test plan

- [x] Code compiles without errors
- [ ] Manual testing: Verify error handling still works correctly

## Checklist

- [x] Tests pass locally
- [x] No new ESLint errors introduced

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)