### PR TITLE
systemd: Add bulk enable action for services

### DIFF
--- a/pkg/systemd/services-list.jsx
+++ b/pkg/systemd/services-list.jsx
@@ -6,6 +6,7 @@
 import React from "react";
 
 import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
+import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox/index.js";
 import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex/index.js";
 import { Tooltip, TooltipPosition } from "@patternfly/react-core/dist/esm/components/Tooltip/index.js";
 import { Badge } from "@patternfly/react-core/dist/esm/components/Badge/index.js";
@@ -18,7 +19,7 @@ import cockpit from "cockpit";
 
 const _ = cockpit.gettext;
 
-export const ServicesList = ({ units, isTimer, onClearAllFilters }) => {
+export const ServicesList = ({ units, isTimer, onClearAllFilters, selectedUnitIds, onSelectUnit }) => {
     let columns;
     if (!isTimer) {
         columns = [
@@ -38,7 +39,14 @@ export const ServicesList = ({ units, isTimer, onClearAllFilters }) => {
                       gridBreakPoint={isTimer ? "grid-xl" : "grid-lg"}
                       showHeader={false}
                       id="services-list"
-                      rows={ units.map(unit => getServicesRow({ key: unit[0], isTimer, shortId: unit[0], ...unit[1] })) }
+                      rows={ units.map(unit => getServicesRow({
+                          key: unit[0],
+                          isTimer,
+                          shortId: unit[0],
+                          selectedUnitIds,
+                          onSelectUnit,
+                          ...unit[1]
+                      })) }
                       emptyComponent={<EmptyStatePanel icon={SearchIcon}
                                                        paragraph={_("No results match the filter criteria. Clear all filters to show results.")}
                                                        action={<Button id="clear-all-filters" onClick={onClearAllFilters} isInline variant='link'>{_("Clear all filters")}</Button>}
@@ -47,7 +55,7 @@ export const ServicesList = ({ units, isTimer, onClearAllFilters }) => {
     );
 };
 
-const getServicesRow = ({ Id, shortId, AutomaticStartup, UnitFileState, LoadState, HasFailed, IsPinned, CombinedState, LastTriggerTime, NextRunTime, Description, isTimer }) => {
+const getServicesRow = ({ Id, shortId, AutomaticStartup, UnitFileState, LoadState, HasFailed, IsPinned, CombinedState, LastTriggerTime, NextRunTime, Description, isTimer, selectedUnitIds, onSelectUnit }) => {
     let displayName = shortId;
     // Remove ".service" from services as this is not necessary
     if (shortId.endsWith(".service"))
@@ -58,6 +66,7 @@ const getServicesRow = ({ Id, shortId, AutomaticStartup, UnitFileState, LoadStat
     const disabled = UnitFileState && UnitFileState.includes("disabled");
     const isStatic = UnitFileState && UnitFileState == "static";
     const masked = LoadState && LoadState.includes("masked");
+    const canBulkEnable = !isTimer && UnitFileState == "disabled";
     let unitFileState;
     if (enabled || disabled)
         unitFileState = <Badge className="service-unit-file-state" isRead={!enabled}>{AutomaticStartup}</Badge>;
@@ -78,6 +87,13 @@ const getServicesRow = ({ Id, shortId, AutomaticStartup, UnitFileState, LoadStat
             title: (
                 <div className='service-unit-first-column'>
                     <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
+                        {canBulkEnable &&
+                            <Checkbox className="service-unit-select"
+                                      id={`select-${shortId}`}
+                                      aria-label={cockpit.format(_("Select $0"), shortId)}
+                                      isChecked={selectedUnitIds?.has(shortId)}
+                                      onClick={event => event.stopPropagation()}
+                                      onChange={(_event, checked) => onSelectUnit(shortId, checked)} />}
                         <Button className='service-unit-id'
                             isInline
                             component="a"

--- a/pkg/systemd/services.jsx
+++ b/pkg/systemd/services.jsx
@@ -9,6 +9,8 @@ import 'cockpit-dark-theme'; // once per page
 
 import React, { useState, useEffect } from "react";
 import { createRoot } from 'react-dom/client';
+import { Alert, AlertActionCloseButton } from "@patternfly/react-core/dist/esm/components/Alert/index.js";
+import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
 import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex/index.js";
 import { Page, PageSection, } from "@patternfly/react-core/dist/esm/components/Page/index.js";
 import { Card, CardHeader } from "@patternfly/react-core/dist/esm/components/Card/index.js";
@@ -169,6 +171,9 @@ class ServicesPageBody extends React.Component {
             isFullyLoaded: false,
             error: null,
             pinnedUnits: [],
+            selectedUnitIds: new Set(),
+            bulkEnableError: null,
+            bulkEnableRunning: false,
         };
 
         /* data storage
@@ -247,6 +252,8 @@ class ServicesPageBody extends React.Component {
         this.onOptionsChanged = this.onOptionsChanged.bind(this);
         this.compareUnits = this.compareUnits.bind(this);
         this.addTimerPropertiesFull = this.addTimerPropertiesFull.bind(this);
+        this.onSelectUnit = this.onSelectUnit.bind(this);
+        this.bulkEnableUnits = this.bulkEnableUnits.bind(this);
     }
 
     onOptionsChanged(options) {
@@ -262,6 +269,37 @@ class ServicesPageBody extends React.Component {
             delete currentOptions.name;
 
         cockpit.location.replace(cockpit.location.path, currentOptions);
+    }
+
+    onSelectUnit(unitId, selected) {
+        this.setState(prevState => {
+            const selectedUnitIds = new Set(prevState.selectedUnitIds);
+            if (selected)
+                selectedUnitIds.add(unitId);
+            else
+                selectedUnitIds.delete(unitId);
+
+            return { selectedUnitIds, bulkEnableError: null };
+        });
+    }
+
+    bulkEnableUnits(unitIds) {
+        if (!unitIds.length)
+            return;
+
+        this.setState({ bulkEnableRunning: true, bulkEnableError: null });
+        systemd_client[this.props.owner].call(s_bus.O_MANAGER, s_bus.I_MANAGER, "EnableUnitFiles", [unitIds, false, false])
+                .then(() => systemd_client[this.props.owner].call(s_bus.O_MANAGER, s_bus.I_MANAGER, "Reload", null))
+                .then(() => {
+                    this.setState(prevState => {
+                        const selectedUnitIds = new Set(prevState.selectedUnitIds);
+                        unitIds.forEach(unitId => selectedUnitIds.delete(unitId));
+
+                        return { selectedUnitIds, bulkEnableRunning: false };
+                    });
+                    this.listUnits();
+                })
+                .catch(ex => this.setState({ bulkEnableError: ex.toString(), bulkEnableRunning: false }));
     }
 
     componentDidMount() {
@@ -695,6 +733,12 @@ class ServicesPageBody extends React.Component {
             }
         });
         const activeTab = this.props.activeTab;
+        const selectedUnits = this.computeSelectedUnits();
+        const bulkEnableUnitIds = activeTab == 'service'
+            ? selectedUnits
+                    .filter(([, unit]) => unit.UnitFileState == 'disabled' && this.state.selectedUnitIds.has(unit.Id))
+                    .map(([unitId]) => unitId)
+            : [];
 
         const onClearAllFilters = () => {
             this.onOptionsChanged({
@@ -714,12 +758,22 @@ class ServicesPageBody extends React.Component {
                                             loadingUnits={this.props.isLoading}
                                             options={cockpit.location.options}
                                             onOptionsChanged={this.onOptionsChanged}
+                                            bulkEnableCount={bulkEnableUnitIds.length}
+                                            bulkEnableRunning={this.state.bulkEnableRunning}
+                                            onBulkEnable={activeTab == 'service' ? () => this.bulkEnableUnits(bulkEnableUnitIds) : null}
                         />
                     </CardHeader>
+                    {this.state.bulkEnableError &&
+                        <Alert variant="danger"
+                               isInline
+                               title={this.state.bulkEnableError}
+                               actionClose={<AlertActionCloseButton onClose={() => this.setState({ bulkEnableError: null })} />} />}
                     <ServicesList key={cockpit.format("$0-list", activeTab)}
                                   isTimer={activeTab == 'timer'}
                                   onClearAllFilters={onClearAllFilters}
-                                  units={this.computeSelectedUnits()} />
+                                  selectedUnitIds={this.state.selectedUnitIds}
+                                  onSelectUnit={this.onSelectUnit}
+                                  units={selectedUnits} />
                 </Card>
             </PageSection>
         );
@@ -733,6 +787,9 @@ const ServicesPageFilters = ({
     options,
     onOptionsChanged,
     onClearAllFilters,
+    bulkEnableCount,
+    bulkEnableRunning,
+    onBulkEnable,
 }) => {
     const { activestate, filestate, name } = options;
 
@@ -861,7 +918,21 @@ const ServicesPageFilters = ({
                  className="pf-m-sticky-top ct-compact services-toolbar"
                  id="services-toolbar"
                  numberOfFiltersText={n => cockpit.format(_("$0 filters applied"), n)}>
-            <ToolbarContent>{toolbarItems}</ToolbarContent>
+            <ToolbarContent>
+                {toolbarItems}
+                {onBulkEnable &&
+                    <ToolbarItem>
+                        <Button id="services-bulk-enable"
+                                variant="secondary"
+                                isLoading={bulkEnableRunning}
+                                isDisabled={bulkEnableRunning || !bulkEnableCount}
+                                onClick={onBulkEnable}>
+                            {bulkEnableCount
+                                ? cockpit.format(cockpit.ngettext("Enable $0 selected service", "Enable $0 selected services", bulkEnableCount), bulkEnableCount)
+                                : _("Enable selected")}
+                        </Button>
+                    </ToolbarItem>}
+            </ToolbarContent>
         </Toolbar>
     );
 };

--- a/pkg/systemd/services.scss
+++ b/pkg/systemd/services.scss
@@ -69,6 +69,10 @@
   --pf-v6-c-button--Display: block;
 }
 
+.service-unit-select {
+  margin-inline-end: var(--pf-t--global--spacer--sm);
+}
+
 .service-unit-triggers {
   min-inline-size: 20ch;
 }

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -224,6 +224,19 @@ ExecStart=/usr/bin/true
 WantedBy=default.target
 """)
 
+        for service in ["bulk-one", "bulk-two"]:
+            self.write_file(f"{path}/{service}.service",
+                            """
+[Unit]
+Description=Bulk Enable Test Service
+
+[Service]
+ExecStart=/usr/bin/true
+
+[Install]
+WantedBy=default.target
+""")
+
         self.make_test_service(path)
 
         url = "/system/services#/?owner=user" if user else "/system/services"
@@ -253,6 +266,14 @@ WantedBy=default.target
         self.wait_service_present("special@:-characters.service")
         self.wait_service_in_panel("special@:-characters.service", "Disabled")
         self.wait_service_state("special@:-characters.service", "inactive")
+
+        self.wait_service_present("bulk-one.service")
+        self.wait_service_present("bulk-two.service")
+        b.set_checked("input[aria-label='Select bulk-one.service']", val=True)
+        b.set_checked("input[aria-label='Select bulk-two.service']", val=True)
+        b.click("#services-bulk-enable")
+        self.wait_service_in_panel("bulk-one.service", "Enabled")
+        self.wait_service_in_panel("bulk-two.service", "Enabled")
 
         # Test breadcrumb link when service id contains special characters
         self.goto_service("special@:-characters.service")


### PR DESCRIPTION
## Summary
- add selection checkboxes for disabled service units in the Services list
- add an "Enable selected" toolbar action that enables all selected services in one systemd D-Bus call
- cover bulk enabling two services in the system services browser test

## Testing
- `./node_modules/.bin/eslint pkg/systemd/services.jsx pkg/systemd/services-list.jsx`
- `./node_modules/.bin/stylelint pkg/systemd/services.scss`
- `python3 -m py_compile test/verify/check-system-services`
- `git diff --check`
