### PR TITLE
test: Explicitly keep using /var/log/btmp

### DIFF
--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -217,6 +217,10 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         m = self.machine
         b = self.browser
 
+        # Allow cockpit-session to record and report bad logins even
+        # on OSes that don't use /var/log/btmp anymore.
+        m.execute("touch /var/log/btmp")
+
         def assert_messages(has_last, n_fail):
             if has_last:
                 b.wait_in_text('#system_last_login', "Last successful login")


### PR DESCRIPTION
Linux is moving away from the traditional utmp, wtmp, and btmp files. Cockpit still uses them and records failed login attempts into /var/log/btmp, for example, and also provides the session with information about past failed logins found in /var/log/btmp.

But only if /var/log/btmp exists.  This file has disappeared in Debian testing now and Cockpit will no longer record failed login attempts.

But by explicitly creating this file in the test, cockpit-session will continue to use it, as a kind of private database just for itself. The rest of the system will probably not reliably record failed login attempts in it anymore.

The replacement for /var/log/btmp seems to be the journal. Programs are supposed to comb through it to find failed login attempts, seemingly.

See https://github.com/cockpit-project/bots/pull/9141