### PR TITLE
test: Run user metric hogs without SELinux on all Fedoras and RHELs

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -810,7 +810,7 @@ class TestCurrentMetrics(testlib.MachineCase):
         b = self.browser
         m = self.machine
 
-        if m.image in ["fedora-44"]:
+        if m.image.startswith(("fedora-", "rhel-")):
             # HACK - https://bugzilla.redhat.com/show_bug.cgi?id=2461071
             m.execute("setenforce 0")
             self.addCleanup(m.execute, "setenforce 1")
@@ -1044,7 +1044,7 @@ class TestCurrentMetrics(testlib.MachineCase):
         b = self.browser
         m = self.machine
 
-        if m.image in ["fedora-44"]:
+        if m.image.startswith(("fedora-", "rhel-")):
             # HACK - https://bugzilla.redhat.com/show_bug.cgi?id=2461071
             m.execute("setenforce 0")
             self.addCleanup(m.execute, "setenforce 1")


### PR DESCRIPTION
The bug has crept into fedora-coreos recently. Let's assume it is unstoppable.