### PR TITLE
qunit: port test-spawn-proc.{js -> ts}

### DIFF
--- a/files.js
+++ b/files.js
@@ -75,7 +75,7 @@ const info = {
         "base1/test-promise.ts",
         "base1/test-protocol.ts",
         "base1/test-series.js",
-        "base1/test-spawn-proc.js",
+        "base1/test-spawn-proc.ts",
         "base1/test-spawn.js",
         "base1/test-stream.ts",
         "base1/test-timeformat.ts",

--- a/pkg/base1/test-protocol.ts
+++ b/pkg/base1/test-protocol.ts
@@ -37,6 +37,44 @@ function read_control(ws: WebSocket): Promise<ControlMessage> {
     });
 }
 
+function read_text_data(ws: WebSocket, expected_channel: string): Promise<string> {
+    const prefix = expected_channel + "\n";
+    return new Promise((resolve, reject) => {
+        ws.onmessage = event => {
+            if (typeof event.data !== "string")
+                return reject(new Error("expected text frame, got binary"));
+            if (!event.data.startsWith(prefix))
+                return reject(new Error(`expected channel ${expected_channel}, got: ${event.data}`));
+            resolve(event.data.substring(prefix.length));
+        };
+    });
+}
+
+function read_binary_data(ws: WebSocket, expected_channel: string): Promise<Uint8Array> {
+    const prefix = new TextEncoder().encode(expected_channel + "\n");
+    return new Promise((resolve, reject) => {
+        ws.onmessage = event => {
+            if (!(event.data instanceof ArrayBuffer))
+                return reject(new Error("expected binary frame, got text"));
+            const frame = new Uint8Array(event.data);
+            if (frame.length < prefix.length || !prefix.every((b, i) => frame[i] === b))
+                return reject(new Error(`expected channel ${expected_channel}`));
+            resolve(frame.subarray(prefix.length));
+        };
+    });
+}
+
+async function init(ws: WebSocket): Promise<string> {
+    const message = await read_control(ws);
+    if (message.command !== "init")
+        throw new Error(`expected init, got ${message.command}`);
+    const seed = message["channel-seed"];
+    if (typeof seed !== "string")
+        throw new Error("missing channel-seed in init message");
+    send_control(ws, { command: "init", version: 1 });
+    return seed;
+}
+
 /* Wait for close, returning the last message received */
 async function wait_close(ws: WebSocket): Promise<ControlMessage> {
     const close_promise = new Promise(resolve => {
@@ -121,6 +159,88 @@ QUnit.test("server accepts extra init messages", async assert => {
     } finally {
         ws.close();
     }
+});
+
+/*
+ * cockpit-ws doesn't check the WebSocket frame type on inbound messages: it
+ * just forwards them blindly to the bridge.  The information about if a
+ * message was binary or text is inherently lost in the cockpit protocol, and
+ * the bridge does the correct thing in all cases.
+ *
+ * The following three tests are meant to document the somewhat-broken status
+ * quo.  This was never an intentionally-supported feature and should probably
+ * be a hard error.  A testcase used to depend on the ability to send text data
+ * to binary channels and has since been fixed.  We have no data on if actual
+ * production code is also accidentally relying on this implementation quirk.
+ */
+QUnit.test("text frame on binary channel: response is binary", async assert => {
+    const ws = await connect();
+    ws.binaryType = "arraybuffer";
+    const channel = await init(ws) + "1";
+
+    send_control(ws, { command: "open", channel, payload: "echo", binary: "raw" });
+
+    const ready = await read_control(ws);
+    assert.equal(ready.command, "ready", "channel ready");
+
+    // send a text frame on a binary channel
+    ws.send(`${channel}\nhello`);
+
+    // make sure it comes back as text
+    const payload = await read_binary_data(ws, channel);
+    assert.equal(new TextDecoder().decode(payload), "hello", "payload survived round-trip");
+
+    ws.close();
+});
+
+QUnit.test("binary frame on text channel: response is text", async assert => {
+    const ws = await connect();
+    ws.binaryType = "arraybuffer";
+    const channel = await init(ws) + "1";
+
+    send_control(ws, { command: "open", channel, payload: "echo" });
+
+    const ready = await read_control(ws);
+    assert.equal(ready.command, "ready", "channel ready");
+
+    // send a binary frame on a text channel
+    ws.send(new TextEncoder().encode(`${channel}\nhello`));
+
+    // make sure it comes back as text
+    const payload = await read_text_data(ws, channel);
+    assert.equal(payload, "hello", "payload survived round-trip");
+
+    ws.close();
+});
+
+QUnit.test("non-utf8 on text channel is rejected by the bridge", async assert => {
+    /* The bridge runs a strict UTF-8 decoder on text channels.  Invalid
+     * bytes cause a protocol-error channel close — the data never reaches
+     * cockpit-ws, which would g_critical() and drop it.
+     */
+    const ws = await connect();
+    ws.binaryType = "arraybuffer";
+    const channel = await init(ws) + "1";
+
+    send_control(ws, { command: "open", channel, payload: "echo" });
+    const ready = await read_control(ws);
+    assert.equal(ready.command, "ready", "channel ready");
+
+    // send invalid UTF-8 bytes via a binary frame on a text channel
+    const header = new TextEncoder().encode(channel + "\n");
+    const garbage = new Uint8Array([0x80, 0xff, 0xfe, 0xc0, 0xc1]);
+    const frame = new Uint8Array(header.length + garbage.length);
+    frame.set(header);
+    frame.set(garbage, header.length);
+    ws.send(frame);
+
+    // the bridge closes the channel with a protocol-error
+    const close = await read_control(ws);
+    assert.equal(close.command, "close", "channel closed");
+    assert.equal(close.channel, channel, "correct channel");
+    assert.equal(close.problem, "protocol-error", "protocol-error due to invalid UTF-8");
+
+    ws.close();
 });
 
 QUnit.module("tests that need test-server warnings disabled", hooks => {

--- a/pkg/base1/test-spawn-proc.js
+++ b/pkg/base1/test-spawn-proc.js
@@ -27,32 +27,24 @@ QUnit.test("error output", async assert => {
     assert.equal(resp, "hi\nyo\n", "showed up");
 });
 
-QUnit.test("error message", assert => {
-    const done = assert.async();
-    assert.expect(3);
-    cockpit.spawn(["/bin/sh", "-c", "echo hi; echo yo >&2"], { err: "message" })
-            .done(function(resp, message) {
-                assert.equal(resp, "hi\n", "produced output");
-                assert.equal(message, "yo\n", "produced message");
-            })
-            .always(function() {
-                assert.equal(this.state(), "resolved", "didn't fail");
-                done();
-            });
+QUnit.test("error message", async assert => {
+    const proc = cockpit.spawn(["/bin/sh", "-c", "echo hi; echo yo >&2"], { err: "message" });
+    proc.done(function(resp, message) {
+        assert.equal(resp, "hi\n", "produced output");
+        assert.equal(message, "yo\n", "produced message");
+    });
+    await proc;
+    assert.equal(proc.state(), "resolved", "didn't fail");
 });
 
-QUnit.test("error message fail", assert => {
-    const done = assert.async();
-    assert.expect(3);
-    cockpit.spawn(["/bin/sh", "-c", "echo hi; echo yo >&2; exit 2"], { err: "message" })
-            .fail(function(ex, resp) {
-                assert.equal(resp, "hi\n", "produced output");
-                assert.equal(ex.message, "yo", "produced message");
-            })
-            .always(function() {
-                assert.equal(this.state(), "rejected", "didn't fail");
-                done();
-            });
+QUnit.test("error message fail", async assert => {
+    const proc = cockpit.spawn(["/bin/sh", "-c", "echo hi; echo yo >&2; exit 2"], { err: "message" });
+    proc.fail(function(ex, resp) {
+        assert.equal(resp, "hi\n", "produced output");
+        assert.equal(ex.message, "yo", "produced message");
+    });
+    await assert.rejects(proc);
+    assert.equal(proc.state(), "rejected", "did fail");
 });
 
 QUnit.test("nonexisting executable", assert => {

--- a/pkg/base1/test-spawn-proc.js
+++ b/pkg/base1/test-spawn-proc.js
@@ -132,15 +132,15 @@ QUnit.test("stream partial", async assert => {
 QUnit.test("stream partial binary", async assert => {
     const streamed = [];
     const resp = await cockpit.spawn(["/bin/cat"], { binary: true })
-            .input("1234")
+            .input(new Uint8Array([0, 1, 2, 3]))
             .stream(chunk => {
                 if (chunk.length > 0) {
                     streamed.push(chunk[0]);
                     return 1;
                 }
             });
-    assert.equal(resp.length, 3, "right then data");
-    assert.deepEqual(streamed, [49], "stream data");
+    assert.deepEqual(resp, new Uint8Array([1, 2, 3]), "unconsumed data");
+    assert.deepEqual(streamed, [0], "stream got first byte");
 });
 
 QUnit.test("script with input", async assert => {

--- a/pkg/base1/test-spawn-proc.ts
+++ b/pkg/base1/test-spawn-proc.ts
@@ -49,12 +49,12 @@ QUnit.test("error message fail", async assert => {
 
 QUnit.test("nonexisting executable", assert => {
     assert.rejects(cockpit.spawn(["/bin/nonexistent"]),
-                   ex => ex.problem == "not-found");
+                   (ex: cockpit.BasicError) => ex.problem == "not-found");
 });
 
 QUnit.test("permission denied", assert => {
     assert.rejects(cockpit.spawn(["/etc/hostname"]),
-                   ex => ex.problem == "access-denied");
+                   (ex: cockpit.BasicError) => ex.problem == "access-denied");
 });
 
 QUnit.test("write eof read", async assert => {
@@ -122,7 +122,7 @@ QUnit.test("stream partial", async assert => {
 });
 
 QUnit.test("stream partial binary", async assert => {
-    const streamed = [];
+    const streamed: number[] = [];
     const resp = await cockpit.spawn(["/bin/cat"], { binary: true })
             .input(new Uint8Array([0, 1, 2, 3]))
             .stream(chunk => {
@@ -192,10 +192,10 @@ QUnit.test("pty window size limits", async assert => {
 });
 
 QUnit.test("stream large output", async assert => {
-    let lastblock = null;
+    let lastblock = "";
     const resp = await cockpit.spawn(["seq", "10000000"])
             .stream(resp => {
-                if (lastblock === null)
+                if (lastblock === "")
                     assert.equal(resp.slice(0, 4), "1\n2\n", "stream data starts with first numbers");
                 lastblock = resp;
             });
@@ -212,7 +212,7 @@ QUnit.test("cancel process", async assert => {
         await proc;
         assert.ok(false, "proc should have failed");
     } catch (ex) {
-        assert.equal(ex.problem, "cancelled", "proc failed with correct problem");
+        assert.equal((ex as cockpit.BasicError).problem, "cancelled", "proc failed with correct problem");
     }
 });
 

--- a/pkg/lib/cockpit.d.ts
+++ b/pkg/lib/cockpit.d.ts
@@ -151,8 +151,11 @@ declare module 'cockpit' {
     }
 
     export interface Spawn<T> extends DeferredPromise<T> {
-        input(message?: T | null, stream?: boolean): DeferredPromise<T>;
-        stream(callback: (data: T) => void): DeferredPromise<T>;
+        input(message?: T | null, stream?: boolean): Spawn<T>;
+        stream(callback: (data: T) => number | null | void): Spawn<T>;
+        done(callback: (data: T, message?: string) => void): Spawn<T>;
+        fail(callback: (exc: Error, data?: string) => void): Spawn<T>;
+        state(): "pending" | "resolved" | "rejected";
         close(options?: string | JsonObject): void;
     }
 
@@ -161,6 +164,7 @@ declare module 'cockpit' {
         err?: "out" | "ignore" | "message";
         environ?: string[];
         pty?: boolean;
+        window?: { rows: number; cols: number };
     }
 
     export function spawn(
@@ -174,13 +178,21 @@ declare module 'cockpit' {
 
     export function script(
         script: string,
-        args?: string[],
         options?: SpawnOptions & { binary?: false }
     ): Spawn<string>;
     export function script(
         script: string,
-        args?: string[],
-        options?: SpawnOptions & { binary: true }
+        options: SpawnOptions & { binary: true }
+    ): Spawn<Uint8Array>;
+    export function script(
+        script: string,
+        args: string[],
+        options?: SpawnOptions & { binary?: false }
+    ): Spawn<string>;
+    export function script(
+        script: string,
+        args: string[],
+        options: SpawnOptions & { binary: true }
     ): Spawn<Uint8Array>;
 
     /* === cockpit.location ========================== */

--- a/pkg/lib/cockpit.d.ts
+++ b/pkg/lib/cockpit.d.ts
@@ -7,20 +7,20 @@ import '_internal/common'; // side-effecting import (`window` augmentations)
 import type { Info } from './cockpit/_internal/info';
 
 declare module 'cockpit' {
-    type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
-    type JsonObject = Record<string, JsonValue>;
+    export type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
+    export type JsonObject = Record<string, JsonValue>;
 
-    class BasicError {
+    export class BasicError {
         problem: string;
         message: string;
         toString(): string;
     }
 
-    type SuperuserMode = "require" | "try" | null | undefined;
+    export type SuperuserMode = "require" | "try" | null | undefined;
 
-    function init(): Promise<void>;
+    export function init(): Promise<void>;
 
-    function assert(predicate: unknown, message?: string): asserts predicate;
+    export function assert(predicate: unknown, message?: string): asserts predicate;
 
     export const manifests: { [package in string]?: JsonObject };
     export const info: Info;
@@ -28,7 +28,7 @@ declare module 'cockpit' {
     export let language: string;
     export let language_direction: string;
 
-    interface Transport {
+    export interface Transport {
         csrf_token: string;
         origin: string;
         host: string;
@@ -44,7 +44,7 @@ declare module 'cockpit' {
 
     /* === jQuery compatible promise ============== */
 
-    interface DeferredPromise<T> extends Promise<T> {
+    export interface DeferredPromise<T> extends Promise<T> {
         /* jQuery Promise compatibility */
         done(callback: (data: T) => void): DeferredPromise<T>
         fail(callback: (exc: Error) => void): DeferredPromise<T>
@@ -52,63 +52,63 @@ declare module 'cockpit' {
         progress(callback: (message: T, cancel: () => void) => void): DeferredPromise<T>
     }
 
-    interface Deferred<T> {
+    export interface Deferred<T> {
         resolve(): Deferred<T>;
         reject(): Deferred<T>;
         notify(): Deferred<T>;
         promise: DeferredPromise<T>
     }
 
-    function defer<T>(): Deferred<T>;
+    export function defer<T>(): Deferred<T>;
 
     /* === Events mix-in ========================= */
 
-    interface EventMap {
+    export interface EventMap {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         [_: string]: (...args: any[]) => void;
     }
 
-    type EventListener<E extends (...args: unknown[]) => void> =
+    export type EventListener<E extends (...args: unknown[]) => void> =
         (event: CustomEvent<Parameters<E>>, ...args: Parameters<E>) => void;
 
-    interface EventSource<EM extends EventMap> {
+    export interface EventSource<EM extends EventMap> {
         addEventListener<E extends keyof EM>(event: E, listener: EventListener<EM[E]>): void;
         removeEventListener<E extends keyof EM>(event: E, listener: EventListener<EM[E]>): void;
         dispatchEvent<E extends keyof EM>(event: E, ...args: Parameters<EM[E]>): void;
     }
 
-    interface CockpitEvents extends EventMap {
+    export interface CockpitEvents extends EventMap {
         locationchanged(): void;
         visibilitychange(): void;
     }
 
-    function addEventListener<E extends keyof CockpitEvents>(
+    export function addEventListener<E extends keyof CockpitEvents>(
         event: E, listener: EventListener<CockpitEvents[E]>
     ): void;
-    function removeEventListener<E extends keyof CockpitEvents>(
+    export function removeEventListener<E extends keyof CockpitEvents>(
         event: E, listener: EventListener<CockpitEvents[E]>
     ): void;
 
-    interface ChangedEvents {
+    export interface ChangedEvents {
         changed(): void;
     }
 
-    function event_target<T, EM extends EventMap>(obj: T): T & EventSource<EM>;
+    export function event_target<T, EM extends EventMap>(obj: T): T & EventSource<EM>;
 
     /* === Channel =============================== */
 
-    interface ControlMessage extends JsonObject {
+    export interface ControlMessage extends JsonObject {
         command: string;
     }
 
-    interface ChannelEvents<T> extends EventMap {
+    export interface ChannelEvents<T> extends EventMap {
         control(options: JsonObject): void;
         ready(options: JsonObject): void;
         close(options: JsonObject): void;
         message(data: T): void;
     }
 
-    interface Channel<T> extends EventSource<ChannelEvents<T>> {
+    export interface Channel<T> extends EventSource<ChannelEvents<T>> {
         id: string | null;
         binary: boolean;
         options: JsonObject;
@@ -121,7 +121,7 @@ declare module 'cockpit' {
     }
 
     // these apply to all channels
-    interface ChannelOptions {
+    export interface ChannelOptions {
         superuser?: SuperuserMode;
         [_: string]: JsonValue | undefined;
         binary?: boolean,
@@ -134,50 +134,50 @@ declare module 'cockpit' {
     }
 
     // this applies to opening a generic channel() with explicit payload
-    interface ChannelOpenOptions extends ChannelOptions {
+    export interface ChannelOpenOptions extends ChannelOptions {
         payload: string;
     }
 
-    function channel(options: ChannelOpenOptions & { binary?: false; }): Channel<string>;
-    function channel(options: ChannelOpenOptions & { binary: true; }): Channel<Uint8Array>;
+    export function channel(options: ChannelOpenOptions & { binary?: false; }): Channel<string>;
+    export function channel(options: ChannelOpenOptions & { binary: true; }): Channel<Uint8Array>;
 
     /* === cockpit.{spawn,script} ============================= */
 
-    class ProcessError {
+    export class ProcessError {
         problem: string | null;
         exit_status: number | null;
         exit_signal: number | null;
         message: string;
     }
 
-    interface Spawn<T> extends DeferredPromise<T> {
+    export interface Spawn<T> extends DeferredPromise<T> {
         input(message?: T | null, stream?: boolean): DeferredPromise<T>;
         stream(callback: (data: T) => void): DeferredPromise<T>;
         close(options?: string | JsonObject): void;
     }
 
-    interface SpawnOptions extends ChannelOptions {
+    export interface SpawnOptions extends ChannelOptions {
         directory?: string;
         err?: "out" | "ignore" | "message";
         environ?: string[];
         pty?: boolean;
     }
 
-    function spawn(
+    export function spawn(
         args: string[],
         options?: SpawnOptions & { binary?: false }
     ): Spawn<string>;
-    function spawn(
+    export function spawn(
         args: string[],
         options: SpawnOptions & { binary: true }
     ): Spawn<Uint8Array>;
 
-    function script(
+    export function script(
         script: string,
         args?: string[],
         options?: SpawnOptions & { binary?: false }
     ): Spawn<string>;
-    function script(
+    export function script(
         script: string,
         args?: string[],
         options?: SpawnOptions & { binary: true }
@@ -185,7 +185,7 @@ declare module 'cockpit' {
 
     /* === cockpit.location ========================== */
 
-    interface Location {
+    export interface Location {
         url_root: string;
         options: { [name: string]: string | Array<string> };
         path: Array<string>;
@@ -201,7 +201,7 @@ declare module 'cockpit' {
 
     /* === cockpit.jump ========================== */
 
-    function jump(path: string | string[], host?: string): void;
+    export function jump(path: string | string[], host?: string): void;
 
     /* === cockpit page visibility =============== */
 
@@ -209,28 +209,28 @@ declare module 'cockpit' {
 
     /* === cockpit.dbus ========================== */
 
-    interface DBusProxyEvents extends EventMap {
+    export interface DBusProxyEvents extends EventMap {
         changed(changes: { [property: string]: unknown }): void;
     }
 
-    interface DBusProxiesEvents extends EventMap {
+    export interface DBusProxiesEvents extends EventMap {
         added(proxy: DBusProxy): void;
         changed(proxy: DBusProxy): void;
         removed(proxy: DBusProxy): void;
     }
 
-    interface DBusProxy extends EventSource<DBusProxyEvents> {
+    export interface DBusProxy extends EventSource<DBusProxyEvents> {
         valid: boolean;
         [property: string]: unknown;
     }
 
-    interface DBusClientEvents extends EventMap {
+    export interface DBusClientEvents extends EventMap {
         notify(data: unknown): void;
         meta(data: unknown): void;
         owner(owner: string): void;
     }
 
-    interface DBusOptions {
+    export interface DBusOptions {
         bus?: string;
         address?: string;
         host?: string;
@@ -238,20 +238,20 @@ declare module 'cockpit' {
         track?: boolean;
     }
 
-    type DBusCallOptions = {
+    export type DBusCallOptions = {
         flags?: "" | "i",
         type?: string,
         timeout?: number,
     };
 
-    interface DBusProxies extends EventSource<DBusProxiesEvents> {
+    export interface DBusProxies extends EventSource<DBusProxiesEvents> {
         client: DBusClient;
         iface: string;
         path_namespace: string;
         wait(callback?: () => void): Promise<void>;
     }
 
-    interface DBusClient extends EventSource<DBusClientEvents> {
+    export interface DBusClient extends EventSource<DBusClientEvents> {
         readonly unique_name: string;
         readonly options: DBusOptions;
         proxy(interface?: string, path?: string, options?: { watch?: boolean }): DBusProxy;
@@ -274,32 +274,32 @@ declare module 'cockpit' {
         close(): void;
     }
 
-    type VariantType = string | Uint8Array | number | boolean | VariantType[];
-    interface Variant {
+    export type VariantType = string | Uint8Array | number | boolean | VariantType[];
+    export interface Variant {
         t: string;
         v: VariantType;
     }
 
-    function dbus(name: string | null, options?: DBusOptions): DBusClient;
+    export function dbus(name: string | null, options?: DBusOptions): DBusClient;
 
-    function variant(type: string, value: VariantType): Variant;
-    function byte_array(string: string): string;
+    export function variant(type: string, value: VariantType): Variant;
+    export function byte_array(string: string): string;
 
     /* === cockpit.file ========================== */
 
-    interface FileSyntaxObject<T, B> {
+    export interface FileSyntaxObject<T, B> {
         parse(content: B): T;
         stringify?(content: T): B;
     }
 
-    type FileTag = string;
+    export type FileTag = string;
 
-    type FileWatchCallback<T> = (data: T | null, tag: FileTag | null, error: BasicError | null) => void;
-    interface FileWatchHandle {
+    export type FileWatchCallback<T> = (data: T | null, tag: FileTag | null, error: BasicError | null) => void;
+    export interface FileWatchHandle {
         remove(): void;
     }
 
-    interface FileHandle<T> {
+    export interface FileHandle<T> {
         // BUG: This should be Promise<T, FileTag>, but this isn't representable (it's a cockpit.defer underneath)
         read(): Promise<T>;
         replace(new_content: T | null, expected_tag?: FileTag): Promise<FileTag>;
@@ -310,31 +310,31 @@ declare module 'cockpit' {
         path: string;
     }
 
-    type FileOpenOptions = {
+    export type FileOpenOptions = {
         max_read_size?: number;
         superuser?: SuperuserMode;
     };
 
-    function file(
+    export function file(
         path: string,
         options?: FileOpenOptions & { binary?: false; syntax?: never; }
     ): FileHandle<string>;
-    function file(
+    export function file(
         path: string,
         options: FileOpenOptions & { binary: true; syntax?: never; }
     ): FileHandle<Uint8Array>;
-    function file<T>(
+    export function file<T>(
         path: string,
         options: FileOpenOptions & { binary?: false; syntax: FileSyntaxObject<T, string>; }
     ): FileHandle<T>;
-    function file<T>(
+    export function file<T>(
         path: string,
         options: FileOpenOptions & { binary: true; syntax: FileSyntaxObject<T, Uint8Array>; }
     ): FileHandle<T>;
 
     /* === cockpit.user ========================== */
 
-    type UserInfo = {
+    export type UserInfo = {
         id: number;
         gid: number;
         name: string;
@@ -393,44 +393,44 @@ declare module 'cockpit' {
         close(): void;
     }
 
-    function http(endpoint: string): HttpInstance<string>;
-    function http(endpoint: string, options: HttpOptions & { binary?: false | undefined }): HttpInstance<string>;
-    function http(endpoint: string, options: HttpOptions & { binary: true }): HttpInstance<Uint8Array>;
+    export function http(endpoint: string): HttpInstance<string>;
+    export function http(endpoint: string, options: HttpOptions & { binary?: false | undefined }): HttpInstance<string>;
+    export function http(endpoint: string, options: HttpOptions & { binary: true }): HttpInstance<Uint8Array>;
 
     /* === String helpers ======================== */
 
-    function message(problem: string | JsonObject): string;
+    export function message(problem: string | JsonObject): string;
 
-    function format(format_string: string, ...args: unknown[]): string;
+    export function format(format_string: string, ...args: unknown[]): string;
 
     /* === i18n ===================== */
 
-    function gettext(message: string): string;
-    function gettext(context: string, message?: string): string;
-    function ngettext(message1: string, messageN: string, n: number): string;
-    function ngettext(context: string, message1: string, messageN: string, n: number): string;
+    export function gettext(message: string): string;
+    export function gettext(context: string, message?: string): string;
+    export function ngettext(message1: string, messageN: string, n: number): string;
+    export function ngettext(context: string, message1: string, messageN: string, n: number): string;
 
-    function translate(): void;
+    export function translate(): void;
 
     /* === Number formatting ===================== */
 
-    type FormatOptions = {
+    export type FormatOptions = {
         precision?: number;
         base2?: boolean;
     };
-    type MaybeNumber = number | null | undefined;
+    export type MaybeNumber = number | null | undefined;
 
-    function format_number(n: MaybeNumber, precision?: number): string
-    function format_bytes(n: MaybeNumber, options?: FormatOptions): string;
-    function format_bytes_per_sec(n: MaybeNumber, options?: FormatOptions): string;
-    function format_bits_per_sec(n: MaybeNumber, options?: FormatOptions & { base2?: false }): string;
+    export function format_number(n: MaybeNumber, precision?: number): string
+    export function format_bytes(n: MaybeNumber, options?: FormatOptions): string;
+    export function format_bytes_per_sec(n: MaybeNumber, options?: FormatOptions): string;
+    export function format_bits_per_sec(n: MaybeNumber, options?: FormatOptions & { base2?: false }): string;
 
-    /** @deprecated */ function format_bytes(n: MaybeNumber, factor: unknown, options?: object | boolean): string | string[];
-    /** @deprecated */ function format_bytes_per_sec(n: MaybeNumber, factor: unknown, options?: object | boolean): string | string[];
-    /** @deprecated */ function format_bits_per_sec(n: MaybeNumber, factor: unknown, options?: object | boolean): string | string[];
+    /** @deprecated */ export function format_bytes(n: MaybeNumber, factor: unknown, options?: object | boolean): string | string[];
+    /** @deprecated */ export function format_bytes_per_sec(n: MaybeNumber, factor: unknown, options?: object | boolean): string | string[];
+    /** @deprecated */ export function format_bits_per_sec(n: MaybeNumber, factor: unknown, options?: object | boolean): string | string[];
 
     /* === Session ====================== */
-    function logout(reload: boolean, reason?: string): void;
+    export function logout(reload: boolean, reason?: string): void;
 
     export let localStorage: Storage;
     export let sessionStorage: Storage;

--- a/src/cockpit/channels/trivial.py
+++ b/src/cockpit/channels/trivial.py
@@ -19,7 +19,7 @@ class EchoChannel(Channel):
         self.ready()
 
     def do_data(self, data: bytes) -> None:
-        self.send_bytes(data)
+        self.send_data(data)
 
     def do_done(self) -> None:
         self.done()

--- a/test/common/lcov.py
+++ b/test/common/lcov.py
@@ -24,8 +24,6 @@ import urllib.parse
 from bisect import bisect_left
 from typing import Any, Mapping, Sequence
 
-from lib import github
-
 BASE_DIR = os.path.realpath(f'{__file__}/../../..')
 
 debug = False
@@ -512,6 +510,8 @@ def create_coverage_report() -> None:
         rev = os.environ.get("TEST_REVISION", None)
         pull = os.environ.get("TEST_PULL", None)
         if rev and pull:
+            from lib import github
+
             api = github.GitHub()
             old_comments = api.get(f"pulls/{pull}/comments?sort=created&direction=desc&per_page=100") or []
             for oc in old_comments:

--- a/test/pytest/test_bridge.py
+++ b/test/pytest/test_bridge.py
@@ -99,6 +99,15 @@ async def test_echo(transport: MockTransport) -> None:
 
 
 @pytest.mark.asyncio
+async def test_echo_invalid_utf8(transport: MockTransport) -> None:
+    echo = await transport.check_open('echo')
+
+    # invalid UTF-8 closes the channel with protocol-error
+    transport.send_data(echo, b'\x80\xff\xfe')
+    await transport.assert_msg('', command='close', channel=echo, problem='protocol-error')
+
+
+@pytest.mark.asyncio
 async def test_host(transport: MockTransport) -> None:
     # try to open a null channel, explicitly naming our host
     await transport.check_open('null', host=MOCK_HOSTNAME)


### PR DESCRIPTION
In preparation for the new spawn API (which is very strongly based on static typing).  Also, go on a nice "oi, cockpit-ws" side-quest yak shave that fell out of the work.