### PR TITLE
shell: Use `isActionCell` for SSH modal switch

### DIFF
--- a/pkg/shell/credentials.scss
+++ b/pkg/shell/credentials.scss
@@ -9,10 +9,6 @@
     font-weight: var(--pf-t--global--font--weight--heading--bold);
   }
 
-  td:last-child {
-    inline-size: 1%;
-  }
-
   // Remove excess padding from compact tables toggles
   // And adjust the padding to left align the toggles with the card header
   .pf-v6-c-table {

--- a/pkg/shell/credentials.tsx
+++ b/pkg/shell/credentials.tsx
@@ -324,6 +324,9 @@ export const CredentialsModal = ({
                                                            isChecked={!!currentKey.loaded}
                                                            key={"switch-" + index}
                                                            onChange={(_event, value) => onToggleKey(currentKeyId, value)} />,
+                                            props: {
+                                                isActionCell: true
+                                            }
                                         }
                                     ],
                                     expandedContent,


### PR DESCRIPTION
Previously a hack was used to make the cell `inline-size: 0`. Though that worked it had some unintended side-effects which made Cockpit Client and some other WebKit clients render the other cells incorrectly as there is expandable rows.

Adding in `isActionCell: true` to the cell that contains the switch fixes the issue. With that we can also remove the CSS rule that was meant to fix this, but ultimately caused the weird spacing on Cockpit Client et. al.

Fixes: https://github.com/cockpit-project/cockpit/issues/23053