### PR TITLE
pkg/systemd: robustify argument quoting

### DIFF
--- a/pkg/systemd/logsJournal.jsx
+++ b/pkg/systemd/logsJournal.jsx
@@ -205,7 +205,8 @@ export class JournalBox extends React.Component {
         const service_options = Object.assign({ output: "verbose" }, options);
         let cmd = journal.build_cmd(match, service_options);
 
-        cmd = cmd.map(i => i.replaceAll(" ", "\\ ")).join(" ");
+        // cribbed from Python's shlex.quote()
+        cmd = cmd.map(i => `'` + i.replaceAll(`'`, `'"'"'`) + `'`).join(" ");
         cmd = "set -o pipefail; " + cmd + " | grep SYSLOG_IDENTIFIER= | sort -u";
         cockpit.spawn(["/bin/bash", "-ec", cmd], { superuser: "try", err: "message" })
                 .then(entries => {


### PR DESCRIPTION
If we were in Python we'd be using `shlex.quote()` here.  Unfortunately we don't have that in JavaScript but the approach is trivial, so let's use it here.