### PR TITLE
storage: Don't ignore "edit excuse" when constructing key slot rows

### DIFF
--- a/pkg/storaged/crypto/keyslots.jsx
+++ b/pkg/storaged/crypto/keyslots.jsx
@@ -637,8 +637,8 @@ const RemoveClevisField = (tag, key, dev) => {
         render: (val, change) => {
             return (
                 <div data-field={tag}>
-                    <p>{ fmt_to_fragments(_("Remove $0?"), <b>{key.url}</b>) }</p>
-                    <p className="slot-warning">{ fmt_to_fragments(_("Keyserver removal may prevent unlocking $0."), <b>{dev}</b>) }</p>
+                    { key.url && <p>{ fmt_to_fragments(_("Remove $0?"), <b>{key.url}</b>) }</p> }
+                    <p className="slot-warning">{ fmt_to_fragments(_("Removal may prevent unlocking $0."), <b>{dev}</b>) }</p>
                 </div>
             );
         }
@@ -647,7 +647,7 @@ const RemoveClevisField = (tag, key, dev) => {
 
 function remove_clevis_dialog(client, block, key) {
     dialog_open({
-        Title: _("Remove Tang keyserver?"),
+        Title: key.url ? _("Remove Tang keyserver?") : cockpit.format(_("Remove key in slot $0?"), key.slot),
         Fields: [
             RemoveClevisField("keyserver", key, block_name(block))
         ],
@@ -720,11 +720,16 @@ export class CryptoKeyslots extends React.Component {
                         <Td>{desc}</Td>
                         <Td>{cockpit.format(_("Slot $0"), slot)}</Td>
                         <Td modifier="nowrap" className="pf-v6-c-table__action">
-                            <StorageButton onClick={edit}
+                            <StorageButton
+                                onClick={edit}
                                 ariaLabel={_("Edit")}
-                                excuse={(keys.length == max_slots)
-                                    ? _("Editing a key requires a free slot")
-                                    : null}>
+                                excuse={
+                                    edit_excuse ||
+                                        ((keys.length == max_slots)
+                                            ? _("Editing a key requires a free slot")
+                                            : null)
+                                }
+                            >
                                 <EditIcon />
                             </StorageButton>
                             { "\n" }
@@ -751,7 +756,7 @@ export class CryptoKeyslots extends React.Component {
                             () => remove_clevis_dialog(client, block, key));
                 } else {
                     add_row(key.slot,
-                            _("Unknown type"), "",
+                            _("Unknown type"), key.pin,
                             null, _("Key slots with unknown types can not be edited here"),
                             () => remove_clevis_dialog(client, block, key));
                 }

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -593,6 +593,19 @@ class TestStorageNBDE(storagelib.StorageCase, packagelib.PackageCase):
         b.wait_in_text(self.card_desc("Filesystem", "Mount point"), "after network")
         b.wait_in_text(self.card_desc("Encryption", "Options"), "_netdev")
 
+        # Add a clevis config that Cockpit doesn't understand, make
+        # sure it can't be edited but can be removed.
+        #
+        thp = tang_m.execute("tang-show-keys").strip()
+        m.execute(f"""echo vainu-reku-toma-rolle-kaja | clevis luks bind -d /dev/sda sss '{{"t":1,"pins":{{"tang":[{{"url":"10.111.112.5","thp":"{thp}"}}]}}}}'""")
+        b.wait_in_text(panel + "tr:nth-child(3)", "Unknown type")
+        b.wait_in_text(panel + "tr:nth-child(3)", "sss")
+        b.wait_visible(panel + "tr:nth-child(3) [aria-label='Edit']:disabled")
+        b.click(panel + 'tr:nth-child(3) button[aria-label="Remove"]')
+        b.wait_in_text("#dialog", "Remove key in slot 2?")
+        self.confirm()
+        b.wait_not_present(panel + "tr:nth-child(3)")
+
         # Mount it.  This should succeed without passphrase.
         #
         b.click(self.card_button("Filesystem", "Mount"))


### PR DESCRIPTION
We would let the user attempt to edit "Unknown type" slots, which would crash.

Fixes #23095
