### PR TITLE
networkmanager: Pass STP options as integers not strings

### DIFF
--- a/pkg/networkmanager/bridge.jsx
+++ b/pkg/networkmanager/bridge.jsx
@@ -90,16 +90,16 @@ export const BridgeDialog = ({ connection, dev, settings }) => {
                     <Checkbox id={idPrefix + "-stp-enabled-input"} isChecked={stp} onChange={(_, s) => setStp(s)} label={_("Spanning tree protocol (STP)")} />
                     {stp && <>
                         <FormGroup fieldId="network-bridge-stp-settings-priority-input" label={_("STP priority")}>
-                            <TextInput id="network-bridge-stp-settings-priority-input" className="network-number-field" value={priority} onChange={(_event, value) => setPriority(value)} />
+                            <TextInput id="network-bridge-stp-settings-priority-input" className="network-number-field" value={priority} onChange={(_event, value) => setPriority(Number.parseInt(value))} />
                         </FormGroup>
                         <FormGroup fieldId="network-bridge-stp-settings-forward-delay-input" label={_("STP forward delay")}>
-                            <TextInput id="network-bridge-stp-settings-forward-delay-input" className="network-number-field" value={forwardDelay} onChange={(_event, value) => setForwardDelay(value)} />
+                            <TextInput id="network-bridge-stp-settings-forward-delay-input" className="network-number-field" value={forwardDelay} onChange={(_event, value) => setForwardDelay(Number.parseInt(value))} />
                         </FormGroup>
                         <FormGroup fieldId="network-bridge-stp-settings-hello-time-input" label={_("STP hello time")}>
-                            <TextInput id="network-bridge-stp-settings-hello-time-input" className="network-number-field" value={helloTime} onChange={(_event, value) => setHelloTime(value)} />
+                            <TextInput id="network-bridge-stp-settings-hello-time-input" className="network-number-field" value={helloTime} onChange={(_event, value) => setHelloTime(Number.parseInt(value))} />
                         </FormGroup>
                         <FormGroup fieldId="network-bridge-stp-settings-max-age-input" label={_("STP maximum message age")}>
-                            <TextInput id="network-bridge-stp-settings-max-age-input" className="network-number-field" value={maxAge} onChange={(_event, value) => setMaxAge(value)} />
+                            <TextInput id="network-bridge-stp-settings-max-age-input" className="network-number-field" value={maxAge} onChange={(_event, value) => setMaxAge(Number.parseInt(value))} />
                         </FormGroup>
                     </>}
                 </FormGroup>

--- a/test/verify/check-networkmanager-bridge
+++ b/test/verify/check-networkmanager-bridge
@@ -64,6 +64,33 @@ class TestBridge(netlib.NetworkCase):
         self.wait_for_iface(iface1)
         self.wait_for_iface(iface2)
 
+        # Add bridge with custom STP
+        b.click("button:contains('Add bridge')")
+        b.wait_visible("#network-bridge-settings-dialog")
+
+        b.set_input_text("#network-bridge-settings-interface-name-input", "tbridge")
+        b.set_checked(f"input[data-iface='{iface1}']", val=True)
+        b.set_checked(f"input[data-iface='{iface2}']", val=True)
+        b.click("#network-bridge-settings-stp-enabled-input")
+        b.set_input_text("#network-bridge-stp-settings-priority-input", "256")
+        b.click("#network-bridge-settings-dialog button:contains('Add')")
+        b.wait_not_present("#network-bridge-settings-dialog")
+        b.wait_visible("#networking-interfaces tr[data-interface='tbridge']")
+
+        b.click("#networking-interfaces tr[data-interface='tbridge'] button")
+        b.wait_visible("#network-interface")
+        b.wait_in_text("dd[data-label='Bridge']", "Priority 256")
+
+        # Edit the bridge STP settings
+        b.click("#networking-edit-bridge")
+        b.wait_visible("#network-bridge-settings-dialog")
+        b.wait_text(".pf-v6-c-modal-box__title", "Edit bridge settings")
+        b.set_input_text("#network-bridge-stp-settings-hello-time-input", "10")
+        b.click("#network-bridge-settings-dialog button:contains('Save')")
+        b.wait_not_present("#network-bridge-settings-dialog")
+
+        b.wait_in_text("dd[data-label='Bridge']", "Hello time 10")
+
     def testActive(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
NetworkManager's bridge STP options are defined as uint32.

See https://www.networkmanager.dev/docs/api/latest/nm-settings-dbus.html

Closes: #23406