### PR TITLE
test: Prevent TestStorageAnaconda.testBtrfs from OOM'ing udisks2

### DIFF
--- a/test/verify/check-storage-anaconda
+++ b/test/verify/check-storage-anaconda
@@ -253,7 +253,7 @@ class TestStorageAnaconda(storagelib.StorageCase):
     def testBtrfs(self):
         b = self.browser
 
-        disk = self.add_ram_disk(200)
+        disk = self.add_ram_disk(128)
 
         anaconda_config = {
             "mount_point_prefix": "/sysroot",


### PR DESCRIPTION
The test creates a RAM backed disk and formats it with luks2 which uses argon2id that uses all available memory. Limiting the disk size to 128 like the btrfs storage tests do is enough to not OOM our test virtual machine with just 1GB of memory.

Closes: #23343