### PR TITLE
debian: Drop static user cleanup

### DIFF
--- a/tools/debian/cockpit-ws.postinst
+++ b/tools/debian/cockpit-ws.postinst
@@ -10,12 +10,6 @@ if [ "$1" = "configure" ] && dpkg-statoverride --list /usr/lib/cockpit/cockpit-s
     chgrp root /usr/lib/cockpit/cockpit-session
 fi
 
-# remove obsolete system user on upgrade (replaced with DynamicUser in version 330)
-if [ "$1" = "configure" ] && getent passwd cockpit-wsinstance >/dev/null; then
-    echo "Cleaning up obsolete static cockpit-wsinstance user"
-    deluser --system cockpit-wsinstance
-fi
-
 # restart cockpit.service on package upgrades, if it's already running
 if [ -d /run/systemd/system ] && [ -n "$2" ]; then
     deb-systemd-invoke try-restart cockpit.service >/dev/null || true

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -138,7 +138,6 @@ Package: cockpit-ws
 Architecture: any
 Depends: ${misc:Depends},
          ${shlibs:Depends},
-         adduser,
          openssl,
          libnss-systemd,
 Suggests: sssd-dbus (>= 2.6.2),

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -28,7 +28,7 @@ Build-Depends: asciidoctor,
                python3-pytest-timeout <!nocheck>,
 Build-Depends-Indep: esbuild,
                      nodejs,
-Standards-Version: 4.7.3
+Standards-Version: 4.7.4
 Homepage: https://cockpit-project.org/
 Vcs-Git: https://salsa.debian.org/utopia-team/cockpit.git
 Vcs-Browser: https://salsa.debian.org/utopia-team/cockpit

--- a/tools/debian/tests/control
+++ b/tools/debian/tests/control
@@ -1,6 +1,5 @@
 Tests: smoke
 Depends: cockpit,
          curl,
-         adduser,
 Restrictions: isolation-container,
               needs-sudo,


### PR DESCRIPTION
The cockpit-wsinstance static user was replaced with DynamicUser in version 330. Cleaning up the obsolete user on upgrade is no longer necessary, as Debian stable already ships version 337. Drop both the workaround and the adduser dependency.

----

By way of https://salsa.debian.org/utopia-team/cockpit/-/merge_requests/5 , thanks @bluca!

This transitional code is still relevant for the Ubuntu 24.04 → 26.04 LTS upgrade, see https://launchpad.net/ubuntu/+source/cockpit . [Release is on April 23](https://documentation.ubuntu.com/release-notes/26.04/schedule/), and cockpit 361 was just released yesterday, so this can go in now.