### PR TITLE
dependabot: Ignore major TypeScript versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,6 +51,11 @@ updates:
       - dependency-name: "eslint"
         update-types: ["version-update:semver-major"]
 
+      # The TypeScript toolchain takes a while to update to a major version
+      # Manually update to major TypeScript versions
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+
   - package-ecosystem: "github-actions"
     directory: "/"
     open-pull-requests-limit: 3


### PR DESCRIPTION
Major TS versions usually break the infra we have due to all the
dependencies we use that utilize TypeScript. Should be a manual update
when needed or warranted due to the issues with other packages.

Signed-off-by: Freya Gustavsson <freya@venefilyn.se>

Related to https://github.com/cockpit-project/cockpit/pull/23071
