### PR TITLE
dialog: Change debouncing API

### DIFF
--- a/pkg/lib/cockpit/dialog.tsx
+++ b/pkg/lib/cockpit/dialog.tsx
@@ -165,7 +165,7 @@
    and methods.
 
    - handle = dlg.field(name)
-   - handle = dlg.field(name, update_func)
+   - handle = dlg.field(name, changed_func)
 
    This returns a handle for a specific field of the dialog
    values. Using handles like this becomes convenient when there are
@@ -173,21 +173,22 @@
    also work well with TypeScript. For simple dialogs they might feel
    a bit clunky.
 
-   The second argument, "update_func", is optional. If given, it
+   The second argument, "changed_func", is optional. If given, it
    should be a function and that function will be called whenever the
    dialog value is changed via the returned handle (and the returned
-   handle only).
+   handle only).  It might also be called some time later, when
+   "set_debounced" is used.
 
    - handle = dlg.top()
-   - handle = dlg.top(update_func)
+   - handle = dlg.top(changed_func)
 
    Get a handle for the whole value object.  The usual
    "dlg.field(name)" call is actually just a shortcut for
    "dlg.top().sub(name)".  But since that looks quite obscure in
    simple dialogs that only have one level of values, we have the
    "dlg.field(name)" shortcut as well.  This whole-value handle is
-   useful for "dlg.top().at(...)", see below, or for update
-   notifications that trigger for each and every change.
+   useful for "dlg.top().at(...)", see below, or for notifications
+   that trigger for each and every change.
 
    - dlg.values
 
@@ -214,23 +215,41 @@
    dialog, and do input validation as necessary and all the other
    things that you don't need to think about.
 
+   This is actually the same as "handle.set_debounced" with a delay of
+   0, see below.
+
+   - handle.set_debounced(val)
+   - handle.set_debounced(val, delay)
+
+   Set the current value of a value handle immediately as described
+   above for "handle.set", and render the dialog.  But validation and
+   calling of the "changed" functions happens only after "delay"
+   milliseconds.
+
+   When "delay" is omitted, it defaults to a sensible value for
+   debouncing keyboard input.
+
+   - handle.notify(changed_func)
+
+   Return a new handle for the same dialog field that "handle"
+   represents, but call "changed_func" whenever the field is changed
+   via the new handle.
+
    - handle.sub(name_or_index)
-   - handle.sub(name_or_index, update_func)
+   - handle.sub(name_or_index, changed_func)
 
    Get a handle for a nested value. When the current value is an
    object, you should pass the name of a nested field. If it is an
    array, pass the index of the desired element.  See "dlg.field()"
    above for more information about handles.
 
-   - handle.get_async(debounce, (val, signal) => ...)
-   - handle.set_async(debounce, (val, signal) => new_val)
+   - handle.get_async((val, signal) => ...)
+   - handle.set_async((val, signal) => new_val)
 
-   These are for running debounced, asynchronous code.  Both functions
-   will run the given function after "debounce" milliseconds, but only
-   if the value of the field hasn't changed in the meantime.  The
-   dialog waits for all asynchronous tasks started by these functions
-   to be finished before running the action function.  When the dialog
-   is cancelled, they all get cancelled.
+   These are for running asynchronous code.  The dialog waits for all
+   asynchronous tasks started by these functions to be finished before
+   running the action function.  When the dialog is cancelled, they
+   all get cancelled.
 
    The return value of "handle.set_async" is made the new value of the
    field, but only if the value of the field hasn't changed in the
@@ -241,8 +260,7 @@
 
    The "handle.get_async" function is a slight variation on this. It
    is meant to perform asynchronous computations that do not modify
-   the field value itself, but have some other side effects.  Maybe
-   they modify multiple other field values or some React state. There
+   the field value itself, but have some other side effects.  There
    can be more than one call active at a given time. They only get
    cancelled when the value of the field changes.
 
@@ -256,17 +274,6 @@
    to figure out when they should stop.  They can also use all other
    features of a AbortSignal, of course, such as setting
    "signal.onabort", adding event listeners, etc.
-
-   As an example, here is how you might implement set_async on top of
-   get_async:
-
-      function set_async(handle, debounce, func) {
-          handle.get_async(debounce, (val, signal) => {
-              const new_val = await func(val, signal);
-              if (!signal.aborted)
-                  handle.set(new_val);
-          })
-      }
 
    - handle.at(witness)
 
@@ -293,7 +300,7 @@
    It is important to use this function instead of just "handle.set()"
    with an appropriately modified array. By using this function, the
    plumbing is able to keep its internal state in synch, which is
-   especially important for asynchronous validation and update
+   especially important for asynchronous validation and "changed"
    functions.
 
    However, it is okay to just replace an array with a different
@@ -416,16 +423,11 @@
    then you can modify field values via calls to "handle.set". (Be
    careful not to create endless validation loops!)
 
-   - handle.validate_async(debounce, async (v, task) >= ...)
+   - handle.validate_async(async (v, task) >= ...)
 
-   Calls the given async function "debounce" milliseconds after the
-   value represented by the handle has last been changed. (Or
-   immediately when the apply button is clicked.)  When the function
-   throws an exception, the validation is considered to have been
-   successful.
-
-   See the documentation for "handle.validate" above for more rules
-   that apply to validation functions.
+   Same as "handle.validate", but the function is asynchronous and
+   "dialog.run_action" will wait for these functions to complete
+   before actually carrying out the dialog action.
 
    UPDATES
 
@@ -443,28 +445,28 @@
 
    It's okay and simplest to just put that code right next to the call
    to "handler.set()".  If that call is in a porcelain component (as
-   it probably often will be), you can pass a "update_func" when
+   it probably often will be), you can pass a "changed_func" when
    creating the handle for that porcelain component with
    "handler.sub()" or "dialog.field()".  For example:
 
-       function on_plate_change(val: string) {
+       function plate_changed(val: string) {
            console.log("NEW LICENSE PLATE", val);
        }
 
        return (
            <DialogTextInput
                label="License plate number"
-               field={dlg.field("plate", on_plate_change)}
+               field={dlg.field("plate", plate_changed)}
            />
        );
 
-   The function "on_plate_change" will be called whenever the user
-   changes the "plate" field via the DialogTextInput.  The
-   "on_plate_change" function will not be called when the "plate" is
-   changed in other places.  If that should happen, you have to
-   arrange for it explicitly.
+   The function "plate_changed" will be called whenever the user
+   changes the "plate" field via the DialogTextInput (subject to
+   debouncing).  The "plate_changed" function will not be called
+   when the "plate" is changed in other places.  If that should
+   happen, you have to arrange for it explicitly.
 
-   Functions like "on_plate_change" can and should modify the dialog
+   Functions like "plate_changed" can and should modify the dialog
    fields via calls to "handle.set()".
 
    If you want to run asynchronous code, you can do so with
@@ -472,8 +474,8 @@
    want to asynchronously fetch the car model for a given license
    plate from a database, you can do it like this:
 
-       function on_plate_change(val: string) {
-           dlg.field("model").set_async(1000, async () => await fetch_model(val));
+       function plate_changed(val: string) {
+           dlg.field("model").set_async(async () => await fetch_model(val));
        }
 
    When arrays are involved, dialog fields can move around while your
@@ -688,17 +690,20 @@ export class DialogField<T> {
     /* eslint-enable */
     #getter: () => T;
     #setter: (val: T) => void;
+    #trigger: () => void;
 
     constructor(
         dialog: DialogState<unknown>,
         state: DialogFieldState,
         getter: () => T,
         setter: (val: T) => void,
+        trigger: () => void,
     ) {
         this.#dialog = dialog;
         this.#state = state;
         this.#getter = getter;
         this.#setter = setter;
+        this.#trigger = trigger;
     }
 
     validation_text(): string | undefined {
@@ -710,8 +715,13 @@ export class DialogField<T> {
     }
 
     set(val: T): void {
+        this.set_debounced(val, 0);
+    }
+
+    set_debounced(val: T, delay?: number): void {
         this.#dialog._abort_state_tasks(this.#state, true);
         this.#setter(val);
+        this.#dialog._set_debounce(this.#state, delay === undefined ? 500 : delay, () => this.#trigger());
     }
 
     ouia_id(tag: string = "field"): string {
@@ -738,6 +748,7 @@ export class DialogField<T> {
         if (Array.isArray(val)) {
             const sub = this.#state.sub.get(index);
             if (sub) {
+                this.#dialog._cancel_debounce(sub);
                 this.#dialog._abort_state_tasks(sub);
                 sub.tag = -1;
             }
@@ -750,6 +761,7 @@ export class DialogField<T> {
             }
             this.#state.sub.delete(val.length - 1);
             this.#setter(toSpliced(val, index, 1) as T);
+            this.#trigger();
         }
     }
 
@@ -757,32 +769,56 @@ export class DialogField<T> {
         const val = this.get();
         if (Array.isArray(val)) {
             this.#setter(val.concat(item) as T);
+            this.#trigger();
         }
     }
 
-    sub<K extends keyof T>(tag: K, update_func?: ((val: T[K]) => void) | undefined): DialogField<T[K]> {
+    notify(changed_func: (val: T) => void): DialogField<T> {
+        return new DialogField<T>(
+            this.#dialog,
+            this.#state,
+            this.#getter,
+            this.#setter,
+            () => {
+                changed_func(this.#getter());
+                this.#trigger();
+            },
+        );
+    }
+
+    sub<K extends keyof T>(tag: K, changed_func?: ((val: T[K]) => void) | undefined): DialogField<T[K]> {
         const sub = this.#dialog._get_sub_state(this.#state, tag);
+
+        const getter = (): T[K] => {
+            const container = this.get();
+            if (Array.isArray(container) && typeof sub.tag == "number") {
+                return container[sub.tag];
+            } else {
+                return container[tag];
+            }
+        };
+
+        const setter = (val: T[K]) => {
+            const container = this.get();
+            if (Array.isArray(container) && typeof sub.tag == "number") {
+                this.#setter(toSpliced(container, sub.tag, 1, val) as T);
+            } else {
+                this.#setter({ ...container, [tag]: val });
+            }
+        };
+
+        const trigger = () => {
+            if (changed_func)
+                changed_func(getter());
+            this.#trigger();
+        };
+
         return new DialogField<T[K]>(
             this.#dialog,
             sub,
-            () => {
-                const container = this.get();
-                if (Array.isArray(container) && typeof sub.tag == "number") {
-                    return container[sub.tag];
-                } else {
-                    return container[tag];
-                }
-            },
-            (val) => {
-                const container = this.get();
-                if (Array.isArray(container) && typeof sub.tag == "number") {
-                    this.#setter(toSpliced(container, sub.tag, 1, val) as T);
-                } else {
-                    this.#setter({ ...container, [tag]: val });
-                }
-                if (update_func)
-                    update_func(val);
-            },
+            getter,
+            setter,
+            trigger,
         );
     }
 
@@ -796,23 +832,23 @@ export class DialogField<T> {
         this.#dialog._validate_value(this.#state, val, () => func(val));
     }
 
-    validate_async(debounce: number, func: (val: T, signal: AbortSignal) => Promise<DialogValidationResult<T>>): void {
+    validate_async(func: (val: T, signal: AbortSignal) => Promise<DialogValidationResult<T>>): void {
         const val = this.get();
-        this.#dialog._validate_value_async(this.#state, val, debounce, signal => func(val, signal));
+        this.#dialog._validate_value_async(this.#state, val, signal => func(val, signal));
     }
 
-    set_async(debounce: number, func: (val: T, signal: AbortSignal) => Promise<T>): void {
+    set_async(func: (val: T, signal: AbortSignal) => Promise<T>): void {
         const val = this.get();
-        this.#dialog._set_value_async(this.#state, debounce, async signal => {
+        this.#dialog._set_value_async(this.#state, async signal => {
             const new_val = await func(val, signal);
             if (!signal.aborted)
                 this.set(new_val);
         });
     }
 
-    get_async(debounce: number, func: (val: T, signal: AbortSignal) => Promise<void>): void {
+    get_async(func: (val: T, signal: AbortSignal) => Promise<void>): void {
         const val = this.get();
-        this.#dialog._get_value_async(this.#state, debounce, signal => func(val, signal));
+        this.#dialog._get_value_async(this.#state, signal => func(val, signal));
     }
 }
 
@@ -827,45 +863,25 @@ function get_validation_result_own_string(result: unknown): string | undefined {
 
 export class DialogTask {
     #name: string;
-    #timeout_id: number = 0;
-    #promise: Promise<void> | null = null;
-    #start: () => void;
-    #done: (task: DialogTask) => void;
+    #promise: Promise<void>;
     #controller: AbortController;
 
     constructor(
         name: string,
-        debounce: number,
         func: (task: DialogTask) => Promise<void>,
         done: (task: DialogTask) => void,
     ) {
+        debug("starting task", name);
         this.#name = name;
-        this.#done = done;
-        this.#start = () => {
-            debug("starting task", this.#name);
-            cockpit.assert(!this.#controller.signal.aborted);
-            this.#promise = func(this);
-            this.#promise.finally(() => {
-                debug("task done", this.#name);
-                done(this);
-            });
-        };
-        this.#timeout_id = window.setTimeout(this.#start, debounce);
         this.#controller = new AbortController();
-        debug("creating task", this.#name, debounce);
-    }
-
-    start_now() {
-        if (!this.#promise && !this.#controller.signal.aborted) {
-            debug("skipping debounce of task", this.#name);
-            window.clearTimeout(this.#timeout_id);
-            this.#start();
-        }
+        this.#promise = func(this);
+        this.#promise.finally(() => {
+            debug("task done", this.#name);
+            done(this);
+        });
     }
 
     async wait() {
-        // Waiting is only allowed for tasks that have actually been started.
-        cockpit.assert(this.#promise);
         debug("waiting for task", this.#name);
         await this.#promise;
     }
@@ -876,12 +892,7 @@ export class DialogTask {
 
     abort() {
         debug("aborting task", this.#name);
-        window.clearTimeout(this.#timeout_id);
         this.#controller.abort();
-        if (!this.#promise) {
-            debug("aborted task done", this.#name);
-            this.#done(this);
-        }
     }
 }
 
@@ -907,6 +918,9 @@ interface DialogFieldState {
     parent: DialogFieldState | null,
     tag: string | number | symbol;
     sub: Map<string | number | symbol, DialogFieldState>;
+    // debouncing
+    debounce_timer: number;
+    debounce_func: null | (() => void);
     // validation
     relevant: boolean;
     validation_text: string | undefined;
@@ -952,6 +966,8 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
             parent: null,
             tag: "",
             sub: new Map(),
+            debounce_timer: 0,
+            debounce_func: null,
             relevant: false,
             validation_text: undefined,
             cached_value: undefined,
@@ -989,6 +1005,8 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
                 parent: state,
                 tag,
                 sub: new Map(),
+                debounce_timer: 0,
+                debounce_func: null,
                 relevant: false,
                 validation_text: undefined,
                 cached_value: undefined,
@@ -1020,24 +1038,79 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
         await visit(this.#top_state);
     }
 
+    /* DEBOUNCING
+     */
+
+    _cancel_debounce(state: DialogFieldState) {
+        if (state.debounce_timer) {
+            debug("cancelling debounce", state_path(state));
+            window.clearTimeout(state.debounce_timer);
+            state.debounce_timer = 0;
+            state.debounce_func = null;
+        }
+        for (const sub of state.sub.values())
+            this._cancel_debounce(sub);
+    }
+
+    _set_debounce(state: DialogFieldState, delay: number, func: () => void) {
+        if (this.#block_updates)
+            return;
+
+        this._cancel_debounce(state);
+
+        if (delay === 0) {
+            debug("no debounce trigger", state_path(state));
+            func();
+        } else {
+            debug("debounce trigger", state_path(state), delay);
+            state.debounce_func = func;
+            state.debounce_timer = window.setTimeout(
+                () => {
+                    state.debounce_timer = 0;
+                    state.debounce_func = null;
+                    func();
+                },
+                delay,
+            );
+        }
+    }
+
+    _run_all_debouncing_now() {
+        let debounced: boolean;
+        do {
+            debounced = false;
+            this._for_each_field_state(state => {
+                if (state.debounce_timer) {
+                    debug("running debounced trigger now", state_path(state));
+                    cockpit.assert(state.debounce_func);
+                    window.clearTimeout(state.debounce_timer);
+                    state.debounce_timer = 0;
+                    state.debounce_func();
+                    debounced = true;
+                }
+            });
+        } while (debounced);
+    }
+
     /* TASKS
 
        Tasks are a little abstraction that runs a asynchronous
-       function after a debounce timeout.  Before running the action
-       function, we need to wait for them all to finish.
+       function.  Before running the action function, we need to wait
+       for them all to finish.
      */
 
     async _run_all_tasks_now() {
-        let awaited: boolean = false;
+        let awaited: boolean;
         do {
-            this._for_each_field_state(state => {
-                if (state.validation_task)
-                    state.validation_task.start_now();
-                if (state.update_task)
-                    state.update_task.start_now();
-                for (const task of state.update_tasks.values())
-                    task.start_now();
-            });
+            // Start all the things that might have been queued up for
+            // debouncing.
+
+            this._run_all_debouncing_now();
+
+            // Wait for the tasks that are currently running.  While
+            // waiting, new things might have been qeued up for
+            // debouncing or new tasks might have been started, so we
+            // have to go back to the beginning.
 
             awaited = false;
             await this._for_each_field_state_async(async state => {
@@ -1201,7 +1274,6 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
     _validate_value_async(
         state: DialogFieldState,
         val: unknown,
-        debounce: number,
         func: (signal: AbortSignal) => Promise<unknown>
     ): void {
         state.relevant = true;
@@ -1213,7 +1285,6 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
                 state.validation_task.abort();
             state.validation_task = new DialogTask(
                 state_path(state) + ":validate",
-                debounce,
                 async task => {
                     const signal = task.get_abort_signal();
                     let result;
@@ -1238,12 +1309,13 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
 
     _set_value_async(
         state: DialogFieldState,
-        debounce: number,
         func: (signal: AbortSignal) => Promise<void>
     ): void {
-        const task = new DialogTask(
+        if (state.update_task)
+            state.update_task.abort();
+
+        state.update_task = new DialogTask(
             state_path(state) + ":set",
-            debounce,
             async task => {
                 try {
                     await func(task.get_abort_signal());
@@ -1256,20 +1328,14 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
                     state.update_task = null;
             }
         );
-
-        if (state.update_task)
-            state.update_task.abort();
-        state.update_task = task;
     }
 
     _get_value_async(
         state: DialogFieldState,
-        debounce: number,
         func: (signal: AbortSignal) => Promise<void>
     ): void {
         const task = new DialogTask(
             state_path(state) + ":get",
-            debounce,
             async task => {
                 try {
                     await func(task.get_abort_signal());
@@ -1339,12 +1405,13 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
             if (this.#cancel_function)
                 this.#cancel_function();
         } else {
+            this._cancel_debounce(this.#top_state);
             this._abort_state_tasks(this.#top_state);
             onClose();
         }
     }
 
-    top(update_func?: ((val: V) => void) | undefined): DialogField<V> {
+    top(changed_func?: ((values: V) => void) | undefined): DialogField<V> {
         return new DialogField<V>(
             this as DialogState<unknown>,
             this.#top_state,
@@ -1364,16 +1431,18 @@ export class DialogState<V> extends EventEmitter<DialogStateEvents> {
                 }
                 this.values = val;
                 this.#update();
+            },
+            () => {
                 if (this.#online_validation)
                     this.#trigger_validation();
-                if (update_func)
-                    update_func(val);
+                if (changed_func)
+                    changed_func(this.values);
             },
         );
     }
 
-    field<K extends keyof V>(tag: K, update_func?: ((val: V[K]) => void) | undefined): DialogField<V[K]> {
-        return this.top().sub(tag, update_func);
+    field<K extends keyof V>(tag: K, changed_func?: ((val: V[K]) => void) | undefined): DialogField<V[K]> {
+        return this.top().sub(tag, changed_func);
     }
 }
 
@@ -1635,6 +1704,7 @@ export const OptionalFormGroup = ({
 export const DialogTextInput = ({
     label = null,
     field,
+    debounce,
     excuse,
     warning,
     explanation,
@@ -1644,6 +1714,7 @@ export const DialogTextInput = ({
 } : {
     label?: React.ReactNode,
     field: DialogField<string>,
+    debounce?: number | undefined,
     excuse?: string | falsy,
     warning?: React.ReactNode,
     explanation?: React.ReactNode,
@@ -1656,7 +1727,7 @@ export const DialogTextInput = ({
                 id={fid}
                 ouiaId={field.ouia_id()}
                 value={field.get()}
-                onChange={(_event, val) => field.set(val)}
+                onChange={(_event, val) => field.set_debounced(val, debounce)}
                 isDisabled={!!excuse || isDisabled}
                 {...props}
             />
@@ -1668,6 +1739,7 @@ export const DialogTextInput = ({
 export const DialogPasswordInput = ({
     label = null,
     field,
+    debounce,
     excuse,
     warning,
     explanation,
@@ -1677,6 +1749,7 @@ export const DialogPasswordInput = ({
 } : {
     label?: React.ReactNode,
     field: DialogField<string>,
+    debounce?: number | undefined,
     excuse?: string | falsy,
     warning?: React.ReactNode,
     explanation?: React.ReactNode,
@@ -1693,7 +1766,7 @@ export const DialogPasswordInput = ({
                         ouiaId={field.ouia_id()}
                         type={visible ? "text" : "password"}
                         value={field.get()}
-                        onChange={(_event, value) => field.set(value)}
+                        onChange={(_event, value) => field.set_debounced(value, debounce)}
                         isDisabled={!!excuse || isDisabled}
                         {...props}
                     />

--- a/pkg/playground/dialog.tsx
+++ b/pkg/playground/dialog.tsx
@@ -107,11 +107,11 @@ const NameInput = ({
 } : {
     field: DialogField<Name>,
 }) => {
-    return <DialogTextInput field={field.sub("name")} />;
+    return <DialogTextInput field={field.sub("name")} debounce={1000} />;
 };
 
 function validate_Name(field: DialogField<Name>, countAsyncValidation: () => void) {
-    field.sub("name").validate_async(1000, async (n, signal) => {
+    field.sub("name").validate_async(async (n, signal) => {
         await async_sleep(2000);
         countAsyncValidation();
         if (!signal.aborted)
@@ -256,7 +256,7 @@ const ExampleDialog = ({
             });
         }
         if (dlg.values.dropdown == "three") {
-            dlg.field("text3").validate_async(1000, async v => {
+            dlg.field("text3").validate(v => {
                 if (!v)
                     return "Can't be empty";
             });
@@ -299,8 +299,8 @@ const ExampleDialog = ({
         }
     }
 
-    function update_color() {
-        dlg.field("color").get_async(0, async (val, signal) => {
+    function color_changed() {
+        dlg.field("color").get_async(async (val, signal) => {
             signal.onabort = countAsyncCancel;
             await async_sleep(2000);
             if (!signal.aborted) {
@@ -310,8 +310,8 @@ const ExampleDialog = ({
         });
     }
 
-    function update_dropdown(val: string) {
-        dlg.field("text2").set_async(0, async () => {
+    function dropdown_changed(val: string) {
+        dlg.field("text2").set_async(async () => {
             await async_sleep(2000);
             return val;
         });
@@ -337,6 +337,7 @@ const ExampleDialog = ({
                     <DialogTextInput
                         label="Text"
                         field={dlg.field("text")}
+                        debounce={0}
                         excuse={!dlg.values.flag && "Disabled"}
                         explanation="Explanation"
                         warning={dlg.values.text == "warn" ? "Warning" : null}
@@ -374,7 +375,7 @@ const ExampleDialog = ({
                     />
                     <DialogDropdownSelect
                         label="Dropdown"
-                        field={dlg.field("dropdown", update_dropdown)}
+                        field={dlg.field("dropdown", dropdown_changed)}
                         options={
                             [
                                 { value: "one", label: "Eins" },
@@ -386,11 +387,11 @@ const ExampleDialog = ({
                     />
                     {
                         dlg.values.dropdown == "three" &&
-                            <DialogTextInput label="Text3" field={dlg.field("text3")} />
+                            <DialogTextInput label="Text3" field={dlg.field("text3")} debounce={1000} />
                     }
                     <DialogDropdownSelectObject
                         label="DropdownObject"
-                        field={dlg.field("color", update_color)}
+                        field={dlg.field("color").notify(color_changed)}
                         options={colors}
                         option_label={c => c.name}
                     />
@@ -591,7 +592,7 @@ const AsyncExampleDialog = ({
     }
 
     function validate(dlg: DialogState<AsyncExampleValues>) {
-        dlg.field("text").validate_async(0, async () => {
+        dlg.field("text").validate_async(async () => {
             throw Error("upps");
         });
     }
@@ -607,7 +608,7 @@ const AsyncExampleDialog = ({
         Dialogs.close();
     }
 
-    function update_top(values: AsyncExampleValues) {
+    function top_changed(values: AsyncExampleValues) {
         console.log("TOP", JSON.stringify(values));
     }
 
@@ -621,10 +622,10 @@ const AsyncExampleDialog = ({
     } else if (dlg instanceof DialogError) {
         body = null;
     } else if (dlg instanceof DialogState) {
-        const vals = dlg.top(update_top);
+        const fields = dlg.top(top_changed);
         body = (
             <Form isHorizontal>
-                <DialogTextInput label="Text" field={vals.sub("text")} />
+                <DialogTextInput label="Text" field={fields.sub("text")} />
             </Form>
         );
     }

--- a/test/verify/check-dialog
+++ b/test/verify/check-dialog
@@ -183,50 +183,41 @@ class TestDialog(testlib.MachineCase):
 
         # Debounced and asynchronous validation
 
-        def enter_online_validation_mode():
-            # put dialog into online validation mode by triggering a
-            # failed validation
-            d.set_Checkbox("flag", val=True)
-            d.set_TextInput("text", "")
-            b.click(d.apply_button())
-            b.wait_in_text(d.helper_text("text"), "Text can not be empty")
-            d.set_Checkbox("flag", val=False)
-
         b.click("#open")
         enter_online_validation_mode()
+        # Add a field. This immediately starts a validation. (1 validation)
         b.click(d.id("async", "add"))
         b.focus(d.field("async.0.name"))
         b.input_text("1")
-        # wait for debounce timeout and validation promise to be done (1 validation)
+        # wait for debounce timeout and validation promise to be done (2 validations)
         b.wait_in_text(d.helper_text("async.0.name"), "Must have even number")
         b.input_text("2")
-        # this starts a new timeout and immediately removes the validation error
-        b.wait_not_present(d.helper_text("async.0.name"))
-        # don't wait for the timeout to be over but change again while it is still pending
+        # this starts a new debounce timeout but the validation error stays
+        # don't wait for the debounce timeout to be over but change again while it is still pending
         time.sleep(0.5)
         b.input_text("3")
         # now wait for the timeout to be over but change while the promise is running
         time.sleep(2)
         b.input_text("4")
-        # the promise for validating "123" will finish soon, but it's result must be ignored (2 validations)
-        # let the validation for "1234" play out to completion (3 validations)
+        # the promise for validating "123" will finish soon, but it's result must be ignored (3 validations)
+        # let the validation for "1234" play out to completion (4 validations)
         time.sleep(5)
         # close dialog
         b.click(d.apply_button())
         b.wait_not_present("#dialog")
 
         b.wait_text("#async", "1234:4")
-        b.wait_text("#asyncVals", "3")
+        b.wait_text("#asyncVals", "4")
 
         b.click("#open")
         enter_online_validation_mode()
-        b.click(d.id("async", "add"))
-        b.click(d.id("async", "add"))
+        b.click(d.id("async", "add"))  # (1 validation)
+        b.click(d.id("async", "add"))  # (2 validations)
         b.focus(d.field("async.1.name"))
         b.input_text("1")
         # remove the first entry during the debounce timeout, this
         # should not disturb anything and the validation for "1"
-        # should finish normally (1 validation)
+        # should finish normally (3 validations)
         b.wait_not_present(d.helper_text("async.0.name"))
         b.click(d.id("async.0", "remove"))
         b.wait_in_text(d.helper_text("async.0.name"), "Must have even number")
@@ -236,7 +227,7 @@ class TestDialog(testlib.MachineCase):
         b.wait_not_present("#dialog")
 
         b.wait_text("#async", "")
-        b.wait_text("#asyncVals", "1")
+        b.wait_text("#asyncVals", "3")
 
         # Trigger validation directly via Apply. This will skip the
         # timeouts.
@@ -251,12 +242,13 @@ class TestDialog(testlib.MachineCase):
         b.wait_text("#asyncVals", "1")
 
         # Trigger validation via Apply when there are timeouts
-        # pending. This will cancel the timeouts.
+        # pending. This will skip the timeouts.
 
         b.click("#open")
         enter_online_validation_mode()
         b.click(d.id("async", "add"))
-        # now there is a timeout pending, clicking apply will cancel it.
+        # now there is a timeout pending, clicking apply will run it
+        # immediately and it will be counted.
         b.click(d.apply_button())
         b.wait_not_present("#dialog")
 
@@ -314,7 +306,8 @@ class TestDialog(testlib.MachineCase):
 
         b.mouse(d.ouia("apply-force"), "mouseenter")
         b.wait_in_text(".pf-v6-c-tooltip", "Force not allowed")
-        b.mouse(d.apply_button(), "mouseenter")  # make tooltip disappear, it obscures the checkbox otherwise
+        b.mouse(d.ouia("apply-force"), "mouseleave")  # make tooltip disappear, it obscures the checkbox otherwise
+        b.wait_not_present(".pf-v6-c-tooltip")
         d.set_Checkbox("allow_force", val=True)
         b.click(d.ouia("apply-force"))
         b.wait_not_present("#dialog")


### PR DESCRIPTION
Debouncing was controlled in the wrong place in the API, during validation and when starting asynchronous computations for new field values.  Instead, it should be specified when handling the event that causes a dialog field to change.  When the event is the result of keyboard input, it should be debounced, but when it comes from a dropdown menu, it should not be.

This matters when a dialog field is changed by different events, for example when a file can either be typed by the user, or selected from the FileChooser dialog.  We want to debounce the former but not the latter.  (It's not a huge problem if the FileChooser selection is also debounced, but it is still not something we want, we just tolerate because the API can't do it otherwise.)

A better example is when a single function should run when any of a number of fields changes.  Some fields should cause debounce the calling of that function, but other should not.

Thus, the "debounce" arguments of "handle.validate_async", "handle.set_async", and "handle.get_async" have been removed. Instead, there is a new "handle.set_debounced" function.  This function is used by DialogTextInput and DialogPasswordInput and should in general be used by all events that result from keyboard input.

There are no "handle.add_debounced" or "handle.remove_debounced" functions although theoretically there should be, since they are special cases of "handle.set".
