### PR TITLE
test: Make sure pmproxy listens on 0.0.0.0 for Grafana

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1512,6 +1512,10 @@ class TestGrafanaClient(testlib.MachineCase):
         # Disable pre-loading packagekit, dnf needs-restarting (dnf 4) consumes tons of cpu/memory on RHEL-10-1
         self.disable_preload("packagekit")
 
+        # HACK - https://github.com/performancecopilot/pcp/issues/2573
+        # Unset PMPROXY_LOCAL, we want it to listen externally.
+        m.execute("! test -f /etc/default/pmproxy || sed -i 's/^PMPROXY_LOCAL/# PMPROXY_LOCAL/' /etc/default/pmproxy")
+
         # avoid dynamic host name changes during PCP data collection, and start from clean slate
         m.execute("""systemctl stop pmlogger || true
                      systemctl reset-failed pmlogger || true


### PR DESCRIPTION
PMPROXY_LOCAL is being set to "1" in recent debian-testing images.