### PR TITLE
host-switcher: Scrollbar for many entries

### DIFF
--- a/pkg/shell/nav.scss
+++ b/pkg/shell/nav.scss
@@ -436,14 +436,13 @@ $desktop: $phone + 1px;
       max-block-size: 100%;
     }
 
-    @media (max-width: $phone) {
-      // Don't run off the top of the page in mobile
-      max-block-size: calc(100vh - var(--nav-icon-size));
-    }
   }
 
   .pf-v6-c-nav {
     overflow: auto;
+    // Don't run off the page when displaying many entries
+    // HACK: Unclear where the spacing comes from
+    max-block-size: calc(100vh - var(--pf-t--global--spacer--3xl) * 3);
   }
 
   .nav-hosts-actions {


### PR DESCRIPTION
Adds a scrollbar for the nav host-switcher. This was broken after PF6 update and we never addressed as I closed it as won't do.

The issue still gets updates from time to time so lets just fix it.

This clamps the height of the entries so that it doesn't run off the screen on mobile view and desktop when it is bigger than viewport height.

Fixes: https://github.com/cockpit-project/cockpit/issues/22384