### PR TITLE
PackageKit: specify a cache-age otherwise it is infinite by default

### DIFF
--- a/pkg/lib/_internal/packagekit.ts
+++ b/pkg/lib/_internal/packagekit.ts
@@ -22,6 +22,10 @@ export class PackageKitManager implements PackageManager {
         this.name = "packagekit";
     }
 
+    async init(): Promise<void> {
+        await PK.cancellableTransaction("SetHints", ["cache-age=86400"], null, null);
+    }
+
     /* Support for installing missing packages.
      *
      * First call check_missing_packages to determine whether something

--- a/pkg/lib/packagemanager.ts
+++ b/pkg/lib/packagemanager.ts
@@ -75,7 +75,9 @@ export async function getPackageManager(force_packagekit: boolean = false): Prom
 
     if (has_packagekit) {
         debug("constructing packagekit");
-        package_manager = new PackageKitManager();
+        let pk_manager = new PackageKitManager();
+        await pk_manager.init();
+        package_manager = pk_manager;
         return Promise.resolve(package_manager);
     }
 


### PR DESCRIPTION
Completely untested because I don't have a dev env to test but something like that should be enough to fix https://github.com/cockpit-project/cockpit/issues/23086 I believe.