### PR TITLE
tls: Clean up TLS session on initialization failures

### DIFF
--- a/src/tls/connection.c
+++ b/src/tls/connection.c
@@ -589,6 +589,7 @@ connection_handshake (Connection *self)
       if (ret != GNUTLS_E_SUCCESS)
         {
           warnx ("gnutls_init failed: %s", gnutls_strerror (ret));
+          self->tls = NULL;
           return false;
         }
 
@@ -596,6 +597,8 @@ connection_handshake (Connection *self)
       if (ret != GNUTLS_E_SUCCESS)
         {
           warnx ("gnutls_set_default_priority failed: %s", gnutls_strerror (ret));
+          gnutls_deinit (self->tls);
+          self->tls = NULL;
           return false;
         }
 
@@ -604,6 +607,8 @@ connection_handshake (Connection *self)
       if (ret != GNUTLS_E_SUCCESS)
         {
           warnx ("gnutls_credentials_set failed: %s", gnutls_strerror (ret));
+          gnutls_deinit (self->tls);
+          self->tls = NULL;
           return false;
         }
 
@@ -621,6 +626,8 @@ connection_handshake (Connection *self)
       if (ret != GNUTLS_E_SUCCESS)
         {
           warnx ("gnutls_handshake failed: %s", gnutls_strerror (ret));
+          gnutls_deinit (self->tls);
+          self->tls = NULL;
           return false;
         }
 


### PR DESCRIPTION
Ensure self->tls is properly cleaned up and set to NULL on all TLS initialization error paths in connection_handshake():

This prevents any possibility of double-free or use of partially- initialized TLS sessions, and makes the error paths more explicit.

----

Broken out from #23175 as there was  [some discussion](https://github.com/cockpit-project/cockpit/pull/23175#discussion_r3145883393). It already tested green.