### PR TITLE
branding: Fix default logo size

### DIFF
--- a/src/branding/default/branding.css
+++ b/src/branding/default/branding.css
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #badge {
     inline-size: 73px;
-    block-size: 69px;
+    block-size: 73px;
     background-image: url("logo.png");
     background-repeat: no-repeat;
 }


### PR DESCRIPTION
With the newer Cockpit logo there was a size change by removing the
spacing in the imagefile itself. This made the bottom of the logo on the
login screen be cropped a few pixels, so this bumps it a bit.

Before
<img width="1308" height="593" alt="Screenshot From 2026-06-08 01-43-08" src="https://github.com/user-attachments/assets/8eaf6ddd-bbdf-4625-818e-6b4aad683ebc" />

After
<img width="1308" height="593" alt="Screenshot From 2026-06-08 01-43-20" src="https://github.com/user-attachments/assets/f29d5944-aaf6-462c-a387-14154f0344d9" />


Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
