### PR TITLE
lib: drop `propTypes` from TypeScript components

### DIFF
--- a/pkg/lib/cockpit-components-dropdown.tsx
+++ b/pkg/lib/cockpit-components-dropdown.tsx
@@ -4,7 +4,6 @@
  */
 
 import React, { useState } from 'react';
-import PropTypes from "prop-types";
 
 import { MenuToggle } from "@patternfly/react-core/dist/esm/components/MenuToggle";
 import { Dropdown, DropdownList, DropdownPopperProps } from "@patternfly/react-core/dist/esm/components/Dropdown";
@@ -57,13 +56,4 @@ export const KebabDropdown = ({ dropdownItems, position = "end", isDisabled = fa
             </DropdownList>
         </Dropdown>
     );
-};
-
-KebabDropdown.propTypes = {
-    dropdownItems: PropTypes.array.isRequired,
-    isDisabled: PropTypes.bool,
-    toggleButtonId: PropTypes.string,
-    position: PropTypes.oneOf(['right', 'left', 'center', 'start', 'end']),
-    isOpen: PropTypes.bool,
-    setIsOpen: PropTypes.func,
 };

--- a/pkg/lib/cockpit-components-empty-state.tsx
+++ b/pkg/lib/cockpit-components-empty-state.tsx
@@ -4,7 +4,6 @@
  */
 
 import React from "react";
-import PropTypes from 'prop-types';
 import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
 import type { ButtonProps } from "@patternfly/react-core/dist/esm/components/Button/index.js";
 import {
@@ -59,16 +58,4 @@ export const EmptyStatePanel = ({
                 </EmptyStateFooter>}
         </EmptyState>
     );
-};
-
-EmptyStatePanel.propTypes = {
-    loading: PropTypes.bool,
-    icon: PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.func]),
-    title: PropTypes.string,
-    paragraph: PropTypes.node,
-    action: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
-    actionVariant: PropTypes.string,
-    isActionInProgress: PropTypes.bool,
-    onAction: PropTypes.func,
-    secondary: PropTypes.node,
 };

--- a/pkg/lib/cockpit-components-inline-notification.tsx
+++ b/pkg/lib/cockpit-components-inline-notification.tsx
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 import React, { useState } from 'react';
-import PropTypes from 'prop-types';
 import cockpit from 'cockpit';
 
 import { Alert, AlertActionCloseButton, AlertProps } from "@patternfly/react-core/dist/esm/components/Alert/index.js";
@@ -44,15 +43,6 @@ export const InlineNotification = ({ text, detail, type = "danger", onDismiss, i
             {isDetail && (<p>{detail}</p>)}
         </Alert>
     );
-};
-
-InlineNotification.propTypes = {
-    onDismiss: PropTypes.func,
-    isInline: PropTypes.bool,
-    text: PropTypes.string.isRequired, // main information to render
-    detail: PropTypes.string, // optional, more detailed information. If empty, the more/less button is not rendered.
-    type: PropTypes.string,
-    isLiveRegion: PropTypes.bool,
 };
 
 export const ModalError = ({ dialogError, dialogErrorDetail, id, isExpandable }: {


### PR DESCRIPTION
`propTypes` are deprecated and will be removed from React 19 as these components are already in TypeScript and thus having type guarantees / hints for users.

---

With this change cockpit-files no longer has a runtime dependency on `prop-types` npm modules shaving off some bundle size.