### PR TITLE
test: Avoid browser connection interruptions

### DIFF
--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -1228,7 +1228,13 @@ until pgrep -f '^(/usr/[^ ]+/[^ /]*python[^ /]* )?/usr/bin/cockpit-bridge'; do s
         m.spawn(f"runuser -u cockpit-session-socket -- {self.ws_executable} --for-tls-proxy -p 9099 -a 127.0.0.1",
                 "ws-fortlsproxy.log")
         m.wait_for_cockpit_running(tls=True)
-        b.open(f"https://{b.address}:{b.port}/system")
+        # Firefox does not handle connection interruptions well, retry once when opening fails.
+        try:
+            b.open(f"https://{b.address}:{b.port}/system")
+        except testlib.Error as exc:
+            if 'NS_ERROR' in str(exc):
+                b.open(f"https://{b.address}:{b.port}/system")
+
         b.wait_visible("#login")
         b.set_val("#login-user-input", "admin")
         b.set_val("#login-password-input", "foobar")


### PR DESCRIPTION
    Firefox is less tolerant in connection interruptions when `cockpit-ws`
    is killed throwing `NS_ERROR_NET_INTERRUPT`. As Cockpit's job is not
    testing Firefox itself, work around this by first switching to a
    different page and then killing cockpit-ws so Firefox does not trip over
    interrupted connections by killing `cockpit-ws`.


---

[check-connection TestConnection.testReverseProxy](https://ci-weather-cockpit.apps.ocp.cloud.ci.centos.org/tests.html?repo=cockpit-project%2Fcockpit&days=5#)	fedora-43/firefox-networking	53.33	[log](https://logs-cockpit.apps.ocp.cloud.ci.centos.org/pull-23102-9d4c70c7-20260415-065042-fedora-43-firefox-networking/log.html)[log](https://logs-cockpit.apps.ocp.cloud.ci.centos.org/pull-23102-9d4c70c7-20260414-141418-fedora-43-firefox-networking/log.html)