### PR TITLE
test: Fix VG cleanup for degraded volume groups

### DIFF
--- a/test/common/storagelib.py
+++ b/test/common/storagelib.py
@@ -125,7 +125,12 @@ class StorageHelpers(MachineCase):
     def addCleanupVG(self, vgname: str) -> None:
         """Ensure the given VG is removed after the test"""
 
-        self.addCleanup(self.machine.execute, f"if [ -d /dev/{vgname} ]; then vgremove --force {vgname}; fi")
+        self.addCleanup(self.machine.execute, f"""
+            if [ -d /dev/{vgname} ]; then
+                vgchange -an {vgname}
+                vgreduce --removemissing --force {vgname} 2>/dev/null || true
+                vgremove --force --yes {vgname}
+            fi""")
 
     def addCleanupMount(self, mount_point: str) -> None:
         self.addCleanup(self.machine.execute,


### PR DESCRIPTION
vgremove --force alone can fail on volume groups with missing physical volumes, leaving loop devices busy and causing subsequent tests to fail with EBUSY when setting up loop devices.