### PR TITLE
test: Restart packagekit more agressively

### DIFF
--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -459,6 +459,9 @@ ExecStart=/usr/local/bin/{package} infinity
 
         startTime = m.execute(f"systemctl show {package}.service --property=ExecMainStartTimestamp")
 
+        # For good measure
+        m.execute("systemctl restart packagekit")
+
         self.addCleanup(m.execute, ("pacman -R --noconfirm " if m.image == "arch" else "rpm -e ") + package)
         self.addCleanup(m.execute, f"systemctl stop {package}")
 


### PR DESCRIPTION
To get it to recognize the just installed package.

This was failing testTracer, where it missed that pear 1-1 has just been installed, sometimes, for some reason.