### PR TITLE
lib: Style select headers like Patternfly group titles

### DIFF
--- a/pkg/lib/cockpit-components-select.scss
+++ b/pkg/lib/cockpit-components-select.scss
@@ -4,4 +4,5 @@
 .ct-select-header .pf-v6-c-menu__item-main {
     color: var(--pf-v6-c-menu__group-title--Color);
     font-size: var(--pf-v6-c-menu__group-title--FontSize, inherit);
+    font-weight: var(--pf-v6-c-menu__group-title--FontWeight, inherit);
 }


### PR DESCRIPTION
Our SimpleSelect, TypeaheadSelect, etc components use regular, disabled SelectOptions for headers and style them to look like PF groups headers.

With the update to PF 6.5 we also need to copy the font weight style.