### PR TITLE
doc: Add cockpit-version from playbook

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -13,3 +13,6 @@ ui:
     snapshot: true
 output:
   dir: ./doc/output/antora
+asciidoc:
+  attributes:
+    cockpit-version: latest+git

--- a/doc/antora.yml
+++ b/doc/antora.yml
@@ -2,10 +2,6 @@ name: cockpit-guide
 version: true
 title: Cockpit
 start_page: guide:index.adoc
-asciidoc:
-  attributes:
-    # Set by CLI option --attribute=cockpit-version=123
-    cockpit-version: latest
 nav:
 - modules/guide/nav.adoc
 - modules/man/nav.adoc


### PR DESCRIPTION
We had set the cockpit-version attribute from the antora file which is used by playbooks. This makes the attribute become locked and can't be modified beforehand (that easily).

Proper usage, for us at least, is to update the cockpit-version through an extension in cockpit-docs repo instead. This is only really a hack we have to do due to publishing through tags instead of branches.