### PR TITLE
test: sssd fails to start without configuration

### DIFF
--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -844,7 +844,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
     def testClientCertAuthentication(self):
         m = self.machine
 
-        if m.image.startswith("debian") or m.image.startswith("ubuntu"):
+        if m.image.startswith("debian") or m.image.startswith("ubuntu") or m.image.startswith("opensuse-tumbleweed"):
             # on Debian/Ubuntu, an unconfigured sssd fails to start, so only restart it at the end if it was running before
             # also, sssd is split into several services
             self.restore_dir("/etc/sssd", post_restore_action="systemctl stop 'sssd*'")


### PR DESCRIPTION
In a recent sssd upgrade (2.13.0-3.1) in OpenSUSE sssd no longer can be started without first configuring it:

opensuse-tumbleweed-127-0-0-2-22:~ # systemctl start sssd Job for sssd.service failed because the control process exited with error code. See "systemctl status sssd.service" and "journalctl -xeu sssd.service" for details.