### PR TITLE
Re-enable s390x and use fedora-branched for bodhi updates

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -146,5 +146,4 @@ jobs:
     trigger: commit
     dist_git_branches:
       # rawhide updates are created automatically
-      - fedora-43
-      - fedora-44
+      - fedora-branched

--- a/packit.yaml
+++ b/packit.yaml
@@ -68,12 +68,11 @@ jobs:
     targets: *test_targets
 
   # run extra build/unit tests on some interesting architectures
-  # https://github.com/fedora-copr/copr/issues/4219
-  # - job: copr_build
-  #   trigger: pull_request
-  #   targets:
-  #     # big-endian
-  #     - fedora-latest-stable-s390x
+  - job: copr_build
+    trigger: pull_request
+    targets:
+      # big-endian
+      - fedora-latest-stable-s390x
 
   # for cross-project testing
   - job: copr_build


### PR DESCRIPTION
According to [#packit](https://matrix.to/#/#packit:fedora.im) this should ignore fedora-42 if we have no updates for it.