### PR TITLE
Allow user authorization to match identities by UID

### DIFF
--- a/src/ws/cockpitwebservice.c
+++ b/src/ws/cockpitwebservice.c
@@ -9,7 +9,10 @@
 
 #include "cockpitws.h"
 
+#include <pwd.h>
+#include <stdlib.h>
 #include <string.h>
+#include <sys/types.h>
 
 #include <json-glib/json-glib.h>
 #include <gio/gunixinputstream.h>
@@ -25,9 +28,6 @@
 #include "cockpitwebserver.h"
 
 #include "websocket.h"
-
-
-#include <stdlib.h>
 
 guint cockpit_ws_ping_interval = 5;
 
@@ -440,6 +440,79 @@ out:
   return ret;
 }
 
+static gchar *
+decode_authorize_subject (const gchar *subject)
+{
+  /* plain1 authorization subjects carry the user name as cockpit_hex_encode(). */
+  gsize length = strlen (subject);
+  g_autofree gchar *decoded = NULL;
+  gsize i;
+
+  if (length % 2 != 0)
+    return NULL;
+
+  decoded = g_malloc (length / 2 + 1);
+  for (i = 0; i < length; i += 2)
+    {
+      gint high = g_ascii_xdigit_value (subject[i]);
+      gint low = g_ascii_xdigit_value (subject[i + 1]);
+      gchar value;
+
+      if (high < 0 || low < 0)
+        return NULL;
+
+      value = (high << 4) | low;
+      if (value == '\0')
+        return NULL;
+
+      decoded[i / 2] = value;
+    }
+
+  decoded[length / 2] = '\0';
+  return g_steal_pointer (&decoded);
+}
+
+static gboolean
+lookup_user_uid (const gchar *user,
+                 uid_t *uid)
+{
+  struct passwd *pwd = getpwnam (user);
+
+  if (!pwd)
+    return FALSE;
+
+  *uid = pwd->pw_uid;
+  return TRUE;
+}
+
+gboolean
+cockpit_web_service_authorize_user_matches_subject (const gchar *user,
+                                                    const gchar *subject,
+                                                    CockpitAuthorizeLookupUserUidFunc lookup_uid)
+{
+  g_autofree gchar *subject_user = NULL;
+  g_autofree char *encoded = NULL;
+  uid_t user_uid;
+  uid_t subject_uid;
+
+  encoded = cockpit_hex_encode (user, -1);
+  if (g_str_equal (encoded, subject))
+    return TRUE;
+
+  subject_user = decode_authorize_subject (subject);
+  if (!subject_user || !lookup_uid)
+    return FALSE;
+
+  /*
+   * PAM can accept aliases that NSS canonicalizes differently.  Keep the
+   * authorize protocol string-based, but accept aliases that resolve to the
+   * same Unix identity.
+   */
+  return lookup_uid (user, &user_uid) &&
+         lookup_uid (subject_user, &subject_uid) &&
+         user_uid == subject_uid;
+}
+
 static gboolean
 authorize_check_user (CockpitCreds *creds,
                       const char *challenge)
@@ -464,20 +537,7 @@ authorize_check_user (CockpitCreds *creds,
         }
       else
         {
-          char *encoded = cockpit_hex_encode (user, -1);
-          ret = g_str_equal (encoded, subject);
-          free (encoded);
-
-          /* domain users are often case insensitive, while NSS/Linux converts them to the canonical lower-case form;
-           * accept the lower-case form of the creds user as well */
-          if (!ret)
-            {
-              gchar *user_lower = g_ascii_strdown (user, -1);
-              encoded = cockpit_hex_encode (user_lower, -1);
-              free (user_lower);
-              ret = g_str_equal (encoded, subject);
-              free (encoded);
-            }
+          ret = cockpit_web_service_authorize_user_matches_subject (user, subject, lookup_user_uid);
         }
     }
 

--- a/src/ws/cockpitwebservice.h
+++ b/src/ws/cockpitwebservice.h
@@ -15,6 +15,8 @@
 
 #include "websocket.h"
 
+#include <sys/types.h>
+
 G_BEGIN_DECLS
 
 #define COCKPIT_TYPE_WEB_SERVICE         (cockpit_web_service_get_type ())
@@ -22,6 +24,9 @@ G_BEGIN_DECLS
 #define COCKPIT_IS_WEB_SERVICE(o)        (G_TYPE_CHECK_INSTANCE_TYPE ((o), COCKPIT_TYPE_WEB_SERVICE))
 
 typedef struct _CockpitWebService   CockpitWebService;
+
+typedef gboolean (*CockpitAuthorizeLookupUserUidFunc) (const gchar *user,
+                                                       uid_t *uid);
 
 GType                cockpit_web_service_get_type    (void);
 
@@ -67,6 +72,11 @@ const gchar *           cockpit_web_service_get_checksum     (CockpitWebService 
 void                    cockpit_web_service_set_host_checksum       (CockpitWebService *self,
                                                                      const gchar *host,
                                                                      const gchar *checksum);
+
+gboolean                cockpit_web_service_authorize_user_matches_subject
+                                                                    (const gchar *user,
+                                                                     const gchar *subject,
+                                                                     CockpitAuthorizeLookupUserUidFunc lookup_uid);
 
 G_END_DECLS
 

--- a/src/ws/test-auth.c
+++ b/src/ws/test-auth.c
@@ -9,7 +9,9 @@
 #include "cockpitws.h"
 
 #include "common/cockpitconf.h"
+#include "common/cockpithex.h"
 #include "cockpiterror.h"
+#include "cockpitwebservice.h"
 #include "cockpitwebrequest-private.h"
 
 #include "websocket.h"
@@ -18,6 +20,7 @@
 #include "testlib/mock-auth.h"
 
 #include <string.h>
+#include <sys/types.h>
 
 /* Mock override these from other files */
 extern const gchar *cockpit_config_file;
@@ -149,6 +152,91 @@ static const UserpassFixture fixture_superuser_any = {
   .superuser_mode = "any",
   .expect_stored_password = TRUE
 };
+
+static gboolean
+lookup_domain_user_uid (const gchar *user,
+                        uid_t *uid)
+{
+  if (g_str_equal (user, "user") ||
+      g_str_equal (user, "User@DOMAIN.LOCAL") ||
+      g_str_equal (user, "user@domain.local") ||
+      g_str_equal (user, "user@DOMAIN.LOCAL"))
+    {
+      *uid = 1000;
+      return TRUE;
+    }
+
+  if (g_str_equal (user, "other@DOMAIN.LOCAL"))
+    {
+      *uid = 1001;
+      return TRUE;
+    }
+
+  return FALSE;
+}
+
+static gboolean
+lookup_uid_should_not_be_called (const gchar *user,
+                                 uid_t *uid)
+{
+  (void) user;
+  (void) uid;
+  g_assert_not_reached ();
+  return FALSE;
+}
+
+static void
+assert_authorize_user_matches_subject (const gchar *case_name,
+                                       const gchar *user,
+                                       const gchar *subject_user,
+                                       gboolean expected,
+                                       CockpitAuthorizeLookupUserUidFunc lookup_uid)
+{
+  g_autofree char *subject = cockpit_hex_encode (subject_user, -1);
+
+  g_test_message ("checking %s", case_name);
+  g_assert_cmpint (cockpit_web_service_authorize_user_matches_subject (user, subject, lookup_uid),
+                   ==,
+                   expected);
+}
+
+static void
+test_authorize_user_matching (void)
+{
+  static const struct {
+    const gchar *case_name;
+    const gchar *user;
+    const gchar *subject_user;
+    gboolean expected;
+    CockpitAuthorizeLookupUserUidFunc lookup_uid;
+  } tests[] = {
+    { "exact match", "user@domain.local", "user@domain.local", TRUE, lookup_uid_should_not_be_called },
+    { "uppercase domain subject", "user@domain.local", "user@DOMAIN.LOCAL", TRUE, lookup_domain_user_uid },
+    { "lowercase subject", "User@DOMAIN.LOCAL", "user@domain.local", TRUE, lookup_domain_user_uid },
+    { "short login", "user", "user@DOMAIN.LOCAL", TRUE, lookup_domain_user_uid },
+    { "different uid", "user@domain.local", "other@DOMAIN.LOCAL", FALSE, lookup_domain_user_uid },
+    { "no lookup", "user@domain.local", "user@DOMAIN.LOCAL", FALSE, NULL },
+    { "unresolved", "abstract@domain.local", "abstract@DOMAIN.LOCAL", FALSE, lookup_domain_user_uid },
+  };
+
+  for (gsize i = 0; i < G_N_ELEMENTS (tests); i++)
+    assert_authorize_user_matches_subject (tests[i].case_name,
+                                           tests[i].user,
+                                           tests[i].subject_user,
+                                           tests[i].expected,
+                                           tests[i].lookup_uid);
+}
+
+static void
+test_authorize_user_invalid_subject (void)
+{
+  g_assert_false (cockpit_web_service_authorize_user_matches_subject ("user@domain.local",
+                                                                      "zz",
+                                                                      lookup_domain_user_uid));
+  g_assert_false (cockpit_web_service_authorize_user_matches_subject ("user",
+                                                                      "757365720078",
+                                                                      lookup_domain_user_uid));
+}
 
 static void
 test_userpass_cookie_check (Test *test,
@@ -1253,6 +1341,8 @@ main (int argc,
   cockpit_test_init (&argc, &argv);
 
   g_test_add ("/auth/application", Test, NULL, NULL, test_application, NULL);
+  g_test_add_func ("/auth/authorize-user/matching", test_authorize_user_matching);
+  g_test_add_func ("/auth/authorize-user/invalid-subject", test_authorize_user_invalid_subject);
   g_test_add ("/auth/userpass-header-check", Test, NULL, setup, test_userpass_cookie_check, teardown);
   g_test_add ("/auth/userpass-store-check", Test, &fixture_superuser_any, setup, test_userpass_cookie_check, teardown);
   g_test_add ("/auth/userpass-bad", Test, NULL, setup, test_userpass_bad, teardown);

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -883,6 +883,38 @@ class TestAD(TestRealms, CommonTests):
     def checkBackendSpecificCleanup(self):
         """Check domain backend specific integration after leaving domain"""
 
+    def testDefaultDomainSuffixUserElevation(self):
+        m = self.machine
+        b = self.browser
+
+        # default_domain_suffix is different from fully-qualified-names = no:
+        # PAM accepts the short login name, while NSS may report a qualified
+        # canonical identity for the same Unix user.
+        m.write("/etc/realmd.conf", "[cockpit.lan]\nfully-qualified-names = yes\n", append=True)
+        m.execute(f"echo {self.admin_password} | realm join -vU {self.admin_user} cockpit.lan", timeout=300)
+
+        m.execute(r"""
+            set -eux
+            sed -i '/^\[sssd\]/a default_domain_suffix = cockpit.lan' /etc/sssd/sssd.conf
+            sss_cache -E || true
+            systemctl restart sssd
+        """)
+
+        m.execute(f"""
+            set -eux
+            while ! id {self.admin_user} || ! id {self.admin_user}@cockpit.lan; do
+                sleep 5
+                sss_cache -E || true
+                systemctl restart sssd
+            done
+        """, timeout=300)
+        self.assertEqual(m.execute(f"id -u {self.admin_user}").strip(),
+                         m.execute(f"id -u {self.admin_user}@cockpit.lan").strip())
+
+        b.login_and_go("/system", user=self.admin_user, password=self.admin_password, superuser=True)
+        b.switch_to_top()
+        b.check_superuser_indicator("Administrative access")
+
     def testUnqualifiedUsers(self):
         """Extend the test to check a new AD user"""
 


### PR DESCRIPTION
Cockpit’s `authorize_check_user()` accepted an authorization challenge only when the challenge subject matched the logged-in user string exactly or matched a lower-case version of that string.

That lower-case fallback helped the case fixed by #13934, but it does not cover AD/SSSD environments where PAM accepts one spelling and NSS canonicalizes to another, for example:

- login: `user@domain.local`
- NSS/SSSD canonical subject: `user@DOMAIN.LOCAL`

On Fedora Server with AD via realmd/SSSD, initial login succeeds with both spellings, and `getent`/`id` resolve both spellings to the same UID. However, administrative elevation fails when the login spelling does not exactly match the canonical SSSD spelling.

Related references:

- https://github.com/cockpit-project/cockpit/issues/21096
- https://github.com/cockpit-project/cockpit/issues/14385
- https://bugzilla.redhat.com/show_bug.cgi?id=1825749
- https://github.com/cockpit-project/cockpit/pull/13934

This PR changes the authorization check to keep the exact string match fast path, but when the strings differ, decode the authorize subject and resolve both names through NSS. Authorization succeeds only if both names resolve and both UIDs are the same.

This preserves normal Linux username case sensitivity: distinct local users such as `User` and `user` are still rejected unless NSS says they are the same Unix identity.

Testing:

- Built in `ghcr.io/cockpit-project/tasks:2026-03-14`
- Ran `./test-auth --verbose -p /auth/authorize-user`
- Ran `make -j8 check TESTS=test-auth`

All new authorize-user tests passed, and `test-auth` passed through Automake.
