### PR TITLE
systemd: fix CVE-2026-4802, sanitize value to prevent command injection

### DIFF
--- a/pkg/systemd/logsHelpers.js
+++ b/pkg/systemd/logsHelpers.js
@@ -28,6 +28,9 @@ export const getFilteredQuery = ({ match, options }) => {
     return filtered_cmd.join(" ");
 };
 
+//Sanitize value to prevent command injection
+export const sanitize = (val) => (val || "").replace(/[^a-zA-Z0-9 _.:\/,+@=\-]/g, "");
+
 export const getGrepFiltersFromOptions = ({ options }) => {
     const grep = options.grep || "";
     let full_grep = "";
@@ -76,6 +79,7 @@ export const getGrepFiltersFromOptions = ({ options }) => {
     });
 
     full_grep += grep;
+    full_grep = sanitize(full_grep);
 
     return [full_grep, match];
 };
@@ -104,7 +108,7 @@ export const getOptionsFromTextInput = (value) => {
             .filter(item => {
                 let s = item.split("=");
                 if (s.length === 2 && s[0] === s[0].toUpperCase()) {
-                    new_items[s[0]] = s[1];
+                    new_items[s[0]] = sanitize(s[1]);
                     return false;
                 }
 
@@ -118,12 +122,12 @@ export const getOptionsFromTextInput = (value) => {
                 };
                 s = item.split(/:(.*)/);
                 if (s.length >= 2 && well_know_keys.includes(s[0])) {
-                    new_items[map_keys(s[0])] = s[1];
+                    new_items[map_keys(s[0])] = sanitize(s[1]);
                     return false;
                 }
 
                 return true;
             });
-    new_items.grep = values.join(" ");
+    new_items.grep = sanitize(values.join(" "));
     return new_items;
 };

--- a/pkg/systemd/logsJournal.jsx
+++ b/pkg/systemd/logsJournal.jsx
@@ -13,7 +13,7 @@ import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
 import { JournalOutput } from "cockpit-components-logs-panel.jsx";
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
-import { getGrepFiltersFromOptions, getFilteredQuery } from "./logsHelpers.js";
+import { getGrepFiltersFromOptions, getFilteredQuery, sanitize } from "./logsHelpers.js";
 
 // We open a couple of long-running channels with { superuser: "try" },
 // so we need to reload the page if the access level changes.
@@ -70,6 +70,11 @@ export class JournalBox extends React.Component {
         this.stop();
 
         this.options = cockpit.location.options;
+        Object.keys(this.options).forEach(key => {
+            if (typeof this.options[key] === 'string') {
+                this.options[key] = sanitize(this.options[key]);
+            }
+        });
         this.match = getGrepFiltersFromOptions({ options: this.options })[1];
         const { dataFollowing, defaultSince, updateIdentifiersList, setFilteredQuery } = this.props;
         const { priority, grep, boot, since, until } = this.options;


### PR DESCRIPTION
## Summary

Add input sanitization using a whitelist mechanism to prevent injection attacks.

## Changes

### 1. Define a sanitization function
Allow only the following characters:
- Uppercase and lowercase English letters (A-Z, a-z)
- Digits (0-9)
- Space
- Underscore (`_`)
- Dot (`.`)
- Colon (`:`)
- Forward slash (`/`)
- Comma (`,`)
- Plus sign (`+`)
- At sign (`@`)
- Equals sign (`=`)
- Hyphen (`-`)

### 2. Apply sanitization in three locations
- **`getOptionsFromTextInput`** – sanitize user input before processing
- **`updateQuery`** – sanitize before executing the query to prevent URL injection
- **`getGrepFiltersOptions`** – sanitize when converting URL parameters back to input fields

## Motivation
Ensures that only safe, expected characters are passed through user inputs and URL parameters, reducing the risk of injection attacks.

## PoC
Manually input on the Logs page:

```
priority:err`touch${IFS}/tmp/testpriority` boot:-err`touch${IFS}/tmp/testboot` since:+err`touch${IFS}/tmp/testsince` until:+err`touch${IFS}/tmp/testuntil` follow:err`touch${IFS}/tmp/testfollow` service:err`touch${IFS}/tmp/testservice` identifier:err`touch${IFS}/tmp/testidentifie` grep`touch${IFS}/tmp/testgrepone`
```

OR open

http://localhost:9090/system/logs#/?priority=err%60touch%24%7BIFS%7D%2Ftmp%2Ftestpriority%60&boot=-err%60touch%24%7BIFS%7D%2Ftmp%2Ftestboot%60&since=%2Berr%60touch%24%7BIFS%7D%2Ftmp%2Ftestsince%60&until=%2Berr%60touch%24%7BIFS%7D%2Ftmp%2Ftestuntil%60&follow=err%60touch%24%7BIFS%7D%2Ftmp%2Ftestfollow%60&unit=err%60touch%24%7BIFS%7D%2Ftmp%2Ftestservice%60&tag=err%60touch%24%7BIFS%7D%2Ftmp%2Ftestidentifie%60&grep=grep%60touch%24%7BIFS%7D%2Ftmp%2Ftestgrepone%60

### Before fix:
<img width="1013" height="287" alt="图片" src="https://github.com/user-attachments/assets/e2ac69c3-d491-4361-bd41-573f04b8f186" />

### After fix:
<img width="1010" height="260" alt="图片" src="https://github.com/user-attachments/assets/2145440e-49ef-4057-b08f-b60a743e8136" />
