### PR TITLE
test: Avoid the "su - -c cmd user" pattern

### DIFF
--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -1073,7 +1073,7 @@ class TestConnection(testlib.MachineCase):
 
         # start ws with --local-session, let it spawn bridge; ensure that this works without /etc/cockpit/
         m.stop_cockpit()
-        m.spawn("su - -c 'G_MESSAGES_DEBUG=all XDG_CONFIG_DIRS=/usr/local %s --no-tls "
+        m.spawn("su -l -c 'G_MESSAGES_DEBUG=all XDG_CONFIG_DIRS=/usr/local %s --no-tls "
                 "--local-session=cockpit-bridge' admin" % self.ws_executable,
                 "cockpit-ws-local")
         check_session()
@@ -1085,7 +1085,7 @@ export G_MESSAGES_DEBUG=all
 export XDG_CONFIG_DIRS=/usr/local
 {self.ws_executable} --no-tls --local-session=- <&${{COPROC[0]}} >&${{COPROC[1]}}
 """, perm="755")
-        m.spawn("su - -c /tmp/local.sh admin", "local.sh")
+        m.spawn("su -l -c /tmp/local.sh admin", "local.sh")
         check_session()
 
         self.allow_journal_messages("couldn't register polkit authentication agent.*")
@@ -1130,7 +1130,7 @@ export XDG_CONFIG_DIRS=/usr/local
 
         for (pages, asserts) in cases:
             for page in pages:
-                m.execute(f"""su - -c 'BROWSER="curl --silent --compressed -o /tmp/out.html" {self.libexecdir}/cockpit-desktop {page}' admin""",
+                m.execute(f"""su -l -c 'BROWSER="curl --silent --compressed -o /tmp/out.html" {self.libexecdir}/cockpit-desktop {page}' admin""",
                           timeout=10)
 
                 out = m.execute("cat /tmp/out.html")
@@ -1162,7 +1162,7 @@ curl --silent --compressed -o /tmp/out.html "$@"
 until pgrep -f '^(/usr/[^ ]+/[^ /]*python[^ /]* )?/usr/bin/cockpit-bridge'; do sleep 1; done
 """)
         m.execute("chmod 755 /tmp/browser.sh")
-        m.execute(f"su - -c 'BROWSER=/tmp/browser.sh {self.libexecdir}/cockpit-desktop system' admin", timeout=10)
+        m.execute(f"su -l -c 'BROWSER=/tmp/browser.sh {self.libexecdir}/cockpit-desktop system' admin", timeout=10)
         self.assertIn('id="overview"', m.execute("cat /tmp/out.html"))
 
         self.assertNoAdminProcessLeaks()

--- a/test/verify/check-selinux
+++ b/test/verify/check-selinux
@@ -15,7 +15,7 @@ mkdir -p ~/selinux_temp
 cd ~/selinux_temp
 cp /bin/ls ls
 chcon -t httpd_exec_t ls
-su - -c 'mkdir public_html; echo world > public_html/hello.txt' admin
+su -l -c 'mkdir public_html; echo world > public_html/hello.txt' admin
 # this won't work, but it generates an error
 runcon -u system_u -r system_r -t httpd_t -- ./ls  ~admin/public_html || true
 """

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -129,7 +129,7 @@ class CommonTests:
         b.logout()
 
         # wait until IPA user works
-        m.execute(f'while ! su - -c "echo {self.admin_password} | sudo -S true" {self.admin_user}@cockpit.lan; do '
+        m.execute(f'while ! su -l -c "echo {self.admin_password} | sudo -S true" {self.admin_user}@cockpit.lan; do '
                   '    sleep 5; sss_cache -E || true; systemctl reset-failed sssd; systemctl try-restart sssd; done',
                   timeout=300)
 
@@ -281,7 +281,7 @@ class CommonTests:
         m.execute(f"echo {self.admin_password} | realm join -vU {self.admin_user} cockpit.lan", timeout=300)
 
         # wait until domain user works
-        m.execute('while ! su - -c "echo %s | sudo -S true" %s; do sleep 5; sss_cache -E || true; systemctl try-restart sssd; done' %
+        m.execute('while ! su -l -c "echo %s | sudo -S true" %s; do sleep 5; sss_cache -E || true; systemctl try-restart sssd; done' %
                   (self.admin_password, self.admin_user), timeout=300)
 
         # login should now work with the domain admin user


### PR DESCRIPTION
Use the more explicit "-l" option instead of "-".  The latter is being mishandled by util-linux 2.42 in this pattern.

See https://github.com/util-linux/util-linux/issues/4292