### PR TITLE
doc: Change links to new docs subdomain and add xrefs

### DIFF
--- a/containers/ws/README.md
+++ b/containers/ws/README.md
@@ -39,7 +39,7 @@ Privileged mode provides tight integration with the host: You can use the
 host's users and their passwords to log in, and Cockpit's branding will adjust
 to the host operating system.
 
-1. Enable password based SSH logins, unless you only use [SSO logins](https://cockpit-project.org/guide/latest/sso.html).
+1. Enable password based SSH logins, unless you only use [SSO logins](https://docs.cockpit-project.org/cockpit-guide/latest/guide/sso.html).
    From localhost only:
    ```bash
     cat << EOF > /etc/ssh/sshd_config.d/02-enable-passwords.conf
@@ -61,7 +61,7 @@ to the host operating system.
    podman container runlabel --name cockpit-ws RUN quay.io/cockpit/ws
    ```
 
-   You can append additional [cockpit-ws CLI options](https://cockpit-project.org/guide/latest/cockpit-ws.8.html),
+   You can append additional [cockpit-ws CLI options](https://docs.cockpit-project.org/cockpit-guide/latest/guide/cockpit-ws.8.html),
    most commonly to change the port:
    ```
    podman container runlabel --name cockpit-ws RUN quay.io/cockpit/ws -- -p 80
@@ -102,7 +102,7 @@ address. [podman](https://podman.io/) provides the special name
 ### Configuration
 
 By default, the container uses an internal
-[cockpit.conf](https://cockpit-project.org/guide/latest/cockpit.conf.5.html)
+[cockpit.conf](https://docs.cockpit-project.org/cockpit-guide/latest/guide/cockpit.conf.5.html)
 which sets `RequireHost = true` and a neutral login title. You can customize
 this by passing your own configuration as a volume:
 

--- a/doc/Makefile-guide.am
+++ b/doc/Makefile-guide.am
@@ -65,10 +65,15 @@ MAN_ADOC_FILES = \
 	doc/modules/man/pages/pam_ssh_add.8.adoc \
 	$(NULL)
 
+ASCIIDOC_EXTENSIONS = \
+	doc/extensions/man-inline-macro.rb \
+	$(NULL)
+
 dist_noinst_DATA += \
 	$(GUIDE_MAIN_ADOC_FILE) \
 	$(MAN_ADOC_FILES) \
 	$(GUIDE_ADOC_FILES) \
+	$(ASCIIDOC_EXTENSIONS) \
 	$(NULL)
 
 GUIDE_MAN_PAGES = \
@@ -150,10 +155,11 @@ GUIDE_ASCIIDOC_ARGS = \
 	-a toclevels=3 \
 	-a webfonts! \
 	-b html5 \
+	$(patsubst %,-r $(srcdir)/%,${ASCIIDOC_EXTENSIONS}) \
 	$(NULL)
 
 DOC_PROC = mkdir -p doc/output/html/ && $(ASCIIDOCTOR) $(GUIDE_ASCIIDOC_ARGS) -a asciidoctor -o $@ $<
-render-docs: $(GUIDE_ADOC_FILES) $(GUIDE_MAIN_ADOC_FILE) $(MAN_ADOC_FILES)
+render-docs: $(ASCIIDOC_EXTENSIONS) $(GUIDE_ADOC_FILES) $(GUIDE_MAIN_ADOC_FILE) $(MAN_ADOC_FILES)
 	mkdir -p doc/output/html/
 	$(ASCIIDOCTOR) $(GUIDE_ASCIIDOC_ARGS) -a asciidoctor -D doc/output/html $(GUIDE_ADOC_FILES) $(MAN_ADOC_FILES)
 	$(ASCIIDOCTOR) $(GUIDE_ASCIIDOC_ARGS) -a asciidoctor -o doc/output/html/index.html $(GUIDE_MAIN_ADOC_FILE)

--- a/doc/Makefile-man.am
+++ b/doc/Makefile-man.am
@@ -22,6 +22,14 @@ MANPAGES = \
 
 if ENABLE_DOC
 
+ASCIIDOC_EXTENSIONS = \
+	doc/extensions/man-inline-macro.rb \
+	$(NULL)
+
+dist_noinst_DATA += \
+	$(ASCIIDOC_EXTENSIONS) \
+	$(NULL)
+
 man_MANS += \
 	$(MANPAGES) \
 	$(NULL)
@@ -34,6 +42,7 @@ MAN_ASCIIDOC_ARGS = \
 	-a doctype="manpage" \
 	-a manmanual="cockpit" \
 	-a mansource="cockpit" \
+	$(patsubst %,-r $(srcdir)/%,${ASCIIDOC_EXTENSIONS}) \
 	$(NULL)
 
 MAN_PROC = mkdir -p doc/output/man/ && $(ASCIIDOCTOR) $(MAN_ASCIIDOC_ARGS) -b manpage -o $@ $<

--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -155,7 +155,7 @@ This uses the `[tls-cert]` authentication scheme.
 When enabling this mode, other authentication types commonly get disabled. See
 the next section for details.
 
-See the [Certificate/smart card authentication guide](https://cockpit-project.org/guide/latest/cert-authentication.html)
+See the [Certificate/smart card authentication guide](https://docs.cockpit-project.org/cockpit-guide/latest/guide/cert-authentication.html)
 for details how to set this up.
 
 Actions

--- a/doc/extensions/README.adoc
+++ b/doc/extensions/README.adoc
@@ -1,0 +1,11 @@
+= Antora & AsciiDoctor Extensions
+
+We need to support AsciiDoctor for generating local HTML pages as well as manpages while packaging to various distros.
+
+But as we also publish using Antora, there might be small differences that we need to address either on the AsciiDoctor or Antora-side, or even both.
+
+== man-inline-macro.rb
+
+An AsciiDoctor extension that converts manpages like cockpit(1) to links `man:cockpit[1]` for HTML pages and boldened `*cockpit(1)*` for manpages.
+
+These manpage macros do not work for the local editing of Antora within the Cockpit repo. Within the Cockpit Docs Antora repo there is an AsciiDoctor.js extension `man-inline-replace.js` that replaces `man:` links. Future improvement here could be to move the extension to the cockpit repo and fetch it from the cockpit-docs repo, but that would require more work and doesn't provide much value at the moment.

--- a/doc/extensions/man-inline-macro.rb
+++ b/doc/extensions/man-inline-macro.rb
@@ -1,0 +1,40 @@
+require 'asciidoctor/extensions' unless RUBY_ENGINE == 'opal'
+
+include Asciidoctor
+
+# An inline macro that generates links to related man pages.
+# For HTML it only generates links to Cockpit man pages as that is what
+# is compiled. But you are able to use man:systemd[1], but it just
+# won't get a link.
+#
+# Usage:
+#
+#   man:gittutorial[7]
+#
+class ManInlineMacro < Extensions::InlineMacroProcessor
+  use_dsl
+
+  named :man
+  name_positional_attributes 'volnum'
+
+  def process parent, target, attrs
+    text = manname = target
+    suffix = ''
+    volnum = attrs['volnum']
+    target = %(#{manname}.#{volnum}.html)
+    suffix = %((#{volnum}))
+    if parent.document.basebackend?('html') && manname.start_with?('cockpit')
+      parent.document.register :links, target
+      node = create_anchor parent, text, type: :link, target: target
+    elsif parent.document.backend == 'manpage'
+      node = create_inline parent, :quoted, manname, type: :strong
+    else
+      node = create_inline parent, :quoted, manname
+    end
+    suffix ? (create_inline parent, :quoted, %(#{node.convert}#{suffix})) : node
+  end
+end
+
+Asciidoctor::Extensions.register do
+  inline_macro ManInlineMacro
+end

--- a/doc/i18n.md
+++ b/doc/i18n.md
@@ -18,7 +18,7 @@ marked as such on Cockpit pages, in one of two ways:
    ```
 
  * If the string appears in JavaScript source, it must use the
-   [cockpit.gettext()](https://cockpit-project.org/guide/latest/cockpit-locale.html#cockpit-locale-gettext)
+   [cockpit.gettext()](https://docs.cockpit-project.org/cockpit-guide/latest/guide/cockpit-locale.html#cockpit-locale-gettext)
    or a related function, commonly called through an alias `_()`, with double-quoted
    strings so that `xgettext` can recognize it. Example:
 
@@ -33,14 +33,14 @@ marked as such on Cockpit pages, in one of two ways:
    </tr>
    ```
    For strings that involve numbers you need to use
-   [cockpit.ngettext()](https://cockpit-project.org/guide/latest/cockpit-locale.html#cockpit-locale-ngettext)
+   [cockpit.ngettext()](https://docs.cockpit-project.org/cockpit-guide/latest/guide/cockpit-locale.html#cockpit-locale-ngettext)
    instead:
 
    ```js
    var translated = cockpit.ngettext("This thing", "The things", numberOfThings);
    ```
 
-   The [cockpit.format()](https://cockpit-project.org/guide/latest/cockpit-util.html#cockpit-format)
+   The [cockpit.format()](https://docs.cockpit-project.org/cockpit-guide/latest/guide/cockpit-util.html#cockpit-format)
    function is useful for parameterized strings where the order of parameters
    might change between languages.
 
@@ -75,12 +75,12 @@ HTML and JavaScript don't directly support gettext po and mo files. The
 translations from po files are converted to a JavaScript function by
 [cockpit-po-plugin](../pkg/lib/cockpit-po-plugin.js)
 which inserts the actual translations into a
-[cockpit.locale()](https://cockpit-project.org/guide/latest/cockpit-locale.html#cockpit-locale-locale) call.
+[cockpit.locale()](https://docs.cockpit-project.org/cockpit-guide/latest/guide/cockpit-locale.html#cockpit-locale-locale) call.
 The resulting files are written to `dist/<page>/po.XX.js` from where they
 can be imported by the page and used by `cockpit.gettext()`.
 
 HTML pages which use `translate="yes"` tags need to call
-[cockpit.translate()](https://cockpit-project.org/guide/latest/cockpit-locale.html#cockpit-locale-translate) which will iterate over all such tags and replace their content with the result of calling `cockpit.gettext()` on their original content.
+[cockpit.translate()](https://docs.cockpit-project.org/cockpit-guide/latest/guide/cockpit-locale.html#cockpit-locale-translate) which will iterate over all such tags and replace their content with the result of calling `cockpit.gettext()` on their original content.
 
 Opening a new branch
 --------------------

--- a/doc/modules/guide/pages/authentication.adoc
+++ b/doc/modules/guide/pages/authentication.adoc
@@ -23,13 +23,13 @@ The most common way to use Cockpit is to just log directly into the
 server that you want to access. This can be done if you have direct
 network access to port 9090 on that server.
 
-By default the cockpit web service is installed on the base system and
-link:#listen[socket activated by systemd]. In this setup access is
+By default the cockpit web service is installed on thec base system and
+xref:listen.adoc[socket activated by systemd]. In this setup access is
 controlled by a cockpit specific pam stack, generally located at
 `+/etc/pam.d/cockpit+`. By default this is configured to allow you to
 login with the username and password of any local account on the system.
-You can also setup a link:#sso[Kerberos based SSO solution] or
-link:#cert-authentication[certificate/smart card authentication].
+You can also setup a xref:sso.adoc[Kerberos based SSO solution] or
+xref:cert-authentication.adoc[certificate/smart card authentication].
 
 You can also
 https://github.com/cockpit-project/cockpit/blob/main/doc/authentication.md#actions[disable
@@ -44,7 +44,7 @@ supported mode. In this setup, cockpit establishes an SSH connection
 from the container to the underlying host, meaning that it is up to your
 SSH server to grant access. To login with a local account, `+sshd+` will
 need to be configured to allow password based authentication.
-Alternatively you can setup a link:#sso[Kerberos based SSO solution].
+Alternatively you can setup a xref:sso.adoc[Kerberos based SSO solution].
 
 Like `+sshd+`, cockpit can be configured to limit the number of
 concurrent login attempts allowed. This is done by adding a
@@ -110,7 +110,7 @@ enabled in `+sshd+`.
 
 The target server will need to be a member of the same domain as the
 primary server and your domain must be whitelisted in your browser. See
-the link:#sso[SSO documentation] for how to set this up.
+the xref:sso.adoc[SSO documentation] for how to set this up.
 
 === Public key
 

--- a/doc/modules/guide/pages/cert-authentication.adoc
+++ b/doc/modules/guide/pages/cert-authentication.adoc
@@ -148,7 +148,7 @@ cp /etc/ipa/ca.crt /etc/sssd/pki/sssd_auth_ca_db.pem
 ....
 
 Certificate authentication needs to be enabled in
-link:./cockpit.conf.5.html[cockpit.conf] explicitly:
+man:cockpit.conf[5] explicitly:
 
 ....
 [WebService]
@@ -174,7 +174,7 @@ action = none
 
 When using certificate authentication, all requests with a particular
 certificate will be handled by a separate and isolated instance of the
-link:./cockpit-ws.8.html[cockpit-ws] web server. This protects against
+man:cockpit-ws[8] web server. This protects against
 possible vulnerabilities in the web server and prevents an attacker from
 impersonating another user. However, this introduces a potential Denial
 of Service: Some remote attacker could create a large number of

--- a/doc/modules/guide/pages/cert-authentication.adoc
+++ b/doc/modules/guide/pages/cert-authentication.adoc
@@ -12,7 +12,7 @@ can associate certificates to users.
 
 To authenticate users from a Identity Management domain, the server that
 Cockpit is running on must be joined to that domain. See the
-link:#sso-server[SSO server requirements] for details.
+xref:sso.adoc#sso-server[SSO server requirements] for details.
 
 [[certauth-server-cert-generation]]
 == User certificate generation

--- a/doc/modules/guide/pages/cockpit-channels.adoc
+++ b/doc/modules/guide/pages/cockpit-channels.adoc
@@ -118,7 +118,7 @@ Close the channel.
 If `+options+` is present it can be a plain javascript object containing
 additional channel close options to send to the peer. If closing for
 because of a problem, set the `+"problem"+` field to a
-link:#cockpit-problems[problem code]. If `+options+` is not an object it
+xref:cockpit-error.adoc#cockpit-problems[problem code]. If `+options+` is not an object it
 will be treated as a `+"problem"+`.
 
 The link:#cockpit-channels-close-ev[close event] will fire. A channel

--- a/doc/modules/guide/pages/cockpit-dbus.adoc
+++ b/doc/modules/guide/pages/cockpit-dbus.adoc
@@ -47,7 +47,7 @@ DBus values are represented as javascript values and objects as follows:
   A javascript object that describes a cockpit channel which represents
   the passed file descriptor. The `+payload+` is always set to
   `+stream+`. Pass it to
-  link:#cockpit-channels-channel[cockpit.channel()] to create the
+  xref:cockpit-channels.adoc#cockpit-channels-channel[cockpit.channel()] to create the
   channel and start reading or writing on it. Handles can only be
   received, not sent from within cockpit.
 
@@ -116,7 +116,7 @@ client.close([problem])
 ....
 
 Close the DBus client. If `+problem+` is specified it should be a
-link:#cockpit-problems[problem code] string.
+xref:cockpit-error.adoc#cockpit-problems[problem code] string.
 
 [[cockpit-dbus-onclose]]
 == client.onclose
@@ -576,7 +576,7 @@ The `+exception+` object passed to the handler can have the following
 properties:
 
 `+problem+`::
-  A link:#cockpit-problems[problem code] string when a problem occurred
+  A xref:cockpit-error.adoc#cockpit-problems[problem code] string when a problem occurred
   starting or communicating with the DBus service. This is `+null+` in
   the cases where an actual DBus error was occurred.
 `+name+`::

--- a/doc/modules/guide/pages/cockpit-file.adoc
+++ b/doc/modules/guide/pages/cockpit-file.adoc
@@ -49,7 +49,7 @@ cockpit.file("/path/to/file").read()
 
 It is recommended to use absolute paths. Relative paths are resolved
 against `+/+`. To work with the current user's files
-link:#cockpit-user[cockpit.user()] can be used to get the user's home
+xref:cockpit-login.adoc#cockpit-user[cockpit.user()] can be used to get the user's home
 directory.
 
 The `+read()+` method returns a
@@ -69,7 +69,7 @@ It is not an error when the file does not exist. In this case, the
 and `+tag+` is `+"-"+`.
 
 The `+superuser+` option can be used the same way as described in the
-link:#cockpit-channels-channel[cockpit.channel()] to provide a different
+xref:cockpit-channels.adoc#cockpit-channels-channel[cockpit.channel()] to provide a different
 access level to the file.
 
 You can use the `+max_read_size+` option to limit the amount of data

--- a/doc/modules/guide/pages/cockpit-http.adoc
+++ b/doc/modules/guide/pages/cockpit-http.adoc
@@ -185,7 +185,7 @@ The `+exception+` object passed to the handler can have the following
 fields:
 
 `+problem+`::
-  A link:#cockpit-problems[problem code] string when a problem occurred
+  A xref:cockpit-error.adoc#cockpit-problems[problem code] string when a problem occurred
   starting or communicating with the server. This is `+null+` if the
   process exited or was terminated.
 `+status+`::
@@ -254,7 +254,7 @@ request.close([problem])
 ....
 
 Cancel the request. If `+problem+` is specified it should be a standard
-link:#cockpit-problems[problem code] string.
+xref:cockpit-error.adoc#cockpit-problems[problem code] string.
 
 [[cockpit-http-close-all]]
 == http.close()

--- a/doc/modules/guide/pages/cockpit-login.adoc
+++ b/doc/modules/guide/pages/cockpit-login.adoc
@@ -45,7 +45,7 @@ Returns a promise that completes once the user information is available.
 ====
 `+cockpit.user()+` is soft-deprecated since Cockpit 336, if your page
 does not need to maintain compatibility with older Cockpit versions you
-can uselink:#cockpit-info[cockpit.info] to obtain the user information.
+can use xref:cockpit-util.adoc#cockpit-info[cockpit.info] to obtain the user information.
 ====
 
 [[cockpit-permission]]

--- a/doc/modules/guide/pages/cockpit-metrics.adoc
+++ b/doc/modules/guide/pages/cockpit-metrics.adoc
@@ -1,10 +1,10 @@
 = cockpit.js: Metrics
 
 Metrics about the system can be retrieved from several sources using
-link:#cockpit-metrics[`+cockpit.metrics()+`] metrics channels. The
+link:#cockpit-metrics-function[`+cockpit.metrics()+`] metrics channels. The
 metrics are made available as series data, and can be used with the
-link:#cockpit-series[`+cockpit.series()+`] and
-link:#cockpit-grid[`+cockpit.grid()+`] facilities.
+xref:cockpit-series-data.adoc#cockpit-series[`+cockpit.series()+`] and
+xref:cockpit-series-data.adoc#cockpit-grid[`+cockpit.grid()+`] facilities.
 
 [[cockpit-metrics-function]]
 == cockpit.metrics()
@@ -15,7 +15,7 @@ metrics = cockpit.metrics(interval, options, cache)
 
 Opens a new metrics channel. The data retrieved will be available in the
 link:#cockpit-metrics-series[`+metrics.series+`] series sink, and can be
-used together with link:#cockpit-grid[`+cockpit.grid()+`] objects.
+used together with xref:cockpit-series-data.adoc#cockpit-grid[`+cockpit.grid()+`] objects.
 
 The `+interval+` is in milliseconds, and is the granularity of the
 series data retrieved. Any grids consuming the data must have the same

--- a/doc/modules/guide/pages/cockpit-spawn.adoc
+++ b/doc/modules/guide/pages/cockpit-spawn.adoc
@@ -46,7 +46,7 @@ the following fields:
   Set to `+"require"+` to spawn the process as root instead of the
   logged in user. If the currently logged in user is not permitted to
   become root (eg: via `+pkexec+`) then the `+client+` will immediately
-  be link:#cockpit-dbus-onclose[closed] with a `+"access-denied"+`
+  be xref:cockpit-spawn.adoc#cockpit-dbus-onclose[closed] with a `+"access-denied"+`
   problem code.
   +
   Set to `+"try"+` to try to run the process as root, but if that fails,
@@ -136,7 +136,7 @@ fields:
   the `+"err"+` option set to `+"message"+` then the second argument
   will contain the standard error output of the process.
 `+problem+`::
-  A link:#cockpit-problems[problem code] string when a problem occurred
+  A xref:cockpit-error.adoc#cockpit-problems[problem code] string when a problem occurred
   starting or communicating with the process. This is `+null+` if the
   process exited or was terminated.
 `+exit_status+`::
@@ -199,5 +199,5 @@ process.close([problem])
 
 Close the process by closing its standard input and output. If
 `+problem+` is specified it should be a standard
-link:#cockpit-problems[problem code] string. In this case the process
+xref:cockpit-error.adoc#cockpit-problems[problem code] string. In this case the process
 will be terminated with a signal.

--- a/doc/modules/guide/pages/embedding.adoc
+++ b/doc/modules/guide/pages/embedding.adoc
@@ -39,15 +39,15 @@ The component will load from the server in question and a WebSocket
 connection will be established with the server to relay the component's
 message stream.
 
-Cockpit components are HTML files contained in link:#packages[packages].
+Cockpit components are HTML files contained in xref:packages.adoc[packages].
 These can be placed in an iframe or web browser window. Each documented
 and stable component has a well-known URL and these are documented in
-the link:#development[API reference]. Each component URL begins with the
+the xref:development.adoc[API reference]. Each component URL begins with the
 string `+/cockpit/@localhost/+` followed a package name, and then the
 component itself.
 
-For example the link:#api-terminal-html[terminal.html] in the
-link:#api-system[system] package, has this URL:
+For example the xref:api-terminal-html.adoc[terminal.html] in the
+xref:api-system.adoc[system] package, has this URL:
 `+/cockpit/@localhost/system/terminal.html+`
 
 [source,html]

--- a/doc/modules/guide/pages/feature-machines.adoc
+++ b/doc/modules/guide/pages/feature-machines.adoc
@@ -10,7 +10,7 @@ Cockpit can connect to multiple machines from a single Cockpit session.
 These are listed in the host switcher.
 
 These additional machines are accessed via SSH from the machine that the
-first machine connected to, and are link:#authentication[authenticated]
+first machine connected to, and are xref:authentication.adoc[authenticated]
 with the logged in user's password and/or SSH keys.
 
 SSH host keys are stored in `+/etc/ssh/ssh_known_hosts+`.

--- a/doc/modules/guide/pages/feature-networkmanager.adoc
+++ b/doc/modules/guide/pages/feature-networkmanager.adoc
@@ -7,7 +7,7 @@ DBus APIs it provides to interact with the system's network
 configuration.
 
 For non root users, NetworkManager controls access to its APIs via
-link:#privileges[Policy Kit] and a user logged into Cockpit will have
+xref:privileges.adoc[Policy Kit] and a user logged into Cockpit will have
 the same permissions as they do from the command line.
 
 To perform similar tasks from the command line, use the

--- a/doc/modules/guide/pages/feature-realmd.adoc
+++ b/doc/modules/guide/pages/feature-realmd.adoc
@@ -10,7 +10,7 @@ Not all systems can join all kinds of domains. This depends on the
 availability of the necessary client software.
 
 For non root users, realmd controls access to its APIs via
-link:#privileges[Policy Kit] and a user logged into Cockpit will have
+xref:privileges.adoc[Policy Kit] and a user logged into Cockpit will have
 the same permissions as they do from the command line.
 
 To perform similar tasks from the command line, use the

--- a/doc/modules/guide/pages/feature-storaged.adoc
+++ b/doc/modules/guide/pages/feature-storaged.adoc
@@ -19,7 +19,7 @@ it's storage related features, including updating `+/etc/fstab+` and
 `+/etc/crypttab+` for stability reasons.
 
 For non root users, storaged controls access to its APIs via
-link:#privileges[Policy Kit] and a user logged into Cockpit will have
+xref:privileges.adoc[Policy Kit] and a user logged into Cockpit will have
 the same permissions as they do from the command line.
 
 To perform similar tasks from the command line, use the `+storagedctl+`

--- a/doc/modules/guide/pages/feature-systemd.adoc
+++ b/doc/modules/guide/pages/feature-systemd.adoc
@@ -6,7 +6,7 @@ and the DBus APIs it provides to configure and monitor core aspects of
 the system. Use of alternate system APIs are not currently implemented.
 
 For non root users, systemd controls access to its APIs via
-link:#privileges[Policy Kit] and a user logged into Cockpit will have
+xref:privileges.adoc[Policy Kit] and a user logged into Cockpit will have
 the same permissions as they do from the command line.
 
 Cockpit retrieves information about the host and changes the hostname
@@ -82,7 +82,7 @@ $ systemctl status cockpit
 ....
 
 In order to customize who can perform various actions in system,
-link:#privileges-polkit[create polkit rules] with the following actions
+xref:privileges.adoc#privileges-polkit[create polkit rules] with the following actions
 and details:
 
 `+org.freedesktop.systemd1.manage-units+`::

--- a/doc/modules/guide/pages/feature-terminal.adoc
+++ b/doc/modules/guide/pages/feature-terminal.adoc
@@ -2,5 +2,5 @@
 = Terminal
 
 Cockpit provides a standard shell in a terminal. This shell and the
-processes running in it have the link:#privileges[same privileges] as if
+processes running in it have the xref:privileges.adoc[same privileges] as if
 the user had logged in via SSH.

--- a/doc/modules/guide/pages/index.adoc
+++ b/doc/modules/guide/pages/index.adoc
@@ -3,4 +3,4 @@
 
 Documentation for Cockpit {cockpit-version}.
 
-Latest version https://cockpit-project.org/guide/latest[available here].
+Latest version https://docs.cockpit-project.org/[available here].

--- a/doc/modules/guide/pages/packages.adoc
+++ b/doc/modules/guide/pages/packages.adoc
@@ -285,7 +285,7 @@ HTML from the `+latest+` package:
 ....
 
 Do not assume you can link to any file in any other package. Refer to
-the link:#development[list of API packages] for those that are available
+the xref:development.adoc[list of API packages] for those that are available
 for use.
 
 [[package-minified]]
@@ -314,7 +314,7 @@ API from various packages can be used to implement Cockpit packages.
 Each package listed here has some API available for use. Only the API
 explicitly documented should be used.
 
-* link:#development[API Listing]
+* xref:development.adoc[API Listing]
 
 To include javascript from the API, simply load it into your HTML using
 a script tag. Alternatively you can use an javascript loader.

--- a/doc/modules/guide/pages/packages.adoc
+++ b/doc/modules/guide/pages/packages.adoc
@@ -322,7 +322,7 @@ a script tag. Alternatively you can use an javascript loader.
 [[package-bridges]]
 == Bridges for specific tasks
 
-On the server side the link:#cockpit-bridge.1[`+cockpit-bridge+`]
+On the server side the man:cockpit-bridge[1]
 connects to various system APIs that the front end UI requests it to.
 There are additional bridges for specific tasks that the main
 `+cockpit-bridge+` cannot handle, such as using the PCP C library API.

--- a/doc/modules/guide/pages/startup.adoc
+++ b/doc/modules/guide/pages/startup.adoc
@@ -8,7 +8,7 @@ activation.
 
 The actual `+cockpit.service+` and `+cockpit-ws+` process will start on
 demand when a browser accesses the `+cockpit.socket+`,
-link:#listen[usually on port 9090]. Once a user logs in then a
+xref:listen.adoc[usually on port 9090]. Once a user logs in then a
 `+cockpit-bridge+` process will be started in a Linux user login
 session.
 

--- a/doc/modules/guide/pages/urls.adoc
+++ b/doc/modules/guide/pages/urls.adoc
@@ -11,7 +11,7 @@ URLs.
 == Component URLs
 
 Cockpit components are HTML documents. They are organized into
-link:#packages[packages]. Each package contains information about which
+xref:packages.adoc[packages]. Each package contains information about which
 HTML components are available in that package. Components should always
 use relative URLs to access resources, such as images, scripts or CSS
 files, even if they refer to a resource in another package.
@@ -27,12 +27,12 @@ below:
 ....
 
 All resource URLs are under the `+/cockpit+` namespace. In cases where a
-Cockpit component is being link:#embedding[embedded] the `+/cockpit+`
+Cockpit component is being xref:embedding.adoc[embedded] the `+/cockpit+`
 may be followed by a plus sign and another `+embedder+` specific
 identifier.
 
 What follows is either a `+@host+` or `+$checksum+` which tells cockpit
-where to link:#packages[find the package]. Checksums are used when more
+where to xref:packages.adoc[find the package]. Checksums are used when more
 than one host has identical packages and the resources can be cached.
 
 The `+package+` name is next, followed by the `+component+` HTML path
@@ -52,8 +52,8 @@ Only refer to resources in packages on the same host.
 The above Component URLs are usually not visible to the user. Instead
 the Cockpit Web Service wraps the components in a shell which allows
 navigation, and provides bookmarkable clean URLs to the component. These
-URLs do not affect link:#embedding[embedders] or
-link:#packages[components] directly.
+URLs do not affect xref:embedding.adoc[embedders] or
+xref:packages.adoc[components] directly.
 
 If no path is present then the Cockpit will redirect to the default page
 for the server.
@@ -62,7 +62,7 @@ If the first segment of the path begins with an `+@+` sign, then the
 component is being shown from a non-local host.
 
 The next segment of the path, (or first if the component is being shown
-on the local host) is the link:#packages[package name]. The remainder of
+on the local host) is the xref:packages.adoc[package name]. The remainder of
 the path is a component file in the package. If no further path segments
 are present, a default `+index.html+` component in the package is
 loaded. An extension of `+.html+` is automatically appended.

--- a/doc/modules/man/pages/cockpit-bridge.1.adoc
+++ b/doc/modules/man/pages/cockpit-bridge.1.adoc
@@ -43,4 +43,4 @@ include::../partials/author.adoc[]
 
 == See also
 
-*cockpit-ws(8)*
+man:cockpit-ws[8]

--- a/doc/modules/man/pages/cockpit-desktop.1.adoc
+++ b/doc/modules/man/pages/cockpit-desktop.1.adoc
@@ -13,7 +13,7 @@ cockpit-desktop - Cockpit Desktop integration
 The *cockpit-desktop* program provides secure access to Cockpit pages
 in an already running desktop session. It starts a web server
 (*cockpit-ws*) and a web browser in an isolated network namespace, and
-a *cockpit-bridge(1)* in the running user session.
+a man:cockpit-bridge[1] in the running user session.
 
 This avoids having to log into Cockpit, and having to enable
 *cockpit.socket* system-wide. The network isolation ensures that no
@@ -51,4 +51,4 @@ include::../partials/author.adoc[]
 
 == See also
 
-*cockpit-ws(8)*, *cockpit-bridge(1)*
+man:cockpit-ws[8], man:cockpit-bridge[1]

--- a/doc/modules/man/pages/cockpit-desktop.1.adoc
+++ b/doc/modules/man/pages/cockpit-desktop.1.adoc
@@ -22,7 +22,7 @@ access this local web server.
 
 *URLPATH* is the Cockpit page to open, i. e. the path component of
 Cockpit URLs. It is highly recommended to only open a
-https://cockpit-project.org/guide/latest/embedding.html[particular page frame], not the entire Cockpit navigation and menu. For example, the
+https://docs.cockpit-project.org/cockpit-guide/latest/guide/embedding.html[particular page frame], not the entire Cockpit navigation and menu. For example, the
 path `+/cockpit/@localhost/storage/index.html+` will open the Storage
 page. It is also possible to give abbreviated forms of urls, such as
 "`+/storage+`" or "`+/network/firewall+`".

--- a/doc/modules/man/pages/cockpit-desktop.1.adoc
+++ b/doc/modules/man/pages/cockpit-desktop.1.adoc
@@ -13,7 +13,7 @@ cockpit-desktop - Cockpit Desktop integration
 The *cockpit-desktop* program provides secure access to Cockpit pages
 in an already running desktop session. It starts a web server
 (*cockpit-ws*) and a web browser in an isolated network namespace, and
-a *cockpit-bridge(8)* in the running user session.
+a *cockpit-bridge(1)* in the running user session.
 
 This avoids having to log into Cockpit, and having to enable
 *cockpit.socket* system-wide. The network isolation ensures that no

--- a/doc/modules/man/pages/cockpit-tls.8.adoc
+++ b/doc/modules/man/pages/cockpit-tls.8.adoc
@@ -11,21 +11,21 @@ cockpit-tls - TLS proxy for Cockpit web service
 == Description
 
 The *cockpit-tls* program is a TLS terminating HTTP proxy for
-*cockpit-ws(8)*. It manages a set of isolated cockpit-ws instances,
+man:cockpit-ws[8]. It manages a set of isolated cockpit-ws instances,
 one per TLS client certificate, plus one for TLS without a client
 certificate, and one for unencrypted HTTP. With that, one session cannot
 tamper with another one through possible security vulnerability
 exploits.
 
 Users or administrators should never need to start this program as it
-automatically started by *systemd(1)* via socket activation.
+automatically started by man:systemd[1] via socket activation.
 
 == Transport security
 
 To specify the TLS certificate the web service should use, simply drop a
 file with the extension *.cert* in the */etc/cockpit/ws-certs.d*
 directory, or below *$XDG_CONFIG_DIRS* if set (see
-link:./cockpit.conf.5.html[cockpit.conf]). If there are multiple files
+man:cockpit.conf[5]). If there are multiple files
 in this directory, then the highest priority one is chosen after
 sorting.
 
@@ -98,7 +98,7 @@ client certificates. This variable is normally set by the
 In addition, *cockpit-tls* will use the *XDG_CONFIG_DIRS*
 environment variable from the
 https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html[XDG
-basedir spec] to find its certificates and the *cockpit.conf(5)*
+basedir spec] to find its certificates and the man:cockpit.conf[5]
 configuration file.
 
 == Bugs
@@ -111,4 +111,4 @@ include::../partials/author.adoc[]
 
 == See also
 
-*cockpit-ws(8)* , *cockpit.conf(5)* , *systemd(1)*
+man:cockpit-ws[8] , man:cockpit.conf[5] , man:systemd[1]

--- a/doc/modules/man/pages/cockpit-ws.8.adoc
+++ b/doc/modules/man/pages/cockpit-ws.8.adoc
@@ -13,11 +13,11 @@ cockpit-ws - Cockpit web service
 
 The *cockpit-ws* program is the web service component used for
 communication between the browser application and various configuration
-tools and services like *cockpit-bridge(1)*.
+tools and services like man:cockpit-bridge[1].
 
 Users or administrators should never need to start this program as it
-automatically started by *systemd(1)* on bootup, through
-*cockpit-tls(8)*.
+automatically started by man:systemd[1] on bootup, through
+man:cockpit-tls[8].
 
 == Transport security
 
@@ -25,11 +25,11 @@ automatically started by *systemd(1)* on bootup, through
 terminating proxy, and only deals with unencrypted HTTP by itself. But
 for backwards compatibility it can also handle TLS connections by itself
 when being run directly. For details how to configure certificates,
-please refer to the *cockpit-tls(8)* documentation.
+please refer to the man:cockpit-tls[8] documentation.
 
 == Timeout
 
-When started via *systemd(1)* then *cockpit-ws* will exit after 90
+When started via man:systemd[1] then *cockpit-ws* will exit after 90
 seconds if nobody logs in, or after the last user is disconnected.
 
 == Options
@@ -54,7 +54,7 @@ seconds if nobody logs in, or after the last user is disconnected.
   that does the TLS termination. Then Cockpit puts https:// URLs into
   the default *Content-Security-Policy*, and accepts only https://
   origins, instead of http: ones by default. However, if *Origins* is
-  set in the *cockpit.conf(5)* configuration file, it will override
+  set in the man:cockpit.conf[5] configuration file, it will override
   this default.
 *--local-ssh*::
   Normally *cockpit-ws* uses *cockpit-session* and PAM to
@@ -84,7 +84,7 @@ can access the session!
 The *cockpit-ws* process will use the *XDG_CONFIG_DIRS* environment
 variable from the
 https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html[XDG
-basedir spec] to find its *cockpit.conf(5)* configuration file.
+basedir spec] to find its man:cockpit.conf[5] configuration file.
 
 In addition the *XDG_DATA_DIRS* environment variable from the
 https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html[XDG
@@ -101,4 +101,4 @@ include::../partials/author.adoc[]
 
 == See also
 
-*cockpit-tls(8)* , *cockpit.conf(5)* , *systemd(1)*
+man:cockpit-tls[8] , man:cockpit.conf[5] , man:systemd[1]

--- a/doc/modules/man/pages/cockpit.1.adoc
+++ b/doc/modules/man/pages/cockpit.1.adoc
@@ -32,4 +32,4 @@ include::../partials/author.adoc[]
 
 == See also
 
-*cockpit-tls(8)* , *cockpit.bridge(1)* , *systemd(1)*, *https://cockpit-project.org/guide/latest[Cockpit guide]*
+*cockpit-tls(8)* , *cockpit.bridge(1)* , *systemd(1)*, *https://docs.cockpit-project.org/cockpit-guide/latest[Cockpit guide]*

--- a/doc/modules/man/pages/cockpit.1.adoc
+++ b/doc/modules/man/pages/cockpit.1.adoc
@@ -32,4 +32,4 @@ include::../partials/author.adoc[]
 
 == See also
 
-*cockpit-tls(8)* , *cockpit.bridge(1)* , *systemd(1)*, *https://docs.cockpit-project.org/cockpit-guide/latest[Cockpit guide]*
+man:cockpit-tls[8] , man:cockpit-bridge[1] , man:systemd[1], *https://docs.cockpit-project.org/cockpit-guide/latest[Cockpit guide]*

--- a/doc/modules/man/pages/cockpit.conf.5.adoc
+++ b/doc/modules/man/pages/cockpit.conf.5.adoc
@@ -193,4 +193,4 @@ include::../partials/author.adoc[]
 
 == See also
 
-*cockpit-ws(8)*, *cockpit-tls(8)*
+man:cockpit-ws[8], man:cockpit-tls[8]

--- a/doc/modules/man/pages/cockpit.conf.5.adoc
+++ b/doc/modules/man/pages/cockpit.conf.5.adoc
@@ -108,7 +108,7 @@ ForwardedForHeader = X-Forwarded-For
   If true, enable TLS client certificates for authenticating users.
   Commonly these are provided by a smart card, but it's equally possible
   to import certificates directly into the web browser. Please see the
-  https://cockpit-project.org/guide/latest/cert-authentication.html[Certificate/smart
+  https://docs.cockpit-project.org/cockpit-guide/latest/guide/cert-authentication.html[Certificate/smart
   card authentication] section in the Cockpit guide for details.
 *Shell*::
   The relative URL to top level component to display in Cockpit once

--- a/examples/xhr-proxy/xhrproxy.js
+++ b/examples/xhr-proxy/xhrproxy.js
@@ -8,7 +8,7 @@
  * (which can be changed in the manifest), and browsers blocking Cross-Origin requests.
  *
  * Documentation links:
- * - https://cockpit-project.org/guide/latest/cockpit-channels.html
+ * - https://docs.cockpit-project.org/cockpit-guide/latest/guide/cockpit-channels.html
  * - doc/protocol.md
  * - doc/urls.md
  */

--- a/pkg/lib/cockpit/_internal/channel.js
+++ b/pkg/lib/cockpit/_internal/channel.js
@@ -7,7 +7,7 @@ import { ensure_transport, transport_globals } from './transport';
 /* -------------------------------------------------------------------------
  * Channels
  *
- * Public: https://cockpit-project.org/guide/latest/api-base1.html
+ * Public: https://docs.cockpit-project.org/cockpit-guide/latest/guide/api-base1.html
  */
 
 export function Channel(options) {

--- a/pkg/lib/hooks.ts
+++ b/pkg/lib/hooks.ts
@@ -46,7 +46,7 @@ import { dequal } from 'dequal/lite';
  * component is re-rendered when it changes. "location" is always a
  * valid object and never null.
  *
- * See https://cockpit-project.org/guide/latest/cockpit-location.html
+ * See https://docs.cockpit-project.org/cockpit-guide/latest/guide/cockpit-location.html
  */
 
 export function usePageLocation() {

--- a/pkg/lib/long-running-process.js
+++ b/pkg/lib/long-running-process.js
@@ -56,7 +56,7 @@ export class LongRunningProcess {
      *  This runs as root, thus will be shared with all privileged Cockpit sessions.
      *  Return cockpit.spawn promise. You need to handle exceptions, but not success.
      * @param {string[]} argv array starting with executable and all of the arguments to pass to it
-     * @param {object} options same properties as cockpit-spawn https://cockpit-project.org/guide/latest/cockpit-spawn.html
+     * @param {object} options same properties as cockpit-spawn https://docs.cockpit-project.org/cockpit-guide/latest/guide/cockpit-spawn.html/cockpit-spawn.html
      * @param {string[]} runArgs arguments to provide to systemd-run itself, such as `--setenv`
      */
     run(argv, options, runArgs = []) {

--- a/pkg/lib/packagekit.js
+++ b/pkg/lib/packagekit.js
@@ -161,7 +161,7 @@ export function watchTransaction(transactionPath, signalHandlers, notifyHandler)
  *                  If undefined, only a transaction will be created without calling a method on it
  * arglist (array): "in" arguments of @method
  * signalHandlers (object): maps PackageKit.Transaction signal names to handlers
- * notifyHandler (function): handler for https://cockpit-project.org/guide/latest/cockpit-dbus.html#cockpit-dbus-onnotify
+ * notifyHandler (function): handler for https://docs.cockpit-project.org/cockpit-guide/latest/guide/cockpit-dbus.html#cockpit-dbus-onnotify
  *                           signals, called on property changes with (changed_properties, transaction_path)
  * Returns: Promise that resolves with transaction path on success, or rejects on an error
  *

--- a/pkg/metrics/metrics.jsx
+++ b/pkg/metrics/metrics.jsx
@@ -1439,7 +1439,7 @@ const PCPConfigDialog = ({
                     <div className="pcp-settings-modal-text">
                         { _("Performance Co-Pilot collects and analyzes performance metrics from your system.") }
 
-                        <Button component="a" variant="link" href="https://cockpit-project.org/guide/latest/feature-pcp.html"
+                        <Button component="a" variant="link" href="https://docs.cockpit-project.org/cockpit-guide/latest/guide/feature-pcp.html"
                                       isInline
                                       target="_blank" rel="noopener noreferrer"
                                       icon={<ExternalLinkAltIcon />}>

--- a/pkg/shell/hosts_dialog.jsx
+++ b/pkg/shell/hosts_dialog.jsx
@@ -258,7 +258,7 @@ class Connect extends React.Component {
                         {_("Connected hosts can fully control each other. This includes running programs that could harm your system or steal data. Only connect to trusted machines.")}
                     </Content>
                     <Content component={ContentVariants.p}>
-                        <a href="https://cockpit-project.org/guide/latest/multi-host.html" target="blank" rel="noopener noreferrer">
+                        <a href="https://docs.cockpit-project.org/cockpit-guide/latest/guide/multi-host.html" target="blank" rel="noopener noreferrer">
                             <ExternalLinkAltIcon /> {_("Read more")}
                         </a>
                     </Content>

--- a/pkg/systemd/README-realmd.md
+++ b/pkg/systemd/README-realmd.md
@@ -61,7 +61,7 @@ above if you do not.
 Use the following guide to configure things, with more troubleshooting advice
 below:
 
-https://cockpit-project.org/guide/latest/sso.html
+https://docs.cockpit-project.org/cockpit-guide/latest/guide/sso.html
 
 **BUG:** The host name of the computer Cockpit is running on should end with
 the domain name. If it does not, then rename the computer Cockpit is running on:
@@ -106,6 +106,6 @@ Use the IPA GUI to setup "Trusted for delegation" for the host and service that
 Cockpit is running on. Make sure to tell the browser to delegate credentials
 as seen in the guide:
 
-https://cockpit-project.org/guide/latest/sso.html
+https://docs.cockpit-project.org/cockpit-guide/latest/guide/sso.html
 
 Ze goggles, zey do nothing!

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -820,7 +820,7 @@ class TestConnection(testlib.MachineCase):
         checkMotdContent('systemctl', expected=False)
         m.execute("systemctl stop cockpit.socket")
 
-        # Change port according to documentation: https://cockpit-project.org/guide/latest/listen.html
+        # Change port according to documentation: https://docs.cockpit-project.org/cockpit-guide/latest/guide/listen.html
         m.execute('! selinuxenabled || semanage port -m -t websm_port_t -p tcp 443')
         self.write_file("/etc/systemd/system/cockpit.socket.d/listen.conf",
                         "[Socket]\nListenStream=\nListenStream=/run/cockpit/sock\nListenStream=443",


### PR DESCRIPTION
Several files, including the deployment guide index page, link to the
old AsciiDoc guide on our website whereas our new docs site is published
under docs subdomain using Antora. While these links will work in the
future thanks to redirects we should update the links where we can to
avoid this unnecessary redirect.

Other changes include changing links from being header anchors within a
single-page to a multi-page navigation with asciidoctor's xref. This
change only applies to links within the same module and doesn't change
any links from guide to manpage for example. That will be tackled in a
future commit as it also has to deal with compiling to manpages.

The referral of cockpit-desktop(1) was set to (8) by accident at some
point.

Adds a new extension for AsciiDoctor in
`doc/extensions/man-inline-macro.rb` followed by a README in the same
directory. This changes the links to manpages during compilation from
asciidoc files into HTML or Manpages so that links work within HTML
pages as well as being properly formatted within manpages.

This started as an initial workaround to handle Antora xref extension to
AsciiDoctor wherein it introduces resource ids such as module,
version, and component. Ultimately this breaks AsciiDoctor parsing of
xref and makes it think that it is a strange URI and not a URL. However
as Cockpit guide only has links to manpages and the fact that this also
improves system manpages a macro `man` suits better.

Using this is fairly straightforward, when you want to reference a
manpage within the Cockpit Guide or within a manpage you define it using
`man:manpage-name[sub-volume]` which will then be translated to an
anchor link in HTML or bold text in Manpage format with the text
`manpage-name(sub-volume)`.

This does not fix the links within Antora and building them locally
within Cockpit repo using our instructions in doc/README.md will make
the links show as unformatted text `man:manpage-name[sub-volume]`. This
is not an issue within our cockpit-docs repo as we have an extension
there that replaces the manpage macros with the proper xref module link
for Antora.

See-also: https://docs.antora.org/antora/latest/page/xref/#structure
See-also: https://github.com/asciidoctor/asciidoctor-extensions-lab/blob/main/lib/man-inline-macro/extension.rb
Related-to: https://github.com/cockpit-project/cockpit-docs/pull/8
