### PR TITLE
test: Retry clicking on memhog row in TestCurrentMetrics.testMemory

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1153,11 +1153,25 @@ BEGIN {{
         if not m.image.startswith("rhel-8"):
             m.execute("su - admin -c 'XDG_RUNTIME_DIR=/run/user/$(id -u admin) systemd-run --user --collect --slice cockpittest --unit mem-userhog memhog.sh'")
             m.execute("while [ ! -e /tmp/hogged ]; do sleep 1; done")
-            # user services are always running underneath user@1000.service, so these two will compete for row 1 or 2
-            b.wait_in_text("table[aria-label='Top 5 memory services'] tbody", "mem-userhog")
-            b.click("table[aria-label='Top 5 memory services'] tbody td[data-label='Service'] a:contains('mem-userhog')")
-            b.enter_page("/system/services")
-            b.wait_in_text(".service-name", "memhog.sh")
+            # The DOM is very volatile and we sometimes click on the
+            # wrong row, so let's try a couple of times
+            n = 0
+            while True:
+                # user services are always running underneath user@1000.service, so these two will compete for row 1 or 2
+                b.wait_in_text("table[aria-label='Top 5 memory services'] tbody", "mem-userhog")
+                b.click("table[aria-label='Top 5 memory services'] tbody td[data-label='Service'] a:contains('mem-userhog')")
+                b.enter_page("/system/services")
+                try:
+                    b.wait_in_text(".service-name", "memhog.sh")
+                    break
+                except testlib.Error as ex:
+                    if n < 5:
+                        print("WARNING: Got the wrong service, retrying")
+                    else:
+                        raise ex
+                b.eval_js("window.history.back()")
+                b.enter_page("/metrics")
+                n = n + 1
 
     def testDiskIO(self):
         b = self.browser


### PR DESCRIPTION
We sometimes end up clicking on some other service, mostly some already dead instance of SetroubleshootPrivileged@.service.