### PR TITLE
flatpak: Add extensions entry

### DIFF
--- a/containers/flatpak/Makefile.am
+++ b/containers/flatpak/Makefile.am
@@ -1,4 +1,7 @@
-build-for-flatpak: cockpit-ws
+build-for-flatpak: flatpak-enable-extensions cockpit-ws
+
+flatpak-enable-extensions:
+	mkdir -p /app/extensions/share/cockpit
 
 INSTALL_FLATPAK_TARGETS = \
 	install-cockpitwsPROGRAMS \

--- a/containers/flatpak/prepare
+++ b/containers/flatpak/prepare
@@ -38,7 +38,7 @@ def write_json(filename: str, content: Any) -> None:
     """Something like g_file_set_contents() for JSON"""
     tmpfile = f'{filename}.tmp'
     try:
-        with open(tmpfile, 'w') as file:
+        with open(tmpfile, 'w', encoding='utf-8') as file:
             json.dump(content, file, indent=2)
             file.write('\n')
 
@@ -46,8 +46,7 @@ def write_json(filename: str, content: Any) -> None:
         with contextlib.suppress(OSError):
             os.unlink(tmpfile)
         raise
-    else:
-        os.rename(tmpfile, filename)
+    os.rename(tmpfile, filename)
 
 
 def fetch_json(url: str) -> Any:
@@ -135,7 +134,7 @@ def get_packages(origin: Optional[str]) -> List[Any]:
     # 4. In any case, write the local file if it changed (or is new)
 
     try:
-        with open(PACKAGES_JSON, 'r') as file:
+        with open(PACKAGES_JSON, 'r', encoding='utf-8') as file:
             local_packages = json.load(file)
     except FileNotFoundError:
         local_packages = None
@@ -170,6 +169,7 @@ def main() -> None:
     packages = get_packages(args.packages)
 
     branch = 'devel'
+    location = {}
     if args.location is None:
         try:
             output = subprocess.check_output([f'{TOP_DIR}/tools/make-dist'],

--- a/containers/flatpak/prepare
+++ b/containers/flatpak/prepare
@@ -94,8 +94,20 @@ def create_manifest(
             '--socket=wayland',
             '--socket=fallback-x11',
             '--device=dri',
-            '--share=ipc'
+            '--share=ipc',
+            '--env=XDG_DATA_DIRS=/app/share:/app/extensions/share'
         ],
+        'add-extensions': {
+            f'{FLATPAK_ID}.Plugin': {
+                'subdirectories': True,
+                'directory': 'extensions',
+                'merge-dirs': 'share/cockpit',
+                'version': 'master',
+                'versions': 'master',
+                'no-autodownload': True,
+                'autodelete': True
+            }
+        },
         'modules': [
             {
                 'name': 'cockpit-client',


### PR DESCRIPTION
Flatpak has for a long time supported extensions wherein other flatpak
applications can install to a specific folder of an already existing
Flatpak app if the Flatpak app has extensions enabled.

To create an extension for Cockpit, we've now added a
`org.cockpit_project.CockpitClient.Plugin` extension entry where plugins
who follow the naming scheme of `.Plugin.<PluginName>` can install their
extensions directly through Flatpak.

With this, we now have another avenue for others to distribute Cockpit
applications for their local system using Flatpak.

Fixes: https://github.com/cockpit-project/cockpit/issues/22981
Signed-off-by: Freya Gustavsson <freya@venefilyn.se>