### PR TITLE
networkmanager: adapt networking pages for Anaconda iframe

### DIFF
--- a/pkg/lib/anaconda/_anaconda.scss
+++ b/pkg/lib/anaconda/_anaconda.scss
@@ -1,0 +1,57 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+@use "../global-variables" as *;
+
+/*
+ * Mixins for Cockpit pages embedded in Anaconda (iframe).
+ * Each page's *-anaconda.scss should @include these under its own root selector(s).
+ */
+
+@mixin embedded-page-shell {
+  .pf-v6-c-page__main-container {
+    border-radius: 0;
+    margin: 0;
+    border: 0;
+    max-block-size: 100%;
+  }
+
+  // ignore cockpit override for mobile layout
+  @media screen and (max-width: $pf-v6-global--breakpoint--md) {
+    .pf-v6-c-page__main > section.pf-v6-c-page__main-section:not(.pf-m-padding) {
+      padding-inline: 0;
+    }
+  }
+
+  .pf-v6-c-page__main {
+    padding-inline: var(--pf-t--global--spacer--gap--group-to-group--vertical--default);
+  }
+
+  .pf-v6-c-page {
+    --pf-v6-c-page--BackgroundColor: var(--pf-t--global--background--color--primary--default);
+  }
+
+  .pf-v6-c-card {
+    --pf-v6-c-card--BorderColor: transparent;
+  }
+
+  // Approximates PageSection padding={{ default: "noPadding" }} isFilled={false} (PF .pf-m-no-padding / .pf-m-no-fill)
+  .pf-v6-c-page__main-section {
+    flex-grow: 0;
+    padding: 0;
+  }
+}
+
+// Emit at stylesheet root (once per bundle that needs it).
+@mixin anaconda-body-overflow-hack {
+  /*
+   * HACK - https://github.com/patternfly/patternfly-react/issues/11987
+   * Allow scrolling if a dropdown menu gets positioned outside the bounds of the window.
+   * Easier to reproduce on 1080p or lower resolutions.
+   * See https://bugzilla.redhat.com/show_bug.cgi?id=2388785
+   */
+  body:has(.anaconda) {
+    overflow-y: auto !important;
+    // containers like pf-v6-c-page won't expand with the viewport when dropdown menus are created
+    background: var(--pf-t--global--background--color--primary--default);
+  }
+}

--- a/pkg/lib/utils.tsx
+++ b/pkg/lib/utils.tsx
@@ -54,6 +54,32 @@ function try_fields(
  *      "platform:el9": { "color": "red" }
  *  }
  */
+
+/** Parse `sessionStorage.cockpit_anaconda` as JSON (storaged uses the object when present). */
+export function read_anaconda_session_storage(): cockpit.JsonValue | null {
+    try {
+        const value = JSON.parse(
+            window.sessionStorage.getItem("cockpit_anaconda") as string
+        ) as cockpit.JsonValue;
+        if (value)
+            console.log("ANACONDA", value);
+        return value;
+    } catch {
+        console.warn("Can't parse cockpit_anaconda configuration as JSON");
+        return null;
+    }
+}
+
+/** True when embedded in Anaconda (parent sets JSON in sessionStorage `cockpit_anaconda`). */
+export function in_anaconda_mode(): boolean {
+    try {
+        const raw = window.sessionStorage.getItem("cockpit_anaconda");
+        return !!JSON.parse(raw ?? "null");
+    } catch {
+        return false;
+    }
+}
+
 export function get_manifest_config_matchlist(
     manifest_name: string, config_name: string, default_value: cockpit.JsonValue, matches: (string | undefined)[]
 ): cockpit.JsonValue {

--- a/pkg/networkmanager/network-anaconda.scss
+++ b/pkg/networkmanager/network-anaconda.scss
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+@use "../lib/anaconda/anaconda" as anaconda;
+
+#networking.anaconda,
+#network-interface.anaconda {
+  @include anaconda.embedded-page-shell;
+}
+
+// Main networking overview only: omit graphs and journal noise in the installer
+#networking.anaconda #networking-graphs,
+#networking.anaconda .cockpit-log-panel {
+  display: none;
+}
+
+@include anaconda.anaconda-body-overflow-hack;

--- a/pkg/networkmanager/network-interface.jsx
+++ b/pkg/networkmanager/network-interface.jsx
@@ -36,7 +36,7 @@ import { KebabDropdown } from "cockpit-components-dropdown";
 import { ListingTable } from "cockpit-components-table.jsx";
 import { Privileged } from "cockpit-components-privileged";
 import { distanceToNow } from "timeformat";
-import { fmt_to_fragments } from 'utils.jsx';
+import { fmt_to_fragments, in_anaconda_mode } from "utils";
 import { useDialogs } from "dialogs.jsx";
 
 import { ModelContext } from './model-context.jsx';
@@ -1208,10 +1208,12 @@ export const NetworkInterfacePage = ({
     const settingsRows = renderConnectionSettingsRows(iface.MainConnection, connectionSettings)
             .map((component, idx) => <React.Fragment key={idx}>{component}</React.Fragment>);
 
+    const anaconda = in_anaconda_mode();
+
     return (
         <Page id="network-interface"
               data-test-wait={operationInProgress}
-              className="pf-m-no-sidebar">
+              className={"pf-m-no-sidebar" + (anaconda ? " anaconda" : "")}>
             <PageBreadcrumb hasBodyWrapper={false} stickyOnBreakpoint={{ default: "top" }}>
                 <Breadcrumb>
                     <BreadcrumbItem to='#/'>

--- a/pkg/networkmanager/network-main.jsx
+++ b/pkg/networkmanager/network-main.jsx
@@ -20,6 +20,7 @@ import { ListingTable } from "cockpit-components-table.jsx";
 import { NetworkAction } from "./dialogs-common.jsx";
 import { LogsPanel } from "cockpit-components-logs-panel.jsx";
 import { NetworkPlots } from "./plots";
+import { in_anaconda_mode } from "utils";
 
 import firewall from './firewall-client.js';
 import {
@@ -161,8 +162,10 @@ export const NetworkPage = ({ privileged, operationInProgress, usage_monitor, pl
         </>
     );
 
+    const anaconda = in_anaconda_mode();
+
     return (
-        <Page data-test-wait={operationInProgress} id="networking" className="pf-m-no-sidebar">
+        <Page data-test-wait={operationInProgress} id="networking" className={"pf-m-no-sidebar" + (anaconda ? " anaconda" : "")}>
             <PageSection hasBodyWrapper={false} id="networking-graphs" className="networking-graphs">
                 <NetworkPlots plot_state={plot_state} />
             </PageSection>

--- a/pkg/networkmanager/networkmanager.jsx
+++ b/pkg/networkmanager/networkmanager.jsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 import '../lib/patternfly/patternfly-6-cockpit.scss';
+import "./network-anaconda.scss";
 import cockpit from "cockpit";
 import 'cockpit-dark-theme'; // once per page
 import React, { useRef } from 'react';

--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -6,7 +6,7 @@
 import cockpit from 'cockpit';
 import * as PK from 'packagekit';
 import { superuser } from 'superuser';
-import { get_manifest_config_matchlist } from 'utils';
+import { get_manifest_config_matchlist, in_anaconda_mode, read_anaconda_session_storage } from 'utils';
 
 import * as utils from './utils.js';
 
@@ -1015,14 +1015,7 @@ function init_model(callback) {
         ).then(() => info);
     }
 
-    try {
-        client.anaconda = JSON.parse(window.sessionStorage.getItem("cockpit_anaconda"));
-        if (client.anaconda)
-            console.log("ANACONDA", client.anaconda);
-    } catch {
-        console.warn("Can't parse cockpit_anaconda configuration as JSON");
-        client.anaconda = null;
-    }
+    client.anaconda = read_anaconda_session_storage();
 
     pull_time().then(() => {
         read_os_release().then(os_release => {
@@ -1500,7 +1493,7 @@ client.wait_for = function wait_for(cond) {
 client.get_config = (name, def) =>
     get_manifest_config_matchlist("storage", name, def, [client.os_release.PLATFORM_ID, client.os_release.ID]);
 
-client.in_anaconda_mode = () => !!client.anaconda;
+client.in_anaconda_mode = in_anaconda_mode;
 
 client.strip_mount_point_prefix = (dir) => {
     const mpp = client.anaconda?.mount_point_prefix;

--- a/pkg/storaged/pages.jsx
+++ b/pkg/storaged/pages.jsx
@@ -857,7 +857,7 @@ export const StoragePage = ({ location, plot_state }) => {
                 <StorageBreadcrumb page={page} />
             </PageBreadcrumb>
             }
-            <PageSection hasBodyWrapper={false} isFilled={false} padding={client.in_anaconda_mode() ? { default: "noPadding" } : {}}>
+            <PageSection hasBodyWrapper={false} isFilled={false}>
                 <Stack hasGutter>
                     <MultipathAlert client={client} />
                     <PageCardStackItems page={page} plot_state={plot_state} noarrow />

--- a/pkg/storaged/storage-anaconda.scss
+++ b/pkg/storaged/storage-anaconda.scss
@@ -1,43 +1,9 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
-@use "global-variables" as *;
 
-// Anaconda mode
+@use "../lib/anaconda/anaconda" as anaconda;
+
 #storage.anaconda {
-  .pf-v6-c-page__main-container {
-    border-radius: 0;
-    margin: 0;
-    border: 0;
-    max-block-size: 100%;
-  }
-
-  // ignore cockpit override for mobile layout
-  @media screen and (max-width: $pf-v6-global--breakpoint--md) {
-    .pf-v6-c-page__main>section.pf-v6-c-page__main-section:not(.pf-m-padding) {
-      padding-inline: 0;
-    }
-  }
-
-  .pf-v6-c-page__main {
-    padding-inline: var(--pf-t--global--spacer--gap--group-to-group--vertical--default);
-  }
-
-  .pf-v6-c-page {
-    --pf-v6-c-page--BackgroundColor: var(--pf-t--global--background--color--primary--default);
-  }
-
-  .pf-v6-c-card {
-    --pf-v6-c-card--BorderColor: transparent;
-  }
+  @include anaconda.embedded-page-shell;
 }
 
-body:has(.anaconda) {
-  // HACK - https://github.com/patternfly/patternfly-react/issues/11987
-  // Allow scrolling if a dropdown menu gets positioned outside the bounds of the window.
-  // This is easier to reproduce on 1080p or lower resolutions
-  // remove this once the proper fix is implemented on PF and the rest of cockpit
-  // (see https://bugzilla.redhat.com/show_bug.cgi?id=2388785)
-  overflow-y: auto !important;
-  // containers like pf-v6-c-page won't expand with the viewport when dropdown menus are created
-  // on lower resolutions, so we force all background to match the default
-  background: var(--pf-t--global--background--color--primary--default);
-}
+@include anaconda.anaconda-body-overflow-hack;


### PR DESCRIPTION
Export in_anaconda_mode() from utils (sessionStorage cockpit_anaconda). When true, add an anaconda class to the networking overview and interface detail Page components.

Factor shared iframe layout into pkg/lib/anaconda/_anaconda.scss as Sass mixins. Storaged and networkmanager each ship a small *-anaconda.scss that applies those mixins under their own page selectors; networking also hides throughput graphs and the journal log panel on the overview.