### PR TITLE
test/realms: Bump memory to 2000MB

### DIFF
--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -483,7 +483,7 @@ class TestRealms(testlib.MachineCase):
 
     provision = {
         "0": {"address": "10.111.113.1/20", "dns": "10.111.112.100"},
-        "services": {"image": "services", "memory_mb": 1500}
+        "services": {"image": "services", "memory_mb": 2048}
     }
 
     def setUp(self):
@@ -1009,7 +1009,7 @@ sed -i '/^sudoers:/ s/files sss/sss files/' /etc/nsswitch.conf
 class TestKerberos(testlib.MachineCase):
     provision = {
         "0": {"address": "10.111.113.1/20", "dns": "10.111.112.100"},
-        "services": {"image": "services", "memory_mb": 1500}
+        "services": {"image": "services", "memory_mb": 2048}
     }
 
     def setUp(self):


### PR DESCRIPTION
When testing there were stderr about memory issues for the freeipa
container. Not evident by looking at the logs themselves but saw it
without detached mode on.

Tested using `bots/vm-run services -M 2000`. Might not work on your
local machine as I also modified services image.

See-also: https://github.com/cockpit-project/bots/pull/9260
Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
