### PR TITLE
sudo-rs password dialog adjustments

### DIFF
--- a/pkg/lib/superuser-dialogs.tsx
+++ b/pkg/lib/superuser-dialogs.tsx
@@ -42,7 +42,7 @@ function sudo_polish(msg: string | null): string | null {
     if (!msg)
         return msg;
 
-    msg = msg.replace(/^\[sudo] /, "");
+    msg = msg.replace(/^\[sudo(: authenticate)?] /, "");
     msg = msg[0].toUpperCase() + msg.slice(1);
 
     return msg;

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1149,7 +1149,7 @@ class Browser:
                 self.click("div[role=dialog] .pf-v6-c-modal-box__footer button")
             else:
                 self.wait_in_text("div[role=dialog]", "Switch to administrative access")
-                self.wait_in_text("div[role=dialog]", f"Password for {user}:")
+                self.wait_in_text("div[role=dialog]", "Password")
                 self.set_input_text("div[role=dialog] input", password or "foobar")
                 self.click("div[role=dialog] button.pf-m-primary")
 


### PR DESCRIPTION
Fixes:

<img width="845" height="207" alt="image" src="https://github.com/user-attachments/assets/eed363c3-8848-4cb5-873a-c36bd501c98c" />

And also the podman [test failure](https://logs-cockpit.apps.ocp.cloud.ci.centos.org/pull-8910-9a3468ad-20260417-093152-ubuntu-2604-cockpit-project-cockpit-podman/log.html)