### PR TITLE
Implement missing http-stream2 channel options

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -784,6 +784,7 @@ The TLS object can have the following options:
  * "key": The client key to use, described below.
  * "authority": Certificate authority(s) to expect as signers of peer.
  * "validate": Validate the peer's certificate.
+ * "proxy": Proxy url to use.
 
 The "certificate", "key" and "authority" are objects with either of
 the following fields:

--- a/pkg/lib/cockpit.d.ts
+++ b/pkg/lib/cockpit.d.ts
@@ -373,6 +373,7 @@ declare module 'cockpit' {
             certificate?: TlsCert;
             key?: TlsCert;
             validate?: boolean;
+            proxy?: string;
         };
         superuser?: SuperuserMode;
         binary?: boolean;

--- a/src/cockpit/channels/http_channel.py
+++ b/src/cockpit/channels/http_channel.py
@@ -10,6 +10,7 @@ import socket
 import ssl
 import tempfile
 from collections.abc import Generator
+from urllib.parse import urlparse
 
 from ..channel import AsyncChannel, ChannelError
 from ..jsonutil import JsonObject, get_dict, get_int, get_object, get_str, typechecked
@@ -83,6 +84,18 @@ class HttpChannel(AsyncChannel):
                         context.load_cert_chain(certfile=certfile, keyfile=keyfile)
                 except ssl.SSLError as exc:
                     raise ChannelError('protocol-error', message=str(exc)) from exc
+
+            proxy_url = get_str(opt_tls, 'proxy', None)
+            if proxy_url is not None:
+                try:
+                    parsed = urlparse(proxy_url)
+                    if not parsed.hostname or not parsed.port:
+                        raise ChannelError('protocol-error', message='invalid "proxy" url')
+                except ValueError as exc:
+                    raise ChannelError('protocol-error', message='invalid "proxy" url') from exc
+                connection = http.client.HTTPSConnection(parsed.hostname, parsed.port, context=context)
+                connection.set_tunnel(opt_address, opt_port)
+                return connection
 
             return http.client.HTTPSConnection(opt_address, port=opt_port, context=context)
 

--- a/src/cockpit/channels/http_channel.py
+++ b/src/cockpit/channels/http_channel.py
@@ -3,15 +3,30 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
+import contextlib
 import http.client
 import logging
 import socket
 import ssl
+import tempfile
+from collections.abc import Generator
 
 from ..channel import AsyncChannel, ChannelError
 from ..jsonutil import JsonObject, get_dict, get_int, get_object, get_str, typechecked
 
 logger = logging.getLogger(__name__)
+
+
+@contextlib.contextmanager
+def _pem_data(obj: JsonObject) -> Generator[str]:
+    path = get_str(obj, 'file', None)
+    if path is not None:
+        yield path
+    else:
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.pem') as f:
+            f.write(get_str(obj, 'data'))
+            f.flush()
+            yield f.name
 
 
 class HttpChannel(AsyncChannel):
@@ -56,6 +71,18 @@ class HttpChannel(AsyncChannel):
             if 'validate' in opt_tls and not opt_tls['validate']:
                 context.check_hostname = False
                 context.verify_mode = ssl.VerifyMode.CERT_NONE
+
+            certificate = get_dict(opt_tls, 'certificate', None)
+            key = get_dict(opt_tls, 'key', None)
+
+            if certificate is not None or key is not None:
+                if certificate is None or key is None:
+                    raise ChannelError('protocol-error', message='need to specify both "certificate" and "key"')
+                try:
+                    with _pem_data(certificate) as certfile, _pem_data(key) as keyfile:
+                        context.load_cert_chain(certfile=certfile, keyfile=keyfile)
+                except ssl.SSLError as exc:
+                    raise ChannelError('protocol-error', message=str(exc)) from exc
 
             return http.client.HTTPSConnection(opt_address, port=opt_port, context=context)
 

--- a/test/pytest/test_http_channel.py
+++ b/test/pytest/test_http_channel.py
@@ -73,7 +73,7 @@ async def http_server(request, tmp_path) -> AsyncGenerator[dict, None]:
 
 
 @pytest_asyncio.fixture()
-async def tls_server() -> AsyncGenerator[int, None]:
+async def tls_server(request) -> AsyncGenerator[int, None]:
     async def serve(reader, writer):
         while True:
             line = await reader.readline()
@@ -85,6 +85,9 @@ async def tls_server() -> AsyncGenerator[int, None]:
 
     server_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
     server_ctx.load_cert_chain(MOCK_DATA / 'mock-server.crt', MOCK_DATA / 'mock-server.key')
+    if hasattr(request, 'param') and request.param == 'client-cert':
+        server_ctx.verify_mode = ssl.CERT_REQUIRED
+        server_ctx.load_verify_locations(MOCK_DATA / 'mock-client.crt')
 
     server = await asyncio.start_server(serve, '127.0.0.1', 0, ssl=server_ctx)
     yield server.sockets[0].getsockname()[1]
@@ -104,6 +107,21 @@ async def test_open_error(transport):
     await transport.check_open('http-stream2', method='GET', path='/test', unix='/tmp/sock',
                                tls={}, problem='protocol-error',
                                reply_keys={'message': 'TLS on Unix socket is not supported'})
+    await transport.check_open('http-stream2', method='GET', path='/test', port=666,
+                               tls={
+                                    'certificate': {'file': str(MOCK_DATA / 'mock-client.crt')},
+                               }, problem='protocol-error',
+                               reply_keys={'message': 'need to specify both "certificate" and "key"'})
+    await transport.check_open('http-stream2', method='GET', path='/test', port=666,
+                               tls={
+                                    'key': {'file': str(MOCK_DATA / 'mock-client.crt')},
+                               }, problem='protocol-error',
+                               reply_keys={'message': 'need to specify both "certificate" and "key"'})
+    await transport.check_open('http-stream2', method='GET', path='/test', port=666,
+                               tls={
+                                    'certificate': {'data': 'invalid'},
+                                    'key': {'data': 'invalid'},
+                               }, problem='protocol-error')
 
 
 @pytest.mark.asyncio
@@ -133,5 +151,36 @@ async def test_tls_request_no_validate(transport, tls_server):
 async def test_tls_no_validate(transport, tls_server):
     ch = await transport.check_open('http-stream2', method='GET', path='/test', port=tls_server,
                                     tls={'validate': False})
+    transport.send_done(ch)
+    await assert_http_response(transport, ch, tls=True)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('tls_server', ['client-cert'], indirect=True)
+async def test_tls_client_cert(transport, tls_server):
+    ch = await transport.check_open('http-stream2', method='GET', path='/test', port=tls_server,
+                                    tls={
+                                        'authority': {'file': str(MOCK_DATA / 'mock-server.crt')},
+                                        'certificate': {'file': str(MOCK_DATA / 'mock-client.crt')},
+                                        'key': {'file': str(MOCK_DATA / 'mock-client.key')},
+                                    })
+    transport.send_done(ch)
+    await assert_http_response(transport, ch, tls=True)
+
+    ch = await transport.check_open('http-stream2', method='GET', path='/test', port=tls_server,
+                                    tls={
+                                        'authority': {'data': (MOCK_DATA / 'mock-server.crt').read_text()},
+                                        'certificate': {'file': str(MOCK_DATA / 'mock-client.crt')},
+                                        'key': {'data': (MOCK_DATA / 'mock-client.key').read_text()},
+                                    })
+    transport.send_done(ch)
+    await assert_http_response(transport, ch, tls=True)
+
+    ch = await transport.check_open('http-stream2', method='GET', path='/test', port=tls_server,
+                                    tls={
+                                        'authority': {'data': (MOCK_DATA / 'mock-server.crt').read_text()},
+                                        'certificate': {'data': (MOCK_DATA / 'mock-client.crt').read_text()},
+                                        'key': {'data': (MOCK_DATA / 'mock-client.key').read_text()},
+                                    })
     transport.send_done(ch)
     await assert_http_response(transport, ch, tls=True)

--- a/test/pytest/test_http_channel.py
+++ b/test/pytest/test_http_channel.py
@@ -122,6 +122,12 @@ async def test_open_error(transport):
                                     'certificate': {'data': 'invalid'},
                                     'key': {'data': 'invalid'},
                                }, problem='protocol-error')
+    await transport.check_open('http-stream2', method='GET', path='/test', port=666,
+                               tls={"proxy": "http://host:notaport"}, problem='protocol-error',
+                               reply_keys={'message': 'invalid "proxy" url'})
+    await transport.check_open('http-stream2', method='GET', path='/test', port=666,
+                               tls={"proxy": "woops"}, problem='protocol-error',
+                               reply_keys={'message': 'invalid "proxy" url'})
 
 
 @pytest.mark.asyncio
@@ -184,3 +190,43 @@ async def test_tls_client_cert(transport, tls_server):
                                     })
     transport.send_done(ch)
     await assert_http_response(transport, ch, tls=True)
+
+
+@pytest.mark.asyncio
+async def test_tls_proxy(transport, tls_server):
+    async def relay(reader, writer):
+        try:
+            while True:
+                data = await reader.read(8192)
+                if not data:
+                    break
+                writer.write(data)
+                await writer.drain()
+        finally:
+            writer.close()
+
+    async def handle_connect(reader, writer):
+        request_line = await reader.readline()
+        while (await reader.readline()).strip():
+            pass
+
+        host, port = request_line.split()[1].split(b':')
+        upstream_reader, upstream_writer = await asyncio.open_connection(host.decode(), int(port))
+
+        writer.write(b'HTTP/1.1 200 Connection established\r\n\r\n')
+        await writer.drain()
+
+        await asyncio.gather(relay(reader, upstream_writer), relay(upstream_reader, writer))
+
+    proxy = await asyncio.start_server(handle_connect, '127.0.0.1', 0)
+    proxy_port = proxy.sockets[0].getsockname()[1]
+
+    ch = await transport.check_open('http-stream2', method='GET', path='/test', port=tls_server,
+                                    tls={
+                                        'authority': {'file': str(MOCK_DATA / 'mock-server.crt')},
+                                        'proxy': f'http://127.0.0.1:{proxy_port}',
+                                    })
+    transport.send_done(ch)
+    await assert_http_response(transport, ch, tls=True)
+
+    proxy.close()

--- a/test/pytest/test_http_channel.py
+++ b/test/pytest/test_http_channel.py
@@ -1,0 +1,137 @@
+#
+# Copyright (C) 2026 Red Hat, Inc.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import argparse
+import asyncio
+import ssl
+from pathlib import Path
+from typing import AsyncGenerator
+
+import pytest
+import pytest_asyncio
+
+from cockpit.bridge import Bridge
+
+from .mocktransport import MockTransport
+
+MOCK_DATA = Path(__file__).parent.parent / 'data'
+
+
+@pytest_asyncio.fixture()
+async def no_init_transport() -> AsyncGenerator[MockTransport, None]:
+    bridge = Bridge(argparse.Namespace(privileged=False, beipack=False))
+    transport = MockTransport(bridge)
+    try:
+        yield transport
+    finally:
+        await transport.stop()
+
+
+@pytest.fixture
+def transport(no_init_transport: MockTransport) -> MockTransport:
+    no_init_transport.init()
+    return no_init_transport
+
+
+async def assert_http_response(transport: MockTransport, ch: str, *, tls: bool = False) -> None:
+    await transport.assert_msg('', command='response', channel=ch, status=200, reason='OK')
+
+    channel, data = await transport.next_frame()
+    assert channel == ch
+    if tls:
+        assert data == b'Hello TLS\r\n'
+    else:
+        assert data == b'Hello\r\n'
+
+    await transport.assert_msg('', command='done', channel=ch)
+    await transport.assert_msg('', command='close', channel=ch)
+
+
+@pytest_asyncio.fixture(params=['tcp', 'unix'])
+async def http_server(request, tmp_path) -> AsyncGenerator[dict, None]:
+    async def serve(reader, writer):
+        while True:
+            line = await reader.readline()
+            if not line.strip():
+                break
+        writer.write(b'HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nHello\r\n')
+        await writer.drain()
+        writer.close()
+
+    if request.param == 'tcp':
+        server = await asyncio.start_server(serve, '127.0.0.1', 0)
+        port = server.sockets[0].getsockname()[1]
+        open_args = {'port': port}
+    else:
+        sock = str(tmp_path / 'http.sock')
+        server = await asyncio.start_unix_server(serve, sock)
+        open_args = {'unix': sock}
+
+    yield open_args
+    server.close()
+
+
+@pytest_asyncio.fixture()
+async def tls_server() -> AsyncGenerator[int, None]:
+    async def serve(reader, writer):
+        while True:
+            line = await reader.readline()
+            if not line.strip():
+                break
+        writer.write(b'HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nHello TLS\r\n')
+        await writer.drain()
+        writer.close()
+
+    server_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    server_ctx.load_cert_chain(MOCK_DATA / 'mock-server.crt', MOCK_DATA / 'mock-server.key')
+
+    server = await asyncio.start_server(serve, '127.0.0.1', 0, ssl=server_ctx)
+    yield server.sockets[0].getsockname()[1]
+    server.close()
+
+
+@pytest.mark.asyncio
+async def test_open_error(transport):
+    await transport.check_open('http-stream2', problem='protocol-error',
+                               reply_keys={'message': "attribute 'method' required"})
+    await transport.check_open('http-stream2', method='POST', path='/tmp/',
+                               problem='protocol-error',
+                               reply_keys={'message': 'no "port" or "unix" option for channel'})
+    await transport.check_open('http-stream2', method='POST', path='/tmp/', port="foo",
+                               problem='protocol-error',
+                               reply_keys={'message': "attribute 'port': must have type int"})
+    await transport.check_open('http-stream2', method='GET', path='/test', unix='/tmp/sock',
+                               tls={}, problem='protocol-error',
+                               reply_keys={'message': 'TLS on Unix socket is not supported'})
+
+
+@pytest.mark.asyncio
+async def test_http_request(transport, http_server):
+    ch = await transport.check_open('http-stream2', method='GET', path='/test', **http_server)
+    transport.send_done(ch)
+    await assert_http_response(transport, ch, tls=False)
+
+
+@pytest.mark.asyncio
+async def test_tls_request(transport, tls_server):
+    ch = await transport.check_open('http-stream2', method='GET', path='/test', port=tls_server,
+                                    tls={'authority': {'file': str(MOCK_DATA / 'mock-server.crt')}})
+    transport.send_done(ch)
+    await assert_http_response(transport, ch, tls=True)
+
+
+@pytest.mark.asyncio
+async def test_tls_request_no_validate(transport, tls_server):
+    ch = await transport.check_open('http-stream2', method='GET', path='/test', port=tls_server,
+                                    tls={'validate': False})
+    transport.send_done(ch)
+    await assert_http_response(transport, ch, tls=True)
+
+
+@pytest.mark.asyncio
+async def test_tls_no_validate(transport, tls_server):
+    ch = await transport.check_open('http-stream2', method='GET', path='/test', port=tls_server,
+                                    tls={'validate': False})
+    transport.send_done(ch)
+    await assert_http_response(transport, ch, tls=True)


### PR DESCRIPTION
One thing missing is:

The following headers are not permitted on requests, some of these
are added automatically as appropriate, and others are stripped from
the response, in particular 'Content-Length':

 * 'Accept-Charset'
 * 'Accept-Ranges'
 * 'Connection'
 * 'Content-Length'
 * 'Content-MD5'
 * 'Content-Range'
 * 'Range'
 * 'TE'
 * 'Trailer'
 * 'Transfer-Encoding'
 * 'Upgrade'

The following are not accepted on non-binary channels:

 * 'Accept-Encoding'
 * 'Content-Encoding'
