### PR TITLE
storage: Fix call to org.storage.stratis3.Manager.r0.SetKey

### DIFF
--- a/pkg/storaged/stratis/stratis3-set-key.py
+++ b/pkg/storaged/stratis/stratis3-set-key.py
@@ -5,7 +5,7 @@ import dbus
 
 reply = dbus.SystemBus().call_blocking('org.storage.stratis3', '/org/storage/stratis3',
                                        'org.storage.stratis3.Manager.r0', 'SetKey',
-                                       'shb', [sys.argv[1], 0, False])
+                                       'sh', [sys.argv[1], 0])
 if reply[1] != 0:
     sys.stderr.write(reply[2] + '\n')
     sys.exit(1)


### PR DESCRIPTION
We have been calling it with 'shb' since forever, while it really should have been 'sh' all along.  I think this mistake happened when creating stratis3-set-key as a copy of stratis2-set-key.

Versions of stratisd before 3.9 would accept the wrong signature and ignore the extra 'b' argument, but 3.9 is now rejecting it.