### PR TITLE
flatpak: Update to Gnome SDK v50

### DIFF
--- a/containers/flatpak/prepare
+++ b/containers/flatpak/prepare
@@ -86,7 +86,7 @@ def create_manifest(
     return {
         'app-id': FLATPAK_ID,
         'runtime': 'org.gnome.Platform',
-        'runtime-version': '49',
+        'runtime-version': '50',
         'sdk': 'org.gnome.Sdk',
         'command': 'cockpit-client',
         'rename-icon': 'cockpit-client',


### PR DESCRIPTION
v49 just had its last update and Flathub CI is warning about it not
being stable anymore. This updates to v50 instead.

Verified that it works locally.

Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
