### PR TITLE
test: Remove extra valkey packages on RHEL

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1356,7 +1356,7 @@ class TestMetricsPackages(packagelib.PackageCase):
         redis_service = redisService(m.image)
         redis_package = "valkey" if redis_service == "valkey" else "redis"
         extra_packages = []
-        if redis_package == "valkey" and m.image.startswith("fedora"):
+        if redis_package == "valkey" and m.image.startswith(("fedora", "rhel-10", "centos-10")):
             # Fedora has a compat package that we need to
             # remove at the same time as valkey.
             # Fedora split out valkey to more packages as


### PR DESCRIPTION
Since a new RHEL 10.3 refresh the test failed with:

error: Failed dependencies:
	valkey(x86-64) = 8.1.6-1.el10 is needed by (installed) valkey-rdma-8.1.6-1.el10.x86_64
Traceback (most recent call last):
  File "/work/make-checkout-workdir/test/verify/check-metrics", line 1370, in testBasic
    m.execute(f"rpm --erase --verbose pcp python3-pcp {redis_package} {' '.join(extra_packages)}")