### PR TITLE
dialog: Make the id prefix configurable

### DIFF
--- a/pkg/lib/cockpit/dialog.tsx
+++ b/pkg/lib/cockpit/dialog.tsx
@@ -354,7 +354,7 @@
    within "dlg.run_action", the cancel function is automatically
    reset.
 
-   Let's now finally talk about input validation.
+   VALIDATION
 
    Input validation is done by a single, central function for the
    whole dialog.  This has been done so that there is a central place
@@ -373,8 +373,8 @@
 
    The formal job of the validation function is to call the "validate"
    method (or "validate_async") of all relevant dialog value handles.
-   If and only if the render function instantiates a component for a
-   dialog value, should the validate function visit it.
+   If and only if a validation failure of a field should prevent
+   running the action function, should the validate function visit it.
 
    - handle.validate(v => ...)
 
@@ -383,14 +383,11 @@
    "undefined". If it fails, the function should return a string with
    the appropriate message. This message will be available from the
    "handle.validation_text" method and should be shown by the React
-   component for this value, of course.
+   component for this value, of course. Returning an error here will
+   also disable the action buttons.
 
    The "v => ..." function is only called when necessary, when the
    value has actually changed.
-
-   The "v => ..." function should not make any modifications to
-   anything involved in the dialog. Specifically, it should not call
-   "set()" on any value handle.
 
    A validation function can also return an object with validation
    errors for its sub-fields.  This is useful if multiple fields need
@@ -404,8 +401,8 @@
    If your validation function needs to communicate out-of-band with
    your action function (maybe to pass the results of some expensive
    operations that you don't want to repeat in your action function),
-   then you need to find some other way. Maybe with a memoized
-   function or an explicit cache.
+   then you can modify field values via calls to "handle.set". (Be
+   careful not to create endless validation loops!)
 
    - handle.validate_async(debounce, async (v, task) >= ...)
 
@@ -1080,22 +1077,39 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
        cancelled.
      */
 
+    #validation_needed: boolean = false;
+    #validation_running: boolean = false;
+
     #trigger_validation(): void {
         debug("trigger validation");
         if (!this.#validate_callback)
             return;
-        this.#validation_failed = false;
-        this._for_each_field_state(state => {
-            state.relevant = false;
-            state.validation_text = undefined;
-        });
-        this.#validate_callback(this);
-        this._for_each_field_state(state => {
-            if (!state.relevant && state.validation_task) {
-                debug("cancelling irrelevant validation task", state_path(state));
-                state.validation_task.cancel();
-            }
-        });
+
+        this.#validation_needed = true;
+        if (this.#validation_running) {
+            debug("validation postponed");
+            return;
+        }
+
+        this.#validation_running = true;
+        while (this.#validation_needed) {
+            debug("running validation");
+            this.#validation_needed = false;
+            this.#validation_failed = false;
+            this._for_each_field_state(state => {
+                state.relevant = false;
+                state.validation_text = undefined;
+            });
+            this.#validate_callback(this);
+            this._for_each_field_state(state => {
+                if (!state.relevant && state.validation_task) {
+                    debug("cancelling irrelevant validation task", state_path(state));
+                    state.validation_task.cancel();
+                }
+            });
+        }
+        this.#validation_running = false;
+
         this.#update();
     }
 

--- a/pkg/lib/cockpit/dialog.tsx
+++ b/pkg/lib/cockpit/dialog.tsx
@@ -44,7 +44,7 @@
         const Dialogs = useDialogs();
 
         function validate() {
-            dlg.value("text").validate(v => {
+            dlg.field("text").validate(v => {
                 if (!v)
                     return "Text can not be empty";
             });
@@ -222,6 +222,47 @@
    array, pass the index of the desired element.  See "dlg.field()"
    above for more information about handles.
 
+   - handle.get_async(debounce, (val, task) => ...)
+   - handle.set_async(debounce, (val, task) => new_val)
+
+   These are for running debounced, asynchronous code.  Both functions
+   will run the given function after "debounce" milliseconds, but only
+   if the value of the field hasn't changed in the meantime.  The
+   dialog waits for all asynchronous tasks started by these functions
+   to be finished before running the action function.  When the dialog
+   is cancelled, they all get cancelled.
+
+   The return value of "handle.set_async" is made the new value of the
+   field, but only if the value of the field hasn't changed in the
+   meantime.  There can only be one currently active "set_async" call.
+   If you call it again before the previous one has finished, that
+   previous call will be cancelled at that point, just as if the field
+   value had changed.
+
+   The "handle.get_async" function is a slight variation on this. It
+   is meant to perform asynchronous computations that do not modify
+   the field value itself, but have some other side effects.  Maybe
+   they modify multiple other field values or some React state. There
+   can be more than one call active at a given time. They only get
+   cancelled when the value of the field changes.
+
+   The asynchronous tasks must be careful to only perform their side
+   effects when they have not been cancelled yet.  Because of the way
+   JavaScript works, the asynchronous functions keep running and they
+   need to voluntarily call "task.is_cancelled()" to figure out when
+   they should stop.
+
+   As an example, here is how you might implement set_async on top of
+   get_async:
+
+      function set_async(handle, debounce, func) {
+          handle.get_async(debounce, (val, task) => {
+              const new_val = await func(val, task);
+              if (!task.is_cancelled())
+                  handle.set(new_val);
+          })
+      }
+
    - handle.at(witness)
 
    Get a handle with a narrowed type for "handle".  The new handle
@@ -247,7 +288,8 @@
    It is important to use this function instead of just "handle.set()"
    with an appropriately modified array. By using this function, the
    plumbing is able to keep its internal state in synch, which is
-   especially important for asynchronous validation functions.
+   especially important for asynchronous validation and update
+   functions.
 
    However, it is okay to just replace an array with a different
    array, so you are not strictly required to use this function. But
@@ -285,19 +327,19 @@
 
    - dlg.run_action(func)
 
-   Performs input validation (if necessary) and if that was
-   successful, calls "func" and puts the dialog into a "busy" state
-   while it runs. When "func" throws an error, it is caught and stored
-   in "dlg.error".
+   Waits for all asynchronous updates and input validation to be done
+   and if that was successful, calls "func" and puts the dialog into a
+   "busy" state while it runs. When "func" throws an error, it is
+   caught and stored in "dlg.error".
 
    "dlg.run_action" returns true when validation has passed and "func"
    has completed without throwing an error.
 
-   All state changes via "field.set()" are denied while
-   "dlg.run_action" is running. This is done to prevent the user from
-   interacting with the dialog while an action runs. But there is
-   nothing fundamentally wrong with programmatically changing dialog
-   state as part of an action. If you want to do that, write code like
+   All state changes via "field.set()" are denied while "func" is
+   running. This is done to prevent the user from interacting with the
+   dialog while an action runs. But there is nothing fundamentally
+   wrong with programmatically changing dialog state as part of an
+   action. If you want to do that, write code like
 
      if (dlg.run_action(...))
        dlg.field("xxx").set(...)
@@ -317,8 +359,7 @@
    Input validation is done by a single, central function for the
    whole dialog.  This has been done so that there is a central place
    that establishes the "shape" of the dialog values. This is
-   important for dialogs that have expander areas or other optional
-   things.
+   important for dialogs that have optional parts.
 
    If such an optional part of the values has failed validation
    earlier, but has subsequently been removed from the dialog by the
@@ -366,7 +407,7 @@
    then you need to find some other way. Maybe with a memoized
    function or an explicit cache.
 
-   - handle.validate_async(debounce, async v >= ...)
+   - handle.validate_async(debounce, async (v, task) >= ...)
 
    Calls the given async function "debounce" milliseconds after the
    value represented by the handle has last been changed. (Or
@@ -376,6 +417,60 @@
 
    See the documentation for "handle.validate" above for more rules
    that apply to validation functions.
+
+   UPDATES
+
+   Sometimes dialog values need to be changed in reaction to other
+   changes.  For example, when the user selects a ISO for creating a
+   new virtual machine, you might want to run some code that detects
+   the OS on that ISO and then adapts the rest of the dialog to the
+   minimum storage requirements of the OS.  Sometimes you can do
+   everything at render time, but sometimes you might want to run some
+   code as part of the event handler for the user action, and
+   sometimes you need to run asynchornous code.
+
+   (Don't use useEffect, please, just stick the code into the event
+   handler.)
+
+   It's okay and simplest to just put that code right next to the call
+   to "handler.set()".  If that call is in a porcelain component (as
+   it probably often will be), you can pass a "update_func" when
+   creating the handle for that porcelain component with
+   "handler.sub()" or "dialog.field()".  For example:
+
+       function on_plate_change(val: string) {
+           console.log("NEW LICENSE PLATE", val);
+       }
+
+       return (
+           <DialogTextInput
+               label="License plate number"
+               field={dlg.field("plate", on_plate_change)}
+           />
+       );
+
+   The function "on_plate_change" will be called whenever the user
+   changes the "plate" field via the DialogTextInput.  The
+   "on_plate_change" function will not be called when the "plate" is
+   changed in other places.  If that should happen, you have to
+   arrange for it explicitly.
+
+   Functions like "on_plate_change" can and should modify the dialog
+   fields via calls to "handle.set()".
+
+   If you want to run asynchronous code, you can do so with
+   "handle.set_async()" or "handle.get_async()".  For example, if you
+   want to asynchronously fetch the car model for a given license
+   plate from a database, you can do it like this:
+
+       function on_plate_change(val: string) {
+           dlg.field("model").set_async(1000, async () => await fetch_model(val));
+       }
+
+   When arrays are involved, dialog fields can move around while your
+   asynchronous update function runs.  To help with this, handles will
+   keep referring to the same field even if it moves around in its
+   array.
 
    TESTING
 
@@ -492,126 +587,6 @@
   data model. A simple case is selecting from an array of strings. In
   that case you can omit the "option_label" function.
 
-  WRITING COMPLEX PORCELAIN COMPONENTS
-
-  Here is a pattern that you might want to follow when writing
-  complicated components. Even if they are not meant to be reused
-  much, it pays of to try to encapsulate their behavior.
-
-  Let's write a component for two level selection.  Parameter is
-  something like
-
-     {
-       "Fruit": [ "Apple", "Banana" ],
-       "Bread": [ "Toast", "Rye" ],
-       "Meat": [ "Chicken", "Pork" ],
-     }
-
-  and there will be two dropdowns in the dialog, one for selecting
-  between "Fruit", "Bread", and "Meat"; and one for selecting "Apple"
-  or "Banana" when the first is "Fruit", etc.
-
-  First, declare the type of the value that the component works with.
-  It should store everything needed by the component, to simplify
-  initialization and validation.
-
-    export interface TwoLevelSelectValue {
-      first: string;
-      second: string;
-
-      _firsts: string[],
-      _options: Record<string, string[]>,
-    }
-
-  Write a "init" function to create such a value:
-
-    export function init_TwoLevelSelect(options: Record<string, string[]>): TwoLevelValue {
-      const _firsts = Object.keys(options);
-      const _seconds = options[_firsts[0]];
-
-      return {
-        first: _firsts[0],
-        second: _seconds[0],
-
-        _firsts,
-        _seconds,
-        _options: options,
-      };
-    }
-
-  And the component itself:
-
-    export const TwoLevelSelect = ({ field } : { field: DialogField<TwoLevelSelectValue> }) => {
-      const { _firsts, _seconds, _options } = field.get();
-
-      function update_first(f: string) {
-        const _seconds = _options[f];
-        value.sub("second").set(_seconds[0]);
-        value.sub("_seconds").set(_seconds);
-      }
-
-      return (
-        <>
-          <DialogDropdownSelectObject
-            label="First"
-            field={field.sub("first", update_first)}
-            options={_firsts}
-          />
-          <DialogDropdownSelectObject
-            label="Second"
-            field={field.sub("second")}
-            options={_seconds}
-          />
-        </>
-      );
-    }
-
-  It would be used in a dialog like this:
-
-    interface DialogValues {
-      food: TwoLevelSelectValue;
-    }
-
-    function init() {
-      return {
-        food: init_TwoLevelSelect({ "Fruit": [ "Apple", "Banana" ], "Bread": [ "Toast", "Rye" ], "Meat": [ "Chicken", "Pork" ] }),
-      }
-    }
-
-    const dlg = useDialogState(init);
-
-    return (
-      ...
-      <TwoLevelSelect field={dlg.field("food")} />
-      ...
-    );
-
-  Here is a pattern for handling types that include alternatives, such
-  as "TwoLevelSelectValue | string".  This could be used to encode
-  either the state for a working TwoLevelSelect component, or an
-  excuse message that explains why it can't work.
-
-    function init_TwoLevelSelect(options: Record<string, string[]>): TwoLevelSelectValue | string {
-      if (Object.keys(options).length == 0)
-        return _("Nothing to select.");
-
-      return { ... };
-    }
-
-    export const TwoLevel = ({ field } : { field: DialogField<TwoLevelValue | string> }) => {
-      const val = field.get();
-      if (typeof val == "string")
-          return null;
-
-      const tls_field = field.at(val);
-
-      const { _firsts, _seconds, _options } = tls_field.get();
-      ...
-    }
-
-  Note the use of the "field.at()" function to get a handle for a
-  TwoLevelSelectValue that can be used to access the "first" sub
-  value, etc.
  */
 
 import React, { useState } from "react";
@@ -726,6 +701,7 @@ export class DialogField<T> {
     }
 
     set(val: T): void {
+        this.#dialog._cancel_state_tasks(this.#state, true);
         this.#setter(val);
     }
 
@@ -764,14 +740,14 @@ export class DialogField<T> {
                 }
                 this.#state.sub.delete(val.length - 1);
             }
-            this.set(toSpliced(val, index, 1) as T);
+            this.#setter(toSpliced(val, index, 1) as T);
         }
     }
 
     add(item: ArrayElement<T>) {
         const val = this.get();
         if (Array.isArray(val)) {
-            this.set(val.concat(item) as T);
+            this.#setter(val.concat(item) as T);
         }
     }
 
@@ -795,7 +771,6 @@ export class DialogField<T> {
                 } else {
                     this.#setter({ ...container, [tag]: val });
                 }
-                this.#dialog._cancel_state_tasks(this.#state);
                 if (update_func)
                     update_func(val);
             },
@@ -815,6 +790,20 @@ export class DialogField<T> {
     validate_async(debounce: number, func: (val: T, task: DialogTask) => Promise<DialogValidationResult<T>>): void {
         const val = this.get();
         this.#dialog._validate_value_async(this.#state, val, debounce, task => func(val, task));
+    }
+
+    set_async(debounce: number, func: (val: T, task: DialogTask) => Promise<T>): void {
+        const val = this.get();
+        this.#dialog._update_value_async(this.#state, true, debounce, async task => {
+            const new_val = await func(val, task);
+            if (!task.is_cancelled())
+                this.set(new_val);
+        });
+    }
+
+    get_async(debounce: number, func: (val: T, task: DialogTask) => Promise<void>): void {
+        const val = this.get();
+        this.#dialog._update_value_async(this.#state, false, debounce, task => func(val, task));
     }
 }
 
@@ -906,7 +895,8 @@ export class DialogTask {
    for example, and calling handle.get() will return
    dlg.values["name"].
 
-   Other members of a DialogFieldState relate to validation.
+   Other members of a DialogFieldState relate to validation and
+   asynchronous updates.
  */
 
 interface DialogFieldState {
@@ -919,6 +909,9 @@ interface DialogFieldState {
     cached_value: unknown;
     cached_result: unknown;
     validation_task: DialogTask | null;
+    // updates
+    update_task: DialogTask | null;
+    update_tasks: Set<DialogTask>;
 }
 
 interface DialogStateEvents {
@@ -960,6 +953,8 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
             cached_value: undefined,
             cached_result: undefined,
             validation_task: null,
+            update_task: null,
+            update_tasks: new Set(),
         };
     }
 
@@ -995,6 +990,8 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
                 cached_value: undefined,
                 cached_result: undefined,
                 validation_task: null,
+                update_task: null,
+                update_tasks: new Set(),
             };
             state.sub.set(tag, sub);
         }
@@ -1032,6 +1029,10 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
             this._for_each_field_state(state => {
                 if (state.validation_task)
                     state.validation_task.start_now();
+                if (state.update_task)
+                    state.update_task.start_now();
+                for (const task of state.update_tasks.values())
+                    task.start_now();
             });
 
             awaited = false;
@@ -1040,16 +1041,28 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
                     await state.validation_task.wait();
                     awaited = true;
                 }
+                if (state.update_task) {
+                    await state.update_task.wait();
+                    awaited = true;
+                }
+                for (const task of state.update_tasks.values()) {
+                    await task.wait();
+                    awaited = true;
+                }
             });
         } while (awaited);
     }
 
-    _cancel_state_tasks(state: DialogFieldState) {
-        debug("cancelling state tasks", state_path(state));
-        if (state.validation_task)
+    _cancel_state_tasks(state: DialogFieldState, only_updates: boolean = false) {
+        debug("cancelling state tasks", state_path(state), only_updates);
+        if (state.validation_task && !only_updates)
             state.validation_task.cancel();
+        if (state.update_task)
+            state.update_task.cancel();
+        for (const task of state.update_tasks.values())
+            task.cancel();
         for (const sub of state.sub.values())
-            this._cancel_state_tasks(sub);
+            this._cancel_state_tasks(sub, only_updates);
     }
 
     /* VALIDATION
@@ -1201,6 +1214,41 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
         }
     }
 
+    _update_value_async(
+        state: DialogFieldState,
+        for_set: boolean,
+        debounce: number,
+        func: (task: DialogTask) => Promise<void>
+    ): void {
+        const task = new DialogTask(
+            state_path(state) + ":update",
+            debounce,
+            async ctxt => {
+                try {
+                    await func(ctxt);
+                } catch (ex) {
+                    console.error(ex);
+                }
+            },
+            task => {
+                if (for_set) {
+                    if (state.update_task == task)
+                        state.update_task = null;
+                } else {
+                    state.update_tasks.delete(task);
+                }
+            }
+        );
+
+        if (for_set) {
+            if (state.update_task)
+                state.update_task.cancel();
+            state.update_task = task;
+        } else {
+            state.update_tasks.add(task);
+        }
+    }
+
     /* The first thing run_action does is to trigger a new validation
        round and then wait for all the asynchronous results to have
        come in.
@@ -1212,6 +1260,7 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
      */
 
     async validate(): Promise<boolean> {
+        this.#online_validation = true;
         this.#trigger_validation();
         await this._run_all_tasks_now();
         return !this.#validation_failed;

--- a/pkg/lib/cockpit/dialog.tsx
+++ b/pkg/lib/cockpit/dialog.tsx
@@ -752,8 +752,10 @@ export class DialogField<T> {
         const val = this.get();
         if (Array.isArray(val)) {
             const sub = this.#state.sub.get(index);
-            if (sub)
+            if (sub) {
+                this.#dialog._cancel_state_tasks(sub);
                 sub.tag = -1;
+            }
             for (let j = index; j < val.length - 1; j++) {
                 const sub = this.#state.sub.get(j + 1);
                 if (sub) {
@@ -793,6 +795,7 @@ export class DialogField<T> {
                 } else {
                     this.#setter({ ...container, [tag]: val });
                 }
+                this.#dialog._cancel_state_tasks(this.#state);
                 if (update_func)
                     update_func(val);
             },
@@ -809,9 +812,9 @@ export class DialogField<T> {
         this.#dialog._validate_value(this.#state, val, () => func(val));
     }
 
-    validate_async(debounce: number, func: (val: T) => Promise<DialogValidationResult<T>>): void {
+    validate_async(debounce: number, func: (val: T, task: DialogTask) => Promise<DialogValidationResult<T>>): void {
         const val = this.get();
-        this.#dialog._validate_value_async(this.#state, val, debounce, () => func(val));
+        this.#dialog._validate_value_async(this.#state, val, debounce, task => func(val, task));
     }
 }
 
@@ -822,6 +825,72 @@ function get_validation_result_own_string(result: unknown): string | undefined {
         return result[""];
     else
         return undefined;
+}
+
+export class DialogTask {
+    #name: string;
+    #cancelled: boolean = false;
+    #on_cancel: (() => void) | null = null;
+    #timeout_id: number = 0;
+    #promise: Promise<void> | null = null;
+    #start: () => void;
+    #done: (task: DialogTask) => void;
+
+    constructor(
+        name: string,
+        debounce: number,
+        func: (task: DialogTask) => Promise<void>,
+        done: (task: DialogTask) => void,
+    ) {
+        this.#name = name;
+        this.#done = done;
+        this.#start = () => {
+            debug("starting task", this.#name);
+            cockpit.assert(!this.#cancelled);
+            this.#promise = func(this);
+            this.#promise.finally(() => {
+                debug("task done", this.#name);
+                done(this);
+            });
+        };
+        this.#timeout_id = window.setTimeout(this.#start, debounce);
+        debug("creating task", this.#name, debounce);
+    }
+
+    start_now() {
+        if (!this.#promise && !this.#cancelled) {
+            debug("skipping debounce of task", this.#name);
+            window.clearTimeout(this.#timeout_id);
+            this.#start();
+        }
+    }
+
+    async wait() {
+        // Waiting is only allowed for tasks that have actually been started.
+        cockpit.assert(this.#promise);
+        debug("waiting for task", this.#name);
+        await this.#promise;
+    }
+
+    set_cancel(cancel: (() => void) | null) {
+        this.#on_cancel = cancel;
+    }
+
+    is_cancelled() {
+        return this.#cancelled;
+    }
+
+    cancel() {
+        debug("cancelling task", this.#name);
+        window.clearTimeout(this.#timeout_id);
+        if (this.#on_cancel)
+            this.#on_cancel();
+        this.#cancelled = true;
+        if (!this.#promise) {
+            debug("cancelled task done", this.#name);
+            this.#done(this);
+        }
+    }
 }
 
 /* A DialogFieldState object holds all state for a field.  Unlike
@@ -845,12 +914,11 @@ interface DialogFieldState {
     tag: string | number | symbol;
     sub: Map<string | number | symbol, DialogFieldState>;
     // validation
+    relevant: boolean;
     validation_text: string | undefined;
     cached_value: unknown;
     cached_result: unknown;
-    timeout_id: number;
-    promise: Promise<void> | undefined;
-    validation_round: number;
+    validation_task: DialogTask | null;
 }
 
 interface DialogStateEvents {
@@ -870,8 +938,9 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
     #validation_failed: boolean = false;
     #online_validation: boolean = false;
     #action_running: boolean = false;
+    #block_updates: boolean = false;
+
     #top_state: DialogFieldState;
-    #validation_round: number = 0;
 
     /* eslint-disable no-use-before-define */
     #validate_callback: undefined | ((dlg: DialogState<V>) => void);
@@ -884,14 +953,13 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
         this.values = init;
         this.#top_state = {
             parent: null,
-            sub: new Map(),
             tag: "",
+            sub: new Map(),
+            relevant: false,
             validation_text: undefined,
             cached_value: undefined,
             cached_result: undefined,
-            timeout_id: 0,
-            promise: undefined,
-            validation_round: -1,
+            validation_task: null,
         };
     }
 
@@ -920,14 +988,13 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
         if (!sub) {
             sub = {
                 parent: state,
-                sub: new Map(),
                 tag,
+                sub: new Map(),
+                relevant: false,
                 validation_text: undefined,
                 cached_value: undefined,
                 cached_result: undefined,
-                timeout_id: 0,
-                promise: undefined,
-                validation_round: -1,
+                validation_task: null,
             };
             state.sub.set(tag, sub);
         }
@@ -952,17 +1019,52 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
         await visit(this.#top_state);
     }
 
-    /* VALIDATION
+    /* TASKS
+
+       Tasks are a little abstraction that runs a asynchronous
+       function after a debounce timeout.  Before running the action
+       function, we need to wait for them all to finish.
      */
 
-    /* Validation is started by calling the #trigger_validation
-       method. This will reset all validation errors, increment the
-       "round number" and then call the provided "validate" callback,
-       which in turn will (eventually but synchronously) call the
-       "_validate_value" or "_validate_value_async" methods of all
-       relevant value paths.  Those functions will eventually call
-       #set_validation to install the validation results in the field
-       states.
+    async _run_all_tasks_now() {
+        let awaited: boolean = false;
+        do {
+            this._for_each_field_state(state => {
+                if (state.validation_task)
+                    state.validation_task.start_now();
+            });
+
+            awaited = false;
+            await this._for_each_field_state_async(async state => {
+                if (state.validation_task) {
+                    await state.validation_task.wait();
+                    awaited = true;
+                }
+            });
+        } while (awaited);
+    }
+
+    _cancel_state_tasks(state: DialogFieldState) {
+        debug("cancelling state tasks", state_path(state));
+        if (state.validation_task)
+            state.validation_task.cancel();
+        for (const sub of state.sub.values())
+            this._cancel_state_tasks(sub);
+    }
+
+    /* VALIDATION
+
+       Validation is started by calling the #trigger_validation
+       method. This will reset all validation errors and mark all
+       fields as "irrelevant". Then it calls the provided "validate"
+       callback, which in turn will (eventually but synchronously)
+       call the "_validate_value" or "_validate_value_async" methods
+       of all relevant value paths.  Those functions will mark their
+       fields as relevant and eventually call #set_validation to
+       install the validation results in the field states.
+
+       After this, all irrelevant asynchronous validation tasks are
+       cancelled.
      */
 
     #trigger_validation(): void {
@@ -970,9 +1072,17 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
         if (!this.#validate_callback)
             return;
         this.#validation_failed = false;
-        this._for_each_field_state(state => { state.validation_text = undefined });
-        this.#validation_round += 1;
+        this._for_each_field_state(state => {
+            state.relevant = false;
+            state.validation_text = undefined;
+        });
         this.#validate_callback(this);
+        this._for_each_field_state(state => {
+            if (!state.relevant && state.validation_task) {
+                debug("cancelling irrelevant validation task", state_path(state));
+                state.validation_task.cancel();
+            }
+        });
         this.#update();
     }
 
@@ -983,7 +1093,6 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
                 state.validation_text = own;
                 this.#validation_failed = true;
                 this.#online_validation = true;
-                this.#update();
             }
             if (typeof result == "object") {
                 for (const [k, v] of Object.entries(result)) {
@@ -1012,24 +1121,15 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
     ) {
         state.cached_value = val;
         state.cached_result = result;
-        state.timeout_id = 0;
-        state.promise = undefined;
-        state.validation_round = -1;
         this.#set_validation(state, result);
     }
 
     /* The first thing should be of course to probe that cache.  If we
        get a hit, it is used immediately to call #set_validation.
-
-       In that case, the DialogFieldState is also made part of
-       the current round since any asynchronous validation that is
-       currently running is still relevant. See below for more about
-       that.
      */
 
     #probe_validation_state_cache(state: DialogFieldState, val: unknown): boolean {
         if (Object.is(state.cached_value, val)) {
-            state.validation_round = this.#validation_round;
             debug("cache hit", state_path(state), JSON.stringify(val), state.cached_result);
             this.#set_validation(state, state.cached_result);
             return true;
@@ -1041,156 +1141,61 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
      */
 
     _validate_value(state: DialogFieldState, val: unknown, func: () => unknown): void {
+        state.relevant = true;
         if (!this.#probe_validation_state_cache(state, val)) {
             const result = func();
-            debug("sync validate", state_path(state), result);
+            debug("sync validate", state_path(state), JSON.stringify(result));
             this.#set_validation_state_result(state, val, result);
         }
     }
 
     /* Now asynchronous validation.
 
-       Each call to #trigger_validation starts a new "validation
-       round" and a DialogFieldState keeps track to which round
-       it applies to.  This matters of course for asynchronous
-       validation: If async validation for a given path was started in
-       one round, and then the next round happens but the path is no
-       longer enumerated by the validation callback (i.e., its value
-       is no longer relevant for the dialog), then this asynchronous
-       validation should have no effect.
-
        If there was no cache hit, asynchronous validation starts with
        a timeout, followed by letting a asynchronous function run to
-       resolution.
+       resolution.  This is managed by a DialogTask.
 
-       Setting a new timeout of course cancels any previously set
-       one. It also installs the current value in the cache, so that
-       subsequent validation rounds do nothing until the value
-       actually changes.
+       Starting a new task of course cancels any previous one. It also
+       installs the current value in the cache, so that subsequent
+       validation rounds do nothing until the value actually changes.
 
-       One interesting thing to note is that when doing the final
-       validation before running an action function, no debouncing
-       delay should be applied of course. We want to get on with
-       validation immediately.
+       When the validation result has been computed, we need to check
+       whether we have been cancelled so that we don't install
+       out-dated results.
      */
 
-    #set_validation_state_timeout(
+    _validate_value_async(
         state: DialogFieldState,
         val: unknown,
-        delay: number,
-        func: () => void,
-    ) {
-        if (state.timeout_id) {
-            debug("timeout cancel", state_path(state));
-            window.clearTimeout(state.timeout_id);
-            state.timeout_id = 0;
-        }
-        if (this.#action_running || delay == 0) {
-            func();
-        } else {
+        debounce: number,
+        func: (task: DialogTask) => Promise<unknown>
+    ): void {
+        state.relevant = true;
+        if (!this.#probe_validation_state_cache(state, val)) {
             state.cached_value = val;
             state.cached_result = undefined;
-            state.timeout_id = window.setTimeout(
-                () => {
-                    debug("timeout", state_path(state));
-                    if (!this.#validation_state_is_current(state)) {
-                        debug("timeout outdated", state_path(state));
-                        return;
-                    }
-                    func();
-                },
-                delay);
-            state.promise = undefined;
-            state.validation_round = this.#validation_round;
-        }
-    }
 
-    /* Once the timeout is over (and the path is still relevant to the
-       current round), the actual asynchronous validation is launched.
-       This promise that represents it is simply installed in the
-       DialogFieldState.
-     */
-
-    #set_validation_state_promise(
-        state: DialogFieldState,
-        val: unknown,
-        prom: Promise<void>,
-    ) {
-        state.cached_value = val;
-        state.cached_result = undefined;
-        state.timeout_id = 0;
-        state.promise = prom;
-        state.validation_round = this.#validation_round;
-    }
-
-    /* Unlike with the timeout, we can not cancel the old promise when
-       installing a new one. Instead we check at the end whether it is
-       still really us that is supposed to deliver the result, by
-       comparing promises.
-
-       To summarize:
-
-       - The round id check will fail if the value is no longer
-         relevant to the dialog.  For example, say there is a text
-         input that can be toggled in and out of the dialog via a
-         checkbox. Now a validation round is started while the text
-         input is part of the dialog. During the debounce timeout or
-         while the asynchronous validation function runs, the user
-         toggles the checkbox (which triggers a new validation round)
-         and the text input is no longer part of the dialog. Now when
-         the timeout or validation for the text input concludes, the
-         round id check fails and the result is ignored, as it should.
-
-       - The promise check will fail when a asynchronous validation
-         takes longer than the debounce timeout.  Let's say there is a
-         text input with a debounce timeout of 1 second and a
-         validation function that takes 2 seconds. The user makes a
-         change that triggers validation and then remains idle for
-         more than a second. After one second, the timeout expires and
-         the promise is created and starts running. It will finish at
-         second 3, but we are not there yet. At second 1.5 the user
-         makes another change, a new timeout expires at 2.5 and a new
-         promise is created. At second 3 the original promise finally
-         comes to a conclusion, and the path is still relevant to the
-         dialog, but this promise is no longer the current
-         promise. Its result will be ignored, as it should.
-     */
-
-    #validation_state_is_current(state: DialogFieldState, prom?: Promise<void>): boolean {
-        return (!prom || Object.is(state.promise, prom)) && this.#validation_round === state.validation_round;
-    }
-
-    /* _validate_value_async puts this all together.
-     */
-
-    _validate_value_async(state: DialogFieldState, val: unknown, debounce: number, func: () => Promise<unknown>): void {
-        if (!this.#probe_validation_state_cache(state, val)) {
-            debug("async validate start debounce", state_path(state), val);
-            this.#set_validation_state_timeout(
-                state,
-                val,
+            if (state.validation_task)
+                state.validation_task.cancel();
+            state.validation_task = new DialogTask(
+                state_path(state) + ":validate",
                 debounce,
-                () => {
-                    debug("async validate start promise", state_path(state), val);
-                    const prom =
-                        func()
-                                .catch(
-                                    ex => {
-                                        console.error(ex);
-                                        return undefined;
-                                    }
-                                )
-                                .then(
-                                    result => {
-                                        if (this.#validation_state_is_current(state, prom)) {
-                                            debug("async validate done", state_path(state), result);
-                                            this.#set_validation_state_result(state, val, result);
-                                        } else {
-                                            debug("promise outdated", state_path(state));
-                                        }
-                                    }
-                                );
-                    this.#set_validation_state_promise(state, val, prom);
+                async task => {
+                    let result;
+                    try {
+                        result = await func(task);
+                    } catch (ex) {
+                        console.error(ex);
+                    }
+                    if (!task.is_cancelled()) {
+                        debug("async validate result", state_path(state), result);
+                        this.#set_validation_state_result(state, val, result);
+                        this.#update();
+                    }
+                },
+                task => {
+                    if (state.validation_task == task)
+                        state.validation_task = null;
                 }
             );
         }
@@ -1207,31 +1212,9 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
      */
 
     async validate(): Promise<boolean> {
-        this.#cancel_all_validation_timeouts();
         this.#trigger_validation();
-        await this.#wait_for_validation_promises();
+        await this._run_all_tasks_now();
         return !this.#validation_failed;
-    }
-
-    #cancel_all_validation_timeouts() {
-        this._for_each_field_state(state => {
-            if (state.timeout_id) {
-                debug("timeout bulk cancel", state_path(state));
-                window.clearTimeout(state.timeout_id);
-                state.validation_round = -1;
-                state.cached_value = undefined;
-            }
-        });
-    }
-
-    async #wait_for_validation_promises(): Promise<void> {
-        await this._for_each_field_state_async(async state => {
-            if (state.validation_round === this.#validation_round && state.promise) {
-                debug("waiting for promise", state_path(state));
-                await state.promise;
-                debug("waiting for promise done", state_path(state));
-            }
-        });
     }
 
     set_cancel(cancel: (() => void) | null) {
@@ -1251,6 +1234,7 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
         }
 
         try {
+            this.#block_updates = true;
             await func(this.values);
         } catch (ex) {
             console.error(String(ex));
@@ -1259,6 +1243,7 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
 
         this.cancel_function = null;
         this.#action_running = false;
+        this.#block_updates = false;
         this.#update();
 
         return !this.error;
@@ -1271,7 +1256,7 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
             () => this.values,
             (val) => {
                 debug("set", val);
-                if (this.#action_running) {
+                if (this.#block_updates) {
                     // Deny state changes while actions run.  This
                     // prevents the user from interacting with the
                     // dialog while it is busy. The alternative would

--- a/pkg/lib/cockpit/dialog.tsx
+++ b/pkg/lib/cockpit/dialog.tsx
@@ -361,6 +361,11 @@
    within "dlg.run_action", the cancel function is automatically
    reset.
 
+   - dlg.set_id_prefix(id_prefix)
+
+   This sets the prefix used by the handle.id() function. This is only
+   necessary when testing stacked dialogs, which should be rare.
+
    VALIDATION
 
    Input validation is done by a single, central function for the
@@ -710,7 +715,7 @@ export class DialogField<T> {
     }
 
     id(tag: string = "field"): string {
-        return "dialog-" + tag + "-" + state_path(this.#state);
+        return this.#dialog.id_prefix + "-" + tag + "-" + state_path(this.#state);
     }
 
     map<X>(func: (val: DialogField<ArrayElement<T>>, index: number) => X): X[] {
@@ -925,6 +930,7 @@ interface DialogStateEvents {
 export class DialogState<V> extends EventEmitter<DialogStateEvents> {
     values: V;
 
+    id_prefix: string = "dialog";
     busy: boolean = false;
     actions_disabled: boolean = false;
     cancel_disabled: boolean = false;
@@ -960,6 +966,11 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
             update_task: null,
             update_tasks: new Set(),
         };
+    }
+
+    set_id_prefix(id_prefix: string): DialogState<V> {
+        this.id_prefix = id_prefix;
+        return this;
     }
 
     #update() {
@@ -1444,9 +1455,11 @@ export function DialogErrorMessage<V>({
         details = String(err);
     }
 
+    const pfx = dialog instanceof DialogState ? dialog.id_prefix : "dialog";
+
     return (
         <Alert
-            id="dialog-error-message"
+            id={`${pfx}-error-message`}
             variant='danger'
             isInline
             title={title}
@@ -1468,9 +1481,11 @@ export function DialogActionButton<V>({
     action: (values: V) => Promise<void>,
     onClose?: undefined | (() => void)
 } & Omit<ButtonProps, "id" | "action" | "isLoading" | "isDisabled" | "variant" | "onClick">) {
+    const pfx = dialog instanceof DialogState ? dialog.id_prefix : "dialog";
+
     return (
         <Button
-            id="dialog-apply"
+            id={`${pfx}-apply`}
             isLoading={!!dialog && !(dialog instanceof DialogError) && dialog.busy}
             isDisabled={!dialog || dialog instanceof DialogError || dialog.actions_disabled}
             variant="primary"
@@ -1494,9 +1509,11 @@ export function DialogCancelButton<V>({
     dialog: DialogState<V> | DialogError | null,
     onClose: () => void
 } & Omit<ButtonProps, "id" | "isDisabled" | "variant" | "onClick">) {
+    const pfx = dialog instanceof DialogState ? dialog.id_prefix : "dialog";
+
     return (
         <Button
-            id="dialog-cancel"
+            id={`${pfx}-cancel`}
             isDisabled={!dialog || (dialog instanceof DialogState && dialog.cancel_disabled)}
             variant="link"
             onClick={() => {

--- a/pkg/lib/cockpit/dialog.tsx
+++ b/pkg/lib/cockpit/dialog.tsx
@@ -344,6 +344,13 @@
      if (dlg.run_action(...))
        dlg.field("xxx").set(...)
 
+   - dlg.cancel(onClose)
+
+   Does whatever should happen when the "Cancel" button is
+   clicked. When an action is running, it will call the "cancel
+   function" (see below).  Otherwise all validation and update tasks
+   are cancelled and the dialog is closed by calling "onClose".
+
    - dlg.set_cancel(func)
 
    Arranges for "func" to be called when the cancel button is clicked.
@@ -921,7 +928,6 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
     busy: boolean = false;
     actions_disabled: boolean = false;
     cancel_disabled: boolean = false;
-    cancel_function: (() => void) | null = null;
 
     error: unknown = null;
 
@@ -929,6 +935,7 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
     #online_validation: boolean = false;
     #action_running: boolean = false;
     #block_updates: boolean = false;
+    #cancel_function: (() => void) | null = null;
 
     #top_state: DialogFieldState;
 
@@ -958,7 +965,7 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
     #update() {
         this.busy = this.#action_running;
         this.actions_disabled = this.#action_running || this.#validation_failed;
-        this.cancel_disabled = this.#action_running && !this.cancel_function;
+        this.cancel_disabled = this.#action_running && !this.#cancel_function;
         this.emit("changed");
     }
 
@@ -1281,13 +1288,13 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
     }
 
     set_cancel(cancel: (() => void) | null) {
-        this.cancel_function = cancel;
+        this.#cancel_function = cancel;
         this.#update();
     }
 
     async run_action(func: (vals: V) => Promise<void>): Promise<boolean> {
         this.error = null;
-        this.cancel_function = null;
+        this.#cancel_function = null;
         this.#action_running = true;
         this.#update();
         if (!await this.validate()) {
@@ -1304,12 +1311,22 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
             this.error = ex;
         }
 
-        this.cancel_function = null;
+        this.#cancel_function = null;
         this.#action_running = false;
         this.#block_updates = false;
         this.#update();
 
         return !this.error;
+    }
+
+    cancel(onClose: () => void): void {
+        if (this.#action_running) {
+            if (this.#cancel_function)
+                this.#cancel_function();
+        } else {
+            this._cancel_state_tasks(this.#top_state);
+            onClose();
+        }
     }
 
     top(update_func?: ((val: V) => void) | undefined): DialogField<V> {
@@ -1483,8 +1500,8 @@ export function DialogCancelButton<V>({
             isDisabled={!dialog || (dialog instanceof DialogState && dialog.cancel_disabled)}
             variant="link"
             onClick={() => {
-                if (dialog instanceof DialogState && dialog.cancel_function)
-                    dialog.cancel_function();
+                if (dialog instanceof DialogState)
+                    dialog.cancel(onClose);
                 else
                     onClose();
             }}

--- a/pkg/lib/cockpit/dialog.tsx
+++ b/pkg/lib/cockpit/dialog.tsx
@@ -691,28 +691,34 @@ export type DialogValidationResult<T> = (
     : undefined | string | { ""?: undefined | string }
 );
 
+function state_path(state: DialogFieldState): string {
+    const p = state.parent ? state_path(state.parent) : "";
+    const t = String(state.tag);
+    return p ? `${p}.${t}` : t;
+}
+
 export class DialogField<T> {
     /* eslint-disable no-use-before-define */
     #dialog: DialogState<unknown>;
+    #state: DialogFieldState;
     /* eslint-enable */
     #getter: () => T;
     #setter: (val: T) => void;
-    #path: string;
 
     constructor(
         dialog: DialogState<unknown>,
+        state: DialogFieldState,
         getter: () => T,
         setter: (val: T) => void,
-        path: string
     ) {
         this.#dialog = dialog;
+        this.#state = state;
         this.#getter = getter;
         this.#setter = setter;
-        this.#path = path;
     }
 
     validation_text(): string | undefined {
-        return this.#dialog._get_validation(this.#path);
+        return this.#state.validation_text;
     }
 
     get(): T {
@@ -724,7 +730,7 @@ export class DialogField<T> {
     }
 
     id(tag: string = "field"): string {
-        return "dialog-" + tag + "-" + this.#path;
+        return "dialog-" + tag + "-" + state_path(this.#state);
     }
 
     map<X>(func: (val: DialogField<ArrayElement<T>>, index: number) => X): X[] {
@@ -745,8 +751,17 @@ export class DialogField<T> {
     remove(index: number) {
         const val = this.get();
         if (Array.isArray(val)) {
-            for (let j = index; j < val.length - 1; j++)
-                this.#dialog._rename_validation_state(this.#path, j + 1, j);
+            const sub = this.#state.sub.get(index);
+            if (sub)
+                sub.tag = -1;
+            for (let j = index; j < val.length - 1; j++) {
+                const sub = this.#state.sub.get(j + 1);
+                if (sub) {
+                    sub.tag = j;
+                    this.#state.sub.set(j, sub);
+                }
+                this.#state.sub.delete(val.length - 1);
+            }
             this.set(toSpliced(val, index, 1) as T);
         }
     }
@@ -759,19 +774,28 @@ export class DialogField<T> {
     }
 
     sub<K extends keyof T>(tag: K, update_func?: ((val: T[K]) => void) | undefined): DialogField<T[K]> {
+        const sub = this.#dialog._get_sub_state(this.#state, tag);
         return new DialogField<T[K]>(
             this.#dialog,
-            () => this.get()[tag],
+            sub,
+            () => {
+                const container = this.get();
+                if (Array.isArray(container) && typeof sub.tag == "number") {
+                    return container[sub.tag];
+                } else {
+                    return container[tag];
+                }
+            },
             (val) => {
                 const container = this.get();
-                if (Array.isArray(container) && typeof tag == "number")
-                    this.#setter(toSpliced(container, tag, 1, val) as T);
-                else
+                if (Array.isArray(container) && typeof sub.tag == "number") {
+                    this.#setter(toSpliced(container, sub.tag, 1, val) as T);
+                } else {
                     this.#setter({ ...container, [tag]: val });
+                }
                 if (update_func)
                     update_func(val);
             },
-            this.#path ? this.#path + "." + String(tag) : String(tag)
         );
     }
 
@@ -779,22 +803,22 @@ export class DialogField<T> {
         cockpit.assert(Object.is(witness, this.get()));
         return new DialogField<TT>(
             this.#dialog,
+            this.#state,
             () => this.get() as TT,
             (val) => {
                 this.#setter(val);
             },
-            this.#path,
         );
     }
 
     validate(func: (val: T) => DialogValidationResult<T>): void {
         const val = this.get();
-        this.#dialog._validate_value(this.#path, val, () => func(val));
+        this.#dialog._validate_value(this.#state, val, () => func(val));
     }
 
     validate_async(debounce: number, func: (val: T) => Promise<DialogValidationResult<T>>): void {
         const val = this.get();
-        this.#dialog._validate_value_async(this.#path, val, debounce, () => func(val));
+        this.#dialog._validate_value_async(this.#state, val, debounce, () => func(val));
     }
 }
 
@@ -807,13 +831,33 @@ function get_validation_result_own_string(result: unknown): string | undefined {
         return undefined;
 }
 
-interface DialogValidationState {
-    path: string;
+/* A DialogFieldState object holds all state for a field.  Unlike
+   handles, there is at most one of these objects for each field, and
+   each handle for a given field refers to the exact same
+   DialogFieldState object.
+
+   DialogFieldStates are created on-demand and will over time form a
+   tree via "parent" and "sub" that corresponds to the dialog value.
+
+   The "tag" is used to access the dialog value.  A handle constructed
+   via dlg.field("name") will point to a state object with tag "name",
+   for example, and calling handle.get() will return
+   dlg.values["name"].
+
+   Other members of a DialogFieldState relate to validation.
+ */
+
+interface DialogFieldState {
+    parent: DialogFieldState | null,
+    tag: string | number | symbol;
+    sub: Map<string | number | symbol, DialogFieldState>;
+    // validation
+    validation_text: string | undefined;
     cached_value: unknown;
     cached_result: unknown;
     timeout_id: number;
     promise: Promise<void> | undefined;
-    round_id: unknown;
+    validation_round: number;
 }
 
 interface DialogStateEvents {
@@ -833,17 +877,29 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
     #validation_failed: boolean = false;
     #online_validation: boolean = false;
     #action_running: boolean = false;
-    #validation: Record<string, string | undefined> = { };
-    #validation_state: Record<string, DialogValidationState> = { };
+    #top_state: DialogFieldState;
+    #validation_round: number = 0;
 
     /* eslint-disable no-use-before-define */
     #validate_callback: undefined | ((dlg: DialogState<V>) => void);
     /* eslint-enable */
 
     constructor(init: V, validate: undefined | ((dlg: DialogState<V>) => void)) {
+        debug("open");
         super();
         this.#validate_callback = validate;
         this.values = init;
+        this.#top_state = {
+            parent: null,
+            sub: new Map(),
+            tag: "",
+            validation_text: undefined,
+            cached_value: undefined,
+            cached_result: undefined,
+            timeout_id: 0,
+            promise: undefined,
+            validation_round: -1,
+        };
     }
 
     #update() {
@@ -853,87 +909,111 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
         this.emit("changed");
     }
 
+    /* FIELD STATES
+
+       During validation and asynchronous updates, a lot is going on.
+
+       We use a DialogFieldState object to keep the necessary
+       state for that, such as cached results, and timeouts and
+       promises.
+
+       These state objects keep their identity when arrays elements
+       move around.  Their "index" field will be changed when that
+       happens.
+     */
+
+    _get_sub_state(state: DialogFieldState, tag: string | number | symbol): DialogFieldState {
+        let sub = state.sub.get(tag);
+        if (!sub) {
+            sub = {
+                parent: state,
+                sub: new Map(),
+                tag,
+                validation_text: undefined,
+                cached_value: undefined,
+                cached_result: undefined,
+                timeout_id: 0,
+                promise: undefined,
+                validation_round: -1,
+            };
+            state.sub.set(tag, sub);
+        }
+        return sub;
+    }
+
+    _for_each_field_state(func: (state: DialogFieldState) => void) {
+        function visit(state: DialogFieldState) {
+            func(state);
+            for (const sub of state.sub.values())
+                visit(sub);
+        }
+        visit(this.#top_state);
+    }
+
+    async _for_each_field_state_async(func: (state: DialogFieldState) => Promise<void>) {
+        async function visit(state: DialogFieldState) {
+            await func(state);
+            for (const sub of state.sub.values())
+                await visit(sub);
+        }
+        await visit(this.#top_state);
+    }
+
     /* VALIDATION
      */
 
     /* Validation is started by calling the #trigger_validation
-       method. This will reset all validation errors and then call the
-       provided "validate" callback, which in turn will (eventually
-       but synchronously) call the "_validate_value" or
-       "_validate_value_async" methods of all relevant value paths.
-       Those functions will eventually call #set_validation to install
-       the validation results in the fresh #validation object created
-       by #trigger_validation.
+       method. This will reset all validation errors, increment the
+       "round number" and then call the provided "validate" callback,
+       which in turn will (eventually but synchronously) call the
+       "_validate_value" or "_validate_value_async" methods of all
+       relevant value paths.  Those functions will eventually call
+       #set_validation to install the validation results in the field
+       states.
      */
 
     #trigger_validation(): void {
         debug("trigger validation");
         if (!this.#validate_callback)
             return;
-        this.#validation = { };
         this.#validation_failed = false;
+        this._for_each_field_state(state => { state.validation_text = undefined });
+        this.#validation_round += 1;
         this.#validate_callback(this);
         this.#update();
     }
 
-    #set_validation(path: string, result: unknown) {
+    #set_validation(state: DialogFieldState, result: unknown) {
         if (result) {
             const own = get_validation_result_own_string(result);
             if (own) {
-                this.#validation[path] = own;
+                state.validation_text = own;
                 this.#validation_failed = true;
                 this.#online_validation = true;
                 this.#update();
             }
             if (typeof result == "object") {
                 for (const [k, v] of Object.entries(result)) {
-                    if (k)
-                        this.#set_validation(path ? path + "." + k : k, v);
+                    const sub = k && state.sub.get(k);
+                    if (sub)
+                        this.#set_validation(sub, v);
                 }
             }
         }
     }
 
-    _get_validation(path: string): string | undefined {
-        if (path in this.#validation)
-            return this.#validation[path];
-        else
-            return undefined;
-    }
+    /* The field state has a cache of the most recently validated
+       value.  If the current value is still the same, actual
+       validation is skipped and the cached result from last time is
+       used.
 
-    /* In between #trigger_validation and #set_validation, a lot is
-       going on, especially with asynchronous validation.
-
-       We use a DialogValidationState object to keep the necessary
-       state for that, such as cached results, and timeouts and
-       promises.
-
-       Note that a DialogValidationState object can change which path
-       it is for, see _rename_validation_state below. So we have to be
-       careful to always get the path out of the DialogValidationState
-       object.
-     */
-
-    #get_validation_state(path: string): DialogValidationState {
-        if (!(path in this.#validation_state))
-            this.#validation_state[path] = {
-                path,
-                cached_value: undefined,
-                cached_result: undefined,
-                timeout_id: 0,
-                promise: undefined,
-                round_id: undefined,
-            };
-        return this.#validation_state[path];
-    }
-
-    /* Calling #set_validation_state_result is the final thing that
-       should happen when validating a given path. It will install the
+       Calling #set_validation_state_result is the final thing that
+       should happen when validating a field. It will install the
        result in the cache and then call #set_validation.
      */
 
     #set_validation_state_result(
-        state: DialogValidationState,
+        state: DialogFieldState,
         val: unknown,
         result: unknown,
     ) {
@@ -941,24 +1021,24 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
         state.cached_result = result;
         state.timeout_id = 0;
         state.promise = undefined;
-        state.round_id = undefined;
-        this.#set_validation(state.path, result);
+        state.validation_round = -1;
+        this.#set_validation(state, result);
     }
 
     /* The first thing should be of course to probe that cache.  If we
        get a hit, it is used immediately to call #set_validation.
 
-       In that case, the DialogValidationState is also made part of
+       In that case, the DialogFieldState is also made part of
        the current round since any asynchronous validation that is
        currently running is still relevant. See below for more about
        that.
      */
 
-    #probe_validation_state_cache(state: DialogValidationState, val: unknown): boolean {
+    #probe_validation_state_cache(state: DialogFieldState, val: unknown): boolean {
         if (Object.is(state.cached_value, val)) {
-            state.round_id = this.#get_current_validation_round_id();
-            debug("cache hit", state.path, state.cached_result);
-            this.#set_validation(state.path, state.cached_result);
+            state.validation_round = this.#validation_round;
+            debug("cache hit", state_path(state), JSON.stringify(val), state.cached_result);
+            this.#set_validation(state, state.cached_result);
             return true;
         } else
             return false;
@@ -967,11 +1047,10 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
     /* And in fact, _validate_value does exactly those two things.
      */
 
-    _validate_value(path: string, val: unknown, func: () => unknown): void {
-        const state = this.#get_validation_state(path);
+    _validate_value(state: DialogFieldState, val: unknown, func: () => unknown): void {
         if (!this.#probe_validation_state_cache(state, val)) {
             const result = func();
-            debug("sync validate", state.path, result);
+            debug("sync validate", state_path(state), result);
             this.#set_validation_state_result(state, val, result);
         }
     }
@@ -979,7 +1058,7 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
     /* Now asynchronous validation.
 
        Each call to #trigger_validation starts a new "validation
-       round" and a DialogValidationState keeps track to which round
+       round" and a DialogFieldState keeps track to which round
        it applies to.  This matters of course for asynchronous
        validation: If async validation for a given path was started in
        one round, and then the next round happens but the path is no
@@ -987,19 +1066,7 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
        is no longer relevant for the dialog), then this asynchronous
        validation should have no effect.
 
-       We use the #validation object as the round identifier, since it
-       is created fresh by each call to #trigger_validation.
-     */
-
-    #get_current_validation_round_id(): unknown {
-        return this.#validation;
-    }
-
-    #is_current_validation_round_id(id: unknown): boolean {
-        return Object.is(id, this.#validation);
-    }
-
-    /* If there was no cache hit, asynchronous validation starts with
+       If there was no cache hit, asynchronous validation starts with
        a timeout, followed by letting a asynchronous function run to
        resolution.
 
@@ -1015,13 +1082,13 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
      */
 
     #set_validation_state_timeout(
-        state: DialogValidationState,
+        state: DialogFieldState,
         val: unknown,
         delay: number,
         func: () => void,
     ) {
         if (state.timeout_id) {
-            debug("timeout cancel", state.path);
+            debug("timeout cancel", state_path(state));
             window.clearTimeout(state.timeout_id);
             state.timeout_id = 0;
         }
@@ -1032,27 +1099,27 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
             state.cached_result = undefined;
             state.timeout_id = window.setTimeout(
                 () => {
-                    debug("timeout", state.path);
+                    debug("timeout", state_path(state));
                     if (!this.#validation_state_is_current(state)) {
-                        debug("timeout outdated", state.path);
+                        debug("timeout outdated", state_path(state));
                         return;
                     }
                     func();
                 },
                 delay);
             state.promise = undefined;
-            state.round_id = this.#get_current_validation_round_id();
+            state.validation_round = this.#validation_round;
         }
     }
 
     /* Once the timeout is over (and the path is still relevant to the
        current round), the actual asynchronous validation is launched.
        This promise that represents it is simply installed in the
-       DialogValidationState.
+       DialogFieldState.
      */
 
     #set_validation_state_promise(
-        state: DialogValidationState,
+        state: DialogFieldState,
         val: unknown,
         prom: Promise<void>,
     ) {
@@ -1060,7 +1127,7 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
         state.cached_result = undefined;
         state.timeout_id = 0;
         state.promise = prom;
-        state.round_id = this.#get_current_validation_round_id();
+        state.validation_round = this.#validation_round;
     }
 
     /* Unlike with the timeout, we can not cancel the old promise when
@@ -1096,26 +1163,22 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
          promise. Its result will be ignored, as it should.
      */
 
-    #validation_state_is_current(state: DialogValidationState, prom?: Promise<void>): boolean {
-        return (
-            (!prom || Object.is(state.promise, prom)) &&
-                this.#is_current_validation_round_id(state.round_id)
-        );
+    #validation_state_is_current(state: DialogFieldState, prom?: Promise<void>): boolean {
+        return (!prom || Object.is(state.promise, prom)) && this.#validation_round === state.validation_round;
     }
 
     /* _validate_value_async puts this all together.
      */
 
-    _validate_value_async(path: string, val: unknown, debounce: number, func: () => Promise<unknown>): void {
-        const state = this.#get_validation_state(path);
+    _validate_value_async(state: DialogFieldState, val: unknown, debounce: number, func: () => Promise<unknown>): void {
         if (!this.#probe_validation_state_cache(state, val)) {
-            debug("async validate start debounce", state.path, val);
+            debug("async validate start debounce", state_path(state), val);
             this.#set_validation_state_timeout(
                 state,
                 val,
                 debounce,
                 () => {
-                    debug("async validate start promise", state.path, val);
+                    debug("async validate start promise", state_path(state), val);
                     const prom =
                         func()
                                 .catch(
@@ -1127,10 +1190,10 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
                                 .then(
                                     result => {
                                         if (this.#validation_state_is_current(state, prom)) {
-                                            debug("async validate done", state.path, result);
+                                            debug("async validate done", state_path(state), result);
                                             this.#set_validation_state_result(state, val, result);
                                         } else {
-                                            debug("promise outdated", state.path);
+                                            debug("promise outdated", state_path(state));
                                         }
                                     }
                                 );
@@ -1140,39 +1203,11 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
         }
     }
 
-    /* Since the DialogValidationState for a path is so important, it
-       is also important to keep them firmly associated with each
-       other when the path of a value changes.
-
-       A path might change when there are arrays involved, and
-       elements get new indices without actually changing identity.
-     */
-
-    _rename_validation_state(path: string, from: number, to: number) {
-        const from_path = path + "." + String(from);
-        const to_path = path + "." + String(to);
-        if (from_path in this.#validation_state) {
-            debug("rename", from_path, to_path);
-            this.#validation_state[to_path] = this.#validation_state[from_path];
-            this.#validation_state[to_path].path = to_path;
-            delete this.#validation_state[from_path];
-        }
-        for (const k in this.#validation_state) {
-            if (k.indexOf(from_path + ".") == 0) {
-                const to = to_path + k.substring(from_path.length);
-                debug("rename", k, to);
-                this.#validation_state[to] = this.#validation_state[k];
-                this.#validation_state[to].path = to;
-                delete this.#validation_state[k];
-            }
-        }
-    }
-
     /* The first thing run_action does is to trigger a new validation
        round and then wait for all the asynchronous results to have
        come in.
 
-       If there are any DialogValidationState objects that are waiting
+       If there are any DialogFieldState objects that are waiting
        for a timeout, we want to cancel those and start over, so that
        their validation starts immediately. (Also, it would be hairy
        to wait for those timeouts to be over from here.)
@@ -1186,25 +1221,24 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
     }
 
     #cancel_all_validation_timeouts() {
-        for (const p in this.#validation_state) {
-            const state = this.#validation_state[p];
+        this._for_each_field_state(state => {
             if (state.timeout_id) {
-                debug("timeout bulk cancel", p);
+                debug("timeout bulk cancel", state_path(state));
                 window.clearTimeout(state.timeout_id);
-                delete this.#validation_state[p];
+                state.validation_round = -1;
+                state.cached_value = undefined;
             }
-        }
+        });
     }
 
     async #wait_for_validation_promises(): Promise<void> {
-        for (const path in this.#validation_state) {
-            const state = this.#validation_state[path];
-            if (state.promise) {
-                debug("waiting for promise", path);
+        await this._for_each_field_state_async(async state => {
+            if (state.validation_round === this.#validation_round && state.promise) {
+                debug("waiting for promise", state_path(state));
                 await state.promise;
-                debug("waiting for promise done", path);
+                debug("waiting for promise done", state_path(state));
             }
-        }
+        });
     }
 
     set_cancel(cancel: (() => void) | null) {
@@ -1240,6 +1274,7 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
     top(update_func?: ((val: V) => void) | undefined): DialogField<V> {
         return new DialogField<V>(
             this as DialogState<unknown>,
+            this.#top_state,
             () => this.values,
             (val) => {
                 debug("set", val);
@@ -1261,7 +1296,7 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
                 if (update_func)
                     update_func(val);
             },
-            "");
+        );
     }
 
     field<K extends keyof V>(tag: K, update_func?: ((val: V[K]) => void) | undefined): DialogField<V[K]> {

--- a/pkg/lib/cockpit/dialog.tsx
+++ b/pkg/lib/cockpit/dialog.tsx
@@ -801,14 +801,7 @@ export class DialogField<T> {
 
     at<TT extends T>(witness: TT): DialogField<TT> {
         cockpit.assert(Object.is(witness, this.get()));
-        return new DialogField<TT>(
-            this.#dialog,
-            this.#state,
-            () => this.get() as TT,
-            (val) => {
-                this.#setter(val);
-            },
-        );
+        return this as unknown as DialogField<TT>;
     }
 
     validate(func: (val: T) => DialogValidationResult<T>): void {

--- a/pkg/playground/dialog.tsx
+++ b/pkg/playground/dialog.tsx
@@ -207,6 +207,7 @@ interface ExampleValues {
     text: string;
     radio: string;
     dropdown: string;
+    text3: string;
     color: Color,
     list: string[];
     async: Name[];
@@ -228,6 +229,7 @@ const ExampleDialog = ({
         text: "",
         radio: "one",
         dropdown: "one",
+        text3: "",
         color: colors[0],
         list: [],
         async: [],
@@ -240,6 +242,12 @@ const ExampleDialog = ({
             dlg.field("text").validate(v => {
                 if (!v)
                     return "Text can not be empty";
+            });
+        }
+        if (dlg.values.dropdown == "three") {
+            dlg.field("text3").validate_async(1000, async v => {
+                if (!v)
+                    return "Can't be empty";
             });
         }
         dlg.field("list").forEach(v => {
@@ -342,6 +350,10 @@ const ExampleDialog = ({
                         }
                         warning={dlg.field("dropdown").get() == "two" ? "There is a discount if you buy three." : null}
                     />
+                    {
+                        dlg.values.dropdown == "three" &&
+                            <DialogTextInput label="Text3" field={dlg.field("text3")} />
+                    }
                     <DialogDropdownSelectObject
                         label="DropdownObject"
                         field={dlg.field("color", update_color)}

--- a/pkg/playground/dialog.tsx
+++ b/pkg/playground/dialog.tsx
@@ -205,6 +205,7 @@ const colors: Color[] = [
 interface ExampleValues {
     flag: boolean;
     text: string;
+    text2: string;
     radio: string;
     dropdown: string;
     text3: string;
@@ -218,15 +219,20 @@ interface ExampleValues {
 const ExampleDialog = ({
     setResult,
     countAsyncValidation,
+    countAsyncUpdate,
+    countAsyncCancel,
 } : {
     setResult: (values: ExampleValues) => void,
     countAsyncValidation: () => void,
+    countAsyncUpdate: () => void,
+    countAsyncCancel: () => void,
 }) => {
     const Dialogs = useDialogs();
 
     const init: ExampleValues = {
         flag: false,
         text: "",
+        text2: "",
         radio: "one",
         dropdown: "one",
         text3: "",
@@ -283,8 +289,22 @@ const ExampleDialog = ({
         }
     }
 
-    function update_color(color: Color) {
-        dlg.field("text").set(color.name);
+    function update_color() {
+        dlg.field("color").get_async(0, async (val, task) => {
+            task.set_cancel(countAsyncCancel);
+            await async_sleep(2000);
+            if (!task.is_cancelled()) {
+                countAsyncUpdate();
+                dlg.field("text").set(val.name);
+            }
+        });
+    }
+
+    function update_dropdown(val: string) {
+        dlg.field("text2").set_async(0, async () => {
+            await async_sleep(2000);
+            return val;
+        });
     }
 
     return (
@@ -310,6 +330,10 @@ const ExampleDialog = ({
                         excuse={!dlg.values.flag && "Disabled"}
                         explanation="Explanation"
                         warning={dlg.values.text == "warn" ? "Warning" : null}
+                    />
+                    <DialogTextInput
+                        label="Text2"
+                        field={dlg.field("text2")}
                     />
                     {
                         // Calling "map" on a non-array should just do nothing.
@@ -340,7 +364,7 @@ const ExampleDialog = ({
                     />
                     <DialogDropdownSelect
                         label="Dropdown"
-                        field={dlg.field("dropdown")}
+                        field={dlg.field("dropdown", update_dropdown)}
                         options={
                             [
                                 { value: "one", label: "Eins" },
@@ -388,8 +412,12 @@ const ExampleDialog = ({
 const ExampleButton = () => {
     const Dialogs = useDialogs();
     const [values, setValues] = useState<ExampleValues | null>(null);
-    const [asyncValidationsBase, setAsycountAsyncValidationsBase] = useState<number>(0);
+    const [asyncValidationsBase, setAsyncValidationsBase] = useState<number>(0);
     const [asyncValidations, countAsyncValidation] = useReducer(x => x + 1, 0);
+    const [asyncUpdatesBase, setAsyncUpdatesBase] = useState<number>(0);
+    const [asyncUpdates, countAsyncUpdate] = useReducer(x => x + 1, 0);
+    const [asyncCancelsBase, setAsyncCancelsBase] = useState<number>(0);
+    const [asyncCancels, countAsyncCancel] = useReducer(x => x + 1, 0);
 
     function entry(id: string, val: string) {
         return (
@@ -406,11 +434,15 @@ const ExampleButton = () => {
                 id="open"
                 onClick={
                     () => {
-                        setAsycountAsyncValidationsBase(asyncValidations);
+                        setAsyncValidationsBase(asyncValidations);
+                        setAsyncUpdatesBase(asyncUpdates);
+                        setAsyncCancelsBase(asyncCancels);
                         Dialogs.show(
                             <ExampleDialog
                                 setResult={setValues}
                                 countAsyncValidation={countAsyncValidation}
+                                countAsyncUpdate={countAsyncUpdate}
+                                countAsyncCancel={countAsyncCancel}
                             />
                         );
                     }
@@ -422,12 +454,15 @@ const ExampleButton = () => {
                 <DescriptionList isHorizontal>
                     { entry("flag", String(values.flag)) }
                     { values.flag && entry("text", values.text) }
+                    { entry("text2", values.text2) }
                     { entry("radio", values.radio) }
                     { entry("dropdown", values.dropdown) }
                     { entry("color", values.color.red + "/" + values.color.green + "/" + values.color.blue) }
                     { entry("list", values.list.join("/")) }
                     { entry("async", values.async.map(n => n.name + ":" + String(n._length_cache[n.name])).join("/")) }
                     { entry("asyncVals", String(asyncValidations - asyncValidationsBase)) }
+                    { entry("asyncUps", String(asyncUpdates - asyncUpdatesBase)) }
+                    { entry("asyncCancels", String(asyncCancels - asyncCancelsBase)) }
                     { entry("alternative", JSON.stringify(values.alternative)) }
                 </DescriptionList>
             }

--- a/pkg/playground/dialog.tsx
+++ b/pkg/playground/dialog.tsx
@@ -542,8 +542,10 @@ interface AsyncExampleValues {
 
 const AsyncExampleDialog = ({
     throwError = 0,
+    cancelCallback = null,
 } : {
     throwError?: number,
+    cancelCallback?: null | (() => void),
 }) => {
     const Dialogs = useDialogs();
 
@@ -568,6 +570,10 @@ const AsyncExampleDialog = ({
     const dlg = useDialogState_async(init, validate);
 
     async function apply() {
+        cockpit.assert(dlg instanceof DialogState);
+
+        dlg.set_cancel(cancelCallback);
+
         await async_sleep(1000);
         Dialogs.close();
     }
@@ -619,6 +625,7 @@ const AsyncExampleDialog = ({
 
 const SimpleExampleButtons = () => {
     const Dialogs = useDialogs();
+    const [cancelled, setCancelled] = useState(false);
 
     return (
         <>
@@ -630,10 +637,18 @@ const SimpleExampleButtons = () => {
             </Button>
             <Button
                 id="open-async"
-                onClick={() => Dialogs.show(<AsyncExampleDialog />)}
+                onClick={
+                    () => {
+                        setCancelled(false);
+                        Dialogs.show(<AsyncExampleDialog cancelCallback={() => setCancelled(true)} />);
+                    }
+                }
             >
                 Open async dialog
             </Button>
+            <div id="cancelled">
+                Cancelled: {cancelled ? "yes" : "no"}
+            </div>
             <Button
                 id="open-error"
                 onClick={() => Dialogs.show(<AsyncExampleDialog throwError={1} />)}

--- a/pkg/playground/dialog.tsx
+++ b/pkg/playground/dialog.tsx
@@ -99,7 +99,7 @@ const StringList = ({
 
 interface Name {
     name: string;
-    _length_cache: Record<string, number>;
+    _length: number;
 }
 
 const NameInput = ({
@@ -111,11 +111,11 @@ const NameInput = ({
 };
 
 function validate_Name(field: DialogField<Name>, countAsyncValidation: () => void) {
-    const { _length_cache } = field.get();
-    field.sub("name").validate_async(1000, async n => {
+    field.sub("name").validate_async(1000, async (n, task) => {
         await async_sleep(2000);
         countAsyncValidation();
-        _length_cache[n] = n.length;
+        if (!task.is_cancelled())
+            field.sub("_length").set(n.length);
         if (n.length % 2)
             return "Must have even number of characters";
     });
@@ -133,7 +133,7 @@ const NameList = ({
             label={label}
             field={field}
             Component={NameInput}
-            init={{ name: "", _length_cache: { } }}
+            init={{ name: "", _length: 0 }}
         />
     );
 };
@@ -258,6 +258,8 @@ const ExampleDialog = ({
         }
         dlg.field("list").forEach(v => {
             v.validate(vv => {
+                if (vv == "magic")
+                    dlg.field("text").set("magic");
                 if (vv == ".")
                     return "No dots";
             });
@@ -459,7 +461,7 @@ const ExampleButton = () => {
                     { entry("dropdown", values.dropdown) }
                     { entry("color", values.color.red + "/" + values.color.green + "/" + values.color.blue) }
                     { entry("list", values.list.join("/")) }
-                    { entry("async", values.async.map(n => n.name + ":" + String(n._length_cache[n.name])).join("/")) }
+                    { entry("async", values.async.map(n => n.name + ":" + String(n._length)).join("/")) }
                     { entry("asyncVals", String(asyncValidations - asyncValidationsBase)) }
                     { entry("asyncUps", String(asyncUpdates - asyncUpdatesBase)) }
                     { entry("asyncCancels", String(asyncCancels - asyncCancelsBase)) }

--- a/pkg/playground/dialog.tsx
+++ b/pkg/playground/dialog.tsx
@@ -267,7 +267,8 @@ const ExampleDialog = ({
         dlg.field("async").forEach(v => validate_Name(v, countAsyncValidation));
     }
 
-    const dlg = useDialogState(init, validate);
+    const dlg = useDialogState(init, validate)
+        .set_id_prefix("example");
 
     async function apply(values: ExampleValues) {
         setResult(values);

--- a/test/common/dialoglib.py
+++ b/test/common/dialoglib.py
@@ -65,11 +65,12 @@ def css_escape(x: str) -> str:
 
 
 class DialogHelpers:
-    def __init__(self, b: testlib.Browser):
+    def __init__(self, b: testlib.Browser, prefix: str = "dialog"):
         self.browser = b
+        self.prefix = prefix
 
     def id(self, path: str, tag: str) -> str:
-        return f"#dialog-{tag}-{css_escape(path)}"
+        return f"#{self.prefix}-{tag}-{css_escape(path)}"
 
     def field(self, path: str) -> str:
         return self.id(path, "field")
@@ -78,13 +79,13 @@ class DialogHelpers:
         return self.id(path, "helper-text")
 
     def error(self) -> str:
-        return "#dialog-error-message"
+        return f"#{self.prefix}-error-message"
 
     def apply_button(self) -> str:
-        return "#dialog-apply"
+        return f"#{self.prefix}-apply"
 
     def cancel_button(self) -> str:
-        return "#dialog-cancel"
+        return f"#{self.prefix}-cancel"
 
     # TextInput
 

--- a/test/verify/check-dialog
+++ b/test/verify/check-dialog
@@ -94,6 +94,21 @@ class TestDialog(testlib.MachineCase):
 
         b.wait_text("#dropdown", "two")
 
+        # Cancelling of irrelevant validations
+
+        b.click("#open")
+        d.set_DropdownSelect("dropdown", "three")
+        b.click(d.apply_button())
+        b.wait_in_text(d.helper_text("text3"), "Can't be empty")
+        # start a debounced validation of text3 and remove it from the
+        # dialog before it has finished.
+        d.set_TextInput("text3", "x")
+        time.sleep(0.5)
+        d.set_TextInput("text3", "")
+        d.set_DropdownSelect("dropdown", "one")
+        b.click(d.apply_button())
+        b.wait_not_present("#dialog")
+
         # DialogDropdownSelectObject, with update_func
 
         b.click("#open")

--- a/test/verify/check-dialog
+++ b/test/verify/check-dialog
@@ -11,7 +11,7 @@ class TestDialog(testlib.MachineCase):
 
     def test(self):
         b = self.browser
-        d = dialoglib.DialogHelpers(b)
+        d = dialoglib.DialogHelpers(b, "example")
 
         # Missing coverage:
         #
@@ -314,6 +314,9 @@ class TestDialog(testlib.MachineCase):
 
         b.click(d.cancel_button())
         b.wait_not_present("#dialog")
+
+        # back to standard prefix
+        d = dialoglib.DialogHelpers(b)
 
         # init func and sub-field validation
 

--- a/test/verify/check-dialog
+++ b/test/verify/check-dialog
@@ -86,18 +86,21 @@ class TestDialog(testlib.MachineCase):
 
         b.click("#open")
         d.wait_DropdownSelect("dropdown", "one")
-        d.set_DropdownSelect("dropdown", "two")
+        d.set_DropdownSelect("dropdown", "three")  # first call to set_async
+        d.set_DropdownSelect("dropdown", "two")  # second call, will cancel first
         self.assertEqual(d.get_DropdownSelect("dropdown"), "two")
         b.wait_in_text(d.helper_text("dropdown"), "discount")
         b.click(d.apply_button())
         b.wait_not_present("#dialog")
 
         b.wait_text("#dropdown", "two")
+        b.wait_text("#text2", "two")
 
         # Cancelling of irrelevant validations
 
         b.click("#open")
         d.set_DropdownSelect("dropdown", "three")
+        d.wait_TextInput("text2", "three")  # wait for async update to be done
         b.click(d.apply_button())
         b.wait_in_text(d.helper_text("text3"), "Can't be empty")
         # start a debounced validation of text3 and remove it from the
@@ -109,18 +112,29 @@ class TestDialog(testlib.MachineCase):
         b.click(d.apply_button())
         b.wait_not_present("#dialog")
 
-        # DialogDropdownSelectObject, with update_func
+        # DialogDropdownSelectObject, with asynchronous updates
 
         b.click("#open")
+        d.set_Checkbox("flag", val=True)
         d.wait_DropdownSelect("color", "red")
         self.assertEqual(d.get_TextInput("text"), "")
         d.set_DropdownSelect("color", "green")
         self.assertEqual(d.get_DropdownSelect("color"), "green")
-        self.assertEqual(d.get_TextInput("text"), "green")
+        # Text does not react immediately.
+        self.assertEqual(d.get_TextInput("text"), "")
+        # Wait a bit and then change color again. This cancels the update.
+        time.sleep(1)
+        d.set_DropdownSelect("color", "blue")
+        self.assertEqual(d.get_DropdownSelect("color"), "blue")
+        self.assertEqual(d.get_TextInput("text"), "")
+        # Apply while the update is still running. It should finish (1 update)
         b.click(d.apply_button())
         b.wait_not_present("#dialog")
 
-        b.wait_text("#color", "0/1/0")
+        b.wait_text("#text", "blue")
+        b.wait_text("#color", "0/0/1")
+        b.wait_text("#asyncUps", "1")
+        b.wait_text("#asyncCancels", "1")
 
         # List of DialogTextInputs
 

--- a/test/verify/check-dialog
+++ b/test/verify/check-dialog
@@ -155,11 +155,12 @@ class TestDialog(testlib.MachineCase):
         d.wait_TextInput("list.1", "bar")
         b.wait_not_present(d.field("list.2"))
         b.click(d.id("list", "add"))
-        d.set_TextInput("list.2", "baz")
+        d.set_TextInput("list.2", "magic")
+        d.wait_TextInput("text", "magic")
         b.click(d.apply_button())
         b.wait_not_present("#dialog")
 
-        b.wait_text("#list", "foo/bar/baz")
+        b.wait_text("#list", "foo/bar/magic")
 
         # Debounced and asynchronous validation
 

--- a/test/verify/check-dialog
+++ b/test/verify/check-dialog
@@ -136,6 +136,25 @@ class TestDialog(testlib.MachineCase):
         b.wait_text("#asyncUps", "1")
         b.wait_text("#asyncCancels", "1")
 
+        # Cancelling of asynchronous tasks when the dialog is
+        # cancelled
+
+        b.click("#open")
+        d.wait_DropdownSelect("color", "red")
+        self.assertEqual(d.get_TextInput("text"), "")
+        d.set_DropdownSelect("color", "green")
+        self.assertEqual(d.get_DropdownSelect("color"), "green")
+        # Text does not react immediately.
+        self.assertEqual(d.get_TextInput("text"), "")
+        b.click(d.cancel_button())
+        b.wait_not_present("#dialog")
+
+        # Wait for update to definitely be done if it wouldn't have
+        # been cancelled
+        time.sleep(3)
+        b.wait_text("#asyncUps", "0")
+        b.wait_text("#asyncCancels", "1")
+
         # List of DialogTextInputs
 
         b.click("#open")
@@ -315,6 +334,9 @@ class TestDialog(testlib.MachineCase):
         b.click("#open-async")
         d.set_TextInput("text", "1234")
         b.click(d.apply_button())
+        b.wait_text("#cancelled", "Cancelled: no")
+        b.click(d.cancel_button())
+        b.wait_text("#cancelled", "Cancelled: yes")
         b.set_input_text(d.field("text"), "", value_check=False)
         d.wait_TextInput("text", "1234")
         b.wait_not_present("#dialog")


### PR DESCRIPTION
 Instead of harcoding "dialog".  This allows nested dialogs without risking ambiguity.

- [ ] #23081 