### PR TITLE
More Ubuntu 26.04 enablement

### DIFF
--- a/src/cockpit/osinfo.py
+++ b/src/cockpit/osinfo.py
@@ -21,8 +21,7 @@ supported_oses: 'list[dict[str, str | None]]' = [
     {"ID": "fedora", "VERSION_ID": "43"},
     {"ID": "fedora", "VERSION_ID": "44"},
 
-    {"ID": "ubuntu", "VERSION_ID": "22.04"},
     {"ID": "ubuntu", "VERSION_ID": "24.04"},
-    {"ID": "ubuntu", "VERSION_ID": "25.04"},
     {"ID": "ubuntu", "VERSION_ID": "25.10"},
+    {"ID": "ubuntu", "VERSION_ID": "26.04"},
 ]

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1900,6 +1900,9 @@ class MachineCase(unittest.TestCase):
         self.multihost_enabled = image.startswith(("rhel-9", "centos-9")) or image in [
                 "ubuntu-2204", "ubuntu-2404"]
 
+        # sudo-rs behaves quite differently, tests need to adapt
+        self.has_sudo_rs = image.startswith("ubuntu") and image not in ["ubuntu-2404", "ubuntu-stable"]
+
     def nonDestructiveSetup(self) -> None:
         """generic setUp/tearDown for @nondestructive tests"""
 

--- a/test/verify/check-client
+++ b/test/verify/check-client
@@ -170,9 +170,11 @@ exec "$@"
 
         # not a sudoer
         b.open_superuser_dialog()
-        b.wait_text(".pf-v6-c-modal-box__title-text", "Switch to administrative access")
-        b.set_input_text(".pf-v6-c-modal-box input", "barfoo")
-        b.click(".pf-v6-c-modal-box button:contains('Authenticate')")
+        if not self.has_sudo_rs:
+            # sudo-ws always asks for password, sudo-rs rejects immediately
+            b.wait_text(".pf-v6-c-modal-box__title-text", "Switch to administrative access")
+            b.set_input_text(".pf-v6-c-modal-box input", "barfoo")
+            b.click(".pf-v6-c-modal-box button:contains('Authenticate')")
         b.wait_text(".pf-v6-c-modal-box__title-text", "Problem becoming administrator")
         b.click(".pf-v6-c-modal-box button.btn-cancel")
         b.wait_not_present(".pf-v6-c-modal-box")

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1523,6 +1523,11 @@ class TestGrafanaClient(testlib.MachineCase):
         # Disable pre-loading packagekit, dnf needs-restarting (dnf 4) consumes tons of cpu/memory on RHEL-10-1
         self.disable_preload("packagekit")
 
+        # HACK - https://github.com/performancecopilot/pcp/issues/2573 https://launchpad.net/bugs/2152271
+        # Unset PMPROXY_LOCAL, we want it to listen externally.
+        if m.image == "ubuntu-2604":
+            m.execute("sed -i 's/^PMPROXY_LOCAL/# PMPROXY_LOCAL/' /etc/default/pmproxy")
+
         # avoid dynamic host name changes during PCP data collection, and start from clean slate
         m.execute("""systemctl stop pmlogger || true
                      systemctl reset-failed pmlogger || true

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -74,7 +74,7 @@ def change_ssh_port(machine, address, sshd_socket, sshd_service, port=None, time
         machine.execute("setenforce 0")
     else:
         machine.execute(f"! selinuxenabled || semanage port -a -t ssh_port_t -p tcp {port}")
-    if machine.image in ["ubuntu-2404", "ubuntu-stable"]:  # always socket activated
+    if machine.image.startswith("ubuntu"):  # always socket activated
         machine.write("/etc/systemd/system/ssh.socket.d/override.conf",
                       f"[Socket]\nListenStream=\nListenStream=127.27.0.15:22\nListenStream={address}:{port}")
         machine.execute("systemctl daemon-reload")

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -12,6 +12,14 @@ import testlib
 
 @testlib.nondestructive
 class TestSuperuser(testlib.MachineCase):
+    def setUp(self):
+        super().setUp()
+        if self.has_sudo_rs:
+            self.sudo_prompt = "Password:"
+        else:
+            user = self.get_sudo_user()
+            self.sudo_prompt = f"Password for {user}:"
+
     def testBasic(self):
         b = self.browser
         m = self.machine
@@ -58,8 +66,7 @@ class TestSuperuser(testlib.MachineCase):
         b.wait_text(".pf-v6-c-modal-box__title-text", "Switch to administrative access")
         if "ubuntu" not in m.image and "debian" not in m.image:
             b.wait_in_text(".pf-v6-c-modal-box", "We trust you have received the usual lecture")
-        user = self.get_sudo_user()
-        b.wait_in_text(".pf-v6-c-modal-box", f"Password for {user}:")
+        b.wait_in_text(".pf-v6-c-modal-box", self.sudo_prompt)
         b.set_input_text(".pf-v6-c-modal-box input", "foobar")
         b.focus(".pf-v6-c-modal-box button:contains('Cancel')")
         b.assert_pixels(".pf-v6-c-modal-box", "superuser-modal",
@@ -144,8 +151,7 @@ session include system-auth
 
         b.open_superuser_dialog()
         b.wait_text(".pf-v6-c-modal-box__title-text", "Switch to administrative access")
-        user = self.get_sudo_user()
-        b.wait_in_text(".pf-v6-c-modal-box", f"Password for {user}:")
+        b.wait_in_text(".pf-v6-c-modal-box", self.sudo_prompt)
         # Let the dialog sit there for 45 seconds, to test that this doesn't trigger a D-Bus timeout.
         time.sleep(45)
         b.set_input_text(".pf-v6-c-modal-box input", "foobar")
@@ -162,17 +168,17 @@ session include system-auth
         # Log in with limited access
         self.login_and_go(superuser=False)
         b.check_superuser_indicator("Limited access")
-        user = self.get_sudo_user()
         b.open_superuser_dialog()
         b.wait_text(".pf-v6-c-modal-box__title-text", "Switch to administrative access")
-        b.wait_in_text(".pf-v6-c-modal-box", f"Password for {user}:")
+        b.wait_in_text(".pf-v6-c-modal-box", self.sudo_prompt)
         b.set_input_text(".pf-v6-c-modal-box input", "wrong")
         b.click(".pf-v6-c-modal-box button:contains('Authenticate')")
-        b.wait_in_text(".pf-v6-c-modal-box", f"Password for {user}:")
+        b.wait_in_text(".pf-v6-c-modal-box", self.sudo_prompt)
+        b.set_input_text(".pf-v6-c-modal-box input", "wrong")
         b.wait_in_text(".pf-v6-c-modal-box", "Sorry, try again")
         b.set_input_text(".pf-v6-c-modal-box input", "wronger")
         b.click(".pf-v6-c-modal-box button:contains('Authenticate')")
-        b.wait_in_text(".pf-v6-c-modal-box", f"Password for {user}:")
+        b.wait_in_text(".pf-v6-c-modal-box", self.sudo_prompt)
         b.wait_in_text(".pf-v6-c-modal-box", "Sorry, try again")
         b.set_input_text(".pf-v6-c-modal-box input", "wrongest")
         b.click(".pf-v6-c-modal-box button:contains('Authenticate')")
@@ -196,7 +202,6 @@ session include system-auth
         m.execute(f"gpasswd -d admin {m.get_admin_group()}")
 
         self.login_and_go()
-        user = self.get_sudo_user()
         b.check_superuser_indicator("Limited access")
 
         b.open_superuser_dialog()
@@ -218,7 +223,7 @@ session include system-auth
             b.click(".pf-v6-c-modal-box button:contains('Close')")
         else:
             b.wait_in_text(".pf-v6-c-modal-box", "Switch to administrative access")
-            b.wait_in_text(".pf-v6-c-modal-box", f"Password for {user}")
+            b.wait_in_text(".pf-v6-c-modal-box", self.sudo_prompt)
             status = m.execute("loginctl --lines=0 user-status admin")
             self.assertIn("sudo", status)
             if not m.ws_container:
@@ -233,7 +238,7 @@ session include system-auth
         if self.has_sudo_rs:
             b.click(".pf-v6-c-modal-box button:contains('Close')")
         else:
-            b.wait_in_text(".pf-v6-c-modal-box", f"Password for {user}")
+            b.wait_in_text(".pf-v6-c-modal-box", self.sudo_prompt)
             if not m.ws_container:
                 self.assertIn("cockpit-askpass", m.execute("loginctl --lines=0 user-status admin"))
             b.click(".pf-v6-c-modal-box button:contains('Cancel')")
@@ -439,12 +444,11 @@ session include system-auth
 
         # Run the regular sudo method, which should work as always
         b.open_superuser_dialog()
-        user = self.get_sudo_user()
         b.wait_text(".pf-v6-c-modal-box__title-text", "Switch to administrative access")
         b.set_val(".pf-v6-c-modal-box select", "Sudo")
         b.wait_in_text(".pf-v6-c-modal-box select", "Sudo")
         b.click(".pf-v6-c-modal-box button:contains('Authenticate')")
-        b.wait_in_text(".pf-v6-c-modal-box", f"Password for {user}:")
+        b.wait_in_text(".pf-v6-c-modal-box", self.sudo_prompt)
         b.set_input_text(".pf-v6-c-modal-box input", "foobar")
         b.click(".pf-v6-c-modal-box button:contains('Authenticate')")
         b.wait_not_present(".pf-v6-c-modal-box")
@@ -454,11 +458,10 @@ session include system-auth
         b = self.browser
 
         self.login_and_go("/system", superuser=False)
-        user = self.get_sudo_user()
         b.wait_in_text(".ct-limited-access-alert", "Web console is running in limited access mode.")
         b.click(".ct-limited-access-alert button")
         b.wait_text(".pf-v6-c-modal-box__title-text", "Switch to administrative access")
-        b.wait_in_text(".pf-v6-c-modal-box", f"Password for {user}:")
+        b.wait_in_text(".pf-v6-c-modal-box", self.sudo_prompt)
         b.set_input_text(".pf-v6-c-modal-box input", "foobar")
         b.click(".pf-v6-c-modal-box button:contains('Authenticate')")
         b.wait_not_present(".pf-v6-c-modal-box")

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -200,9 +200,11 @@ session include system-auth
         b.check_superuser_indicator("Limited access")
 
         b.open_superuser_dialog()
-        b.wait_text(".pf-v6-c-modal-box__title-text", "Switch to administrative access")
-        b.set_input_text(".pf-v6-c-modal-box input", "foobar")
-        b.click(".pf-v6-c-modal-box button:contains('Authenticate')")
+        if not self.has_sudo_rs:
+            # sudo-ws always asks for password, sudo-rs rejects immediately
+            b.wait_text(".pf-v6-c-modal-box__title-text", "Switch to administrative access")
+            b.set_input_text(".pf-v6-c-modal-box input", "foobar")
+            b.click(".pf-v6-c-modal-box button:contains('Authenticate')")
         b.wait_text(".pf-v6-c-modal-box__title-text", "Problem becoming administrator")
         b.wait_in_text(".pf-v6-c-modal-box__body", "Admin is not in the sudoers file.")
         b.click(".pf-v6-c-modal-box button.btn-cancel")
@@ -210,26 +212,31 @@ session include system-auth
 
         # no stray/hanging sudo process
         testlib.wait(lambda: "sudo" not in m.execute("loginctl --lines=0 user-status admin"), tries=5)
-        # cancelling auth dialog stops sudo
+        # cancelling auth dialog stops sudo (you can't do that without a prompt)
         b.open_superuser_dialog()
-        b.wait_in_text(".pf-v6-c-modal-box", "Switch to administrative access")
-        b.wait_in_text(".pf-v6-c-modal-box", f"Password for {user}")
-        status = m.execute("loginctl --lines=0 user-status admin")
-        self.assertIn("sudo", status)
-        if not m.ws_container:
-            self.assertIn("cockpit-askpass", status)
-
-        b.click(".pf-v6-c-modal-box button:contains('Cancel')")
+        if self.has_sudo_rs:
+            b.click(".pf-v6-c-modal-box button:contains('Close')")
+        else:
+            b.wait_in_text(".pf-v6-c-modal-box", "Switch to administrative access")
+            b.wait_in_text(".pf-v6-c-modal-box", f"Password for {user}")
+            status = m.execute("loginctl --lines=0 user-status admin")
+            self.assertIn("sudo", status)
+            if not m.ws_container:
+                self.assertIn("cockpit-askpass", status)
+            b.click(".pf-v6-c-modal-box button:contains('Cancel')")
         b.wait_not_present(".pf-v6-c-modal-box")
 
         testlib.wait(lambda: "sudo" not in m.execute("loginctl --lines=0 user-status admin"), tries=5)
 
         # logging out cleans up pending sudo auth; user should either go to "State: closing" or disappear completely
         b.open_superuser_dialog()
-        b.wait_in_text(".pf-v6-c-modal-box", f"Password for {user}")
-        if not m.ws_container:
-            self.assertIn("cockpit-askpass", m.execute("loginctl --lines=0 user-status admin"))
-        b.click(".pf-v6-c-modal-box button:contains('Cancel')")
+        if self.has_sudo_rs:
+            b.click(".pf-v6-c-modal-box button:contains('Close')")
+        else:
+            b.wait_in_text(".pf-v6-c-modal-box", f"Password for {user}")
+            if not m.ws_container:
+                self.assertIn("cockpit-askpass", m.execute("loginctl --lines=0 user-status admin"))
+            b.click(".pf-v6-c-modal-box button:contains('Cancel')")
         b.wait_not_present(".pf-v6-c-modal-box")
         b.logout()
         testlib.wait(lambda: "sudo" not in m.execute("loginctl --lines=0 user-status admin || true"), tries=10)

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -93,6 +93,7 @@ class TestSuperuser(testlib.MachineCase):
         b.click(".pf-v6-c-modal-box__close button")
         b.check_superuser_indicator("Limited access")
 
+    @testlib.skipImage("sudo-rs does not support IO logging", "ubuntu-2604")
     def testSudoIOLogging(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -165,6 +165,8 @@ session include system-auth
     def testWrongPasswd(self):
         b = self.browser
 
+        fail_text = "Authentication failed, try again." if self.has_sudo_rs else "Sorry, try again"
+
         # Log in with limited access
         self.login_and_go(superuser=False)
         b.check_superuser_indicator("Limited access")
@@ -175,15 +177,15 @@ session include system-auth
         b.click(".pf-v6-c-modal-box button:contains('Authenticate')")
         b.wait_in_text(".pf-v6-c-modal-box", self.sudo_prompt)
         b.set_input_text(".pf-v6-c-modal-box input", "wrong")
-        b.wait_in_text(".pf-v6-c-modal-box", "Sorry, try again")
+        b.wait_in_text(".pf-v6-c-modal-box", fail_text)
         b.set_input_text(".pf-v6-c-modal-box input", "wronger")
         b.click(".pf-v6-c-modal-box button:contains('Authenticate')")
         b.wait_in_text(".pf-v6-c-modal-box", self.sudo_prompt)
-        b.wait_in_text(".pf-v6-c-modal-box", "Sorry, try again")
+        b.wait_in_text(".pf-v6-c-modal-box", fail_text)
         b.set_input_text(".pf-v6-c-modal-box input", "wrongest")
         b.click(".pf-v6-c-modal-box button:contains('Authenticate')")
         b.wait_text(".pf-v6-c-modal-box__title-text", "Problem becoming administrator")
-        b.wait_in_text(".pf-v6-c-modal-box", "Sudo: 3 incorrect password attempts")
+        b.wait_text_matches(".pf-v6-c-modal-box", r".*3 incorrect (password|authentication) attempts.*")
         b.click(".pf-v6-c-modal-box button:contains('Close')")
         b.wait_not_present(".pf-v6-c-modal-box")
         b.check_superuser_indicator("Limited access")
@@ -211,7 +213,9 @@ session include system-auth
             b.set_input_text(".pf-v6-c-modal-box input", "foobar")
             b.click(".pf-v6-c-modal-box button:contains('Authenticate')")
         b.wait_text(".pf-v6-c-modal-box__title-text", "Problem becoming administrator")
-        b.wait_in_text(".pf-v6-c-modal-box__body", "Admin is not in the sudoers file.")
+        b.wait_in_text(".pf-v6-c-modal-box__body",
+                       "I'm sorry admin. I'm afraid I can't do that" if self.has_sudo_rs
+                       else "Admin is not in the sudoers file.")
         b.click(".pf-v6-c-modal-box button.btn-cancel")
         b.wait_not_present(".pf-v6-c-modal-box")
 
@@ -278,7 +282,7 @@ session include system-auth
 
         b.open_superuser_dialog()
         b.wait_text(".pf-v6-c-modal-box__title-text", "Problem becoming administrator")
-        b.wait_in_text(".pf-v6-c-modal-box__body", "Sudo: no askpass program specified, try setting SUDO_ASKPASS")
+        b.wait_text_matches(".pf-v6-c-modal-box__body", "Sudo: [nN]o askpass program specified.*SUDO_ASKPASS")
         b.click(".pf-v6-c-modal-box button.btn-cancel")
         b.wait_not_present(".pf-v6-c-modal-box")
         b.check_superuser_indicator("Limited access")

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -899,17 +899,8 @@ class TestSystemInfoTime(packagelib.PackageCase):
         self.login_and_go("/system", superuser=False)
         b.wait_text_not("#system_information_systime_button", "")
         b.wait_visible('#system_information_systime_button[disabled]')
-
         # Gain admin access
-        user = self.get_sudo_user()
-        b.wait_in_text(".ct-limited-access-alert", "Web console is running in limited access mode.")
-        b.click(".ct-limited-access-alert button")
-        b.wait_text(".pf-v6-c-modal-box__title-text", "Switch to administrative access")
-        b.wait_in_text(".pf-v6-c-modal-box", f"Password for {user}:")
-        b.set_input_text(".pf-v6-c-modal-box input", "foobar")
-        b.click(".pf-v6-c-modal-box button:contains('Authenticate')")
-        b.wait_not_present(".pf-v6-c-modal-box")
-        b.wait_not_present(".ct-limited-access-alert")
+        b.become_superuser()
 
         # Change the date
         b.click("#system_information_systime_button")

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -534,7 +534,7 @@ class TestIPA(TestRealms, CommonTests):
         self.allow_journal_messages('/bin/bash: /home/admin/.bashrc: Permission denied')
 
         # sudo-rs does not support centralized sudoers rules (FreeIPA), switch to classic sudo
-        if m.image in ["ubuntu-2604"]:
+        if self.has_sudo_rs:
             if "currently points to /usr/lib/cargo/bin/sudo" not in m.execute("update-alternatives --display sudo"):
                 raise NotImplementedError("expected sudo-rs by default; adjust the test setup")
             m.execute("update-alternatives --set sudo /usr/bin/sudo.ws")


### PR DESCRIPTION
Follow-up for https://github.com/cockpit-project/bots/pull/8957 . This addresses all of the failures in [/other](https://cockpit-ci-logs.s3.us-east-1.amazonaws.com/pull-8957-9bffe60f-20260512-172707-ubuntu-2604-other-cockpit-project-cockpit/log.html) and [/expensive](https://cockpit-ci-logs.s3.us-east-1.amazonaws.com/pull-8957-9bffe60f-20260512-172705-ubuntu-2604-expensive-cockpit-project-cockpit/log.html).  