### PR TITLE
packit: Use empty string for `fix-spec-file`

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -103,7 +103,7 @@ jobs:
           tools/fix-spec "${PACKIT_DOWNSTREAM_REPO:-${PACKIT_UPSTREAM_REPO}}/cockpit.spec"
           '
 
-      fix-spec-file: null
+      fix-spec-file: ""
   - job: propose_downstream
     trigger: release
     actions: *official_release_actions


### PR DESCRIPTION
We had another failure with Packit release infra where Packit workflow
failed due to type incorrectly being `None` where it needs to be either
string or list.

Checking with Packit team again and they apologized and proposed we just
use empty string. This took place in ther Matrix.

Signed-off-by: Freya Gustavsson <freya@venefilyn.se>


Failed workflows:
- https://dashboard.packit.dev/jobs/srpm/588790