### PR TITLE
doc: Document new fsinfo options introduced in 339

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -956,6 +956,9 @@ is simply not reported.
  * `target`: for symbolic links: the target of the link (a string)
  * `targets`: for directories: extra information about symlink targets for
    symlinks found in the directory (see below)
+ * `r-ok`: boolean, whether reading is allowed. (note: checking access is expensive)
+ * `w-ok`: boolean, whether writing is allowed. (note: checking access is expensive)
+ * `x-ok`: boolean, whether executing is allowed. (note: checking access is expensive)
 
 The `entries` attribute is reported iff `fnmatch` is non-empty, and `path`
 refers to a readable directory.  It is an object where each key is the name of


### PR DESCRIPTION
Support for querying access was introduced in 339.

---

Note, that we might optimise `os.access` by combining `w-ok`, `r-ok` when we request both in the same `os.access` call instead of doing a call per attribute as we do now.