### PR TITLE
storaged: Fix subvol option parsing

### DIFF
--- a/pkg/storaged/btrfs/utils.jsx
+++ b/pkg/storaged/btrfs/utils.jsx
@@ -54,7 +54,7 @@ export function btrfs_is_volume_mounted(client, block_devices) {
 export function parse_subvol_from_options(options) {
     const subvol = { };
     const subvolid_match = options.match(/subvolid=(?<subvolid>\d+)/);
-    const subvol_match = options.match(/subvol=(?<subvol>[\w\\/]+)/);
+    const subvol_match = options.match(/subvol=(?<subvol>[^\s,]+)/);
     if (subvolid_match)
         subvol.id = subvolid_match.groups.subvolid;
     if (subvol_match)

--- a/test/verify/check-storage-anaconda
+++ b/test/verify/check-storage-anaconda
@@ -297,6 +297,14 @@ class TestStorageAnaconda(storagelib.StorageCase):
         self.dialog_apply()
         self.dialog_wait_close()
 
+        # Popular subvolume names starting with @ are allowed.
+        self.click_dropdown(self.card_row("Storage", location=f"{self.mnt_dir}/butter"), "Create subvolume")
+        self.dialog_wait_open()
+        self.dialog_set_val("name", "@data")
+        self.dialog_set_val("mount_point", "/data")
+        self.dialog_apply()
+        self.dialog_wait_close()
+
         # Lock, mount point exporting should still work
 
         self.click_dropdown(self.card_row("Storage", name=disk), "Lock")
@@ -317,6 +325,9 @@ class TestStorageAnaconda(storagelib.StorageCase):
                                               },
                                               "home": {
                                                   "dir": "/home"
+                                              },
+                                              "@data": {
+                                                  "dir": "/data"
                                               },
                                           }
                                       }


### PR DESCRIPTION
The previous regex didn't allow for '@', a popular naming convention for btrfs subvolumes. btrfs subvolumes are path names and Cockpit should not have to validate if subvol is well formed but just parse it.

Related:  https://bugzilla.redhat.com/show_bug.cgi?id=2483145