### PR TITLE
test: Drop ignored -days from alice's openssl CSR request

### DIFF
--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -725,7 +725,7 @@ ipa user-mod --password-expiration=2030-01-01T00:00:00Z alice' """)
 
         ipa_machine.execute(r"""podman exec -i freeipa sh -exc '
 # generate IPA CA signed certificate for alice
-openssl req -new -newkey rsa:2048 -days 365 -nodes -keyout /tmp/alice.key -out /tmp/alice.csr -subj "/CN=alice"
+openssl req -new -newkey rsa:2048 -nodes -keyout /tmp/alice.key -out /tmp/alice.csr -subj "/CN=alice"
 ipa cert-request /tmp/alice.csr --principal=alice --certificate-out=/tmp/alice.pem
 # make alice an admin
 ipa group-add-member admins --users=alice


### PR DESCRIPTION
`openssl req -new` only honours `-days` together with `-x509`, i.e. when
it self-signs a certificate. In `TestIPA.testClientCertAuthentication`
the command merely produces a certificate signing request that is handed
to `ipa cert-request`, which determines the validity period. The `-days`
flag is therefore ignored and openssl prints a warning to the test logs:

```
+ openssl req -new -newkey rsa:2048 -days 365 -nodes -keyout /tmp/alice.key -out /tmp/alice.csr -subj /CN=alice
Ignoring -days without -x509; not generating a certificate
```

Drop the flag to silence the warning. The generated CSR and the
IPA-issued certificate are unaffected.

Verified locally that `openssl req -new` without `-days` produces a valid
CSR and no longer prints the warning.

Fixes: #23047