### PR TITLE
pytest: Don't add unneeded fixture parentheses

### DIFF
--- a/test/pytest/test_bridge.py
+++ b/test/pytest/test_bridge.py
@@ -68,7 +68,7 @@ def add_pseudo(bridge: Bridge) -> None:
     ])
 
 
-@pytest_asyncio.fixture()
+@pytest_asyncio.fixture
 async def no_init_transport(bridge: Bridge) -> AsyncGenerator[MockTransport, None]:
     transport = MockTransport(bridge)
     try:

--- a/test/pytest/test_http_channel.py
+++ b/test/pytest/test_http_channel.py
@@ -18,7 +18,7 @@ from .mocktransport import MockTransport
 MOCK_DATA = Path(__file__).parent.parent / 'data'
 
 
-@pytest_asyncio.fixture()
+@pytest_asyncio.fixture
 async def no_init_transport() -> AsyncGenerator[MockTransport, None]:
     bridge = Bridge(argparse.Namespace(privileged=False, beipack=False))
     transport = MockTransport(bridge)
@@ -72,7 +72,7 @@ async def http_server(request: pytest.FixtureRequest, tmp_path: Path) -> AsyncGe
     server.close()
 
 
-@pytest_asyncio.fixture()
+@pytest_asyncio.fixture
 async def tls_server() -> AsyncGenerator[int, None]:
     async def serve(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
         while True:

--- a/test/pytest/test_pcp.py
+++ b/test/pytest/test_pcp.py
@@ -38,7 +38,7 @@ from cockpit.bridge import Bridge
 from .mocktransport import MockTransport
 
 
-@pytest_asyncio.fixture()
+@pytest_asyncio.fixture
 async def no_init_transport() -> AsyncGenerator[MockTransport, None]:
     bridge = Bridge(argparse.Namespace(privileged=False, beipack=False))
     transport = MockTransport(bridge)

--- a/test/pytest/test_peer.py
+++ b/test/pytest/test_peer.py
@@ -40,7 +40,7 @@ def bridge():
 
 
 # requires an event loop for queue in MockTransport
-@pytest_asyncio.fixture()
+@pytest_asyncio.fixture
 async def transport(bridge):  # noqa: RUF029
     return MockTransport(bridge)
 


### PR DESCRIPTION
These fixtures take no argument, fixes PT001. Shows up in ruff 0.15.18.