### PR TITLE
unit tests: Don't load cockpit.js in the qunit HTML template

### DIFF
--- a/pkg/lib/qunit-template.html.in
+++ b/pkg/lib/qunit-template.html.in
@@ -8,7 +8,6 @@ SPDX-License-Identifier: LGPL-2.1-or-later
     <meta charset="utf-8" />
     <title>%title%</title>
     <link rel="stylesheet" href="%title%.css" type="text/css" />
-    <script src="%builddir%dist/base1/cockpit.js"></script>
     <script src="%script%"></script>
 </head>
 <body class="pf-v6-m-tabular-nums">


### PR DESCRIPTION
The tests are in the "pkg/base1/" directory, which means that "build.js" will include pkg/lib/cockpit.js into their bundles (when they import it) and they don't need to also load it dynamically via their HTML.