### PR TITLE
apps: fix a race in watch-appstream.py

### DIFF
--- a/pkg/apps/watch-appstream.py
+++ b/pkg/apps/watch-appstream.py
@@ -52,11 +52,11 @@ class Watcher:
 
         def handler(mask, name):
             if ((mask & IN_CREATE or mask & IN_MOVED_TO) and
-                    cur_wait and name == cur_wait):
+                    cur_wait_name and name == cur_wait_name):
                 reset()
             elif mask & (IN_DELETE_SELF | IN_MOVE_SELF):
                 reset()
-            elif not cur_wait and len(name) > 0:
+            elif not cur_wait_name and len(name) > 0:
                 if mask & (IN_CLOSE_WRITE | IN_MOVED_TO | IN_DELETE | IN_MOVED_FROM):
                     callback(os.path.join(path, name))
 
@@ -65,14 +65,21 @@ class Watcher:
             self.watch_directory(path, callback)
 
         cur_path = path
-        cur_wait = None
+        cur_wait_path = None
+        cur_wait_name = None
         while not os.path.exists(cur_path):
-            cur_wait = os.path.basename(cur_path)
+            cur_wait_path = cur_path
+            cur_wait_name = os.path.basename(cur_wait_path)
             cur_path = os.path.dirname(cur_path)
 
         self.__add_watch(cur_path, events, handler)
 
-        if not cur_wait:
+        if cur_wait_path and os.path.exists(cur_wait_path):
+            # Directory was created between our check and the watch setup
+            reset()
+            return
+
+        if not cur_wait_name:
             for f in os.listdir(cur_path):
                 callback(os.path.join(cur_path, f))
 


### PR DESCRIPTION
We have a recursive directory-watching rig which uses inotify to watch for files in a directory and also supports situations where the directories don't exist to start with.  We attempt to that that in `TestApps.testBasic` by deleting the directories and waiting for them to be created by appstream.

Unfortunately this code contains a race: if we find a directory missing, we register a watch for it and wait for it to appear.  We don't check if the directory got created before our watch was established though, which means we could end up waiting forever.  The test is also arranged in such a way that these two things happen at approximately the same time.

Let's double-check after establishing the watch: if the path exists, reset() the watch to start the process from the start.  It's not the most elegant way to do this, but it should hopefully be rare.

This should hopefully solve one of our most common current flakes.  Even if it doesn't, it's a bug that deserves to be fixed.

Assisted-by: Claude Opus 4.6