### PR TITLE
AWS runner -  systemd flakes

### DIFF
--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -1286,6 +1286,7 @@ Where=/fail
 
         # Changing the UI filters should also affect the URL
         b.click("#system")
+        self.wait_page_load()
         url = b.eval_js("window.location.hash")
         self.assertIn("owner=system", url)
 


### PR DESCRIPTION
Fixes [testServicesFiltersURLConsistency](https://cockpit-ci-logs.s3.us-east-1.amazonaws.com/pull-23442-9e9756d4-20260706-153614-arch-other/log.html) retries