### PR TITLE
nav: Fix mobile spacing for System button

### DIFF
--- a/pkg/shell/nav.scss
+++ b/pkg/shell/nav.scss
@@ -579,6 +579,7 @@ $desktop: $phone + 1px;
   button.ct-nav-toggle,
   #nav-system-item > .pf-v6-c-button__text {
     // Remove gap between text and icon
+    --pf-v6-c-button--Gap: 0;
     --pf-v6-c-menu-toggle--Gap: 0;
     // Stretch to navbar
     block-size: 100%;


### PR DESCRIPTION
At some point we either changed the System button to a different
component or PatternFly started using a different CSS variable. Fixing
this is simple as we can also zero the button gap for the CSS grid.

Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
