### PR TITLE
tests: exclude vpd_use_hostno=0 on rhel-9

### DIFF
--- a/test/common/storagelib.py
+++ b/test/common/storagelib.py
@@ -48,7 +48,9 @@ class StorageHelpers(MachineCase):
         # sanity test: should not yet be loaded
         self.machine.execute("test ! -e /sys/module/scsi_debug")
         delay_option = f'ndelay={delay}' if delay else ''
-        self.machine.execute(f"modprobe scsi_debug dev_size_mb={size} vpd_use_hostno=0 {delay_option}")
+        # HACK: Don't set the vpd_use_hostno=0 on rhel-9, it is causing issues on c9s downstream release gating
+        vpd_use_hostno = "" if self.machine.image.startswith("rhel-9") else "vpd_use_hostno=0"
+        self.machine.execute(f"modprobe scsi_debug dev_size_mb={size} {vpd_use_hostno} {delay_option}")
         dev = self.machine.execute('while true; do O=$(ls /sys/bus/pseudo/drivers/scsi_debug/adapter*/host*/target*/*:*/block 2>/dev/null || true); '
                                    '[ -n "$O" ] && break || sleep 0.1; done; echo "/dev/$O"').strip()
         # don't use addCleanup() here, this is often busy and needs to be cleaned up late; done in MachineCase.nonDestructiveSetup()

--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -143,7 +143,9 @@ ExecStart=/usr/bin/sleep infinity
         wait_ratio_in_range(bar_selector, 0.0, 0.1)
 
         self.click_card_row("Storage", location=mount_point_bar)
-        b.wait_in_text(self.card_desc("Solid State Drive", "Serial number"), "2000")  # scsi_debug serial
+        # On rhel-9 we don't use the 'vpd_use_hostno=0' option so S/N is different
+        serial_num = "8000" if b.machine.image.startswith("rhel-9") else "2000"
+        b.wait_in_text(self.card_desc("Solid State Drive", "Serial number"), serial_num)  # scsi_debug serial
 
         # Remove fstab entry
 


### PR DESCRIPTION
It is causing issues on c9s downstream releases.
Quick fix because we need this, we'll revisit later.

* [x] https://github.com/cockpit-project/cockpit/pull/23143