### PR TITLE
networkmanger: Move to interface details page after creation

### DIFF
--- a/pkg/networkmanager/dialogs-common.jsx
+++ b/pkg/networkmanager/dialogs-common.jsx
@@ -277,6 +277,8 @@ export const dialogSave = ({ model, dev, connection, members, membersInit, setti
                     onClose();
                     if (connection && iface)
                         cockpit.location.go([iface]);
+                    else if (!connection && iface)
+                        return model.synchronize().then(() => cockpit.location.go([iface]));
                     if (connection && dev?.ActiveConnection?.Connection === connection && !isNonPersistentMultiCon(connection)) {
                         return reactivateConnection({ con: connection, dev });
                     }

--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -1433,10 +1433,12 @@ export function NetworkManagerModel() {
 
         prototype: {
             add_connection: function (conf) {
+                // https://www.networkmanager.dev/docs/api/latest/nm-dbus-types.html
+                const NM_SETTINGS_ADD_CONNECTION2_FLAG_TO_DISK = 0x1;
                 return call_object_method(this,
                                           'org.freedesktop.NetworkManager.Settings',
-                                          'AddConnection',
-                                          settings_to_nm(conf, { }))
+                                          'AddConnection2',
+                                          settings_to_nm(conf, { }), NM_SETTINGS_ADD_CONNECTION2_FLAG_TO_DISK, { })
                         .then(([path]) => get_object(path, type_Connection));
             }
         },

--- a/test/verify/check-networkmanager-bond
+++ b/test/verify/check-networkmanager-bond
@@ -52,11 +52,9 @@ class TestBonding(netlib.NetworkCase):
         b.set_checked(f"input[data-iface='{iface2}']", val=True)
         b.click("#network-bond-settings-dialog button:contains('Add')")
         b.wait_not_present("#network-bond-settings-dialog")
-        b.wait_visible("#networking-interfaces tr[data-interface='tbond']")
 
         # Check that the members are displayed and both On
-        b.click("#networking-interfaces tr[data-interface='tbond'] button")
-        b.wait_visible("#network-interface")
+        b.wait_text("#network-interface-name", "tbond")
         b.wait_visible(f"#network-interface-members tr[data-interface='{iface1}']")
         self.wait_onoff(f"#network-interface-members tr[data-interface='{iface1}']", val=True)
         b.wait_visible(f"#network-interface-members tr[data-interface='{iface2}']")
@@ -136,8 +134,7 @@ class TestBonding(netlib.NetworkCase):
         b.click("#network-bond-settings-dialog button:contains('Add')")
         b.wait_not_present("#network-bond-settings-dialog")
 
-        b.click("#networking-interfaces tr[data-interface='tbond'] button")
-        b.wait_visible("#network-interface")
+        b.wait_text("#network-interface-name", "tbond")
         self.wait_for_iface_setting('IPv4', 'Link local')
 
     def testRename(self):
@@ -168,7 +165,7 @@ class TestBonding(netlib.NetworkCase):
         # Rename while it is active
         self.addCleanup(m.execute, "nmcli dev delete tbond3000 2>/dev/null || true")
 
-        b.click("#networking-interfaces tr[data-interface='tbond'] button")
+        b.wait_text("#network-interface-name", "tbond")
         self.wait_onoff("#network-interface .pf-v6-c-card__header", val=True)
 
         self.configure_iface_setting('Bond')
@@ -212,8 +209,7 @@ class TestBonding(netlib.NetworkCase):
         b.wait_not_present("#network-bond-settings-dialog")
 
         # Check that it has the interface and the right IP address
-        b.click("#networking-interfaces tr[data-interface='tbond'] button")
-        b.wait_visible("#network-interface")
+        b.wait_text("#network-interface-name", "tbond")
         b.wait_visible(f"#network-interface-members tr[data-interface='{iface}']")
         b.wait_in_text("#network-interface .pf-v6-c-card:contains('tbond')", ip)
 
@@ -239,10 +235,7 @@ class TestBonding(netlib.NetworkCase):
         # finish creating the bond
         b.click("#network-bond-settings-dialog button:contains('Add')")
         b.wait_not_present("#network-bond-settings-dialog")
-
-        # Navigate to bond and edit it
-        b.click("#networking-interfaces tr[data-interface='tbond'] button")
-        b.wait_visible("#network-interface")
+        b.wait_text("#network-interface-name", "tbond")
         b.click("#network-interface #networking-edit-bond")
 
         # edit bond dialog
@@ -310,8 +303,7 @@ class TestBondingVirt(netlib.NetworkCase):
         b.wait_not_present("#network-bond-settings-dialog")
 
         # Check that it has the main connection and the right IP address
-        b.click("#networking-interfaces tr[data-interface='tbond'] button")
-        b.wait_visible("#network-interface")
+        b.wait_text("#network-interface-name", "tbond")
         b.wait_visible(f"#network-interface-members tr[data-interface='{iface}']")
         b.wait_in_text("#network-interface .pf-v6-c-card:contains('tbond')", "10.111.113.1")
 
@@ -349,8 +341,7 @@ class TestBondingVirt(netlib.NetworkCase):
         b.wait_not_present("#network-bond-settings-dialog")
 
         # Check that it has the main connection and the right IP address
-        b.click("#networking-interfaces tr[data-interface='tbond'] button")
-        b.wait_visible("#network-interface")
+        b.wait_text("#network-interface-name", "tbond")
         b.wait_visible(f"#network-interface-members tr[data-interface='{iface}']")
         b.wait_in_text("#network-interface .pf-v6-c-card:contains('tbond')", "10.111.113.1")
 

--- a/test/verify/check-networkmanager-bridge
+++ b/test/verify/check-networkmanager-bridge
@@ -42,10 +42,9 @@ class TestBridge(netlib.NetworkCase):
         b.set_checked(f"input[data-iface='{iface2}']", val=True)
         b.click("#network-bridge-settings-dialog button:contains('Add')")
         b.wait_not_present("#network-bridge-settings-dialog")
-        b.wait_visible("#networking-interfaces tr[data-interface='tbridge']")
 
         # Check that the members are displayed and both On
-        b.click("#networking-interfaces tr[data-interface='tbridge'] button")
+        b.wait_text("#network-interface-name", "tbridge")
         b.wait_visible("#network-interface")
         self.wait_onoff(f"#network-interface-members tr[data-interface='{iface1}']", val=True)
         self.wait_onoff(f"#network-interface-members tr[data-interface='{iface2}']", val=True)
@@ -75,9 +74,8 @@ class TestBridge(netlib.NetworkCase):
         b.set_input_text("#network-bridge-stp-settings-priority-input", "256")
         b.click("#network-bridge-settings-dialog button:contains('Add')")
         b.wait_not_present("#network-bridge-settings-dialog")
-        b.wait_visible("#networking-interfaces tr[data-interface='tbridge']")
+        b.wait_text("#network-interface-name", "tbridge")
 
-        b.click("#networking-interfaces tr[data-interface='tbridge'] button")
         b.wait_visible("#network-interface")
         b.wait_in_text("dd[data-label='Bridge']", "Priority 256")
 
@@ -114,8 +112,7 @@ class TestBridge(netlib.NetworkCase):
         b.wait_not_present("#network-bridge-settings-dialog")
 
         # Check that it has the interface and the right IP address
-        b.click("#networking-interfaces tr[data-interface='tbridge'] th button")
-        b.wait_visible("#network-interface")
+        b.wait_text("#network-interface-name", "tbridge")
         b.wait_visible(f"#network-interface-members tr[data-interface='{iface}']")
         b.wait_in_text("#network-interface .pf-v6-c-card:contains('tbridge')", "10.111")
 

--- a/test/verify/check-networkmanager-mac
+++ b/test/verify/check-networkmanager-mac
@@ -62,9 +62,7 @@ class TestNetworkingMAC(netlib.NetworkCase):
         b.click("#network-bond-settings-dialog button:contains('Add')")
         b.wait_not_present("#network-bond-settings-dialog")
 
-        self.select_iface('tbond')
-        b.wait_visible("#network-interface")
-
+        b.wait_text("#network-interface-name", "tbond")
         mac = m.execute("cat /sys/class/net/tbond/address").strip()
         b.wait_text("#network-interface-mac", mac.upper())
 

--- a/test/verify/check-networkmanager-settings
+++ b/test/verify/check-networkmanager-settings
@@ -122,7 +122,7 @@ class TestNetworkingSettings(netlib.NetworkCase):
             b.set_input_text("#network-wireguard-settings-addresses-input", "1.2.3.4/24")
             wg_iface = b.val("#network-wireguard-settings-interface-name-input")
             b.click("#network-wireguard-settings-save")
-            self.select_iface(wg_iface)
+            b.wait_text("#network-interface-name", wg_iface)
             self.configure_iface_setting("IPv4")
             b._wait_present("#network-ip-settings-select-method option[value='manual']")
             b._wait_present("#network-ip-settings-select-method option[value='disabled']")

--- a/test/verify/check-networkmanager-settings
+++ b/test/verify/check-networkmanager-settings
@@ -116,7 +116,7 @@ class TestNetworkingSettings(netlib.NetworkCase):
 
         # Check that IPv4/IPv6 settings dialogs only show the supported IP methods for wireguard
         # Skip images without the wireguard-tools package
-        if m.image not in ["centos-10"] and not m.image.startswith("rhel-8"):
+        if not m.image.startswith("rhel-8"):
             b.go("/network")
             b.click("#networking-add-wg")
             b.set_input_text("#network-wireguard-settings-addresses-input", "1.2.3.4/24")

--- a/test/verify/check-networkmanager-team
+++ b/test/verify/check-networkmanager-team
@@ -47,13 +47,10 @@ class TestTeam(netlib.NetworkCase):
         b.click("#network-team-settings-dialog button:contains('Add')")
         b.wait_not_present("#network-team-settings-dialog")
 
-        b.wait_attr("#networking", "data-test-wait", "false")
+        b.wait_text("#network-interface-name", "tteam")
         b.wait(lambda: 'nmcli con show | grep tteam')
-        b.wait_visible("#networking-interfaces tr[data-interface='tteam']")
 
         # Check that the members are displayed
-        self.select_iface('tteam')
-        b.wait_visible("#network-interface")
         b.wait_visible(f"#network-interface-members tr[data-interface='{iface1}']")
         b.wait_visible(f"#network-interface-members tr[data-interface='{iface2}']")
 
@@ -100,12 +97,10 @@ class TestTeam(netlib.NetworkCase):
         b.click("#network-team-settings-dialog button:contains('Add')")
         b.wait_not_present("#network-team-settings-dialog")
 
-        b.wait_attr("#networking", "data-test-wait", "false")
+        b.wait_text("#network-interface-name", "tteam")
         b.wait(lambda: 'nmcli con show | grep tteam')
 
         # Check that it has the interface and the right IP address
-        self.select_iface('tteam')
-        b.wait_visible("#network-interface")
         b.wait_visible(f"#network-interface-members tr[data-interface='{iface}']")
         b.wait_in_text("#network-interface .pf-v6-c-card:contains('tteam')", "10.111")
 

--- a/test/verify/check-networkmanager-vlan
+++ b/test/verify/check-networkmanager-vlan
@@ -38,10 +38,10 @@ class TestNetworkingVLAN(netlib.NetworkCase):
         b.set_input_text("#network-vlan-settings-vlan-id-input", "123")
         b.click("#network-vlan-settings-dialog button:contains('Add')")
         b.wait_not_present("#network-vlan-settings-dialog")
-        b.wait_visible("#networking-interfaces tr[data-interface='tvlan']")
+        b.wait_text("#network-interface-name", "tvlan")
 
         # It automatically activates.  It won't get an IP address, but that's okay.
-        self.wait_for_iface("tvlan", state="Configuring IP")
+        self.wait_for_iface_setting("Status", "Configuring IP")
 
         # Check that the actual kernel device has the REORDER_HDR flag
         # set.  NetworkManager stopped doing that for connections
@@ -49,7 +49,6 @@ class TestNetworkingVLAN(netlib.NetworkCase):
         self.assertIn("REORDER_HDR", m.execute("ip -d link show tvlan | grep vlan"))
 
         # Delete it
-        self.select_iface('tvlan')
         b.click("#network-interface button:contains('Delete')")
         b.wait_visible("#networking")
         b.wait_not_present("#networking-interfaces tr[data-interface='tvlan']")

--- a/test/verify/check-networkmanager-wifi
+++ b/test/verify/check-networkmanager-wifi
@@ -9,10 +9,11 @@ import time
 import netlib
 import testlib
 from dialoglib import DialogHelpers
+from lib.constants import TEST_OS_DEFAULT
 
 
 @testlib.nondestructive
-@testlib.onlyImage("hostapd/NM-wifi not installed on our test image", "fedora-43")
+@testlib.onlyImage("hostapd/NM-wifi not installed on our test image", TEST_OS_DEFAULT)
 class TestNetworkingWifi(netlib.NetworkCase):
     def setUp(self):
         super().setUp()

--- a/test/verify/check-networkmanager-wireguard
+++ b/test/verify/check-networkmanager-wireguard
@@ -127,7 +127,8 @@ class TestWireGuard(packagelib.PackageCase, netlib.NetworkCase):
                                 "#network-wireguard-settings-publickey-peer-0"])
         b.click("#network-wireguard-settings-save")
         b.wait_not_present("#network-wireguard-settings-dialog")
-        b.wait_in_text(f"#networking-interfaces tr[data-row-id='{iface_name}'] td[data-label='IP address']", f"1.2.3.4/32, {m1_ip4}/24")
+        b.wait_text("#network-interface-name", iface_name)
+        self.wait_for_iface_setting("Status", f"1.2.3.4/32, {m1_ip4}/24")
 
         # if some wg properties are not valid, for example, if it was changed by some external tool, don't crash
         # this doesn't work on Ubuntu as the config is done through netplan; but this is just testing
@@ -138,10 +139,8 @@ class TestWireGuard(packagelib.PackageCase, netlib.NetworkCase):
             m1.execute("systemctl restart NetworkManager")
             b.reload()
             b.enter_page("/network")
-            b.wait_visible("#networking")
+            b.wait_visible("#network-interface")
 
-        b.click(f"#networking-interfaces button:contains('{iface_name}')")
-        b.wait_visible("#network-interface")
         b.click("#networking-edit-wg")
 
         if invalid_props_test:
@@ -161,7 +160,8 @@ class TestWireGuard(packagelib.PackageCase, netlib.NetworkCase):
         b2.set_input_text("#network-wireguard-settings-allowedips-peer-0", f"{m1_ip4}/32")
         b2.click("#network-wireguard-settings-save")
         b2.wait_not_present("#network-wireguard-settings-dialog")
-        b2.wait_in_text(f"#networking-interfaces tr[data-row-id='{m2_iface_name}'] td[data-label='IP address']", f"{m2_ip4}/24")
+        b2.wait_text("#network-interface-name", m2_iface_name)
+        b2.wait_in_text("[data-label='Status']", f"{m2_ip4}/24")
 
         # check connection over ipv4
         try:
@@ -174,8 +174,6 @@ class TestWireGuard(packagelib.PackageCase, netlib.NetworkCase):
             raise
 
         # check connection over ipv6
-        b2.click(f"#networking-interfaces button:contains('{m2_iface_name}')")
-
         b2.click("#networking-edit-wg")
         b2.wait_visible("#network-wireguard-settings-dialog")
         b2.set_input_text("#network-wireguard-settings-addresses-input", f"{m2_ip4}/24, {m2_ip6}/64")
@@ -304,7 +302,8 @@ class TestWireGuard(packagelib.PackageCase, netlib.NetworkCase):
         b.set_input_text("#network-wireguard-settings-allowedips-peer-0", f"{m2_wg1_ipv6}/128")
         b.click("#network-wireguard-settings-save")
         b.wait_not_present("#network-wireguard-settings-dialog")
-        b.wait_in_text(f"#networking-interfaces tr[data-row-id='{wg1_iface}'] td[data-label='IP address']", f"{m1_wg1_ipv6}/64")
+        b.wait_text("#network-interface-name", wg1_iface)
+        self.wait_for_iface_setting("IPv6", f"{m1_wg1_ipv6}/64")
 
         m1.execute(f"until wg show wg1 | grep -q 'allowed ips.*{m2_wg1_ipv6}/128'; do sleep 1; done")
         m1.execute(f"until ip a show dev {wg1_iface} | grep -q 'inet6 {m1_wg1_ipv6}/64 scope global'; do sleep 0.3; done", timeout=10)
@@ -319,7 +318,8 @@ class TestWireGuard(packagelib.PackageCase, netlib.NetworkCase):
         b2.set_input_text("#network-wireguard-settings-allowedips-peer-0", f"{m1_wg1_ipv6}/128")
         b2.click("#network-wireguard-settings-save")
         b2.wait_not_present("#network-wireguard-settings-dialog")
-        b2.wait_in_text(f"#networking-interfaces tr[data-row-id='{wg1_iface}'] td[data-label='IP address']", f"{m2_wg1_ipv6}/64")
+        b2.wait_text("#network-interface-name", wg1_iface)
+        b2.wait_in_text("[data-label='IPv6']", f"{m2_wg1_ipv6}/64")
 
         m2.execute(f"until wg show wg1 | grep -q 'allowed ips.*{m1_wg1_ipv6}/128'; do sleep 1; done")
         m2.execute(f"until ip a show dev {wg1_iface} | grep -q 'inet6 {m2_wg1_ipv6}/64 scope global'; do sleep 0.3; done", timeout=10)
@@ -337,7 +337,6 @@ class TestWireGuard(packagelib.PackageCase, netlib.NetworkCase):
         m1_wg1_ipv4 = "10.0.1.1"
         m2_wg1_ipv4 = "10.0.1.2"
 
-        b.click(f"#networking-interfaces button:contains('{wg1_iface}')")
         b.click("#networking-edit-wg")
         b.wait_visible("#network-wireguard-settings-dialog")
         b.set_input_text("#network-wireguard-settings-addresses-input", f"{m1_wg1_ipv6}/64, {m1_wg1_ipv4}/24")
@@ -349,7 +348,6 @@ class TestWireGuard(packagelib.PackageCase, netlib.NetworkCase):
         m1.execute(f"until wg show wg1 | grep -q 'allowed ips.*{m2_wg1_ipv4}/32'; do sleep 1; done")
         m1.execute(f"until ip a show dev {wg1_iface} | grep -q 'inet {m1_wg1_ipv4}/24'; do sleep 0.3; done", timeout=10)
 
-        b2.click(f"#networking-interfaces button:contains('{wg1_iface}')")
         b2.click("#networking-edit-wg")
         b2.wait_visible("#network-wireguard-settings-dialog")
         b2.set_input_text("#network-wireguard-settings-addresses-input", f"{m2_wg1_ipv6}/64, {m2_wg1_ipv4}/24")


### PR DESCRIPTION
This pull request is preparation work for moving to not enabling the network interfaces creates for vlan/bridge/bond etc. by default. Moves to CreateConnection2 API so we can so we can block auto activating the device on creation. The other major change is navigating to the details page after creation, this will make it more obvious to the user that an interface is disconnected after creation when we decide to change that behavior.

---

# networkmanager: Navigate to details page after creation

After adding a VLan or other virtual network device Cockpit now shows the interface detail page instead of the networking overview page. Allowing the user to directly further configure the newly created interface.