### PR TITLE
Remove unimplemented http channel options and add pytest tests for http channel

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -779,14 +779,10 @@ You may also specify these options:
 
 The TLS object can have the following options:
 
- * "certificate": The client certificate to use, represented as an
-   object described below.
- * "key": The client key to use, described below.
  * "authority": Certificate authority(s) to expect as signers of peer.
  * "validate": Validate the peer's certificate.
 
-The "certificate", "key" and "authority" are objects with either of
-the following fields:
+The "authority" is an object with either of the following fields:
 
  * "file": String with a file name
  * "data": String with PEM encoded data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ module = [
     # test/pytest
     'test.pytest.test_beiboot',
     'test.pytest.test_packages',
+    'test.pytest.test_http_channel',
 ]
 
 [tool.pylint]

--- a/test/pytest/mocktransport.py
+++ b/test/pytest/mocktransport.py
@@ -17,7 +17,7 @@ class MockTransport(asyncio.Transport):
         await asyncio.sleep(0.1)
         assert self.queue.qsize() == 0
 
-    def send_json(self, channel_: str, **kwargs) -> None:
+    def send_json(self, channel_: str, **kwargs: JsonValue) -> None:
         # max_read_size is one of our special keys which uses underscores
         msg = {k.replace('_', '-') if k != "max_read_size" else k: v for k, v in kwargs.items()}
         self.send_data(channel_, json.dumps(msg).encode('ascii'))
@@ -27,7 +27,7 @@ class MockTransport(asyncio.Transport):
         msg = str(len(msg)).encode('ascii') + b'\n' + msg
         self.protocol.data_received(msg)
 
-    def send_init(self, version=1, host=MOCK_HOSTNAME, **kwargs):
+    def send_init(self, version: int = 1, host:  str = MOCK_HOSTNAME, **kwargs: JsonValue) -> None:
         self.send_json('', command='init', version=version, host=host, **kwargs)
 
     def init(self, **kwargs: Any) -> Dict[str, object]:
@@ -42,7 +42,7 @@ class MockTransport(asyncio.Transport):
         self.next_id += 1
         return f'{prefix}.{self.next_id}'
 
-    def send_open(self, payload, channel=None, **kwargs):
+    def send_open(self, payload: str, channel: 'str | None' = None, **kwargs: JsonValue) -> str:
         if channel is None:
             channel = self.get_id('channel')
         self.send_json('', command='open', channel=channel, payload=payload, **kwargs)
@@ -50,13 +50,13 @@ class MockTransport(asyncio.Transport):
 
     async def check_open(
         self,
-        payload,
-        channel=None,
-        problem=None,
+        payload: str,
+        channel: 'str | None' = None,
+        problem: 'str | None' = None,
         reply_keys: Optional[JsonObject] = None,
         absent_keys: 'Iterable[str]' = (),
-        **kwargs,
-    ):
+        **kwargs: JsonValue,
+    ) -> str:
         assert isinstance(self.protocol, Router)
         ch = self.send_open(payload, channel, **kwargs)
         if problem is None:
@@ -68,17 +68,17 @@ class MockTransport(asyncio.Transport):
             assert ch not in self.protocol.open_channels
         return ch
 
-    def send_done(self, channel, **kwargs):
+    def send_done(self, channel: str, **kwargs: JsonValue) -> None:
         self.send_json('', command='done', channel=channel, **kwargs)
 
-    def send_close(self, channel, **kwargs):
+    def send_close(self, channel: str, **kwargs: JsonValue):
         self.send_json('', command='close', channel=channel, **kwargs)
 
-    async def check_close(self, channel, **kwargs):
+    async def check_close(self, channel: str, **kwargs: JsonValue):
         self.send_close(channel, **kwargs)
         await self.assert_msg('', command='close', channel=channel)
 
-    def send_ping(self, **kwargs):
+    def send_ping(self, **kwargs: JsonValue):
         self.send_json('', command='ping', **kwargs)
 
     def __init__(self, protocol: asyncio.Protocol):

--- a/test/pytest/test_bridge.py
+++ b/test/pytest/test_bridge.py
@@ -1188,7 +1188,7 @@ class FsInfoClient:
     ) -> 'FsInfoClient':
         channel = await transport.check_open('fsinfo', path=str(path), attrs=attrs,
                                              fnmatch=fnmatch, reply_keys=None,
-                                             absent_keys=(), **kwargs)
+                                             absent_keys=(), **kwargs)  # type: ignore[arg-type]
         return cls(transport, channel)
 
     async def next_state(self) -> JsonObject:

--- a/test/pytest/test_http_channel.py
+++ b/test/pytest/test_http_channel.py
@@ -1,0 +1,137 @@
+#
+# Copyright (C) 2026 Red Hat, Inc.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import argparse
+import asyncio
+import ssl
+from pathlib import Path
+from typing import Any, AsyncGenerator
+
+import pytest
+import pytest_asyncio
+
+from cockpit.bridge import Bridge
+
+from .mocktransport import MockTransport
+
+MOCK_DATA = Path(__file__).parent.parent / 'data'
+
+
+@pytest_asyncio.fixture()
+async def no_init_transport() -> AsyncGenerator[MockTransport, None]:
+    bridge = Bridge(argparse.Namespace(privileged=False, beipack=False))
+    transport = MockTransport(bridge)
+    try:
+        yield transport
+    finally:
+        await transport.stop()
+
+
+@pytest.fixture
+def transport(no_init_transport: MockTransport) -> MockTransport:
+    no_init_transport.init()
+    return no_init_transport
+
+
+async def assert_http_response(transport: MockTransport, ch: str, *, tls: bool = False) -> None:
+    await transport.assert_msg('', command='response', channel=ch, status=200, reason='OK')
+
+    channel, data = await transport.next_frame()
+    assert channel == ch
+    if tls:
+        assert data == b'Hello TLS\r\n'
+    else:
+        assert data == b'Hello\r\n'
+
+    await transport.assert_msg('', command='done', channel=ch)
+    await transport.assert_msg('', command='close', channel=ch)
+
+
+@pytest_asyncio.fixture(params=['tcp', 'unix'])
+async def http_server(request: pytest.FixtureRequest, tmp_path: Path) -> AsyncGenerator[dict[str, Any], None]:
+    async def serve(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        while True:
+            line = await reader.readline()
+            if not line.strip():
+                break
+        writer.write(b'HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nHello\r\n')
+        await writer.drain()
+        writer.close()
+
+    if request.param == 'tcp':
+        server = await asyncio.start_server(serve, '127.0.0.1', 0)
+        port = server.sockets[0].getsockname()[1]
+        open_args = {'port': port}
+    else:
+        sock = str(tmp_path / 'http.sock')
+        server = await asyncio.start_unix_server(serve, sock)
+        open_args = {'unix': sock}
+
+    yield open_args
+    server.close()
+
+
+@pytest_asyncio.fixture()
+async def tls_server() -> AsyncGenerator[int, None]:
+    async def serve(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        while True:
+            line = await reader.readline()
+            if not line.strip():
+                break
+        writer.write(b'HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nHello TLS\r\n')
+        await writer.drain()
+        writer.close()
+
+    server_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    server_ctx.load_cert_chain(MOCK_DATA / 'mock-server.crt', MOCK_DATA / 'mock-server.key')
+
+    server = await asyncio.start_server(serve, '127.0.0.1', 0, ssl=server_ctx)
+    yield server.sockets[0].getsockname()[1]
+    server.close()
+
+
+@pytest.mark.asyncio
+async def test_open_error(transport: MockTransport) -> None:
+    await transport.check_open('http-stream2', problem='protocol-error',
+                               reply_keys={'message': "attribute 'method' required"})
+    await transport.check_open('http-stream2', method='POST', path='/tmp/',
+                               problem='protocol-error',
+                               reply_keys={'message': 'no "port" or "unix" option for channel'})
+    await transport.check_open('http-stream2', method='POST', path='/tmp/', port="foo",
+                               problem='protocol-error',
+                               reply_keys={'message': "attribute 'port': must have type int"})
+    await transport.check_open('http-stream2', method='GET', path='/test', unix='/tmp/sock',
+                               tls={}, problem='protocol-error',
+                               reply_keys={'message': 'TLS on Unix socket is not supported'})
+
+
+@pytest.mark.asyncio
+async def test_http_request(transport: MockTransport, http_server: dict[str, Any]) -> None:
+    ch = await transport.check_open('http-stream2', method='GET', path='/test', **http_server)
+    transport.send_done(ch)
+    await assert_http_response(transport, ch, tls=False)
+
+
+@pytest.mark.asyncio
+async def test_tls_request(transport: MockTransport, tls_server: int) -> None:
+    ch = await transport.check_open('http-stream2', method='GET', path='/test', port=tls_server,
+                                    tls={'authority': {'file': str(MOCK_DATA / 'mock-server.crt')}})
+    transport.send_done(ch)
+    await assert_http_response(transport, ch, tls=True)
+
+
+@pytest.mark.asyncio
+async def test_tls_request_no_validate(transport: MockTransport, tls_server: int) -> None:
+    ch = await transport.check_open('http-stream2', method='GET', path='/test', port=tls_server,
+                                    tls={'validate': False})
+    transport.send_done(ch)
+    await assert_http_response(transport, ch, tls=True)
+
+
+@pytest.mark.asyncio
+async def test_tls_no_validate(transport: MockTransport, tls_server: int) -> None:
+    ch = await transport.check_open('http-stream2', method='GET', path='/test', port=tls_server,
+                                    tls={'validate': False})
+    transport.send_done(ch)
+    await assert_http_response(transport, ch, tls=True)


### PR DESCRIPTION
Main benefit of the pytest tests is that it is way easier to work with then QUnit and it can test unix sockets.