### PR TITLE
tls: Various cleanups and hardening

### DIFF
--- a/src/tls/connection.c
+++ b/src/tls/connection.c
@@ -369,11 +369,10 @@ request_dynamic_wsinstance (const char *fingerprint)
 {
   bool status = false;
   char reply[20];
-  int fd;
 
   debug (CONNECTION, "requesting dynamic wsinstance for %s:\n", fingerprint);
 
-  fd = socket (AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+  int fd = socket (AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
   if (fd == -1)
     {
       warn ("socket() failed");

--- a/src/tls/connection.c
+++ b/src/tls/connection.c
@@ -724,7 +724,7 @@ connection_create_metadata (Connection *self)
       {
         struct sockaddr_in *in_addr = (struct sockaddr_in *) &addr;
 
-        port = in_addr->sin_port;
+        port = ntohs (in_addr->sin_port);
         const char *r = inet_ntop (AF_INET, &in_addr->sin_addr, ip, sizeof ip);
         assert (r != NULL);
       }
@@ -734,7 +734,7 @@ connection_create_metadata (Connection *self)
       {
         struct sockaddr_in6 *in6_addr = (struct sockaddr_in6 *) &addr;
 
-        port = in6_addr->sin6_port;
+        port = ntohs (in6_addr->sin6_port);
         const char *r = inet_ntop (AF_INET6, &in6_addr->sin6_addr, ip, sizeof ip);
         assert (r != NULL);
 

--- a/src/tls/httpredirect.c
+++ b/src/tls/httpredirect.c
@@ -96,6 +96,13 @@ http_redirect (FILE *input,
   if (!host)
     return write_error (output);
 
+  /* Defense-in-depth: validate that host and path don't contain CR or LF. The current read_line() implementation
+   * already prevents this, but add explicit validation just in case, and reject invalid values.
+   */
+  if (strchr (host, '\r') || strchr (host, '\n') ||
+      strchr (path, '\r') || strchr (path, '\n'))
+    return write_error (output);
+
   fprintf (output, "HTTP/1.1 301 Moved Permanently\r\n"
                    "Content-Type: text/html\r\n"
                    "Location: https://%s%s\r\n"

--- a/src/tls/httpredirect.c
+++ b/src/tls/httpredirect.c
@@ -46,6 +46,7 @@ static bool
 write_error (FILE *output)
 {
   fprintf (output, "HTTP/1.1 400 Client Error\r\n"
+                   "Connection: close\r\n"
                    "\r\n"
                    "Incorrect request.\r\n");
 
@@ -104,8 +105,8 @@ http_redirect (FILE *input,
     return write_error (output);
 
   fprintf (output, "HTTP/1.1 301 Moved Permanently\r\n"
-                   "Content-Type: text/html\r\n"
                    "Location: https://%s%s\r\n"
+                   "Connection: close\r\n"
                    "\r\n", host, path);
 
   return true;

--- a/src/tls/server.c
+++ b/src/tls/server.c
@@ -10,6 +10,7 @@
 #include <assert.h>
 #include <err.h>
 #include <errno.h>
+#include <limits.h>
 #include <netinet/in.h>
 #include <pthread.h>
 #include <stdio.h>
@@ -58,8 +59,9 @@ check_sd_listen_pid (void)
       return false;
     }
 
+  errno = 0;
   pid = strtol (pid_str, &endptr, 10);
-  if (pid <= 0 || *endptr != '\0')
+  if (pid <= 0 || *endptr != '\0' || errno != 0)
     errx (EXIT_FAILURE, "$LISTEN_PID contains invalid value '%s'", pid_str);
   if ((pid_t) pid != getpid ())
     {
@@ -202,9 +204,10 @@ server_init (const char *wsinstance_sockdir,
   if (env_listen_fds && check_sd_listen_pid ())
     {
       char *endptr = NULL;
+      errno = 0;
       unsigned long n = strtoul (env_listen_fds, &endptr, 10);
 
-      if (n < 1 || n > INT_MAX || *endptr != '\0')
+      if (n < 1 || n > INT_MAX || *endptr != '\0' || errno != 0)
         errx (EXIT_FAILURE, "Invalid $LISTEN_FDS value '%s'", env_listen_fds);
 
       server.first_listener = SD_LISTEN_FDS_START;

--- a/src/tls/server.c
+++ b/src/tls/server.c
@@ -146,14 +146,19 @@ handle_accept (int listen_fd)
                           server_connection_thread_start_routine,
                           (void *) (uintptr_t) fd);
 
+  pthread_attr_destroy (&attr);
+
   if (r != 0)
     {
       errno = r;
       warn ("pthread_create() failed.  dropping connection");
       close (fd);
-    }
 
-  pthread_attr_destroy (&attr);
+      /* Decrement connection_count since thread was never created */
+      pthread_mutex_lock (&server.connection_mutex);
+      server.connection_count--;
+      pthread_mutex_unlock (&server.connection_mutex);
+    }
 }
 
 /***********************************

--- a/src/tls/socket-io.c
+++ b/src/tls/socket-io.c
@@ -16,6 +16,7 @@
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 
@@ -80,7 +81,8 @@ get_remaining_timeout (struct timespec *start,
   return true;
 }
 
-static int
+/* Return true if IO on fd is pending, false on timeout */
+static bool
 wait_for_io (struct timespec *start,
              int              fd,
              short            events,
@@ -93,7 +95,7 @@ wait_for_io (struct timespec *start,
   debug (SOCKET_IO, "wait_for_io(%d, %u, %ju):", fd, (unsigned) events, (uintmax_t) timeout_us);
 
   if (!get_remaining_timeout (start, &remaining, timeout_us))
-    return 0;
+    return false;
 
   debug (SOCKET_IO, "  -> waiting for %jd", (uintmax_t) remaining);
 
@@ -101,9 +103,12 @@ wait_for_io (struct timespec *start,
     r = poll (&pfd, 1, (remaining + 999) / 1000);
   while (r == -1 && errno == EINTR);
 
-  debug (SOCKET_IO, "  -> result is %d/%s", r, r < 0 ? strerror (errno) : "-");
+  if (r < 0)
+    err (EXIT_FAILURE, "poll() failed");
 
-  return r;
+  debug (SOCKET_IO, "  -> result is %d", r);
+
+  return r == 1;
 }
 
 /**
@@ -142,7 +147,7 @@ recv_all (int     fd,
    * extra byte, we'd need to have a separate throwaway variable and a
    * separately-coded function call.
    */
-  while (count < size && wait_for_io (&start, fd, POLLIN, timeout) == 1)
+  while (count < size && wait_for_io (&start, fd, POLLIN, timeout))
     {
       ssize_t s = recv (fd, buffer + count, size - count, MSG_DONTWAIT);
       debug (SOCKET_IO, "  -> recv returned %zd/%m", s);
@@ -233,7 +238,7 @@ send_all (int         fd,
   struct timespec start = { 0, 0 };
   size_t count = 0;
 
-  while (count < size && wait_for_io (&start, fd, POLLOUT, timeout) == 1)
+  while (count < size && wait_for_io (&start, fd, POLLOUT, timeout))
     {
       ssize_t s = send (fd, buffer + count, size - count, MSG_DONTWAIT | MSG_NOSIGNAL);
 

--- a/src/tls/socket-io.c
+++ b/src/tls/socket-io.c
@@ -99,7 +99,7 @@ wait_for_io (struct timespec *start,
 
   do
     r = poll (&pfd, 1, (remaining + 999) / 1000);
-  while (r == -1 && errno == ENOENT);
+  while (r == -1 && errno == EINTR);
 
   debug (SOCKET_IO, "  -> result is %d/%s", r, r < 0 ? strerror (errno) : "-");
 

--- a/src/tls/socket-io.c
+++ b/src/tls/socket-io.c
@@ -173,7 +173,10 @@ recv_all (int     fd,
     }
 
   /* either the buffer overflowed or we timed out */
-  warnx ("recv_all() failed: buffer is full and no EOF received");
+  if (count >= size)
+    warnx ("recv_all() failed: buffer is full and no EOF received");
+  else
+    warnx ("recv_all() failed: timeout; got %zu bytes, size == %zu", count, size);
   return -1;
 }
 

--- a/src/tls/test-server.c
+++ b/src/tls/test-server.c
@@ -724,6 +724,42 @@ test_tls_redirect (TestCase *tc, gconstpointer data)
 }
 
 static void
+test_tls_redirect_header_safety (TestCase *tc, gconstpointer data)
+{
+  /* verify that the redirect response doesn't contain any headers from the request,
+   * possibly through crafted host/path values. */
+  int fd = do_connect_ipv4_mapped (tc, "::ffff:127.0.0.2");
+  g_assert_cmpint (fd, >, 0);
+
+  const char *res = do_request_fd (fd, "GET /test HTTP/1.0\r\nHost: some.remote:1234\r\nX-Injected: evil\r\n\r\n");
+
+  cockpit_assert_strmatch (res, "HTTP/1.1 301 Moved Permanently*");
+  cockpit_assert_strmatch (res, "*Location: https://some.remote:1234/test*");
+  g_assert_null (strstr (res, "X-Injected"));
+  g_assert_null (strstr (res, "evil"));
+
+  /* Request headers should not leak into response */
+  fd = do_connect_ipv4_mapped (tc, "::ffff:127.0.0.2");
+  g_assert_cmpint (fd, >, 0);
+
+  res = do_request_fd (fd, "GET /path?query HTTP/1.0\r\nHost: example.org\r\nCookie: secret=data\r\n\r\n");
+  cockpit_assert_strmatch (res, "HTTP/1.1 301 Moved Permanently*");
+  cockpit_assert_strmatch (res, "*Location: https://example.org/path?query*");
+  g_assert_null (strstr (res, "Cookie"));
+  g_assert_null (strstr (res, "secret"));
+
+  /* Verify URL-encoded CRLF in path is safely handled (preserved as literal %0D%0A) */
+  fd = do_connect_ipv4_mapped (tc, "::ffff:127.0.0.2");
+  g_assert_cmpint (fd, >, 0);
+  res = do_request_fd (fd, "GET /path%0D%0A HTTP/1.0\r\nHost: example.org\r\n\r\n");
+  cockpit_assert_strmatch (res, "HTTP/1.1 301 Moved Permanently*");
+  cockpit_assert_strmatch (res, "*Location: https://example.org/path%0D%0A*");
+  /* The URL encoding should not be decoded into actual CRLF */
+  g_assert_null (strstr (res, "path\r\n"));
+  g_assert_null (strstr (res, "path\n"));
+}
+
+static void
 test_tls_client_cert (TestCase *tc, gconstpointer data)
 {
   assert_https (tc, data, 1);
@@ -952,6 +988,8 @@ main (int argc, char *argv[])
               setup, test_tls_no_server_cert, teardown);
   g_test_add ("/server/tls/redirect", TestCase, &fixture_separate_crt_key,
               setup, test_tls_redirect, teardown);
+  g_test_add ("/server/tls/redirect-header-safety", TestCase, &fixture_separate_crt_key,
+              setup, test_tls_redirect_header_safety, teardown);
   g_test_add ("/server/tls/blocked-handshake", TestCase, &fixture_separate_crt_key,
               setup, test_tls_blocked_handshake, teardown);
   g_test_add ("/server/mixed-protocols", TestCase, &fixture_separate_crt_key,


### PR DESCRIPTION
I sat down with Claude and checked the cockpit-tls code in detail. Turns out it's actually really good, so most of this is just defense in depth. The `ENOENT` vs. `EINTR` typo was somewhat of a :see_no_evil: though :grin: 