### PR TITLE
packit: Prevent Packit from modifying Source URLs

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -93,17 +93,6 @@ jobs:
       post-upstream-clone:
         - cp tools/cockpit.spec .
 
-      # Download the real GitHub release tarball instead of creating git archive
-      create-archive:
-        - |
-          bash -exc '
-          # Download Source0 from GitHub releases
-          curl -L -o "cockpit-${PACKIT_PROJECT_VERSION}.tar.xz" \
-            "https://github.com/cockpit-project/cockpit/releases/download/${PACKIT_PROJECT_VERSION}/cockpit-${PACKIT_PROJECT_VERSION}.tar.xz"
-          # Output the filename for Packit (required by create-archive)
-          echo "cockpit-${PACKIT_PROJECT_VERSION}.tar.xz"
-          '
-
       # resolve NPM_PROVIDES, but otherwise keep packit's %changelog
       post-modifications:
         - |
@@ -114,9 +103,7 @@ jobs:
           tools/fix-spec "${PACKIT_DOWNSTREAM_REPO:-${PACKIT_UPSTREAM_REPO}}/cockpit.spec" "${PACKIT_PROJECT_VERSION}"
           '
 
-      fix-spec-file:
-        # packit needs local file names, not URLs
-        - sed -i 's|^\(Source[0-9]*:\s*\).*\/|\1|' cockpit.spec
+      fix-spec-file: null
   - job: propose_downstream
     trigger: release
     actions: *official_release_actions


### PR DESCRIPTION
By default Packit only grabs `Source0`. Problem is that Packit converts
all other Source URLs to local files and thus cannot download Source
files.[1] By overriding `fix-spec-file` and preventing Packit from
replacing all Source URLs it should in theory download all the tarballs.

With this we also no longer need to override `create-archive` as Packit
already does this.

[1] Due to Packit usually building directly from upstream repos
Signed-off-by: Freya Gustavsson <freya@venefilyn.se>

Related to https://github.com/cockpit-project/cockpit/issues/22883
