### PR TITLE
[codex] Add a basic ZFS Cockpit page

### DIFF
--- a/files.js
+++ b/files.js
@@ -36,6 +36,7 @@ const info = {
         "sosreport/sosreport.jsx",
         "static/login.js",
         "storaged/storaged.jsx",
+        "zfs/index.js",
 
         "systemd/services.jsx",
         "systemd/logs.jsx",
@@ -143,6 +144,7 @@ const info = {
         "static/login.html",
 
         "storaged/index.html",
+        "zfs/index.html",
 
         "systemd/index.html",
         "systemd/logs.html",

--- a/pkg/zfs/index.css
+++ b/pkg/zfs/index.css
@@ -1,0 +1,81 @@
+body {
+    margin: 0;
+    padding: 24px;
+    background: var(--pf-t--global--background--color--secondary--default);
+}
+
+.zfs-hero {
+    display: flex;
+    justify-content: space-between;
+    align-items: end;
+    gap: 16px;
+    margin-bottom: 24px;
+}
+
+.zfs-hero h1,
+.zfs-card h2 {
+    margin: 0 0 8px;
+}
+
+.zfs-muted {
+    margin: 0;
+    color: var(--pf-t--global--text--color--subtle);
+}
+
+.zfs-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 16px;
+    margin-bottom: 16px;
+}
+
+.zfs-card {
+    background: var(--pf-t--global--background--color--primary--default);
+    border: 1px solid var(--pf-t--global--border--color--default);
+    border-radius: 12px;
+    padding: 16px;
+    margin-bottom: 16px;
+}
+
+.zfs-table-wrap {
+    overflow-x: auto;
+}
+
+.zfs-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.zfs-table th,
+.zfs-table td {
+    text-align: left;
+    padding: 10px 8px;
+    border-bottom: 1px solid var(--pf-t--global--border--color--default);
+}
+
+.zfs-terminal {
+    margin: 0;
+    padding: 16px;
+    min-height: 120px;
+    background: #111827;
+    color: #e5e7eb;
+    border-radius: 10px;
+    overflow: auto;
+    white-space: pre-wrap;
+    font: 13px/1.45 ui-monospace, monospace;
+}
+
+.zfs-state-ok {
+    color: #166534;
+    font-weight: 700;
+}
+
+.zfs-state-bad {
+    color: #b91c1c;
+    font-weight: 700;
+}
+
+.zfs-error {
+    color: #b91c1c;
+    font-weight: 600;
+}

--- a/pkg/zfs/index.html
+++ b/pkg/zfs/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<!--
+Copyright (C) 2026
+SPDX-License-Identifier: LGPL-2.1-or-later
+-->
+<html id="zfs-page" lang="en">
+<head>
+    <title translate="yes">ZFS</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+    <link rel="stylesheet" href="index.css" />
+    <link href="../../static/branding.css" rel="stylesheet" />
+
+    <script src="../base1/cockpit.js"></script>
+    <script src="../manifests.js"></script>
+    <script src="../base1/po.js"></script>
+    <script src="index.js"></script>
+</head>
+<body class="pf-v6-m-tabular-nums">
+    <header class="zfs-hero">
+        <div>
+            <h1>ZFS</h1>
+            <p class="zfs-muted">Pool, dataset, and service status from the host.</p>
+        </div>
+        <button id="refresh" class="pf-v6-c-button pf-m-primary" type="button">Refresh</button>
+    </header>
+
+    <section class="zfs-grid">
+        <article class="zfs-card">
+            <h2>Pool Summary</h2>
+            <div id="pool-summary" class="zfs-table-wrap"></div>
+        </article>
+        <article class="zfs-card">
+            <h2>Services</h2>
+            <div id="service-summary" class="zfs-table-wrap"></div>
+        </article>
+    </section>
+
+    <section class="zfs-card">
+        <h2>Datasets</h2>
+        <div id="dataset-summary" class="zfs-table-wrap"></div>
+    </section>
+
+    <section class="zfs-card">
+        <h2>Pool Health</h2>
+        <pre id="pool-status" class="zfs-terminal">Loading...</pre>
+    </section>
+
+    <section class="zfs-card">
+        <h2>Recent Events</h2>
+        <pre id="zed-log" class="zfs-terminal">Loading...</pre>
+    </section>
+</body>
+</html>

--- a/pkg/zfs/index.js
+++ b/pkg/zfs/index.js
@@ -1,0 +1,103 @@
+function run(command) {
+    return cockpit.spawn(command, { superuser: "require", err: "message" });
+}
+
+function escapeHtml(value) {
+    return String(value)
+            .replaceAll("&", "&amp;")
+            .replaceAll("<", "&lt;")
+            .replaceAll(">", "&gt;");
+}
+
+function renderTable(targetId, headers, rows) {
+    const target = document.getElementById(targetId);
+    if (!rows.length) {
+        target.innerHTML = '<p class="zfs-muted">No data</p>';
+        return;
+    }
+
+    const head = headers.map(header => `<th>${escapeHtml(header)}</th>`).join("");
+    const body = rows.map(row => {
+        const cols = row.map(value => `<td>${value}</td>`).join("");
+        return `<tr>${cols}</tr>`;
+    }).join("");
+
+    target.innerHTML = `<table class="zfs-table"><thead><tr>${head}</tr></thead><tbody>${body}</tbody></table>`;
+}
+
+function badge(value) {
+    const lowered = String(value).toLowerCase();
+    const ok = ["online", "active", "mounted", "yes"];
+    const className = ok.includes(lowered) ? "zfs-state-ok" : "zfs-state-bad";
+    return `<span class="${className}">${escapeHtml(value)}</span>`;
+}
+
+async function loadPoolSummary() {
+    const output = await run(["zpool", "list", "-H", "-o", "name,size,alloc,free,health,frag,capacity"]);
+    const rows = output.trim().split("\n").filter(Boolean).map(line => {
+        const [name, size, alloc, free, health, frag, capacity] = line.split("\t");
+        return [name, size, alloc, free, badge(health), frag, capacity];
+    });
+    renderTable("pool-summary", ["Pool", "Size", "Used", "Free", "Health", "Frag", "Cap"], rows);
+}
+
+async function loadDatasets() {
+    const output = await run(["zfs", "list", "-H", "-o", "name,used,avail,mountpoint,mounted"]);
+    const rows = output.trim().split("\n").filter(Boolean).map(line => {
+        const [name, used, avail, mountpoint, mounted] = line.split("\t");
+        return [name, used, avail, mountpoint, badge(mounted)];
+    });
+    renderTable("dataset-summary", ["Dataset", "Used", "Avail", "Mountpoint", "Mounted"], rows);
+}
+
+async function loadServices() {
+    const services = [
+        "zfs-load-module.service",
+        "zfs-import-cache.service",
+        "zfs-mount.service",
+        "zfs-zed.service",
+    ];
+
+    const rows = [];
+    for (const service of services) {
+        try {
+            const output = await run(["systemctl", "is-active", service]);
+            rows.push([service, badge(output.trim())]);
+        } catch (error) {
+            rows.push([service, `<span class="zfs-error">${escapeHtml(error.message || String(error))}</span>`]);
+        }
+    }
+    renderTable("service-summary", ["Service", "State"], rows);
+}
+
+async function loadStatus() {
+    const output = await run(["zpool", "status"]);
+    document.getElementById("pool-status").textContent = output.trim() || "No pool status output";
+}
+
+async function loadZedLog() {
+    const output = await run(["journalctl", "-u", "zfs-zed.service", "-n", "30", "--no-pager"]);
+    document.getElementById("zed-log").textContent = output.trim() || "No recent zed events";
+}
+
+async function refresh() {
+    document.getElementById("pool-status").textContent = "Loading...";
+    document.getElementById("zed-log").textContent = "Loading...";
+
+    try {
+        await Promise.all([
+            loadPoolSummary(),
+            loadDatasets(),
+            loadServices(),
+            loadStatus(),
+            loadZedLog(),
+        ]);
+    } catch (error) {
+        const message = error.message || String(error);
+        document.getElementById("pool-status").textContent = `Error: ${message}`;
+        document.getElementById("zed-log").textContent = `Error: ${message}`;
+    }
+}
+
+document.getElementById("refresh").addEventListener("click", refresh);
+refresh();

--- a/pkg/zfs/manifest.json
+++ b/pkg/zfs/manifest.json
@@ -1,0 +1,18 @@
+{
+    "name": "zfs",
+    "requires": {
+        "cockpit": "287"
+    },
+    "menu": {
+        "index": {
+            "label": "ZFS",
+            "order": 35,
+            "keywords": [
+                {
+                    "matches": ["zfs", "pool", "dataset", "raidz", "snapshot", "tank"]
+                }
+            ]
+        }
+    },
+    "content-security-policy": "default-src 'self'; connect-src 'self' ws: wss:; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'"
+}


### PR DESCRIPTION
## Summary
Add a small native Cockpit `ZFS` page that surfaces host ZFS state.

## What it shows
- pool summary via `zpool list`
- datasets via `zfs list`
- key ZFS service state via `systemctl is-active`
- full `zpool status`
- recent `zfs-zed` journal output

## Notes
- This is implemented as a standalone `pkg/zfs` package and wired into `files.js`.
- It is intentionally minimal and does not try to extend the existing `storaged`/`udisks2` pipeline.
- It currently relies on privileged host command execution through Cockpit to query ZFS state.

## Validation
- installed locally on a Debian host with OpenZFS
- verified page loads in Cockpit and reports the active `tank` pool
- verified ZFS services and dataset state render from the host
