### PR TITLE
shell: Fix SSH keys list layout in WebKit browsers

### DIFF
--- a/pkg/shell/credentials.scss
+++ b/pkg/shell/credentials.scss
@@ -9,7 +9,10 @@
     font-weight: var(--pf-t--global--font--weight--heading--bold);
   }
 
-  td:last-child {
+  // Shrink-wrap the key toggle column, but leave the expanded content's
+  // spanning cell alone: WebKit distributes a percentage width on a colspan
+  // cell across all spanned columns, which blows up the expand toggle column.
+  td:last-child:not([colspan]) {
     inline-size: 1%;
   }
 


### PR DESCRIPTION
Fixes #23053

The SSH keys dialog (Session menu → SSH keys) shrink-wraps the key toggle column with `inline-size: 1%` on `td:last-child`. That selector also matches the spanning cell (`colspan=3`) of the expanded content rows. Since expandable rows stay in the layout while collapsed (they are only `visibility: hidden` because of the `pf-m-animate-expand` table modifier), WebKit-based browsers — Cockpit Client and GNOME Web — distribute the percentage width of that spanning cell across all spanned columns. This inflates the expand toggle column and produces the large gap between the expand toggle and the key file name seen in the issue screenshot. Chromium and Firefox resolve the same markup without any visible problem, which is why the pixel tests never caught it.

Exempting cells with a `colspan` from the width override keeps the toggle switch column shrink-wrapped while leaving the expanded-content cell alone.

Verified by rendering the dialog in Playwright WebKit, Firefox, and Chrome: before the change the WebKit column widths were `[162, 544, 87]` (expand toggle, name, switch) vs. `[37, 680, 75]` in the other engines; after the change all three engines agree, and the expanded panel still spans the full table width. Expand/collapse behaviour is unchanged.