### PR TITLE
fix: align group rename validation with groupadd rules

### DIFF
--- a/pkg/users/rename-group-dialog.jsx
+++ b/pkg/users/rename-group-dialog.jsx
@@ -54,7 +54,7 @@ function validate_name(name) {
             continue;
 
         if (!is_valid_char_name(name[i]))
-            return _("Group name can only contain letters, digits, underscores, dashes, dots, or a trailing dollar sign");
+            return _("Group name can only consist of letters, digits, dots, dashes, and underscores");
     }
 
     return null;

--- a/pkg/users/rename-group-dialog.jsx
+++ b/pkg/users/rename-group-dialog.jsx
@@ -3,25 +3,20 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
-
 import cockpit from 'cockpit';
 import React from 'react';
 import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form/index.js";
 import { HelperText, HelperTextItem } from "@patternfly/react-core/dist/esm/components/HelperText/index.js";
 import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput/index.js";
 
-
 import { apply_modal_dialog, show_modal_dialog } from "cockpit-components-dialog.jsx";
 import { FormHelper } from "cockpit-components-form-helper";
 import { has_errors, is_valid_char_name } from "./dialog-utils.js";
 
-
 const _ = cockpit.gettext;
-
 
 function RenameGroupDialogBody({ state, errors, change }) {
     const { name } = state;
-
 
     return (
         <Form isHorizontal onSubmit={apply_modal_dialog}>
@@ -37,7 +32,6 @@ function RenameGroupDialogBody({ state, errors, change }) {
         </Form>
     );
 }
-
 
 function validate_name(name) {
     if (!name)
@@ -63,23 +57,19 @@ function validate_name(name) {
     return null;
 }
 
-
 export function rename_group_dialog(group) {
     let dlg = null;
-
 
     const state = {
         name: group
     };
     let errors = { };
 
-
     function change(field, value) {
         state[field] = value;
         errors = { };
         update();
     }
-
 
     function update() {
         const props = {
@@ -88,7 +78,6 @@ export function rename_group_dialog(group) {
             body: <RenameGroupDialogBody state={state} errors={errors} change={change} />,
             variant: 'small',
         };
-
 
         const footer = {
             actions: [
@@ -107,7 +96,6 @@ export function rename_group_dialog(group) {
             ]
         };
 
-
         if (!dlg)
             dlg = show_modal_dialog(props, footer);
         else {
@@ -115,7 +103,6 @@ export function rename_group_dialog(group) {
             dlg.setFooterProps(footer);
         }
     }
-
 
     update();
 }

--- a/pkg/users/rename-group-dialog.jsx
+++ b/pkg/users/rename-group-dialog.jsx
@@ -3,20 +3,25 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
+
 import cockpit from 'cockpit';
 import React from 'react';
 import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form/index.js";
 import { HelperText, HelperTextItem } from "@patternfly/react-core/dist/esm/components/HelperText/index.js";
 import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput/index.js";
 
+
 import { apply_modal_dialog, show_modal_dialog } from "cockpit-components-dialog.jsx";
 import { FormHelper } from "cockpit-components-form-helper";
 import { has_errors, is_valid_char_name } from "./dialog-utils.js";
 
+
 const _ = cockpit.gettext;
+
 
 function RenameGroupDialogBody({ state, errors, change }) {
     const { name } = state;
+
 
     return (
         <Form isHorizontal onSubmit={apply_modal_dialog}>
@@ -33,31 +38,48 @@ function RenameGroupDialogBody({ state, errors, change }) {
     );
 }
 
+
 function validate_name(name) {
     if (!name)
         return _("Group name cannot be empty");
 
+    if (name == "." || name == "..")
+        return _("Group name cannot be '.' or '..'");
+
+    if (/^\d+$/.test(name))
+        return _("Group name cannot consist only of digits");
+
+    if (name[0] == '-')
+        return _("Group name cannot start with a dash");
+
     for (let i = 0; i < name.length; i++) {
+        if (name[i] == '$' && i == name.length - 1)
+            continue;
+
         if (!is_valid_char_name(name[i]))
-            return _("Group name can only consist of letters, digits, dots, dashes, and underscores");
+            return _("Group name can only contain letters, digits, underscores, dashes, dots, or a trailing dollar sign");
     }
 
     return null;
 }
 
+
 export function rename_group_dialog(group) {
     let dlg = null;
+
 
     const state = {
         name: group
     };
     let errors = { };
 
+
     function change(field, value) {
         state[field] = value;
         errors = { };
         update();
     }
+
 
     function update() {
         const props = {
@@ -66,6 +88,7 @@ export function rename_group_dialog(group) {
             body: <RenameGroupDialogBody state={state} errors={errors} change={change} />,
             variant: 'small',
         };
+
 
         const footer = {
             actions: [
@@ -84,6 +107,7 @@ export function rename_group_dialog(group) {
             ]
         };
 
+
         if (!dlg)
             dlg = show_modal_dialog(props, footer);
         else {
@@ -91,6 +115,7 @@ export function rename_group_dialog(group) {
             dlg.setFooterProps(footer);
         }
     }
+
 
     update();
 }

--- a/pkg/users/rename-group-dialog.jsx
+++ b/pkg/users/rename-group-dialog.jsx
@@ -37,6 +37,9 @@ function validate_name(name) {
     if (!name)
         return _("Group name cannot be empty");
 
+    if (name.length > 32)
+        return _("Group name is longer than 32 characters");
+
     if (name == "." || name == "..")
         return _("Group name cannot be '.' or '..'");
 


### PR DESCRIPTION
## Problem

The rename group dialog only checked the allowed character set and rejected dollar signs entirely. That did not match the groupadd rules described in #23312: group names cannot be numeric-only, cannot be . or .., cannot start with a dash, and may end with a dollar sign.

## Solution

I updated the dialog validation to reject the extra invalid cases and allow a dollar sign only as the final character. I also adjusted the invalid-character helper text to mention the trailing dollar sign case.

## Testing

Chrome-only run; I inspected the GitHub diff manually and verified it only changes pkg/users/rename-group-dialog.jsx. I also checked #23312, the linked #23232 discussion, and open PR searches for #23312, "valid group name", and "group validation message" before opening this PR.