### PR TITLE
branding: Fix Ubuntu 22.04 logo fetching

### DIFF
--- a/src/branding/ubuntu/Makefile.am
+++ b/src/branding/ubuntu/Makefile.am
@@ -6,8 +6,13 @@ dist_ubuntubranding_DATA = \
 	src/branding/ubuntu/favicon.ico \
 	$(NULL)
 
-# Icons provided by base-files package
+# Icons provided by base-files package. Fallback to plymouth ubuntu logo if base-files don't have logos
 install-data-hook::
-	ln -sTfr $(DESTDIR)/usr/share/pixmaps/ubuntu-logo-text.png $(DESTDIR)$(ubuntubrandingdir)/logo.png
-	ln -sTfr $(DESTDIR)/usr/share/pixmaps/ubuntu-logo-text-dark.png $(DESTDIR)$(ubuntubrandingdir)/logo-dark.png
-	ln -sTfr $(DESTDIR)/usr/share/pixmaps/ubuntu-logo.svg $(DESTDIR)$(ubuntubrandingdir)/logo.svg
+	if [ -f "/usr/share/pixmaps/ubuntu-logo-text.png" ]; then \
+		ln -sTfr $(DESTDIR)/usr/share/pixmaps/ubuntu-logo-text.png $(DESTDIR)$(ubuntubrandingdir)/logo.png; \
+		ln -sTfr $(DESTDIR)/usr/share/pixmaps/ubuntu-logo-text-dark.png $(DESTDIR)$(ubuntubrandingdir)/logo-dark.png; \
+		ln -sTfr $(DESTDIR)/usr/share/pixmaps/ubuntu-logo.svg $(DESTDIR)$(ubuntubrandingdir)/logo.svg; \
+	else \
+		ln -sTfr $(DESTDIR)/usr/share/plymouth/ubuntu-logo.png $(DESTDIR)$(ubuntubrandingdir)/logo.png; \
+		ln -sTfr $(DESTDIR)/usr/share/plymouth/ubuntu-logo.png $(DESTDIR)$(ubuntubrandingdir)/logo-dark.png; \
+	fi


### PR DESCRIPTION
We previously used `plymouth` package to get the Ubuntu logo, but it
didn't include variants for both light and dark mode which was a bit of
an issue. In Ubuntu 24.04 and higher `base-files` package includes the
normal branding files we need, but we now fail tests as we didn't verify
these files exist on Ubuntu 22.04.

Reverting the change isn't great as we run into the light and dark mode
issues again, but we can conditionally fetch the new logos if they exist
and fallback to `plymouth` for the logo.

Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
