### PR TITLE
backport some skips from main

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -107,6 +107,7 @@ def login(self):
         self.login_and_go("/metrics")
 
 
+@testlib.skipImage("FIXME: python3-pcp not currently on image", "rhel-8-10")
 @testlib.skipDistroPackage()
 class TestHistoryMetrics(testlib.MachineCase):
     def setUp(self):
@@ -1271,6 +1272,7 @@ BEGIN {{
 
 
 @testlib.skipImage("TODO: Arch Linux packagekit support", "arch")
+@testlib.skipImage("FIXME: python3-pcp not currently on image", "rhel-8-10")
 @testlib.skipDistroPackage()
 class TestMetricsPackages(packagelib.PackageCase):
     # HACK: PF modal can have multiple id's in certain scenario's https://github.com/patternfly/patternfly-react/issues/9399
@@ -1386,6 +1388,7 @@ class TestMetricsPackages(packagelib.PackageCase):
         self.assertIn("redis", m.execute("systemctl show -p Wants --value pmproxy").strip())
 
 
+@testlib.skipImage("FIXME: python3-pcp not currently on image", "rhel-8-10")
 @testlib.skipDistroPackage()
 class TestMultiCPU(testlib.MachineCase):
 

--- a/test/verify/check-networkmanager-firewall
+++ b/test/verify/check-networkmanager-firewall
@@ -64,6 +64,7 @@ class TestFirewall(netlib.NetworkCase):
         if m.image == "arch":
             m.execute("firewall-cmd --zone 'public' --change-interface='eth0'; firewall-cmd --runtime-to-permanent")
 
+    @testlib.skipImage("FIXME: get_num_zones() race condition, moves from 1 to 2", "rhel-8-10")
     def testNetworkingPage(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -669,6 +669,7 @@ ExecStart=/usr/local/bin/{packageName}
         b.wait_visible("#restart-services-modal .pf-v5-c-alert")
 
     @testlib.skipImage("No security changelog support in packagekit", "arch")
+    @testlib.skipImage("FIXME: currently fails", "rhel-8-10")
     def testInfoSecurity(self):
         b = self.browser
         m = self.machine
@@ -840,6 +841,7 @@ ExecStart=/usr/local/bin/{packageName}
         b.wait_visible("table.updates-history tbody:not(.pf-m-expanded)")
 
     @testlib.skipImage("No security changelog support in packagekit", "arch")
+    @testlib.skipImage("FIXME: currently fails", "rhel-8-10")
     @testlib.nondestructive
     def testSecurityOnly(self):
         b = self.browser

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -654,6 +654,7 @@ OnCalendar=daily
             b.wait_in_text(f"#file-autocomplete-widget-preselected li:nth-of-type({i + 1}) button", paths[i])
 
     @testlib.skipOstree("No PCP available")
+    @testlib.skipImage("FIXME: python3-pcp not currently on image", "rhel-8-10")
     def testPlots(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -255,6 +255,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         verify_correct(has_last=True, n_fail=0)
 
     @testlib.skipImage("Arch Linux has no pwquality by default", "arch")
+    @testlib.skipImage("FIXME: does not support /etc/ssh/sshd_condfig.d", "rhel-8-10")
     def testExpired(self):
         m = self.machine
         b = self.browser
@@ -354,6 +355,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
                                     '.*Sorry, passwords do not match.')
         self.allow_restart_journal_messages()
 
+    @testlib.skipImage("FIXME: does not support /etc/ssh/sshd_condfig.d", "rhel-8-10")
     def testConversation(self):
         m = self.machine
         b = self.browser
@@ -398,6 +400,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
     @testlib.skipImage("No tlog", "debian-*", "ubuntu-*", "arch", "centos-8-stream")
     @testlib.skipOstree("No tlog")
+    @testlib.skipImage("FIXME: tlog messes up bridge frame protocol", "rhel-8-10")
     def testSessionRecordingShell(self):
         m = self.machine
         b = self.browser
@@ -453,6 +456,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
     @testlib.skipImage("No SELinux", "debian-*", "ubuntu-*", "arch")
     @testlib.skipOstree("No semanage")
+    @testlib.skipImage("FIXME: Authentication failed: unknown-host", "rhel-8-10")
     def testSELinuxRestrictedUser(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-storage-anaconda
+++ b/test/verify/check-storage-anaconda
@@ -154,6 +154,7 @@ class TestStorageAnaconda(storagelib.StorageCase):
         b.wait_not_present(self.card_row("Storage", location="/var"))
 
     @testlib.skipImage("No Stratis", "debian-*", "ubuntu-*")
+    @testlib.skipImage("commit 817c957899a4 removed Statis 2 support", "rhel-8-*")
     def testStratis(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -32,6 +32,7 @@ def console_screenshot(machine, name):
 
 
 @testlib.nondestructive
+@testlib.skipImage("cryptsetup uses too much memory, OOM on our test VMs", "rhel-8-*")
 class TestStorageLuks(storagelib.StorageCase):
 
     def testLuks(self):

--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -281,6 +281,7 @@ ExecStart=/usr/bin/sleep infinity
             m.execute(r"sed -i '/run\/data/ s/auto.*$/auto/' /etc/fstab")
         b.wait_in_text(self.card_desc(desc, "Mount point"), "/run/data (stop boot on failure)")
 
+    @testlib.skipImage("FIXME: ought to work, investigate", "rhel-8-10")
     def testBadOption(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -394,6 +394,7 @@ ExecStart=/usr/bin/sleep infinity
 
 
 @testlib.nondestructive
+@testlib.skipImage("cryptsetup uses too much memory, OOM on our test VMs", "rhel-8-*")
 class TestStorageMountingLUKS(storagelib.StorageCase):
     def testEncryptedMountingHelp(self):
         m = self.machine

--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -198,6 +198,7 @@ class TestStorageResize(storagelib.StorageCase):
         size = int(m.execute("lvs TEST/vol -o lv_size --noheading --units b --nosuffix"))
         self.assertLess(size, 250000000)
 
+    @testlib.skipImage("cryptsetup uses too much memory, OOM on our test VMs", "rhel-8-*")
     def testGrowShrinkEncryptedHelp(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -47,6 +47,7 @@ def create_pool_key(machine, keyname, passphrase):
 
 
 @testlib.skipImage("No Stratis", "debian-*", "ubuntu-*")
+@testlib.skipImage("commit 817c957899a4 removed Statis 2 support", "rhel-8-*")
 @testlib.nondestructive
 class TestStorageStratis(storagelib.StorageCase):
     def setUp(self):
@@ -410,6 +411,7 @@ systemctl restart stratisd
 
 
 @testlib.skipImage("No Stratis", "debian-*", "ubuntu-*")
+@testlib.skipImage("commit 817c957899a4 removed Statis 2 support", "rhel-8-*")
 class TestStorageStratisReboot(storagelib.StorageCase):
     # LUKS uses memory hard PBKDF, 1 GiB is not enough; see https://bugzilla.redhat.com/show_bug.cgi?id=1881829
     provision = {

--- a/test/verify/check-storage-swap
+++ b/test/verify/check-storage-swap
@@ -96,6 +96,7 @@ class TestStorageswap(storagelib.StorageCase):
         b.wait_text(self.card_desc("Swap", "Used"), "0")
         testlib.wait(lambda: "defaults" in m.execute(f"findmnt --fstab -n -o OPTIONS {disk}"))
 
+    @testlib.skipImage("cryptsetup uses too much memory, OOM on our test VMs", "rhel-8-*")
     def testEncrypted(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-storage-swap
+++ b/test/verify/check-storage-swap
@@ -24,6 +24,13 @@ import testlib
 @testlib.nondestructive
 class TestStorageswap(storagelib.StorageCase):
 
+    def checkSwapUsed(self):
+        # this relies on PCP, which is missing on some images
+        if self.machine.image in ["debian-testing", "rhel-8-10"]:
+            return
+
+        self.browser.wait_text(self.card_desc("Swap", "Used"), "0 B")
+
     def testBasic(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
Thee got added to main instead of rhel-8, so they have no effect on the normal rhel-8 runs (vs. the rhel-8 wscontainer scenario which *does* run from main).  Backport them to the rhel-8 branch.