### PR TITLE
packit: don't use fix-spec to change version in specfile

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -111,7 +111,7 @@ jobs:
           # for debugging of official runs, CLI is different from packit service
           env | grep PACKIT
           tar -xJf "${PACKIT_DOWNSTREAM_REPO:-${PACKIT_UPSTREAM_REPO}}/cockpit-${PACKIT_PROJECT_VERSION}.tar.xz" "cockpit-*/runtime-npm-modules.txt" --strip-components=1
-          tools/fix-spec "${PACKIT_DOWNSTREAM_REPO:-${PACKIT_UPSTREAM_REPO}}/cockpit.spec" "${PACKIT_PROJECT_VERSION}"
+          tools/fix-spec "${PACKIT_DOWNSTREAM_REPO:-${PACKIT_UPSTREAM_REPO}}/cockpit.spec"
           '
 
       fix-spec-file:

--- a/tools/fix-spec
+++ b/tools/fix-spec
@@ -12,7 +12,7 @@ PROVIDES=$(awk '{print "Provides: bundled(npm(" $1 ")) = " $2}' "${ROOT_DIR}/run
 awk -v p="$PROVIDES" 'gsub(/#NPM_PROVIDES/, p) 1' "$spec" > "$spec".new
 
 if [ -n "$version" ]; then
-    sed -i '/Version/ s/0/'"$version"'/' "$spec".new
+    sed -i '/Version/ s/\b0\b/'"$version"'/' "$spec".new
 fi
 
 mv -f "$spec".new "$spec"


### PR DESCRIPTION
As release of cockpit 360 showed the version in cockpit.spec is already set to the correct number. As a result the correct version was replaced as 360 -> 36360.