### PR TITLE
dialog: Use OUIA to identify dialog elements in tests

### DIFF
--- a/pkg/lib/cockpit/dialog.tsx
+++ b/pkg/lib/cockpit/dialog.tsx
@@ -489,28 +489,27 @@
    attributes. The code that instantiates an element can get suitable
    IDs for dialog value handles with the following function:
 
-   - handle.id(tag)
+   - handle.ouia_id(tag)
 
-   This will return a unique and predictable string for the value
-   handle that will also include "tag". This is suitable for the "id"
-   attribute of DOM elements associated with "value".  The "tag"
-   parameter can be used to generate multiple IDs if a component has
-   multiple interesting DOM elements.  The "tag" parameter defaults to
-   "field", see below.
+   This will return a predictable string for the value handle.  This
+   is suitable for the "data-ouia-component-id" attribute of DOM
+   elements associated with "handle".  The "tag" parameter can be used
+   to generate multiple IDs if a component has multiple interesting
+   DOM elements.  The "tag" parameter defaults to "field", see below.
 
    There is a support library for use by the tests that can generate
    the same IDs, and there are also some guidelines for how to use
    these IDs:
 
-   - The main input element (text input, form select, ...) should use
-     the "field" tag.
+     - The main input element (text input, form select, ...) should use
+       the "field" tag.
 
-   - The helper text should use the "helper-text" tag.
+     - The helper text should use the "helper-text" tag.
 
-   - A set of radio buttons should use a different tag for each
-     button. Whatever makes sense in the specific case.
+     - A set of radio buttons should use a different tag for each
+       button. Whatever makes sense in the specific case.
 
-   - ...
+     - ...
 
    PORCELAIN GALLERY
 
@@ -598,7 +597,7 @@
 
  */
 
-import React, { useState } from "react";
+import React, { useState, useId } from "react";
 import { useObject, useInit, useOn } from 'hooks';
 import { EventEmitter } from 'cockpit/event';
 
@@ -714,7 +713,7 @@ export class DialogField<T> {
         this.#setter(val);
     }
 
-    id(tag: string = "field"): string {
+    ouia_id(tag: string = "field"): string {
         return "dialog-" + tag + "-" + state_path(this.#state);
     }
 
@@ -1461,7 +1460,7 @@ export function DialogErrorMessage<V>({
 
     return (
         <Alert
-            id="dialog-error-message"
+            ouiaId="dialog-error-message"
             variant='danger'
             isInline
             title={title}
@@ -1485,7 +1484,7 @@ export function DialogActionButton<V>({
 } & Omit<ButtonProps, "id" | "action" | "isLoading" | "isDisabled" | "variant" | "onClick">) {
     return (
         <Button
-            id="dialog-apply"
+            ouiaId="dialog-apply"
             isLoading={!!dialog && !(dialog instanceof DialogError) && dialog.busy}
             isDisabled={!dialog || dialog instanceof DialogError || dialog.actions_disabled}
             variant="primary"
@@ -1511,7 +1510,7 @@ export function DialogCancelButton<V>({
 } & Omit<ButtonProps, "id" | "isDisabled" | "variant" | "onClick">) {
     return (
         <Button
-            id="dialog-cancel"
+            ouiaId="dialog-cancel"
             isDisabled={!dialog || (dialog instanceof DialogState && dialog.cancel_disabled)}
             variant="link"
             onClick={() => {
@@ -1564,7 +1563,7 @@ export function DialogHelperText<V>({
     return (
         <FormHelperText>
             <HelperText>
-                <HelperTextItem id={field.id("helper-text")} variant={variant}>
+                <HelperTextItem data-ouia-component-id={field.ouia_id("helper-text")} variant={variant}>
                     {text}
                 </HelperTextItem>
             </HelperText>
@@ -1572,18 +1571,38 @@ export function DialogHelperText<V>({
     );
 }
 
+/* Many of the porcelain wrappers can put themselves automatically
+   into a FormGroup.  In that case, the <label> produced by the
+   FormGroup and the actual input element should be connected via
+   "for" and "id" attributes, for a11y reasons.
+
+   But a porcelain wrapper can also be used without an automatic
+   FormGroup. In that case the user has to provide an explicit id for
+   making that connection or maybe an aria-label.
+
+   The useFormId hook helps with that.
+ */
+
+function useFormId(id: string | undefined, label: React.ReactNode) {
+    const random_id = useId();
+    return id || (label ? random_id : undefined);
+}
+
 export const OptionalFormGroup = ({
     label,
     children,
+    fieldId,
     ...props
 } : {
     label: React.ReactNode,
     children: React.ReactNode,
-} & Omit<FormGroupProps, "label" | "children">) => {
+    fieldId?: string | undefined,
+} & Omit<FormGroupProps, "fieldId" | "label" | "children">) => {
     if (label) {
         return (
             <FormGroup
                 label={label}
+                {...fieldId ? { fieldId } : {} }
                 {...props}
             >
                 {children}
@@ -1601,6 +1620,7 @@ export const DialogTextInput = ({
     warning,
     explanation,
     isDisabled = false,
+    id,
     ...props
 } : {
     label?: React.ReactNode,
@@ -1609,11 +1629,13 @@ export const DialogTextInput = ({
     warning?: React.ReactNode,
     explanation?: React.ReactNode,
     isDisabled?: boolean,
-} & Omit<TextInputProps, "id" | "label" | "value" | "onChange">) => {
+} & Omit<TextInputProps, "label" | "value" | "onChange">) => {
+    const fid = useFormId(id, label);
     return (
-        <OptionalFormGroup label={label} fieldId={field.id()}>
+        <OptionalFormGroup label={label} fieldId={fid}>
             <TextInput
-                id={field.id()}
+                id={fid}
+                ouiaId={field.ouia_id()}
                 value={field.get()}
                 onChange={(_event, val) => field.set(val)}
                 isDisabled={!!excuse || isDisabled}
@@ -1631,6 +1653,7 @@ export const DialogPasswordInput = ({
     warning,
     explanation,
     isDisabled = false,
+    id,
     ...props
 } : {
     label?: React.ReactNode,
@@ -1639,15 +1662,16 @@ export const DialogPasswordInput = ({
     warning?: React.ReactNode,
     explanation?: React.ReactNode,
     isDisabled?: boolean,
-} & Omit<TextInputProps, "id" | "label" | "value" | "onChange">) => {
+} & Omit<TextInputProps, "label" | "value" | "onChange">) => {
     const [visible, setVisible] = useState(false);
-
+    const fid = useFormId(id, label);
     return (
-        <OptionalFormGroup label={label} fieldId={field.id()}>
+        <OptionalFormGroup label={label} fieldId={fid}>
             <InputGroup>
                 <InputGroupItem isFill>
                     <TextInput
-                        id={field.id()}
+                        id={fid}
+                        ouiaId={field.ouia_id()}
                         type={visible ? "text" : "password"}
                         value={field.get()}
                         onChange={(_event, value) => field.set(value)}
@@ -1685,10 +1709,12 @@ export const DialogCheckbox = ({
     warning?: React.ReactNode,
     explanation?: React.ReactNode,
 }) => {
+    const id = useId();
     return (
         <OptionalFormGroup label={field_label} hasNoPaddingTop>
             <Checkbox
-                id={field.id()}
+                id={id}
+                ouiaId={field.ouia_id()}
                 isChecked={field.get()}
                 label={checkbox_label}
                 onChange={(_event, checked) => field.set(checked)}
@@ -1721,11 +1747,13 @@ export function DialogRadioSelect<T extends string>({
     explanation?: React.ReactNode,
     isInline?: boolean,
 }) {
+    const random_id = useId();
+
     function makeLabel(o: DialogRadioSelectOption<T>, i: number) {
         const exc = o.excuse ? <> ({o.excuse})</> : null;
         const pad = (!isInline && i < options.length - 1) ? <><br />{"\u00A0"}</> : null;
         const exp = o.explanation ? <><br /><small>{o.explanation}{pad}</small></> : null;
-        return <div id={field.id(o.value + "-label")}>{o.label}{exc}{exp}</div>;
+        return <div data-ouia-component-id={field.ouia_id(o.value + "-label")}>{o.label}{exc}{exp}</div>;
     }
 
     return (
@@ -1733,14 +1761,15 @@ export function DialogRadioSelect<T extends string>({
             label={label}
             hasNoPaddingTop
             isInline={isInline}
-            id={field.id()}
+            data-ouia-component-id={field.ouia_id()}
             data-value={field.get()}
         >
             {
                 options.map((o, i) =>
                     <Radio
                         key={o.value}
-                        id={field.id(o.value)}
+                        id={random_id + o.value}
+                        ouiaId={field.ouia_id(o.value)}
                         name={o.value}
                         isChecked={field.get() == o.value}
                         label={makeLabel(o, i)}
@@ -1766,6 +1795,7 @@ export function DialogDropdownSelect<T extends string>({
     warning,
     explanation,
     options,
+    id,
     ...props
 } : {
     label?: React.ReactNode,
@@ -1775,10 +1805,12 @@ export function DialogDropdownSelect<T extends string>({
     explanation?: React.ReactNode,
     options: DialogDropdownSelectOption<T>[],
 } & Omit<FormSelectProps, "ref" | "children">) {
+    const fid = useFormId(id, label);
     return (
-        <OptionalFormGroup label={label}>
+        <OptionalFormGroup label={label} fieldId={fid}>
             <FormSelect
-                id={field.id()}
+                id={fid}
+                ouiaId={field.ouia_id()}
                 onChange={(_event, val) => field.set(val as T) }
                 validated={warning ? "warning" : undefined}
                 isDisabled={!!excuse}
@@ -1806,6 +1838,7 @@ export function DialogDropdownSelectObject<T>({
     explanation,
     options,
     option_label = (o: T): string => { cockpit.assert(typeof o == "string"); return o },
+    id,
     ...props
 } : {
     label?: React.ReactNode,
@@ -1816,10 +1849,12 @@ export function DialogDropdownSelectObject<T>({
     options: T[],
     option_label?: (o: T) => string,
 } & Omit<FormSelectProps, "ref" | "children">) {
+    const fid = useFormId(id, label);
     return (
-        <OptionalFormGroup label={label}>
+        <OptionalFormGroup label={label} fieldId={fid}>
             <FormSelect
-                id={field.id()}
+                id={fid}
+                ouiaId={field.ouia_id()}
                 onChange={(_event, val) => {
                     const opt = options.find(o => option_label(o) == val);
                     field.set(opt!);

--- a/pkg/playground/dialog.tsx
+++ b/pkg/playground/dialog.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
-import React, { useState, useReducer } from "react";
+import React, { useState, useReducer, useId } from "react";
 import { createRoot } from 'react-dom/client';
 import cockpit from 'cockpit';
 
@@ -51,7 +51,7 @@ function List<T>({
     init: T,
 }) {
     return (
-        <FormGroup label={label} id={field.id()}>
+        <FormGroup label={label} data-ouia-component-id={field.ouia_id()}>
             { field.map((f, i) => (
                 <Split key={i}>
                     <SplitItem isFilled>
@@ -59,7 +59,7 @@ function List<T>({
                     </SplitItem>
                     <SplitItem>
                         <Button
-                            id={f.id("remove")}
+                            ouiaId={f.ouia_id("remove")}
                             variant="link"
                             onClick={() => field.remove(i)}
                         >
@@ -70,7 +70,7 @@ function List<T>({
             ))}
             <DialogHelperText field={field} />
             <Button
-                id={field.id("add")}
+                ouiaId={field.ouia_id("add")}
                 variant="link"
                 onClick={() => field.add(init)}
             >
@@ -147,13 +147,15 @@ const OptionalTextInput = ({
     checkbox_label: string;
     field: DialogField<false | string>,
 }) => {
+    const id = useId();
     const val = field.get();
     let body;
 
     if (val === false) {
         body = (
             <Checkbox
-                id={field.id("checkbox")}
+                id={id}
+                ouiaId={field.ouia_id("checkbox")}
                 isChecked={false}
                 label={checkbox_label}
                 onChange={() => field.set("")}
@@ -163,7 +165,8 @@ const OptionalTextInput = ({
         body = (
             <>
                 <Checkbox
-                    id={field.id("checkbox")}
+                    id={id}
+                    ouiaId={field.ouia_id("checkbox")}
                     isChecked
                     label={checkbox_label}
                     onChange={() => field.set(false)}

--- a/test/common/dialoglib.py
+++ b/test/common/dialoglib.py
@@ -5,17 +5,22 @@
 # DIALOG HELPERS
 #
 # This is a class of dialog helpers. The idea is to instantiate one
-# for each test that wants it, maybe like so:
+# for each dialog that wants it, maybe like so:
 #
 #
 #    def testBasic(self):
 #       b = self.browser
-#       d = DialogHelpers(b)
 #
-#       ...
+#       b.click("#open-my-dialog")
+#       b.wait_visible("#my-dialog")
+#
+#       d = DialogHelpers(b, "#my-dialog")
 #       d.set_TextInput("name.first"), "Jim")
 #       d.set_TextInput("name.last"), "Kirk")
 #
+# You need to pass the CSS selector prefix of the <Modal> component to
+# DialogHelpers.  This makes it possible to work with multiple stacked
+# dialogs.
 #
 # There are helpers for constructing CSS selectors for dialog elements
 # such as input fields, helper texts, and the buttons. There are
@@ -26,21 +31,24 @@
 # - d.id(path, tag)
 #
 # This constructs the CSS selector for the DOM element that has been
-# instantiated with an ID attribute computed by "value.id(tag)", see
-# the documentation for the JavaScript dialog framework.  The "path"
-# parameter describes the way the value handle was derived in
-# JavaScript: For top-level ones created by "dlg.value(name)" it is
-# just "name". For sub-values created by "value.sub(name_or_index)" it
-# is the path of "value" followed by ".", followed by
-# "name_or_index". Nothing fancy.
+# instantiated with an OUIA component ID computed by
+# "value.ouia_id(tag)", see the documentation for the JavaScript
+# dialog framework.  The "path" parameter describes the way the value
+# handle was derived in JavaScript: For top-level ones created by
+# "dlg.field(name)" it is just "name". For sub-values created by
+# "handle.sub(name_or_index)" it is the path of "handle" followed by
+# ".", followed by "name_or_index". Nothing fancy.
 #
 # For example,
 #
-#    <input id={dlg.value("name").sub("first").id("input")} />
+#    <input
+#        data-ouia-component-id={dlg.field("name").sub("first").ouia_id("input")}
+#        ...
+#    />
 #
 # can be selected in a test like this:
 #
-#    b.set_input_text(d.field("name.first", "input"), "Jim")
+#    b.set_input_text(d.id("name.first", "input"), "Jim")
 #
 # There are some functions that encode the guidelines for choosing
 # tags. These should be used most of the time:
@@ -53,23 +61,29 @@
 #
 # The helper text for a field.  Same as d.id(path, "helper-text").
 #
-# The helpers for interacting with elements are called set_TextInput,
-# wait_TextInput, set_RadioSelect, etc. They are hopefully easy to
-# figure out.
+# The helpers for interacting with porcelain elements are called
+# set_TextInput, wait_TextInput, set_RadioSelect, etc. They are
+# hopefully easy to figure out.
+#
+# For example,
+#
+#    <DialogTextInput label="First" field={dlg.field("name").sub("first")} />
+#
+# can be controlled like this by a test:
+#
+#    d.set_TextInput("name.first", "Jim")
+#
 
 import testlib
 
 
-def css_escape(x: str) -> str:
-    return x.replace(".", "\\.")
-
-
 class DialogHelpers:
-    def __init__(self, b: testlib.Browser):
+    def __init__(self, b: testlib.Browser, dialogSelector: str):
         self.browser = b
+        self.dialogSelector = dialogSelector
 
     def id(self, path: str, tag: str) -> str:
-        return f"#dialog-{tag}-{css_escape(path)}"
+        return f"{self.dialogSelector} [data-ouia-component-id='dialog-{tag}-{path}']"
 
     def field(self, path: str) -> str:
         return self.id(path, "field")
@@ -78,13 +92,13 @@ class DialogHelpers:
         return self.id(path, "helper-text")
 
     def error(self) -> str:
-        return "#dialog-error-message"
+        return f"{self.dialogSelector} [data-ouia-component-id='dialog-error-message']"
 
     def apply_button(self) -> str:
-        return "#dialog-apply"
+        return f"{self.dialogSelector} [data-ouia-component-id='dialog-apply']"
 
     def cancel_button(self) -> str:
-        return "#dialog-cancel"
+        return f"{self.dialogSelector} [data-ouia-component-id='dialog-cancel']"
 
     # TextInput
 
@@ -103,7 +117,7 @@ class DialogHelpers:
         return self.browser.get_checked(self.field(path))
 
     def wait_Checkbox(self, path: str, val: bool) -> None:
-        # XXX - implemnt Browser.wait_checked and use it here
+        # XXX - implement Browser.wait_checked and use it here
         x = ":checked" if val else ":not(:checked)"
         self.browser.wait_visible(self.field(path) + x)
 

--- a/test/verify/check-dialog
+++ b/test/verify/check-dialog
@@ -11,7 +11,7 @@ class TestDialog(testlib.MachineCase):
 
     def test(self):
         b = self.browser
-        d = dialoglib.DialogHelpers(b)
+        d = dialoglib.DialogHelpers(b, "#dialog")
 
         # Missing coverage:
         #

--- a/test/verify/check-networkmanager-wifi
+++ b/test/verify/check-networkmanager-wifi
@@ -87,7 +87,7 @@ wpa_passphrase=hidden99""")
     def testWifi(self):
         m = self.machine
         b = self.browser
-        d = DialogHelpers(b)
+        d = DialogHelpers(b, "#network-wifi-connect-dialog")
 
         self.login_and_go("/network")
         b.wait_visible("#networking")
@@ -324,7 +324,7 @@ wpa_passphrase=hidden99""")
 
     def testHidden(self):
         b = self.browser
-        d = DialogHelpers(b)
+        d = DialogHelpers(b, "#network-wifi-connect-dialog")
 
         self.login_and_go("/network")
         b.wait_visible("#networking")


### PR DESCRIPTION
We don't want to use the "id" attribute with values like
"dialog-field-name" since that is not automatically unique when
multiple dialogs are displayed at the same time.  Instead, we want to
use something like
    
  #my-dialog [data-id=dialog-field-name]
    
to find elements for a field called "name".  And if we are using a
data attribute, why not use the one specified by OUIA.  It has
dedicated support from Patternfly.
    
(Maybe Patternfly makes us fully OUIA compliant, or maybe not. This is
not important to us.)
    
Some elements still need "id" attributes, but they don't need to be
predictable.  We implement random-but-stable ids for fields for this.
