### PR TITLE
selinux: give cockpit_session_t Kerberos access

### DIFF
--- a/selinux/cockpit.te
+++ b/selinux/cockpit.te
@@ -120,8 +120,9 @@ optional_policy(`
 ')
 
 optional_policy(`
-    kerberos_use(cockpit_ws_t)
-    kerberos_etc_filetrans_keytab(cockpit_ws_t)
+    kerberos_use(cockpit_session_t)
+    kerberos_etc_filetrans_keytab(cockpit_session_t)
+    kerberos_filetrans_named_content(cockpit_session_t)
 ')
 
 optional_policy(`

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -1058,11 +1058,18 @@ class TestKerberos(testlib.MachineCase):
         # user has no cockpit kerberos session tickets initially
         m.execute("! ls /run/user/$(id -u admin)/*.ccache")
 
+        # clear the krb5 replay cache so we can verify it gets created with
+        # the correct SELinux context (krb5_host_rcache_t, not cockpit_tmp_t)
+        m.execute("rm -f /var/tmp/krb5_0.rcache2")
+
         output = m.execute(['/usr/bin/curl', '-s', '--negotiate', '--delegation', 'always', '-u', ':', "-D", "-",
                             '--resolve', 'x0.cockpit.lan:9090:10.111.113.1',
                             'http://x0.cockpit.lan:9090/cockpit/login'])
         self.assertIn("HTTP/1.1 200 OK", output)
         self.assertIn('"csrf-token"', output)
+
+        context = m.execute("ls -Z /var/tmp/krb5_0.rcache2")
+        self.assertIn("krb5_host_rcache_t", context)
 
         cookie = re.search("Set-Cookie: cockpit=([^ ;]+)", output).group(1)
         b.open("/system/terminal", cookie={"name": "cockpit", "value": cookie, "domain": m.web_address, "path": "/"})


### PR DESCRIPTION
Our cockpit.te file incorrectly allows access to Kerberos to cockpit-ws, which doesn't actually need to use it at all.  cockpit-session does, however, and it's currently creating /var/tmp/krb5_0.rcache2 with an incorrect SELinux label.

Change the SELinux `kerberos` macros to reference `cockpit_session_t` and add `kerberos_filetrans_named_content` to make sure we get the right label.

Add a test (which was failing before this change).

https://redhat.atlassian.net/browse/RHEL-185926