### PR TITLE
test/common: Increase memory for non-destructive VMs to 2 GiB

### DIFF
--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -694,7 +694,7 @@ def main() -> int:
         "--nondestructive-cpus", type=int, default=None, help="Number of CPUs for nondestructive test global machines"
     )
     parser.add_argument(
-        "--nondestructive-memory-mb", type=int, default=DEFAULT_MACHINE_MEMORY_MB,
+        "--nondestructive-memory-mb", type=int, default=2048,
         help="RAM size for nondestructive test global machines (default: %(default)s MB)",
     )
     parser.add_argument(
@@ -733,11 +733,6 @@ def main() -> int:
     image = testvm.DEFAULT_IMAGE
     testvm.DEFAULT_IMAGE = image
     os.environ["TEST_OS"] = image
-
-    # on RHEL 8, provide enough RAM for cryptsetup's PBKDF (https://issues.redhat.com/browse/RHEL-8258)
-    # On any newer OS, cryptsetup gets along with less RAM
-    if image.startswith("rhel-8") and opts.nondestructive_memory_mb == DEFAULT_MACHINE_MEMORY_MB:
-        opts.nondestructive_memory_mb = 1400
 
     # Make sure tests can make relative imports
     sys.path.append(os.path.realpath(opts.test_dir))


### PR DESCRIPTION
Destructive machines can help themselves when they need more memory via the "provision" declarations, but non-destructive ones can not so easily.

Let's go with the times finally and make our lives easier, at least until we have a mechanism where a non-destructive test can ask for more memory.