### PR TITLE
branding: Include ELN branding

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -174,6 +174,7 @@ include src/branding/arch/Makefile.am
 include src/branding/centos/Makefile.am
 include src/branding/debian/Makefile.am
 include src/branding/default/Makefile.am
+include src/branding/eln/Makefile.am
 include src/branding/fedora/Makefile.am
 include src/branding/opensuse/Makefile.am
 include src/branding/rhel/Makefile.am

--- a/src/branding/eln/Makefile.am
+++ b/src/branding/eln/Makefile.am
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+elnbrandingdir = $(datadir)/cockpit/branding/eln
+
+dist_elnbranding_DATA = \
+	src/branding/eln/branding.css \
+	$(NULL)
+
+# Opportunistically use fedora-logos
+install-data-hook::
+	ln -sTfr $(DESTDIR)/usr/share/pixmaps/fedora-logo.png $(DESTDIR)$(elnbrandingdir)/logo.png
+	ln -sTfr $(DESTDIR)/usr/share/pixmaps/system-logo-white.png $(DESTDIR)$(elnbrandingdir)/logo-dark.png
+	ln -sTfr $(DESTDIR)/usr/share/pixmaps/eln-logo-sprite.png $(DESTDIR)$(elnbrandingdir)/apple-touch-icon.png
+	ln -sTfr $(DESTDIR)/etc/favicon.png $(DESTDIR)$(elnbrandingdir)/favicon.ico

--- a/src/branding/eln/branding.css
+++ b/src/branding/eln/branding.css
@@ -1,0 +1,39 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#badge {
+    inline-size: 279px;
+    block-size: 80px;
+    background-image: url("logo.png");
+    background-size: contain;
+    background-repeat: no-repeat;
+}
+
+.pf-v6-theme-dark #badge {
+    background-image: url("logo-dark.png");
+}
+
+#brand::before {
+    content: "${NAME}";
+}
+
+.anaconda {
+    /* Brand palette */
+    --brand-default-light: #79db32;
+    --brand-default: #db3279;
+    --brand-default-dark: #e59728;
+
+    .logo {
+        background-image: url("logo.png");
+    }
+}
+
+:not(.pf-v6-theme-dark) .anaconda {
+    /* Default (light theme) token mapping */
+    --pf-t--global--color--brand--default: var(--brand-default);
+    --pf-t--global--color--brand--hover: var(--brand-default-dark);
+}
+
+.pf-v6-theme-dark .anaconda {
+    /* Dark theme token mapping */
+    --pf-t--global--color--brand--default: var(--brand-default-light);
+    --pf-t--global--color--brand--hover: var(--brand-default);
+}


### PR DESCRIPTION
Fedora ELN has a different `ID` so won't match fedora's branding. Upstream this from fedora-eln-release so we can maintain and keep it up to date.

https://src.fedoraproject.org/rpms/fedora-eln-release/blob/eln/f/branding.css

Closes: #23289