### PR TITLE
fix a critical in cockpit-ws on invalid "binary" for external channel

### DIFF
--- a/files.js
+++ b/files.js
@@ -58,7 +58,7 @@ const info = {
         "base1/test-dbus.js",
         "base1/test-echo.js",
         "base1/test-events.js",
-        "base1/test-external.js",
+        "base1/test-external.ts",
         "base1/test-file.ts",
         "base1/test-format.ts",
         "base1/test-framed-cache.js",

--- a/pkg/base1/test-external.js
+++ b/pkg/base1/test-external.js
@@ -2,39 +2,29 @@
 import cockpit from "cockpit";
 import QUnit from "qunit-tests";
 
-QUnit.test("external get", function (assert) {
-    const done = assert.async();
-    assert.expect(4);
+function channel_url(query) {
+    return "/cockpit/channel/" + cockpit.transport.csrf_token + "?" + window.btoa(JSON.stringify(query));
+}
 
-    /* The query string used to open the channel */
-    const query = window.btoa(JSON.stringify({
+QUnit.test("external get", async assert => {
+    const resp = await fetch(channel_url({
         payload: "fslist1",
         path: "/tmp",
         watch: false
     }));
 
-    const req = new XMLHttpRequest();
-    req.open("GET", "/cockpit/channel/" + cockpit.transport.csrf_token + '?' + query);
-    req.onreadystatechange = function() {
-        if (req.readyState == 4) {
-            assert.equal(req.status, 200, "got right status");
-            assert.equal(req.statusText, "OK", "got right reason");
-            assert.equal(req.getResponseHeader("Content-Type"), "application/octet-stream", "default type");
-            assert.ok(req.responseText.indexOf('"present"'), "got listing");
-            done();
-        }
-    };
-    req.send();
+    assert.equal(resp.status, 200, "got right status");
+    assert.equal(resp.statusText, "OK", "got right reason");
+    assert.equal(resp.headers.get("Content-Type"), "application/octet-stream", "default type");
+    const text = await resp.text();
+    assert.ok(text.indexOf('"present"'), "got listing");
 });
 
 QUnit.test("external fsread1", async assert => {
-    const done = assert.async();
-    assert.expect(5);
-    const resp = await cockpit.spawn(["stat", "--format", "%s", "/usr/lib/os-release"]);
-    const filesize = resp.replace(/\n$/, "");
+    const stat = await cockpit.spawn(["stat", "--format", "%s", "/usr/lib/os-release"]);
+    const filesize = stat.replace(/\n$/, "");
 
-    /* The query string used to open the channel */
-    const query = window.btoa(JSON.stringify({
+    const resp = await fetch(channel_url({
         payload: "fsread1",
         path: '/usr/lib/os-release',
         binary: "raw",
@@ -44,26 +34,15 @@ QUnit.test("external fsread1", async assert => {
         }
     }));
 
-    const req = new XMLHttpRequest();
-    req.open("GET", "/cockpit/channel/" + cockpit.transport.csrf_token + '?' + query);
-    req.onreadystatechange = function() {
-        if (req.readyState == 4) {
-            assert.equal(req.status, 200, "got right status");
-            assert.equal(req.statusText, "OK", "got right reason");
-            assert.equal(req.getResponseHeader("Content-Type"), "application/octet-stream", "default type");
-            assert.equal(req.getResponseHeader("Content-Disposition"), 'attachment; filename="foo"', "default type");
-            assert.equal(req.getResponseHeader("Content-Length"), parseInt(filesize), "expected file size");
-            done();
-        }
-    };
-    req.send();
+    assert.equal(resp.status, 200, "got right status");
+    assert.equal(resp.statusText, "OK", "got right reason");
+    assert.equal(resp.headers.get("Content-Type"), "application/octet-stream", "expected type");
+    assert.equal(resp.headers.get("Content-Disposition"), 'attachment; filename="foo"', "expected disposition");
+    assert.equal(resp.headers.get("Content-Length"), filesize, "expected file size");
 });
 
-QUnit.test("external headers", function (assert) {
-    const done = assert.async();
-    assert.expect(3);
-
-    const query = window.btoa(JSON.stringify({
+QUnit.test("external headers", async assert => {
+    const resp = await fetch(channel_url({
         payload: "fslist1",
         path: "/tmp",
         watch: false,
@@ -73,87 +52,52 @@ QUnit.test("external headers", function (assert) {
         },
     }));
 
-    const req = new XMLHttpRequest();
-    req.open("GET", "/cockpit/channel/" + cockpit.transport.csrf_token + '?' + query);
-    req.onreadystatechange = function() {
-        if (req.readyState == 4) {
-            assert.equal(this.status, 200, "got right status");
-            assert.equal(this.getResponseHeader("Content-Type"), "test/blah", "got type");
-            assert.equal(this.getResponseHeader("Content-Disposition"), "my disposition; blah", "got disposition");
-            done();
-        }
-    };
-    req.send();
+    assert.equal(resp.status, 200, "got right status");
+    assert.equal(resp.headers.get("Content-Type"), "test/blah", "got type");
+    assert.equal(resp.headers.get("Content-Disposition"), "my disposition; blah", "got disposition");
 });
 
-QUnit.test("external invalid", function (assert) {
-    const done = assert.async();
-    assert.expect(1);
-
-    const req = new XMLHttpRequest();
-    req.open("GET", "/cockpit/channel/invalid");
-    req.onreadystatechange = function() {
-        if (req.readyState == 4) {
-            assert.equal(this.status, 404, "got not found");
-            done();
-        }
-    };
-    req.send();
+QUnit.test("external invalid", async assert => {
+    const resp = await fetch("/cockpit/channel/invalid");
+    assert.equal(resp.status, 404, "got not found");
 });
 
-QUnit.test("external no token", function (assert) {
-    const done = assert.async();
-    assert.expect(1);
-
-    /* The query string used to open the channel */
+QUnit.test("external no token", async assert => {
     const query = window.btoa(JSON.stringify({
         payload: "fslist1",
         path: "/tmp",
         watch: false
     }));
 
-    const req = new XMLHttpRequest();
-    req.open("GET", "/cockpit/channel/?" + query);
-    req.onreadystatechange = function() {
-        if (req.readyState == 4) {
-            assert.equal(this.status, 404, "got not found");
-            done();
-        }
-    };
-    req.send();
+    const resp = await fetch("/cockpit/channel/?" + query);
+    assert.equal(resp.status, 404, "got not found");
 });
 
-QUnit.test("external websocket", function (assert) {
-    const done = assert.async();
-    assert.expect(3);
-
+QUnit.test("external websocket", async assert => {
     const query = window.btoa(JSON.stringify({
         payload: "echo"
     }));
 
-    let count = 0;
     const ws = new WebSocket("ws://" + window.location.host + "/cockpit/channel/" +
                              cockpit.transport.csrf_token + '?' + query, "protocol-unused");
-    ws.onopen = function() {
-        assert.ok(true, "websocket is open");
+
+    await new Promise((resolve, reject) => {
+        ws.onopen = resolve;
+        ws.onerror = reject;
+    });
+    assert.ok(true, "websocket is open");
+
+    try {
         ws.send("oh marmalade");
-    };
-    ws.onerror = function() {
-        assert.ok(false, "websocket error");
-    };
-    ws.onmessage = function(ev) {
-        if (count === 0) {
-            assert.equal(ev.data, "oh marmalade", "got payload");
-            ws.send("another test");
-            count += 1;
-        } else {
-            assert.equal(ev.data, "another test", "got payload again");
-            ws.close(1000);
-        }
-    };
-    ws.onclose = function() {
-        done();
-    };
+        let ev = await new Promise(resolve => { ws.onmessage = resolve });
+        assert.equal(ev.data, "oh marmalade", "got payload");
+
+        ws.send("another test");
+        ev = await new Promise(resolve => { ws.onmessage = resolve });
+        assert.equal(ev.data, "another test", "got payload again");
+    } finally {
+        ws.close(1000);
+    }
 });
 
 cockpit.transport.wait(function() {

--- a/pkg/base1/test-external.ts
+++ b/pkg/base1/test-external.ts
@@ -2,7 +2,15 @@
 import cockpit from "cockpit";
 import QUnit from "qunit-tests";
 
-function channel_url(query) {
+interface ChannelOptions {
+    payload: string;
+    path?: string;
+    watch?: boolean;
+    binary?: string;
+    external?: Record<string, string>;
+}
+
+function channel_url(query: ChannelOptions): string {
     return "/cockpit/channel/" + cockpit.transport.csrf_token + "?" + window.btoa(JSON.stringify(query));
 }
 
@@ -81,19 +89,19 @@ QUnit.test("external websocket", async assert => {
     const ws = new WebSocket("ws://" + window.location.host + "/cockpit/channel/" +
                              cockpit.transport.csrf_token + '?' + query, "protocol-unused");
 
-    await new Promise((resolve, reject) => {
-        ws.onopen = resolve;
-        ws.onerror = reject;
+    await new Promise<void>((resolve, reject) => {
+        ws.onopen = () => resolve();
+        ws.onerror = () => reject(new Error("WebSocket connection failed"));
     });
     assert.ok(true, "websocket is open");
 
     try {
         ws.send("oh marmalade");
-        let ev = await new Promise(resolve => { ws.onmessage = resolve });
+        let ev = await new Promise<MessageEvent>(resolve => { ws.onmessage = resolve });
         assert.equal(ev.data, "oh marmalade", "got payload");
 
         ws.send("another test");
-        ev = await new Promise(resolve => { ws.onmessage = resolve });
+        ev = await new Promise<MessageEvent>(resolve => { ws.onmessage = resolve });
         assert.equal(ev.data, "another test", "got payload again");
     } finally {
         ws.close(1000);

--- a/pkg/base1/test-external.ts
+++ b/pkg/base1/test-external.ts
@@ -6,7 +6,7 @@ interface ChannelOptions {
     payload: string;
     path?: string;
     watch?: boolean;
-    binary?: string;
+    binary?: string | boolean | null;
     external?: Record<string, string>;
 }
 
@@ -47,6 +47,74 @@ QUnit.test("external fsread1", async assert => {
     assert.equal(resp.headers.get("Content-Type"), "application/octet-stream", "expected type");
     assert.equal(resp.headers.get("Content-Disposition"), 'attachment; filename="foo"', "expected disposition");
     assert.equal(resp.headers.get("Content-Length"), filesize, "expected file size");
+});
+
+QUnit.test("external content-type default with binary:raw", async assert => {
+    const resp = await fetch(channel_url({
+        payload: "fslist1",
+        path: "/tmp",
+        watch: false,
+        binary: "raw",
+    }));
+
+    assert.equal(resp.status, 200, "got right status");
+    assert.equal(resp.headers.get("Content-Type"), "application/octet-stream", "default type for binary channel");
+});
+
+QUnit.module("tests that need test-server warnings disabled", hooks => {
+    hooks.before(async () => { await fetch("/mock/expect-warnings") });
+    hooks.after(async () => { await fetch("/mock/dont-expect-warnings") });
+
+    QUnit.test("external rejects binary:empty-string", async assert => {
+        const resp = await fetch(channel_url({
+            payload: "fslist1",
+            path: "/tmp",
+            watch: false,
+            binary: "",
+        }));
+
+        // This should ideally be a 400 (rejected by -ws itself), but
+        // currently -ws accepts any string and forwards it to the bridge,
+        // which rejects it as a protocol error, resulting in a 500.
+        assert.ok(resp.status === 400 || resp.status === 500, "empty string rejected");
+    });
+
+    QUnit.test("external rejects binary:false", async assert => {
+        const resp = await fetch(channel_url({
+            payload: "fslist1",
+            path: "/tmp",
+            watch: false,
+            binary: false,
+        }));
+
+        assert.equal(resp.status, 400, "false rejected");
+    });
+
+    QUnit.test("external rejects binary:null", async assert => {
+        const resp = await fetch(channel_url({
+            payload: "fslist1",
+            path: "/tmp",
+            watch: false,
+            binary: null,
+        }));
+
+        assert.equal(resp.status, 400, "null rejected");
+    });
+});
+
+QUnit.test("external ignores mixed-case Content-Type", async assert => {
+    const resp = await fetch(channel_url({
+        payload: "fslist1",
+        path: "/tmp",
+        watch: false,
+        external: {
+            "Content-Type": "text/fancy",
+        },
+    }));
+
+    assert.equal(resp.status, 200, "got right status");
+    assert.equal(resp.headers.get("Content-Type"), "application/octet-stream",
+                 "only lowercase 'content-type' key is recognized");
 });
 
 QUnit.test("external headers", async assert => {

--- a/pkg/base1/test-protocol.ts
+++ b/pkg/base1/test-protocol.ts
@@ -75,6 +75,25 @@ QUnit.test("host must ensure that init is the first message", async assert => {
     assert.equal(message.problem, "protocol-error");
 });
 
+QUnit.test("host tolerates payload message before init", async assert => {
+    const ws = await connect();
+    await read_control(ws); // skip the init
+
+    // send payload message before init — the server should reject this
+    // with a protocol-error (like it does for control messages before
+    // init) but currently it silently ignores it.
+    ws.send("somechannel\npayload");
+
+    // connection should still work
+    send_control(ws, { command: "init", version: 1 });
+    send_control(ws, { command: "ping", still: "alive" });
+    const pong = await read_control(ws);
+    assert.equal(pong.command, "pong");
+    assert.equal(pong.still, "alive");
+
+    ws.close();
+});
+
 QUnit.test("server accepts extra init messages", async assert => {
     /* Old versions of the shell used to accidentally forward the init message
      * from each iframe to the webserver, and since a new webserver may be used
@@ -125,6 +144,95 @@ QUnit.module("tests that need test-server warnings disabled", hooks => {
         send_control(ws, { command: "open", payload: "fsread", path: "/etc/passwd" });
 
         // wait for the shutdown
+        const message = await wait_close(ws);
+        assert.equal(message.command, "close");
+        assert.equal(message.problem, "protocol-error");
+    });
+
+    QUnit.test("host ignores frame without newline", async assert => {
+        const ws = await connect();
+        await read_control(ws); // skip the init
+
+        send_control(ws, { command: "init", version: 1 });
+
+        // send a frame without a newline — this should be a
+        // protocol-error, but currently it's silently ignored.
+        ws.send("no newline here");
+
+        // connection should still work - verify with ping/pong
+        send_control(ws, { command: "ping", test: "still-alive" });
+        const pong = await read_control(ws);
+        assert.equal(pong.command, "pong");
+        assert.equal(pong.test, "still-alive");
+
+        ws.close();
+    });
+
+    QUnit.test("host rejects control message that is not an object (array)", async assert => {
+        const ws = await connect();
+        await read_control(ws); // skip the init
+
+        send_control(ws, { command: "init", version: 1 });
+
+        // send a control message that's an array, not an object
+        ws.send("\n[1, 2, 3]");
+
+        const message = await wait_close(ws);
+        assert.equal(message.command, "close");
+        assert.equal(message.problem, "protocol-error");
+    });
+
+    QUnit.test("host rejects control message that is not an object (null)", async assert => {
+        const ws = await connect();
+        await read_control(ws); // skip the init
+
+        send_control(ws, { command: "init", version: 1 });
+
+        // send a control message that's null
+        ws.send("\nnull");
+
+        const message = await wait_close(ws);
+        assert.equal(message.command, "close");
+        assert.equal(message.problem, "protocol-error");
+    });
+
+    QUnit.test("host rejects control message with invalid JSON", async assert => {
+        const ws = await connect();
+        await read_control(ws); // skip the init
+
+        send_control(ws, { command: "init", version: 1 });
+
+        // send invalid JSON
+        ws.send("\n{not valid json}");
+
+        const message = await wait_close(ws);
+        assert.equal(message.command, "close");
+        assert.equal(message.problem, "protocol-error");
+    });
+
+    QUnit.test("host rejects control message without command", async assert => {
+        const ws = await connect();
+        await read_control(ws); // skip the init
+
+        send_control(ws, { command: "init", version: 1 });
+
+        // send a control message without "command" field
+        ws.send('\n{"channel": "test"}');
+
+        const message = await wait_close(ws);
+        assert.equal(message.command, "close");
+        assert.equal(message.problem, "protocol-error");
+    });
+
+    QUnit.test("host rejects empty control message", async assert => {
+        const ws = await connect();
+        await read_control(ws); // skip the init
+
+        send_control(ws, { command: "init", version: 1 });
+
+        // send an empty object as a control message
+        ws.send("\n{}");
+
         const message = await wait_close(ws);
         assert.equal(message.command, "close");
         assert.equal(message.problem, "protocol-error");

--- a/src/ws/cockpitchannelresponse.c
+++ b/src/ws/cockpitchannelresponse.c
@@ -770,7 +770,11 @@ cockpit_channel_response_open (CockpitWebService *service,
   if (!content_type)
     {
       if (!cockpit_web_service_parse_binary (open, &data_type))
-        g_return_if_reached ();
+        {
+          cockpit_web_response_error (response, 400, NULL, "Bad channel request");
+          g_hash_table_unref (headers);
+          return;
+        }
       if (data_type == WEB_SOCKET_DATA_TEXT)
         content_type = "text/plain";
       else


### PR DESCRIPTION
...and add some weird edgecase qunit tests, porting another file to async/TS in the process.