### PR TITLE
packit: Fix cockpit-preview COPR build

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -1,4 +1,5 @@
 upstream_project_url: https://github.com/cockpit-project/cockpit
+issue_repository: https://github.com/cockpit-project/cockpit
 specfile_path: cockpit.spec
 actions:
   # create-archive does not work with multiple sources, so do the spec mangling ourselves

--- a/packit.yaml
+++ b/packit.yaml
@@ -83,6 +83,19 @@ jobs:
     project: "main-builds"
     preserve_project: True
 
+    # testing changes to this:
+    # 1. Create a personal COPR, and change owner/project below
+    # 2. Make a temporary commit that:
+    #    - disables all jobs except "source" from .github/workflows/release.yml
+    #    - drops copr_build/commit, propose_downstream, and bodhi_update from packit.yaml
+    #    - sets upstream_project_url/issue_repository at the top to your fork
+    #    - updates Source0/1: in tools/cockpit.spec to your fork
+    # 3. Commit your adjustments. Push your changes to your fork's main branch
+    # 4. Tag and push a release to your fork. Replace the `my` remote with your fork:
+    #    R=362.99; git tag -d $R; git push my :$R; git tag -s -F /tmp/tagmsg $R; git push my -f; git push my $R
+    # 5. The initial release will fail. Wait for the "packit is requesting
+    #    permissions change" email, and grant it in your COPR's Settings → Permissions
+    # 6. Iterate (step 3.) and re-tag (step 4).
   - job: copr_build
     trigger: release
     owner: "@cockpit"

--- a/packit.yaml
+++ b/packit.yaml
@@ -107,17 +107,13 @@ jobs:
       post-upstream-clone:
         - cp tools/cockpit.spec .
 
-      # resolve NPM_PROVIDES, but otherwise keep packit's %changelog
-      post-modifications:
-        - |
-          bash -exc '
-          # for debugging of official runs, CLI is different from packit service
-          env | grep PACKIT
-          tar -xJf "${PACKIT_DOWNSTREAM_REPO:-${PACKIT_UPSTREAM_REPO}}/cockpit-${PACKIT_PROJECT_VERSION}.tar.xz" "cockpit-*/runtime-npm-modules.txt" --strip-components=1
-          tools/fix-spec "${PACKIT_DOWNSTREAM_REPO:-${PACKIT_UPSTREAM_REPO}}/cockpit.spec"
-          '
+      fix-spec-file:
+        # Don't rebuild the tarball for official releases (https://github.com/packit/packit-service/issues/1505)
+        - bash -c "curl -L --fail -O https://github.com/martinpitt/${PACKIT_UPSTREAM_PACKAGE_NAME}/releases/download/${PACKIT_PROJECT_VERSION}/${PACKIT_PROJECT_NAME_VERSION}.tar.xz"
+        - bash -c "curl -L --fail -O https://github.com/martinpitt/${PACKIT_UPSTREAM_PACKAGE_NAME}/releases/download/${PACKIT_PROJECT_VERSION}/${PACKIT_UPSTREAM_PACKAGE_NAME}-node-${PACKIT_PROJECT_VERSION}.tar.xz"
+        # Extract the correct spec from the release (with correct Version and NPM Provides:)
+        - bash -c "tar -xJf cockpit-${PACKIT_PROJECT_VERSION}.tar.xz cockpit-${PACKIT_PROJECT_VERSION}/tools/cockpit.spec --strip-components=2"
 
-      fix-spec-file: ""
   - job: propose_downstream
     trigger: release
     actions: *official_release_actions


### PR DESCRIPTION
The previous commits fd980a6b480f, 3167867cff7008, f08f4bbfec23ca5 all
unsuccessfully tried to fix the copr_build/release job (e.g. setting
`fix-spec-file:` to an empty string is invalid syntax).

Rework this to be similar to what cockpit-podman etc. do. Our spec file
in the upstream release tarball is already correct, so download these,
extract its cockpit.spec, and tell packit to leave it alone by
overwriting the `fix-spec-file:` action.

----

I tested this on my fork, and documented how to do that. https://github.com/martinpitt/cockpit/commit/a9e35fb73acc725464c1131787d0ee10c88416e1 implements the "make a temporary commit" steps, and the [intial test release](https://copr.fedorainfracloud.org/coprs/martinpitt/test-fixes/build/10492423/) [failed with the exact same error](https://download.copr.fedorainfracloud.org/results/martinpitt/test-fixes/srpm-builds/10492138/builder-live.log.gz) as [in production](https://copr.fedorainfracloud.org/coprs/g/cockpit/cockpit-preview/build/10488354/).

With the fix, the [build succeeds](https://copr.fedorainfracloud.org/coprs/martinpitt/test-fixes/build/10493267/) (both srpm and binary rpms).