### PR TITLE
Test adjustments for Ubuntu 26.04

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -2164,6 +2164,8 @@ class MachineCase(unittest.TestCase):
 
         # Ubuntu 25.10 triggers systemd-detect-virt apparmor violations
         '.*apparmor="DENIED" operation="capable" class="cap" profile="systemd-detect-virt".*',
+        # similar on 26.04
+        '.*apparmor="DENIED" operation="sendmsg" class="file" profile="systemd-detect-virt".*',
     ]
 
     default_allowed_messages += os.environ.get("TEST_ALLOW_JOURNAL_MESSAGES", "").split(",")

--- a/test/verify/check-storage-format
+++ b/test/verify/check-storage-format
@@ -37,7 +37,7 @@ class TestStorageFormat(storagelib.StorageCase):
 
         self.login_and_go("/storage")
 
-        disk = self.add_ram_disk(size=320)  # xfs minimum size is ~300MB
+        disk = self.add_loopback_disk(size=320)  # xfs minimum size is ~300MB
         self.click_card_row("Storage", name=disk)
 
         def check_type(fstype, label_limit):

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -197,7 +197,7 @@ class TestStorageLuks(storagelib.StorageCase):
 
         self.login_and_go("/storage")
 
-        disk = self.add_ram_disk(400)
+        disk = self.add_loopback_disk(320)  # xfs minimum size is ~300MB
         self.click_card_row("Storage", name=disk)
 
         # Create a encrypted filesystem and mount it readonly. This

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -503,6 +503,8 @@ class TestRealms(testlib.MachineCase):
 class TestIPA(TestRealms, CommonTests):
     def setUp(self):
         super().setUp()
+        m = self.machine
+
         self.admin_user = "admin"
         self.admin_password = "foobarfoo"
         self.alice_password = 'WonderLand123'
@@ -521,15 +523,21 @@ class TestIPA(TestRealms, CommonTests):
             """, timeout=300)
 
         # during image creation the /var/cache directory gets cleaned up, recreate the krb5rcache
-        self.machine.execute("mkdir -pZ /var/cache/krb5rcache")
+        m.execute("mkdir -pZ /var/cache/krb5rcache")
 
         # IPA CA cert has OCSP entry with that host name, make it available
-        self.machine.execute("echo '10.111.112.100 ipa-ca.cockpit.lan' >> /etc/hosts")
+        m.execute("echo '10.111.112.100 ipa-ca.cockpit.lan' >> /etc/hosts")
 
         # HACK: Figure out why this happens
         self.allow_journal_messages(""".*didn't receive expected "authorize" message""",
                                     'cockpit-session:$')
         self.allow_journal_messages('/bin/bash: /home/admin/.bashrc: Permission denied')
+
+        # sudo-rs does not support centralized sudoers rules (FreeIPA), switch to classic sudo
+        if m.image in ["ubuntu-2604"]:
+            if "currently points to /usr/lib/cargo/bin/sudo" not in m.execute("update-alternatives --display sudo"):
+                raise NotImplementedError("expected sudo-rs by default; adjust the test setup")
+            m.execute("update-alternatives --set sudo /usr/bin/sudo.ws")
 
     def checkBackendSpecifics(self):
         """Check domain backend specific integration"""

--- a/test/vm.install
+++ b/test/vm.install
@@ -51,6 +51,11 @@ if [ "$ID" = "opensuse-tumbleweed" ]; then
     echo "127.0.1.1 codecs.opensuse.org" >> /etc/hosts
 fi
 
+if [ "$ID" = "ubuntu" ] && [ "$VERSION_ID" = "26.04" ]; then
+    # HACK: https://launchpad.net/bugs/2151857
+    echo '/usr/share/coreutils/locales/** r,' > /etc/apparmor.d/local/who
+fi
+
 PLATFORM_ID="${PLATFORM_ID:-}"
 if [ "${PLATFORM_ID#platform:el}" != "$PLATFORM_ID" ]; then
     # allow /usr/local/bin/ in sudo shells, to use our installed tools like the Python bridge


### PR DESCRIPTION
See https://github.com/cockpit-project/bots/pull/8957 - this unblocks most/all of the failures. I ran the storage and FreeIPA tests locally, and they all pass now (with the extra adjustments in the bots PR).