### PR TITLE
apps: Support empty lang attribute

### DIFF
--- a/pkg/apps/watch-appstream.py
+++ b/pkg/apps/watch-appstream.py
@@ -99,10 +99,24 @@ def attr_lang(elt):
 
 
 def element(xml, tag):
-    if lang:
-        for elt in xml.iter(tag):
-            if attr_lang(elt) == lang:
-                return elt
+    """Get an XML element from the DOM tag
+
+    Retrieves the element with the matching language or by best effort
+    - If element has the selected language (or langauge selection is none), return it
+    - If the selected language can't be found, use empty language as a fallback
+    - If no elements are found with empty language attribute, use first element found
+    """
+
+    empty_lang = None
+    for elt in xml.iter(tag):
+        language = attr_lang(elt)
+        if language == lang:
+            return elt
+        elif language is None and empty_lang is None:
+            empty_lang = elt
+
+    if empty_lang is not None:
+        return empty_lang
     return xml.find(tag)
 
 

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -111,7 +111,7 @@ class TestApps(packagelib.PackageCase):
         # Install package metadata
         b.click(".pf-v6-c-alert button")
 
-        with b.wait_timeout(45):
+        with b.wait_timeout(60):
             b.wait_visible(".app-list #app-1")
             b.wait_not_present(".pf-v6-c-alert")
             b.click(".app-list #app-1")


### PR DESCRIPTION
When we look for a specific language for an element in AppStream, such
as Summary or Description, we first try to find the requested language
otherwise we fallback to the first element we found.

As the first item might not be the default language in some cases we
could get a format like this

```xml
<summary xml:lang="fr">Gestionnaire d'abonnement dans Cockpit</summary>
<summary>Subscription Manager in Cockpit</summary>
<summary xml:lang="it">Gestore abbonamenti nel Cockpit</summary>
<summary xml:lang="ja">Cockpit のサブスクリプションマネージャー</summary>
<summary xml:lang="ka">გამოწერების მმართველი Cockpit-ში</summary>
<summary xml:lang="ko">Cockpit 서브스크립션 관리자</summary>
<summary xml:lang="ru">Менеджер подписок в Cockpit</summary>
<summary xml:lang="zh-Hans-CN">Cockpit 中的订阅管理器</summary>
```

In this case we'd choose the first summary found which would be French
instead of English.

Instead, we can first look for the language we want, and if we found an
element without language attribute we use that as a fallback. If both
fail we still fallback to the first element found.

Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
