### PR TITLE
test: Really purge libpcp-pmda-perl on Debian based distros

### DIFF
--- a/test/verify/check-client
+++ b/test/verify/check-client
@@ -25,7 +25,7 @@ class TestClient(testlib.MachineCase):
         self.m_target.execute("hostnamectl set-hostname target")
         # validate on-demand install: this does not work on arch, non-split package
         if self.m_target.image.startswith("debian") or self.m_target.image.startswith("ubuntu"):
-            self.m_target.execute("dpkg --purge libpcp-pdma-perl pcp")
+            self.m_target.execute("dpkg --purge libpcp-pmda-perl pcp python3-pcp")
         elif self.m_target.image == 'arch':
             self.m_target.execute("pacman -Rdd --noconfirm pcp")
         else:

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1363,7 +1363,7 @@ class TestMetricsPackages(packagelib.PackageCase):
             return
 
         if m.image.startswith("debian") or m.image.startswith("ubuntu"):
-            m.execute("dpkg --purge libpcp-pdma-perl python3-pcp pcp redis redis-server")
+            m.execute("dpkg --purge libpcp-pmda-perl python3-pcp pcp redis redis-server")
             # HACK: pcp does not clean up correctly on Debian https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=986074
             m.execute("rm -f /etc/systemd/system/pmlogger.service.requires/pmlogger_farm.service")
         else:


### PR DESCRIPTION
Commit 5357f22570e typoed the package name. It also forgot python3-pcp in the beiboot test.

---

Blocks https://github.com/cockpit-project/bots/pull/9073 . I ran [all three failed tests](https://cockpit-ci-logs.s3.us-east-1.amazonaws.com/pull-9073-373fdb8e-20260528-035127-debian-testing-other-cockpit-project-cockpit/log.html) against the new image, and they pass.