### PR TITLE
test: Only wait 10s before providing a password during boot

### DIFF
--- a/test/common/storagelib.py
+++ b/test/common/storagelib.py
@@ -443,7 +443,7 @@ class StorageHelpers(MachineCase):
                         f"""#!/bin/sh
 # Sleep a bit to avoid starting this agent too quickly over and over,
 # and so that other agents get a chance as well.
-sleep 30
+sleep 10
 
 for s in $(grep -h ^Socket= /run/systemd/ask-password/ask.* | sed 's/^Socket=//'); do
   printf '%s' '{password}' | /usr/lib/systemd/systemd-reply-password 1 $s


### PR DESCRIPTION
Otherwise the jobs that wait for Stratis filesystem devices might time out. They only wait 45 seconds on Fedora 43 (at least), and wasting 30 seconds of that is apparently too much sometimes.