### PR TITLE
test: Replace setTimeout with requestAnimationFrame

### DIFF
--- a/test/common/test-functions.js
+++ b/test/common/test-functions.js
@@ -98,9 +98,10 @@ window.ph_find_scroll_into_view = function(sel) {
        window.innerHeight does not work if the element is in e.g. a scrollable dialog area */
     return new Promise(resolve => {
         el.scrollIntoView({ behavior: 'instant', block: 'center', inline: 'center' });
-        // scrolling needs a little bit of time to stabilize, and it's not predictable
-        // in particular, 'scrollend' is not reliably emitted
-        window.setTimeout(() => resolve(el), 200);
+        // Force a paint to happen as 'scrollend' is not reliably emitted.
+        // requestAnimationFrame is called before the next paint, so two are
+        // needed.
+        window.requestAnimationFrame(() => window.requestAnimationFrame(() => resolve(el)));
     });
 };
 


### PR DESCRIPTION
Replace the fixed 200ms "sleep" with a forced re-paint, for TestAccounts.testBasic this saves 7 seconds in the total test run.


[jelle@carbon][~/projects/cockpit-bots]%./compare-pr-runs.py --output table --repo cockpit-project/cockpit --filter other --base 23693 23435
Test failures for context: 'fedora-44/other', skipping...
Test failures for context: 'arch/other', skipping...
| context                      | total time (sec) | base time (sec) | diff (sec) | tests | nd tests |
| ---------------------------- | ---------------- | --------------- | ---------- | ----- | -------- |
| arch/other                   | 853              | 943             | -90        | 37    | 129      |
| centos-9-bootc/other         | 798              | 1003            | -205       | 37    | 129      |
| debian-testing/other         | 853              | 1058            | -205       | 37    | 129      |
| debian-trixie/other          | 868              | 1043            | -175       | 37    | 129      |
| fedora-43/other              | 903              | 1128            | -225       | 37    | 129      |
| fedora-44/firefox-other      | 903              | 1124            | -221       | 37    | 129      |
| fedora-44/other              | 928              | 1014            | -86        | 37    | 129      |
| opensuse-tumbleweed/other    | 773              | 983             | -210       | 37    | 129      |
| rhel-8-10/ws-container-other | 823              | 1023            | -200       | 37    | 129      |
| rhel-9-9/other               | 883              | 1108            | -225       | 37    | 129      |
| ubuntu-2604/other            | 938              | 1088            | -150       | 37    | 129      |
| ubuntu-stable/other          | 909              | 1084            | -175       | 37    | 129      |

Average difference: -181s across 12 contexts

---

[jelle@carbon][~/projects/cockpit-bots]%./compare-pr-runs.py --output table --repo cockpit-project/cockpit --filter storage --base 23693 23435
Test failures for context: 'rhel-8-10/ws-container-storage', skipping...
Test failures for context: 'rhel-8-10/ws-container-storage', skipping...
Test failures for context: 'rhel-8-10/ws-container-storage', skipping...
| context                   | total time (sec) | base time (sec) | diff (sec) | tests | nd tests |
| ------------------------- | ---------------- | --------------- | ---------- | ----- | -------- |
| arch/storage              | 694              | 713             | -19        | 32    | 88       |
| centos-9-bootc/storage    | 648              | 663             | -15        | 32    | 88       |
| debian-testing/storage    | 703              | 729             | -26        | 32    | 88       |
| debian-trixie/storage     | 708              | 718             | -10        | 32    | 88       |
| fedora-43/storage         | 775              | 810             | -35        | 32    | 88       |
| fedora-44/firefox-storage | 805              | 835             | -30        | 32    | 88       |
| fedora-44/storage         | 820              | 830             | -10        | 32    | 88       |
| rhel-9-9/storage          | 760              | 730             | +30        | 32    | 88       |
| ubuntu-2604/storage       | 783              | 753             | +30        | 32    | 88       |
| ubuntu-stable/storage     | 733              | 738             | -5         | 32    | 88       |

