### PR TITLE
networkmanager: Disable activating new connections

### DIFF
--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -1435,10 +1435,11 @@ export function NetworkManagerModel() {
             add_connection: function (conf) {
                 // https://www.networkmanager.dev/docs/api/latest/nm-dbus-types.html
                 const NM_SETTINGS_ADD_CONNECTION2_FLAG_TO_DISK = 0x1;
+                const NM_SETTINGS_ADD_CONNECTION2_FLAG_BLOCK_AUTOCONNECT = 0x20;
                 return call_object_method(this,
                                           'org.freedesktop.NetworkManager.Settings',
                                           'AddConnection2',
-                                          settings_to_nm(conf, { }), NM_SETTINGS_ADD_CONNECTION2_FLAG_TO_DISK, { })
+                                          settings_to_nm(conf, { }), NM_SETTINGS_ADD_CONNECTION2_FLAG_TO_DISK | NM_SETTINGS_ADD_CONNECTION2_FLAG_BLOCK_AUTOCONNECT, { })
                         .then(([path]) => get_object(path, type_Connection));
             }
         },

--- a/test/verify/check-networkmanager-bond
+++ b/test/verify/check-networkmanager-bond
@@ -79,8 +79,7 @@ class TestBonding(netlib.NetworkCase):
 
         # Deactivate the bond and make sure it is still there after a
         # reload.
-        self.wait_onoff("label[for='interface-switch']", val=True)
-        self.toggle_onoff("label[for='interface-switch']")
+        self.wait_onoff("label[for='interface-switch']", val=False)
         self.wait_for_iface_setting('Status', 'Inactive')
         b.wait_not_present("#interface-switch:disabled")
 
@@ -166,6 +165,8 @@ class TestBonding(netlib.NetworkCase):
         self.addCleanup(m.execute, "nmcli dev delete tbond3000 2>/dev/null || true")
 
         b.wait_text("#network-interface-name", "tbond")
+        self.wait_onoff("#network-interface .pf-v6-c-card__header", val=False)
+        self.toggle_onoff("label[for='interface-switch']")
         self.wait_onoff("#network-interface .pf-v6-c-card__header", val=True)
 
         self.configure_iface_setting('Bond')
@@ -211,6 +212,7 @@ class TestBonding(netlib.NetworkCase):
         # Check that it has the interface and the right IP address
         b.wait_text("#network-interface-name", "tbond")
         b.wait_visible(f"#network-interface-members tr[data-interface='{iface}']")
+        self.toggle_onoff("label[for='interface-switch']")
         b.wait_in_text("#network-interface .pf-v6-c-card:contains('tbond')", ip)
 
     def testPrimary(self):

--- a/test/verify/check-networkmanager-bridge
+++ b/test/verify/check-networkmanager-bridge
@@ -42,6 +42,7 @@ class TestBridge(netlib.NetworkCase):
         b.set_checked(f"input[data-iface='{iface2}']", val=True)
         b.click("#network-bridge-settings-dialog button:contains('Add')")
         b.wait_not_present("#network-bridge-settings-dialog")
+        self.toggle_onoff("label[for='interface-switch']")
 
         # Check that the members are displayed and both On
         b.wait_text("#network-interface-name", "tbridge")
@@ -114,6 +115,7 @@ class TestBridge(netlib.NetworkCase):
         # Check that it has the interface and the right IP address
         b.wait_text("#network-interface-name", "tbridge")
         b.wait_visible(f"#network-interface-members tr[data-interface='{iface}']")
+        self.toggle_onoff("label[for='interface-switch']")
         b.wait_in_text("#network-interface .pf-v6-c-card:contains('tbridge')", "10.111")
 
         # Check bridge port

--- a/test/verify/check-networkmanager-mac
+++ b/test/verify/check-networkmanager-mac
@@ -61,6 +61,8 @@ class TestNetworkingMAC(netlib.NetworkCase):
         b.set_checked(f"input[data-iface='{iface2}']", val=True)
         b.click("#network-bond-settings-dialog button:contains('Add')")
         b.wait_not_present("#network-bond-settings-dialog")
+        self.toggle_onoff("label[for='interface-switch']")
+        self.wait_onoff("#network-interface .pf-v6-c-card__header", val=True)
 
         b.wait_text("#network-interface-name", "tbond")
         mac = m.execute("cat /sys/class/net/tbond/address").strip()

--- a/test/verify/check-networkmanager-other
+++ b/test/verify/check-networkmanager-other
@@ -38,7 +38,13 @@ class TestNetworkingOther(netlib.NetworkCase):
         b.click("#network-ip-settings-dialog button:contains('Save')")
         self.addCleanup(m.execute, "nmcli con del tun0")
         b.wait_not_present("#network-ip-settings-dialog")
-        self.wait_for_iface_setting('Status', '1.2.3.4/24')
+        b.wait_visible("#network-interface")
+        b.wait_text("#network-interface-name", "tun0")
+        self.wait_for_iface_setting('IPv4', 'Address 1.2.3.4/24')
+        self.toggle_onoff("label[for='interface-switch']")
+        self.wait_onoff("#network-interface .pf-v6-c-card__header", val=True)
+        with b.wait_timeout(60):
+            self.wait_for_iface_setting('Status', '1.2.3.4/24')
 
 
 if __name__ == '__main__':

--- a/test/verify/check-networkmanager-settings
+++ b/test/verify/check-networkmanager-settings
@@ -44,6 +44,7 @@ class TestNetworkingSettings(netlib.NetworkCase):
         b.click("#network-ip-settings-save")
         b.wait_not_present("#network-ip-settings-dialog")
         self.wait_for_iface_setting('IPv4', 'Address 1.2.3.4/24')
+        self.toggle_onoff("label[for='interface-switch']")
 
         def assert_connection_setting(con_id, field, value):
             self.assertEqual(m.execute(f'nmcli -m tabular -t -f {field} con show "{con_id}"').strip(),

--- a/test/verify/check-networkmanager-team
+++ b/test/verify/check-networkmanager-team
@@ -46,6 +46,7 @@ class TestTeam(netlib.NetworkCase):
         b.set_checked(f"input[data-iface='{iface2}']", val=True)
         b.click("#network-team-settings-dialog button:contains('Add')")
         b.wait_not_present("#network-team-settings-dialog")
+        self.toggle_onoff("label[for='interface-switch']")
 
         b.wait_text("#network-interface-name", "tteam")
         b.wait(lambda: 'nmcli con show | grep tteam')
@@ -96,6 +97,7 @@ class TestTeam(netlib.NetworkCase):
         b.set_checked(f"input[data-iface='{iface}']", val=True)
         b.click("#network-team-settings-dialog button:contains('Add')")
         b.wait_not_present("#network-team-settings-dialog")
+        self.toggle_onoff("label[for='interface-switch']")
 
         b.wait_text("#network-interface-name", "tteam")
         b.wait(lambda: 'nmcli con show | grep tteam')

--- a/test/verify/check-networkmanager-team
+++ b/test/verify/check-networkmanager-team
@@ -20,6 +20,7 @@ class TestTeam(netlib.NetworkCase):
         b = self.browser
 
         self.login_and_go("/network")
+        b.wait_visible("#networking")
 
         b.wait_visible("button:contains('Add team')")
 

--- a/test/verify/check-networkmanager-vlan
+++ b/test/verify/check-networkmanager-vlan
@@ -38,6 +38,7 @@ class TestNetworkingVLAN(netlib.NetworkCase):
         b.set_input_text("#network-vlan-settings-vlan-id-input", "123")
         b.click("#network-vlan-settings-dialog button:contains('Add')")
         b.wait_not_present("#network-vlan-settings-dialog")
+        self.toggle_onoff("label[for='interface-switch']")
         b.wait_text("#network-interface-name", "tvlan")
 
         # It automatically activates.  It won't get an IP address, but that's okay.

--- a/test/verify/check-networkmanager-wireguard
+++ b/test/verify/check-networkmanager-wireguard
@@ -127,6 +127,7 @@ class TestWireGuard(packagelib.PackageCase, netlib.NetworkCase):
                                 "#network-wireguard-settings-publickey-peer-0"])
         b.click("#network-wireguard-settings-save")
         b.wait_not_present("#network-wireguard-settings-dialog")
+        self.toggle_onoff("label[for='interface-switch']")
         b.wait_text("#network-interface-name", iface_name)
         self.wait_for_iface_setting("Status", f"1.2.3.4/32, {m1_ip4}/24")
 
@@ -160,6 +161,7 @@ class TestWireGuard(packagelib.PackageCase, netlib.NetworkCase):
         b2.set_input_text("#network-wireguard-settings-allowedips-peer-0", f"{m1_ip4}/32")
         b2.click("#network-wireguard-settings-save")
         b2.wait_not_present("#network-wireguard-settings-dialog")
+        b2.click("label[for='interface-switch'] input[type=checkbox]")
         b2.wait_text("#network-interface-name", m2_iface_name)
         b2.wait_in_text("[data-label='Status']", f"{m2_ip4}/24")
 
@@ -303,6 +305,7 @@ class TestWireGuard(packagelib.PackageCase, netlib.NetworkCase):
         b.click("#network-wireguard-settings-save")
         b.wait_not_present("#network-wireguard-settings-dialog")
         b.wait_text("#network-interface-name", wg1_iface)
+        self.toggle_onoff("label[for='interface-switch']")
         self.wait_for_iface_setting("IPv6", f"{m1_wg1_ipv6}/64")
 
         m1.execute(f"until wg show wg1 | grep -q 'allowed ips.*{m2_wg1_ipv6}/128'; do sleep 1; done")
@@ -318,6 +321,7 @@ class TestWireGuard(packagelib.PackageCase, netlib.NetworkCase):
         b2.set_input_text("#network-wireguard-settings-allowedips-peer-0", f"{m1_wg1_ipv6}/128")
         b2.click("#network-wireguard-settings-save")
         b2.wait_not_present("#network-wireguard-settings-dialog")
+        b2.click("label[for='interface-switch'] input[type=checkbox]")
         b2.wait_text("#network-interface-name", wg1_iface)
         b2.wait_in_text("[data-label='IPv6']", f"{m2_wg1_ipv6}/64")
 


### PR DESCRIPTION
When adding a new virtual network interface (bond,bridge,vpn) or
configuring a new connection (e.g. ethernet/wifi) don't activate it
directly but allow a system administrator to configure it first.

This behaviour is similar to what GNOME does when adding new network interfaces.

Closes: https://redhat.atlassian.net/browse/RHEL-34153

---

# networkmanager: Don't activate network connections by default

Previously Cockpit would automatically activate a new VLAN interface without allowing an administrator to configure it first. All new connections are now disabled by default.