### PR TITLE
test: Move TestRHEL8 to rhel-8-10 image

### DIFF
--- a/test/verify/check-shell-multi-os
+++ b/test/verify/check-shell-multi-os
@@ -46,7 +46,7 @@ def add_machine(b, address, password):
 class TestRHEL8(testlib.MachineCase):
     provision = {
         "0": {"address": "10.111.113.1/20"},
-        "stock": {"address": "10.111.113.5/20", "image": "rhel-8-8"}
+        "stock": {"address": "10.111.113.5/20", "image": "rhel-8-10"}
     }
 
     @testlib.todoPybridgeRHEL8()


### PR DESCRIPTION
The rhel-8-8 image was removed in
https://github.com/cockpit-project/bots/commit/5b114db7cfe8

On main this was part of commit c3b3266916b6a.

----

Unblocks https://github.com/cockpit-project/bots/pull/9090