### PR TITLE
networking/firewall: Track DBus name owner explicitly 

### DIFF
--- a/pkg/lib/cockpit.d.ts
+++ b/pkg/lib/cockpit.d.ts
@@ -264,7 +264,7 @@ declare module 'cockpit' {
                 path_namespace?: string,
                 interface?: string,
                 member?: string,
-                arg?: string
+                arg0?: string
             },
             callback: (path: string, iface: string, signal: string, args: unknown[]) => void,
             rule?: boolean,

--- a/pkg/networkmanager/firewall-client.js
+++ b/pkg/networkmanager/firewall-client.js
@@ -42,10 +42,11 @@ function debug() {
 }
 
 firewall.debouncedGetZones = debounce(300, () => {
-    getZones()
-            .then(() => getServices())
-            .then(() => firewall.debouncedEvent('changed'))
-            .catch(error => console.warn(error));
+    if (firewalld_dbus)
+        getZones()
+                .then(() => getServices())
+                .then(() => firewall.debouncedEvent('changed'))
+                .catch(error => console.warn(error));
 });
 
 /* As certain dbus signal callbacks might change the firewall frequently
@@ -59,38 +60,23 @@ firewall.debouncedGetServices = debounce(300, () => {
     getServices().then(() => firewall.debouncedEvent('changed'));
 });
 
-function initFirewalldDbus() {
-    debug("initializing D-Bus connection");
-    if (firewalld_dbus)
-        firewalld_dbus.close();
+function initFirewalldDbus(owner) {
+    debug("initializing D-Bus connection", owner);
+    firewall.owner = owner;
+    firewall.enabled = !!owner;
 
-    firewalld_dbus = cockpit.dbus('org.fedoraproject.FirewallD1', { superuser: "try" });
+    firewall.zones = {};
+    firewall.activeZones = new Set();
+    firewall.services = {};
+    firewall.enabledServices = new Set();
 
-    firewalld_dbus.addEventListener('owner', (event, owner) => {
-        if (firewall.owner === owner)
-            return;
-        debug("owner changed:", JSON.stringify(owner));
+    if (!firewall.enabled) {
+        firewall.ready = true;
+        firewall.dispatchEvent('changed');
+        return;
+    }
 
-        firewall.owner = owner;
-        firewall.enabled = !!owner;
-
-        firewall.zones = {};
-        firewall.activeZones = new Set();
-        firewall.services = {};
-        firewall.enabledServices = new Set();
-
-        if (!firewall.enabled) {
-            firewall.ready = true;
-            firewall.dispatchEvent('changed');
-            return;
-        }
-
-        getZones()
-                .then(() => getServices())
-                .catch(error => console.warn(error))
-                .then(() => { firewall.ready = true })
-                .then(() => firewall.debouncedEvent('changed'));
-    });
+    firewalld_dbus = cockpit.dbus(owner, { superuser: "try", track: true });
 
     firewalld_dbus.subscribe({
         interface: 'org.fedoraproject.FirewallD1.zone',
@@ -186,6 +172,12 @@ function initFirewalldDbus() {
         path: '/org/fedoraproject/FirewallD1',
         member: 'SourceRemoved'
     }, () => firewall.debouncedGetZones());
+
+    getZones()
+            .then(() => getServices())
+            .catch(error => console.warn(error))
+            .then(() => { firewall.ready = true })
+            .then(() => firewall.debouncedEvent('changed'));
 }
 
 firewalld_service.addEventListener('changed', () => {
@@ -200,13 +192,6 @@ firewalld_service.addEventListener('changed', () => {
 
     debug("systemd service changed: exists", firewalld_service.exists, "state", firewalld_service.state,
           "firewall.enabled:", JSON.stringify(firewall.enabled));
-
-    /* HACK: cockpit.dbus() remains dead for non-activatable names, so reinitialize it if the service gets enabled and started
-     * See https://github.com/cockpit-project/cockpit/pull/9125 */
-    if (!firewall.enabled && is_running) {
-        debug("reinitializing D-Bus connection after unit got started");
-        initFirewalldDbus();
-    }
 
     firewall.dispatchEvent('changed');
 });
@@ -333,7 +318,57 @@ function fetchZoneInfos(zones) {
     }));
 }
 
-initFirewalldDbus();
+/* We watch the name owner explicitly.
+
+   The org.fedoraproject.FirewallD service might appear on D-Bus only
+   some time after the firewalld.service is active and thus we want to
+   only try connecting to it once we know that it is definitely there.
+   However, while cockpit.dbus() does work with services that
+   disappear and then reappear on the bus while the channel is open,
+   it doesn't work with names that are not present when the channel is
+   initially opened (see
+   https://github.com/cockpit-project/cockpit/pull/9125).
+
+   Thus, we track the name explicitly via the org.freedesktop.DBus
+   API.
+ */
+
+function dbus_watch_name_owner(name, owner_callback) {
+    const bus = cockpit.dbus('org.freedesktop.DBus', { superuser: "try" });
+    let owner = null;
+
+    function owner_changed(new_owner) {
+        if (new_owner != owner) {
+            owner = new_owner;
+            owner_callback(owner);
+        }
+    }
+
+    bus.subscribe({
+        path: "/org/freedesktop/DBus",
+        interface: "org.freedesktop.DBus",
+        member: "NameOwnerChanged",
+        arg0: name,
+    }, (_path, _iface, _member, [_name, _old_owner, new_owner]) => {
+        owner_changed(new_owner);
+    });
+
+    bus.call(
+        "/org/freedesktop/DBus", "org.freedesktop.DBus", "GetNameOwner",
+        [name]
+    )
+            .then(([owner]) => {
+                owner_changed(owner);
+            })
+            .catch(ex => {
+                if (ex.name == "org.freedesktop.DBus.Error.NameHasNoOwner")
+                    owner_changed("");
+                else
+                    throw ex;
+            });
+}
+
+dbus_watch_name_owner('org.fedoraproject.FirewallD1', initFirewalldDbus);
 
 cockpit.spawn(['sh', '-c', 'pkcheck --action-id org.fedoraproject.FirewallD1.all --process $$ --allow-user-interaction 2>&1'], { superuser: "try" })
         .then(() => {

--- a/test/verify/check-networkmanager-firewall
+++ b/test/verify/check-networkmanager-firewall
@@ -43,6 +43,8 @@ class TestFirewall(netlib.NetworkCase):
         self.restore_dir("/etc/firewalld", restart_unit="firewalld")
 
         m.execute("systemctl restart firewalld")
+        testlib.wait(lambda: m.execute("firewall-cmd --state"))
+
         self.btn_danger = "pf-m-danger"
         self.btn_primary = "pf-m-primary"
         self.default_zone = "Public zone"
@@ -56,6 +58,7 @@ class TestFirewall(netlib.NetworkCase):
         m = self.machine
 
         def get_num_zones():
+            testlib.wait(lambda: m.execute("firewall-cmd --state"))
             return int(m.execute("firewall-cmd --get-active-zones | grep --count '^[a-zA-Z]'").strip())
 
         self.login_and_go("/network", superuser=False)


### PR DESCRIPTION
So that we don't rely on the name appearing at the same time as the systemd unit becoming active.  This is no longer the case since firewalld 2.4.1, see https://github.com/firewalld/firewalld/pull/1528

The test runs into the same issue, and now needs to wait for firewalld to be officially running before trying to manage it via firewall-cmd.