### PR TITLE
test: Fix loop device cleanup to handle dm/md holders and udisks references; fix Stratis cleanup order

### DIFF
--- a/test/common/storagelib.py
+++ b/test/common/storagelib.py
@@ -84,8 +84,39 @@ class StorageHelpers(MachineCase):
         # non-functional state. Running partprobe will get rid of
         # them.
         self.machine.execute("partprobe '%s'" % dev)
-        # right after unmounting the device is often still busy, so retry a few times
-        self.addCleanup(self.machine.execute, f"until losetup -d {dev}; do sleep 1; done; rm {backf}", timeout=10)
+        # Clean up: remove any holders, detach loop device, verify it's gone
+        self.addCleanup(self.machine.execute, f"""
+            udevadm settle --timeout=10
+            for h in /sys/block/{os.path.basename(dev)}/holders/*; do
+                [ -e "$h" ] || break
+                if [ -f "$h/dm/name" ]; then
+                    n=$(cat "$h/dm/name")
+                else
+                    n=$(basename "$h")
+                fi
+                dmsetup remove --force "$n" || true
+                cryptsetup close "$n" || true
+                mdadm --stop --force "/dev/$n" || true
+            done
+            # Stop udisks to ensure it releases any references to the loop device
+            systemctl stop udisks2 || true
+            udevadm settle --timeout=5
+            # Actively wait for loop device to be detached (kernel may do it async after md/dm removal)
+            for retry in {{1..30}}; do
+                losetup -a | grep -qw {dev} || break
+                losetup -d {dev} && break
+                [ $retry -eq 10 ] && echo "Still waiting for {dev} to detach (retry $retry/30)..." >&2
+                sleep 0.5
+            done
+            if losetup -a | grep -qw {dev}; then
+                echo "ERROR: {dev} still attached after 30 retries!" >&2
+                losetup -a | grep {dev} >&2
+                ls -la /sys/block/{os.path.basename(dev)}/holders/ >&2 || true
+                fuser -v {dev} >&2 || true
+                exit 1
+            fi
+            rm -f {backf}
+        """, timeout=30)
         self.addCleanup(self.machine.execute, f"findmnt -n -o TARGET {dev} | xargs --no-run-if-empty umount;")
 
         return dev

--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -61,18 +61,16 @@ class TestStorageStratis(storagelib.StorageCase):
 
         self.stop_type_opt = get_stratis_stop_type_opt(exe)
 
-        # Also remove partially constructed pools
-        self.addCleanup(exe,
-                        "dmsetup ls | cut -f1 | grep ^stratis | xargs  -n1 --no-run-if-empty dmsetup remove --force")
+    def tearDown(self):
+        # we need to clean up stratis *first*, before add_loopback_disk()'s addCleanup() handlers
+        # tearDown() runs before addCleanup()
+        exe = self.machine.execute
+        exe("mount | grep mapper/stratis | awk '{print $1}' | xargs --no-run-if-empty umount")
+        exe(f"stratis report | jq -r '.pools[] | .name' | xargs -n1 --no-run-if-empty stratis pool stop {self.stop_type_opt}")
+        exe("stratis report | jq -r '.pools[] | .name' | xargs -n1 --no-run-if-empty stratis pool destroy")
+        exe("dmsetup ls | cut -f1 | grep ^stratis | xargs -n1 --no-run-if-empty dmsetup remove --force")
 
-        self.addCleanup(exe,
-                        "stratis report | jq -r '.pools[] | .name' |"
-                        "xargs -n1 --no-run-if-empty stratis pool destroy")
-        self.addCleanup(exe,
-                        "stratis report | jq -r '.pools[] | .name' |"
-                        f"xargs -n1 --no-run-if-empty stratis pool stop {self.stop_type_opt}")
-        self.addCleanup(exe,
-                        "mount | grep mapper/stratis | awk '{print $1}' | xargs --no-run-if-empty umount")
+        super().tearDown()
 
     def testBasic(self, legacy=False):
         m = self.machine


### PR DESCRIPTION
See individual commit messages for details.

Fixes the [C10s/RHEL10 storage TF failures](https://artifacts.dev.testing-farm.io/259b480d-cd46-4024-9b9d-31380d4e788f/work-storage-extra1iku4j0w/plans/all/storage-extra/execute/data/guest/default-0/test/browser/storage-extra-1/output.txt) that have plagued us for weeks now.