### PR TITLE
shell: Align navmenu second column between groups

### DIFF
--- a/pkg/shell/nav.scss
+++ b/pkg/shell/nav.scss
@@ -375,10 +375,14 @@ $desktop: $phone + 1px;
 .nav-system-menu {
   overflow-x: hidden;
   overflow-y: auto;
-  // Flow items, if wider (useful for mobile)
+
+  // Flow items, if wider (useful for mobile). Use 1fr (not auto) so every
+  // group's column tracks are equal-width; otherwise each group's grid sizes
+  // its columns to its own content and the second column fails to align
+  // between groups (e.g. System vs Tools).
   .pf-v6-c-nav__list {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(10rem, auto));
+    grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
   }
 
   // Give additional style to individual menu items


### PR DESCRIPTION
The mobile navmenu renders each group (System, Tools, and so on) as its own `ul.pf-v6-c-nav__list` grid. The column track is `repeat(auto-fill, minmax(10rem, auto))`, and the `auto` maximum sizes each group's column tracks to that group's own content. When two groups have different longest-item widths, their second columns land at different positions, which is the misalignment reported in #23333.

Changing the track maximum from `auto` to `1fr` makes every column an equal fraction of the shared container width, so all groups get identical column boundaries and the second column aligns between groups.

This is a CSS-only change in `pkg/shell/nav.scss`. `npm run stylelint` passes and the shell bundle builds cleanly.

The existing pixel assertion `TestServices.testNotifyFailed` (`menu_error-mobile` in `test/verify/check-system-services`) covers this view. Opening as a draft so CI can regenerate the reference image for that layout.

Fixes #23333

## After

<img width="951" height="927" alt="Screenshot 2026-05-30 195228" src="https://github.com/user-attachments/assets/30157146-0b13-4287-a7e4-8b3c56a13e89" />

Mobile navmenu at 414px width, with the fix applied. The second columns of the System group (Logs, Networking, Services) and the Tools group (Diagnostic reports, Terminal) now align. The before misalignment is shown in the pixeldiff linked in #23333.