### PR TITLE
users: Reword group field validation messages

### DIFF
--- a/pkg/users/group-create-dialog.js
+++ b/pkg/users/group-create-dialog.js
@@ -49,7 +49,7 @@ function validate_name(name, groups) {
 
     for (let i = 0; i < name.length; i++) {
         if (!is_valid_char_name(name[i]))
-            return _("The group name can only consist of letters from a-z, digits, dots, dashes and underscores");
+            return _("Group name can only consist of letters, digits, dots, dashes, and underscores");
     }
 
     for (let k = 0; k < groups.length; k++) {
@@ -66,7 +66,7 @@ function validate_group(id, groups) {
 
     const id_num = parseInt(id);
     if (id_num.toString() !== id || id_num < 0)
-        return _("The group ID must be positive integer");
+        return _("Group ID must be positive integer");
 
     return null;
 }

--- a/pkg/users/rename-group-dialog.jsx
+++ b/pkg/users/rename-group-dialog.jsx
@@ -39,7 +39,7 @@ function validate_name(name) {
 
     for (let i = 0; i < name.length; i++) {
         if (!is_valid_char_name(name[i]))
-            return _("The group name can only consist of letters from a-z, digits, dots, dashes and underscores");
+            return _("Group name can only consist of letters, digits, dots, dashes, and underscores");
     }
 
     return null;

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -1283,12 +1283,12 @@ class TestAccounts(testlib.MachineCase):
         b.set_input_text("#groups-create-name", "titan@1000")
         b.set_input_text("#groups-create-id", "12f")
         b.click("#groups-create-dialog button.pf-m-primary")
-        b.wait_in_text("#groups-create-name-helper", "The group name can only consist of letters")
-        b.wait_in_text("#groups-create-id-helper", "The group ID must be positive integer")
+        b.wait_in_text("#groups-create-name-helper", "Group name can only consist of letters")
+        b.wait_in_text("#groups-create-id-helper", "Group ID must be positive integer")
         b.set_input_text("#groups-create-id", "-12")
         b.wait_not_present("#groups-create-id-helper")
         b.click("#groups-create-dialog button.pf-m-primary")
-        b.wait_in_text("#groups-create-id-helper", "The group ID must be positive integer")
+        b.wait_in_text("#groups-create-id-helper", "Group ID must be positive integer")
 
         # Validate no name and no group
         b.set_input_text("#groups-create-name", "")
@@ -1317,7 +1317,7 @@ class TestAccounts(testlib.MachineCase):
 
         b.set_input_text("#group-confirm-rename-dialog #group-name", "foo bar")
         b.click("#group-confirm-rename-dialog .apply")
-        b.wait_in_text("#group-name-helper", "The group name can only consist of letters from a-z")
+        b.wait_in_text("#group-name-helper", "Group name can only consist of letters")
 
         b.set_input_text("#group-confirm-rename-dialog #group-name", "")
         b.click("#group-confirm-rename-dialog .apply")


### PR DESCRIPTION
Add an oxford comma, drop superfluous "The", and be less specific about the accepted letters.