### PR TITLE
session: Fix EINTR handling in scan_btmp, Use proper JSON escaping for PAM error messages

### DIFF
--- a/src/session/session-utils.c
+++ b/src/session/session-utils.c
@@ -153,14 +153,21 @@ __attribute__((__noreturn__)) void
 exit_init_problem (const char *problem, const char *message)
 {
   char *payload = NULL;
+  size_t payload_size = 0;
 
   debug ("writing init problem %s message %s", problem, message);
 
-  if (asprintf (&payload, "\n{\"command\":\"init\",\"version\":1,\"problem\":\"%s\",\"message\":\"%s\"}",
-                problem, message) < 0)
+  FILE *stream = open_memstream (&payload, &payload_size);
+  if (!stream)
     errx (EX, "couldn't allocate memory for message");
 
-  if (cockpit_frame_write (STDOUT_FILENO, (unsigned char *)payload, strlen (payload)) < 0)
+  fprintf (stream, "\n{\"command\":\"init\",\"version\":1");
+  cockpit_json_print_string_property (stream, "problem", problem, -1);
+  cockpit_json_print_string_property (stream, "message", message, -1);
+  fprintf (stream, "}");
+  fclose (stream);
+
+  if (cockpit_frame_write (STDOUT_FILENO, (unsigned char *)payload, payload_size) < 0)
     err (EX, "couldn't write init message");
 
   free (payload);

--- a/src/session/session-utils.c
+++ b/src/session/session-utils.c
@@ -329,7 +329,7 @@ scan_btmp (const char *username,
 
       do
         r = read (fd, &entry, sizeof entry);
-      while (r == -1 && errno != EINTR);
+      while (r == -1 && errno == EINTR);
 
       if (r == 0)
         break;

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -385,15 +385,7 @@ exit_pam_init_problem (int result_code)
   else
     message = pam_strerror (NULL, result_code);
 
-  /* we send the message through the Cockpit protocol, make sure we don't break JSON encoding */
-  char *message_sanitized = strdupx (message);
-  char *c;
-  while ((c = strchr (message_sanitized, '"')) != NULL)
-    *c = '\'';
-  while ((c = strchr (message_sanitized, '\\')) != NULL)
-    *c = '/';
-
-  exit_init_problem (problem, message_sanitized);
+  exit_init_problem (problem, message);
 }
 
 static pam_handle_t *


### PR DESCRIPTION
Security review of cockpit-session. Fortunately didn't find much! But we have a knack for messing up `EINTR`, we already messed that up in c-tls (see #23175)