### PR TITLE
systemd: Relax cockpit-wsinstance-socket-user dependencies

### DIFF
--- a/src/systemd/cockpit-wsinstance-socket-user.service
+++ b/src/systemd/cockpit-wsinstance-socket-user.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Dynamic user for /run/cockpit/wsinstance/ sockets
 Documentation=man:cockpit-ws(8)
+# avoid dependency loop with basic.target/sockets.target shutdown
+DefaultDependencies=no
 BindsTo=cockpit.service
 
 [Service]


### PR DESCRIPTION
Follow up from 2a9728129e1833e0487002114255f9a70,

> basic.target: Job cockpit-session-socket-user.service/stop deleted to break ordering cycle starting with basic.target/stop

Closes: #23078