### PR TITLE
test: Handle buildroot Cockpit branding

### DIFF
--- a/src/ws/test-branding.c
+++ b/src/ws/test-branding.c
@@ -85,17 +85,19 @@ test_roots_basic (gconstpointer data)
 {
   const gchar *data_dir = (const gchar *)data;
 
+  g_auto(GStrv) roots_initial = cockpit_branding_calculate_static_roots (NULL, NULL, NULL, FALSE);
+  guint roots_length = g_strv_length (roots_initial);
   setup_branding_dir (data_dir);
 
   /* No IDs at all */
   g_auto(GStrv) roots_none = cockpit_branding_calculate_static_roots (NULL, NULL, NULL, FALSE);
-  g_assert_cmpint (g_strv_length (roots_none), ==, 2);
+  g_assert_cmpint (g_strv_length (roots_none), ==, roots_length + 2);
   assert_roots_contains (roots_none, data_dir, "cockpit/branding/default");
   assert_roots_contains (roots_none, data_dir, "cockpit/static");
 
   /* ID */
   g_auto(GStrv) roots_id = cockpit_branding_calculate_static_roots ("rhel", NULL, NULL, FALSE);
-  g_assert_cmpint (g_strv_length (roots_id), ==, 3);
+  g_assert_cmpint (g_strv_length (roots_id), ==, roots_length + 3);
   assert_roots_contains (roots_id, data_dir, "cockpit/branding/rhel");
   assert_roots_contains (roots_id, data_dir, "cockpit/branding/default");
   assert_roots_contains (roots_id, data_dir, "cockpit/static");
@@ -103,14 +105,14 @@ test_roots_basic (gconstpointer data)
   /* ID + VARIANT; We don't actually have rhel-server nor any other variant branding, so it
    * should not appear; see test_roots_variant() below */
   g_auto(GStrv) roots_variant = cockpit_branding_calculate_static_roots ("rhel", "server", NULL, FALSE);
-  g_assert_cmpint (g_strv_length (roots_variant), ==, 3);
+  g_assert_cmpint (g_strv_length (roots_variant), ==, roots_length + 3);
   assert_roots_contains (roots_variant, data_dir, "cockpit/branding/rhel");
   assert_roots_contains (roots_variant, data_dir, "cockpit/branding/default");
   assert_roots_contains (roots_variant, data_dir, "cockpit/static");
 
   /* ID_LIKE */
   g_auto(GStrv) roots_like = cockpit_branding_calculate_static_roots ("centos", NULL, "rhel fedora", FALSE);
-  g_assert_cmpint (g_strv_length (roots_like), ==, 5);
+  g_assert_cmpint (g_strv_length (roots_like), ==, roots_length + 5);
   assert_roots_contains (roots_like, data_dir, "cockpit/branding/centos");
   assert_roots_contains (roots_like, data_dir, "cockpit/branding/rhel");
   assert_roots_contains (roots_like, data_dir, "cockpit/branding/fedora");
@@ -121,6 +123,10 @@ test_roots_basic (gconstpointer data)
 static void
 test_roots_variant (gconstpointer data)
 {
+
+  g_auto(GStrv) roots_initial = cockpit_branding_calculate_static_roots (NULL, NULL, NULL, FALSE);
+  guint roots_length = g_strv_length (roots_initial);
+
   const gchar *data_dir = (const gchar *)data;
 
   /* Create a test variant branding directory (rhel-server) */
@@ -131,12 +137,12 @@ test_roots_variant (gconstpointer data)
 
   /* That is found */
   g_auto(GStrv) roots_variant = cockpit_branding_calculate_static_roots ("rhel", "server", NULL, FALSE);
-  g_assert_cmpint (g_strv_length (roots_variant), ==, 4);
+  g_assert_cmpint (g_strv_length (roots_variant), ==, roots_length + 2);
   assert_roots_contains (roots_variant, data_dir, "cockpit/branding/rhel-server");
 
   /* Non-existing variant */
   g_auto(GStrv) roots_missing = cockpit_branding_calculate_static_roots ("rhel", "workstation", NULL, FALSE);
-  g_assert_cmpint (g_strv_length (roots_missing), ==, 3);
+  g_assert_cmpint (g_strv_length (roots_missing), ==, roots_length + 1);
   assert_roots_contains (roots_variant, data_dir, "cockpit/branding/rhel");
   assert_roots_contains (roots_variant, data_dir, "cockpit/branding/default");
   assert_roots_contains (roots_variant, data_dir, "cockpit/static");
@@ -145,6 +151,9 @@ test_roots_variant (gconstpointer data)
 static void
 test_roots_config (gconstpointer data)
 {
+  g_auto(GStrv) roots_initial = cockpit_branding_calculate_static_roots (NULL, NULL, NULL, FALSE);
+  guint roots_length = g_strv_length (roots_initial);
+
   const gchar *tmp_dir = (const gchar *)data;
   g_autofree gchar *data_dir = g_build_filename (tmp_dir, "data", NULL);
   g_autofree gchar *config_dir = g_build_filename (tmp_dir, "config", NULL);
@@ -155,7 +164,7 @@ test_roots_config (gconstpointer data)
 
   g_auto(GStrv) roots = cockpit_branding_calculate_static_roots ("fedora", NULL, NULL, FALSE);
 
-  g_assert_cmpint (g_strv_length (roots), ==, 4);
+  g_assert_cmpint (g_strv_length (roots), ==, roots_length + 2);
   assert_roots_contains (roots, config_dir, "cockpit/branding");
   assert_roots_contains (roots, data_dir, "cockpit/branding/fedora");
   assert_roots_contains (roots, data_dir, "cockpit/branding/default");


### PR DESCRIPTION
When doing branding tests we are explicitly testing that we have an exact number of branding directories, whereas the underlying OS could've added the branding as part of buildroot. This became evident as an issue in tests when Fedora ELN included Cockpit specific branding in buildroot without contributing it upstream to us.

This changes the test so we always ensure we have the expected value or more in case there are folders we don't control.