### PR TITLE
test: disable packagekit preloading for testPlots

### DIFF
--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -667,6 +667,14 @@ OnCalendar=daily
         self.addCleanup(m.execute, "systemctl stop pmcd")
         m.execute("systemctl start pmcd")
 
+        # packagekit/dnf often eats a lot of CPU/Memory; silence it to have better control over memory usage
+        packagekitd = "/usr/lib/packagekitd" if m.image == "arch" else "/usr/libexec/packagekitd"
+        m.execute(f"systemctl mask packagekit && killall -9 {packagekitd} && killall -9 dnf || true")
+        self.addCleanup(m.execute, "systemctl unmask packagekit")
+
+        # packagekitd consumes tons of memory on logging into Cockpit
+        self.disable_preload("packagekit")
+
         self.login_and_go("/playground/plot")
         b.wait_visible("#plot-direct")
         b.wait_visible("#plot-pmcd")

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -667,6 +667,11 @@ OnCalendar=daily
         self.addCleanup(m.execute, "systemctl stop pmcd")
         m.execute("systemctl start pmcd")
 
+        # settroubleshootd eats memory in an unpredictable manner, silence it to reduce test flakes
+        if m.image.startswith(("fedora-", "rhel-")):
+            self.addCleanup(m.execute, "systemctl unmask setroubleshootd")
+            m.execute("systemctl stop setroubleshootd; systemctl mask setroubleshootd")
+
         # packagekit/dnf often eats a lot of CPU/Memory; silence it to have better control over memory usage
         packagekitd = "/usr/lib/packagekitd" if m.image == "arch" else "/usr/libexec/packagekitd"
         m.execute(f"systemctl mask packagekit && killall -9 {packagekitd} && killall -9 dnf || true")


### PR DESCRIPTION
testPlots started to fail recently in our nightly scenario, this can be reproduced by first running TestUpdates.testUnprivileged and then TestPages.testPlots. On the first load of the page, packagekitd eats tons of memory causing a huge spike. The initial MemAvailable range will so small that it falls out of the range of the plateau.

Closes: #22824