### PR TITLE
testlib: Recognize one more error caused by page reloads

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -831,6 +831,7 @@ class Browser:
                     "execution contexts cleared",
                     # firefox
                     "MessageHandlerFrame' destroyed",
+                    "DiscardedBrowsingContextError",
                     # page helpers not yet loaded
                     "ph_wait_cond is not defined",
                    ]):


### PR DESCRIPTION
I have seen this here: https://logs-cockpit.apps.ocp.cloud.ci.centos.org/pull-23115-1abe6765-20260413-060832-fedora-43-firefox-storage/log.html