### PR TITLE
users: Don't rely on chage to recognize "99999" max days as "never".

### DIFF
--- a/pkg/users/account-details.js
+++ b/pkg/users/account-details.js
@@ -68,6 +68,25 @@ function get_expire(name) {
             }
         });
 
+        // 99999 traditionally meant "never" but the modern value for
+        // that is -1.
+        //
+        // Modern versions of "chage" will not treat 99999 any special
+        // and will output bogus expiration dates somewhere in 2300.
+        // But let's recognize both, since old accounts will still use
+        // 99999, and /etc/login.def also still uses 99999 as the
+        // default for new accounts.
+        //
+        // Passord expiration is being removed completely from
+        // shadow-utils, and we probably should continue to recognize
+        // 99999 as "never" until we stop supporting password expiry
+        // entirely.
+
+        if (parseInt(password_days) >= 99999 || parseInt(password_days) < 0) {
+            password_days = null;
+            password_expiration = _("Never expire password");
+        }
+
         return {
             account_text: account_expiration,
             account_date,

--- a/pkg/users/expiration-dialogs.js
+++ b/pkg/users/expiration-dialogs.js
@@ -160,9 +160,6 @@ export function password_expiration_dialog(account, expire_days) {
     /* TRANSLATORS: This is split up and therefore cannot use ngettext plurals */
     const parts = _("Require password change every $0 days").split("$0");
 
-    if (parseInt(expire_days) >= 99999)
-        expire_days = null;
-
     const state = {
         mode: expire_days ? "expires" : "never",
         before: parts[0],
@@ -204,7 +201,7 @@ export function password_expiration_dialog(account, expire_days) {
                     style: "primary",
                     clicked: () => {
                         if (validate()) {
-                            const days = state.mode == "expires" ? parseInt(state.days) : 99999;
+                            const days = state.mode == "expires" ? parseInt(state.days) : -1;
                             return cockpit.spawn(["passwd", "-x", String(days), account.name],
                                                  { superuser: "require", err: "message" });
                         } else {

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -1064,7 +1064,7 @@ class TestAccounts(testlib.MachineCase):
 
         # Try to expire a password
         b.wait_text("#password-expiration-text", "Never expire password")
-        self.assertEqual(self.accountExpiryInfo("scruffy", "Password expires"), "never")
+        self.assertEqual(self.accountExpiryInfo("scruffy", "Maximum number of days between password change"), "99999")
         b.click("#password-expiration-button")
         b.wait_visible("#password-expiration")
         b.click("#password-expiration-expires")
@@ -1089,6 +1089,7 @@ class TestAccounts(testlib.MachineCase):
         b.wait_not_present("#password-expiration")
         b.wait_text("#password-expiration-text", "Never expire password")
         self.assertEqual(self.accountExpiryInfo("scruffy", "Password expires"), "never")
+        self.assertEqual(self.accountExpiryInfo("scruffy", "Maximum number of days between password change"), "-1")
 
         # Now change it to expire again
         b.click("#password-expiration-button")


### PR DESCRIPTION
It has stopped doing that in Fedora 44 and elsewhere.

The documented value for "never" is -1, and we recognize this now as well.  We also use "passwd -x -1" when setting password expiry to "never".