### PR TITLE
po: add missing 'lo' in language_map.txt

### DIFF
--- a/po/language_map.txt
+++ b/po/language_map.txt
@@ -50,6 +50,7 @@ kn:ಕನ್ನಡ:kn-in
 ko:한국어:ko-kr
 kw_GB:kernewek (Rywvaneth Unys):kn-gb
 ky:кыргызча:ky-kg
+lo:ພາສາລາວ:lo-la
 lt:lietuvių:lt-lt
 lv:latviešu:lv-lv
 mai:मैथिली:mai-in


### PR DESCRIPTION
This has been causing our po-refresh workflow to fail since a month or so.

I took the Endonym for the language (Laotian) from https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes