### PR TITLE
flatpak: Filter out links from description

### DIFF
--- a/containers/flatpak/add-release
+++ b/containers/flatpak/add-release
@@ -9,7 +9,7 @@ import xml.etree.ElementTree as ET
 # Pretend like this is a little bit functional
 def element(tag, text=None, children=(), **kwargs):
     tag = ET.Element(tag, kwargs)
-    tag.text = text
+    tag.text = text if text is None else re.sub(r'\S+http\S+', '', text).strip()
     tag.extend(children)
     return tag
 


### PR DESCRIPTION
Within the changelog we cannot have URLs within changelog entries
themselves, instead FlatHub needs us to have all links within the URL
element itself.

As we already have a tag now that includes plaintext links - which we
didn't before - we need to filter this out to prevent the changelog to
update with data that fails validation.

Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
