### PR TITLE
test: Workaround nfs-utils regression in rawhide

### DIFF
--- a/test/verify/check-storage-nfs
+++ b/test/verify/check-storage-nfs
@@ -13,6 +13,14 @@ import testlib
 @testlib.nondestructive
 class TestStorageNfs(storagelib.StorageCase):
 
+    def setUp(self):
+        super().setUp()
+        # HACK: nfs-utils 2.9.1 rpc.mountd fails when /var/lib/nfs/etab does not exist
+        # Start the server before restarting to work around the issue
+        # https://bugzilla.redhat.com/show_bug.cgi?id=2496417
+        if self.machine.image.startswith("fedora-"):
+            self.machine.execute("systemctl start nfs-server")
+
     def testNfsClient(self):
         m = self.machine
         b = self.browser


### PR DESCRIPTION
In our test virtual machines nfs-server is not started on boot and /var/lib/nfs/etab does not exist yet. Restarting nfs-server results in rpc.mountd error'ing out due as etab is not found, this can be worked around by starting nfs-server before the we restart it.

> rpc.mountd[2613]: couldn't open /var/lib/nfs/etab