### PR TITLE
cockpit-desktop: check if cockpit-bridge exists

### DIFF
--- a/src/ws/cockpit-desktop.in
+++ b/src/ws/cockpit-desktop.in
@@ -105,6 +105,11 @@ esac
 
 detect_browser
 
+if ! ${2:+ssh "$2"} command -v cockpit-bridge >/dev/null 2>&1; then
+    echo "cockpit-bridge is not installed${2:+ on $2}" >&2
+    exit 1
+fi
+
 # start the bridge; this needs to run in the normal user session/namespace
 coproc ${2:+ssh "$2"} cockpit-bridge
 trap "kill $COPROC_PID; wait $COPROC_PID || true" EXIT INT QUIT PIPE


### PR DESCRIPTION
Check it upfront so the user does not have to wade through a wall of error messages. Nor does the opened browser so an error message but just "Internal error in login process" if cockpit-ws is installed locally.

Fixes: #20766