### PR TITLE
test: skip teaming/btrfs tests on Fedora ELN

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -41,6 +41,7 @@ jobs:
       fedora-44: {}
       fedora-latest-aarch64: {}
       fedora-rawhide: {}
+      fedora-eln-x86_64: {}
       centos-stream-9-x86_64:
         distros: ["centos-stream-9", "CentOS-Stream-9-image-mode"]
       centos-stream-9-aarch64: {}

--- a/packit.yaml
+++ b/packit.yaml
@@ -42,6 +42,7 @@ jobs:
       fedora-45: {}
       fedora-latest-aarch64: {}
       fedora-rawhide: {}
+      fedora-eln-x86_64: {}
       centos-stream-9-x86_64:
         distros: ["centos-stream-9", "CentOS-Stream-9-image-mode"]
       centos-stream-9-aarch64: {}

--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -3,10 +3,6 @@
   require:
     # ourself
     - cockpit
-    # done in browser.sh, see https://issues.redhat.com/browse/TFT-2564
-    # - cockpit-kdump
-    # - cockpit-networkmanager
-    # - cockpit-sosreport
     - cockpit-packagekit
     # build/test infra dependencies
     - podman

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -214,12 +214,6 @@ if [ "$PLAN" = "storage-extra" ]; then
            TestStorageMountingLUKS
            TestStorageLvm
            "
-    if [ "$TEST_OS" = "fedora-eln" ]; then
-       EXCLUDES="$EXCLUDES
-              TestStorageAnaconda.testBtrfs
-              TestStorageAnaconda.testDegradedBtrfs
-              "
-    fi
 
     # These don't test more external APIs
     EXCLUDES="$EXCLUDES

--- a/test/verify/check-networkmanager-team
+++ b/test/verify/check-networkmanager-team
@@ -13,7 +13,7 @@ import testlib
 
 @testlib.skipOstree("NetworkManager-team not installed")
 @testlib.skipImage("TODO: networkmanager fails on Arch Linux", "arch")
-@testlib.skipImage("team not supported", "centos-10*", "rhel-10*")
+@testlib.skipImage("team not supported", "centos-10*", "rhel-10*", "fedora-eln")
 @testlib.nondestructive
 class TestTeam(netlib.NetworkCase):
     def testBasic(self):

--- a/test/verify/check-storage-anaconda
+++ b/test/verify/check-storage-anaconda
@@ -255,7 +255,7 @@ class TestStorageAnaconda(storagelib.StorageCase):
         self.confirm()
         m.execute("! findmnt --fstab -n /sysroot/var")
 
-    @testlib.skipImage('no btrfs support', 'rhel-*', 'centos-*')
+    @testlib.skipImage('no btrfs support', 'rhel-*', 'centos-*', 'fedora-eln')
     def testBtrfs(self):
         b = self.browser
 
@@ -339,7 +339,7 @@ class TestStorageAnaconda(storagelib.StorageCase):
                                       }
                                   })
 
-    @testlib.skipImage('no btrfs support', 'rhel-*', 'centos-*')
+    @testlib.skipImage('no btrfs support', 'rhel-*', 'centos-*', 'fedora-eln')
     def testDegradedBtrfs(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-storage-btrfs
+++ b/test/verify/check-storage-btrfs
@@ -12,7 +12,7 @@ import testlib
 
 
 @testlib.nondestructive
-@testlib.skipImage('no btrfs support', 'rhel-*', 'centos-*')
+@testlib.skipImage('no btrfs support', 'rhel-*', 'centos-*', 'fedora-eln')
 class TestStorageBtrfs(storagelib.StorageCase):
     def setUp(self):
         super().setUp()

--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -22,7 +22,7 @@ class TestStorageMounting(storagelib.StorageCase):
     def testMounting(self):
         self._testMounting()
 
-    @testlib.skipImage('no btrfs support', 'rhel-*', 'centos-*')
+    @testlib.skipImage('no btrfs support', 'rhel-*', 'centos-*', 'fedora-eln')
     def testMountingBtrfs(self):
         self._testMounting("btrfs", "btrfs subvolume")
 
@@ -155,7 +155,7 @@ ExecStart=/usr/bin/sleep infinity
         self.assertEqual(self.configuration_field("/dev/sda", "fstab", "dir"), "")
         b.wait_in_text(self.card_desc(filesystem, "Mount point"), "The filesystem has no permanent mount point.")
 
-    @testlib.skipImage('no btrfs support', 'rhel-*', 'centos-*')
+    @testlib.skipImage('no btrfs support', 'rhel-*', 'centos-*', 'fedora-eln')
     def testMountingHelpBtrfs(self):
         self._testMountingHelp("btrfs", "btrfs subvolume")
 
@@ -249,7 +249,7 @@ ExecStart=/usr/bin/sleep infinity
     def testFstabOptions(self):
         self._testFstabOptions()
 
-    @testlib.skipImage('no btrfs support', 'rhel-*', 'centos-*')
+    @testlib.skipImage('no btrfs support', 'rhel-*', 'centos-*', 'fedora-eln')
     def testFsabOptionsBtrfs(self):
         self._testFstabOptions("btrfs", "btrfs subvolume")
 

--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -17,7 +17,7 @@ PV_SIZE = 4000  # 4 GB in MB
 # default. When this gets empty, Cockpit itself can be cleaned up to
 # drop support for Stratis API revisions before "r8".
 #
-V1_POOL_IMAGES = ["rhel-9-9", "rhel-9-8", "rhel-9-7", "centos-9-bootc", "centos-9"]
+V1_POOL_IMAGES = ["rhel-9-9", "rhel-9-8", "rhel-9-7", "centos-9-bootc", "centos-9", "fedora-eln"]
 
 
 def get_stratis_stop_type_opt(execute):


### PR DESCRIPTION
Commit fd355335440ae5a624baad was insufficient, it only fixed one scenario where we have to exclude tests, while storage-{basic,extra} and main are left unfixed as they still ran teaming/btrfs tests.

Blocked on:

* [x] https://github.com/cockpit-project/cockpit/pull/23321