### PR TITLE
workflows: declare permissions for verify-antora

### DIFF
--- a/.github/workflows/verify-antora.yml
+++ b/.github/workflows/verify-antora.yml
@@ -8,6 +8,8 @@ on:
       - main
 jobs:
   verify-antora:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
The permissions are otherwise inherited from the Cockpit repository and organisation settings.