### PR TITLE
pixel: Enable icon anti-aliasing

### DIFF
--- a/pkg/lib/page.scss
+++ b/pkg/lib/page.scss
@@ -219,13 +219,6 @@ body {
   .pf-v6-c-backdrop {
     --pf-t--global--background--color--backdrop--default: var(--pf-t--global--background--color--secondary--default) !important;
   }
-
-  // We set svg aliasing to precision instead of auto/optimizeSpeed to try to ensure
-  // consistent rendering between test runs.
-  svg {
-    // https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/shape-rendering
-    shape-rendering: crispedges;
-  }
 }
 
 // Set patternfly-6 native font-weight for bold elements


### PR DESCRIPTION
With us now using pixelmatch library to manage pixel changes, we should
have a much better control for anti-aliasing related changes. Previously
we disabled anti-aliasing for icons completely so that they were pixel
perfect, but with the icons being vector images the pixels can change
slightly due to various factors.

Resetting this back to how it was before with anti-aliasing means that
the subpixel render changes will not trigger pixel tests changes due to
pixelmatch detecting that it is only an anti-alias change.

Related-to: https://github.com/cockpit-project/cockpit/pull/23349
Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
