### PR TITLE
bridge: Skip unreadable PCP archives instead of failing the whole history

### DIFF
--- a/src/cockpit/channels/pcp.py
+++ b/src/cockpit/channels/pcp.py
@@ -320,8 +320,14 @@ class PcpMetricsChannel(AsyncChannel):
                 archive_start = float(log_label.start) * 1000
                 yield ArchiveInfo(context, archive_start, archive_path)
             except pmapi.pmErr as exc:
+                # A single unreadable archive (for example an empty or corrupted
+                # *.index left behind by an interrupted or freshly rotated
+                # pmlogger) must not hide the metrics history of the other,
+                # healthy archives in this directory. Skip it and carry on;
+                # get_archives() still reports 'not-found' when *no* archive in
+                # the directory can be read.
                 if exc.errno() != c_api.PM_ERR_LOGFILE:
-                    raise ChannelError('not-found', message=f'could not read archive {archive_path}') from None
+                    logger.warning('could not read archive %s: %s', archive_path, exc)
 
     @staticmethod
     def semantic_val(sem_id: int) -> str:

--- a/test/pytest/test_pcp.py
+++ b/test/pytest/test_pcp.py
@@ -69,6 +69,37 @@ def broken_archive(tmpdir_factory):
 
 
 @pytest.fixture
+def partially_broken_archive(tmpdir_factory):
+    """A directory holding one healthy archive next to an unreadable one.
+
+    A single corrupted or empty archive (as left behind by an interrupted or
+    freshly rotated pmlogger) must not prevent the metrics history from the
+    remaining healthy archives from loading.
+    cf. https://github.com/cockpit-project/cockpit/issues/23023
+        https://github.com/cockpit-project/cockpit/issues/23214
+    """
+    pcp_dir = tmpdir_factory.mktemp('partially-broken-archives')
+
+    archive = pmi.pmiLogImport(f"{pcp_dir}/0")
+    archive.pmiAddMetric("mock.value", PM_ID_NULL, PM_TYPE_U32, PM_INDOM_NULL,
+                         PM_SEM_INSTANT, archive.pmiUnits(0, 0, 0, 0, 0, 0))
+    archive.pmiPutValue("mock.value", None, "10")
+    archive.pmiWrite(0, 0)
+    archive.pmiPutValue("mock.value", None, "11")
+    archive.pmiWrite(1, 0)
+    archive.pmiEnd()
+
+    with open(pcp_dir / '1.index', 'w') as f:
+        f.write("not a pcp index file")
+    with open(pcp_dir / '1.meta', 'w') as f:
+        f.write("not a pcp meta file")
+    with open(pcp_dir / '1.0', 'w') as f:
+        f.write("not a pcp sample file")
+
+    return pcp_dir
+
+
+@pytest.fixture
 def discrete_metric_archive(tmpdir_factory):
     pcp_dir = tmpdir_factory.mktemp('discrete-archive')
     archive_1 = pmi.pmiLogImport(f"{pcp_dir}/0")
@@ -529,10 +560,28 @@ async def test_pcp_limit_archive(transport, big_archive):
 
 @pytest.mark.asyncio
 async def test_pcp_broken_archive(transport, broken_archive):
+    # When *no* archive in the directory can be read, the channel reports the
+    # same 'not-found' as an empty or non-existent source.
     await transport.check_open('metrics1', source=str(broken_archive),
                                metrics=[{"name": "mock.value", "derive": "rate"}],
-                               problem='not-found',
-                               reply_keys={'message': f'could not read archive {broken_archive}/0.index'})
+                               problem='not-found', absent_keys=['message'])
+
+
+@pytest.mark.asyncio
+async def test_pcp_partially_broken_archive(transport, partially_broken_archive):
+    """A single unreadable archive must not hide the healthy archives' history."""
+    await transport.check_open('metrics1', source=str(partially_broken_archive),
+                               metrics=[{"name": "mock.value"}])
+
+    _, data = await transport.next_frame()
+    # first message is always the meta message
+    meta = json.loads(data)
+    assert_metrics_meta(meta, str(partially_broken_archive))
+    assert meta['metrics'][0]['name'] == 'mock.value'
+
+    _, data = await transport.next_frame()
+    data = json.loads(data)
+    assert data == [[10], [11]]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

The metrics channel globs every `*.index` file in the pmlogger archive
directory and opens each one as a PCP archive context. Until now only
`PM_ERR_LOGFILE` (a missing data volume) was tolerated when opening an
archive; **any** other error raised `ChannelError('not-found')`, which
aborted reading of *all* archives in the directory.

As a result a single damaged archive disabled the entire metrics history
in the web UI, even though the remaining archives were perfectly
readable. This shows up in practice in two reported ways:

- An empty `*.index` file left behind by a freshly rotated or interrupted
  pmlogger (`PM_ERR_NODATA` / `PM_ERR_LABEL`) — #23214
- A corrupted record (`PM_ERR_LOGREC`) — #23023

In both cases the user only sees "Metrics history could not be loaded"
with no indication of which file is at fault.

## Fix

Treat an unreadable individual archive the same way as a missing data
volume: log a warning naming the offending file and skip it, so the
history from the healthy archives keeps loading. When *no* archive in the
directory can be read at all, `get_archives()` still reports `not-found`,
matching the behaviour of an empty or non-existent source.

## Testing

- New `test_pcp_partially_broken_archive` puts a healthy archive next to
  an unreadable one and asserts the healthy archive's samples are still
  returned. It fails before the change and passes after.
- `test_pcp_broken_archive` is updated to assert that a directory where
  every archive is unreadable still reports a bare `not-found`.
- Full `test/pytest/test_pcp.py` suite passes (17 tests).

Fixes: #23023
Fixes: #23214

## Metrics history survives a single corrupt PCP archive

A single corrupted or empty PCP archive (for example one left behind by an
interrupted or freshly rotated pmlogger) no longer disables the whole
metrics history page. Cockpit now skips the unreadable archive, logs a
warning naming it, and shows the data from the remaining healthy archives.