### PR TITLE
test: Skip pulling pixel tests when not needed

### DIFF
--- a/test/run
+++ b/test/run
@@ -18,7 +18,9 @@
 set -eu
 
 test/common/make-bots
-test/common/pixel-tests pull
+if [ "$(cat test/reference-image)" = "$TEST_OS" ]; then
+    test/common/pixel-tests pull
+fi
 
 PREPARE_OPTS=""
 RUN_OPTS=""


### PR DESCRIPTION
On the EC2 setup there won't be a Git cache for pixel tests so every test run would pull pixels.