### PR TITLE
storage: Remember passphrase for encrypted Stratis pools in Anaconda mode

### DIFF
--- a/pkg/storaged/stratis/create-dialog.jsx
+++ b/pkg/storaged/stratis/create-dialog.jsx
@@ -10,6 +10,7 @@ import { dialog_open, TextInput, CheckBoxes, PassInput, SelectSpaces } from "../
 import { decode_filename, get_available_spaces, prepare_available_spaces } from "../utils.js";
 
 import { validate_pool_name, std_reply, get_unused_keydesc, with_stored_passphrase, confirm_tang_trust } from "./utils.jsx";
+import { remember_passphrase } from "../anaconda.jsx";
 import { validate_url, get_tang_adv } from "../crypto/tang.jsx";
 
 const _ = cockpit.gettext;
@@ -151,6 +152,13 @@ export function create_stratis_pool() {
                         return manager_create_pool(vals.name, devs, key_desc, clevis_info)
                                 .then(std_reply)
                                 .then(result => {
+                                    if (key_desc && vals.passphrase) {
+                                        for (const p of paths) {
+                                            const block = client.blocks[p];
+                                            if (block)
+                                                remember_passphrase(block, vals.passphrase);
+                                        }
+                                    }
                                     if (vals.overprov && !vals.overprov.on && result[0]) {
                                         const path = result[1][0];
                                         return client.wait_for(() => client.stratis_pools[path])

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -224,6 +224,7 @@ if [ "$PLAN" = "storage-extra" ]; then
     # These don't test more external APIs
     EXCLUDES="$EXCLUDES
               TestStorageAnaconda.testBasic
+              TestStorageAnaconda.testStratis
 
               TestStorageMountingLUKS.testEncryptedMountingHelp
               TestStorageMountingLUKS.testDuplicateMountPoints

--- a/test/verify/check-storage-anaconda
+++ b/test/verify/check-storage-anaconda
@@ -164,6 +164,7 @@ class TestStorageAnaconda(storagelib.StorageCase):
 
     @testlib.skipImage("No Stratis", "debian-*", "ubuntu-*", "arch")
     @testlib.skipImage("commit 817c957899a4 removed Statis 2 support", "rhel-8-*")
+    @testlib.skipImage("Stratis v1 pools are unsupported", "rhel-9-*")
     def testStratis(self):
         m = self.machine
         b = self.browser
@@ -187,13 +188,17 @@ class TestStorageAnaconda(storagelib.StorageCase):
         self.login_and_go("/storage")
         self.enterAnacondaMode(anaconda_config)
 
-        # Create a Stratis pool
+        # Create an encrypted Stratis pool
         self.click_devices_dropdown("Create Stratis pool")
         self.dialog_wait_open()
         b.wait_count("#dialog .select-space-name", 1)
         self.dialog_set_val("disks", {disk: True})
+        self.dialog_set_val("encrypt_pass.on", val=True)
+        self.dialog_set_val("passphrase", "vainu-reku-toma-rolle-kaja")
+        self.dialog_set_val("passphrase2", "vainu-reku-toma-rolle-kaja")
         self.dialog_apply()
         self.dialog_wait_close()
+
         self.click_dropdown(self.card_row("Storage", name="pool0"), "Create new filesystem")
         self.dialog_wait_open()
         b.wait_not_present(self.dialog_field("at_boot"))
@@ -231,7 +236,8 @@ class TestStorageAnaconda(storagelib.StorageCase):
         self.dialog_wait_close()
         self.assertIn("noauto", m.execute("findmnt --fstab -n -o OPTIONS /sysroot/var"))
 
-        # Check exported mount point information.
+        # Check exported mount point and passphrase information.
+        self.expectExportedDevicePassphrase(disk, "vainu-reku-toma-rolle-kaja")
 
         self.expectExportedDevice("/dev/stratis/pool0/root",
                                   {
@@ -244,8 +250,8 @@ class TestStorageAnaconda(storagelib.StorageCase):
 
         # Check and delete pool
         b.click(self.card_parent_link())
-        b.wait_visible(self.card_row("Stratis pool", name=disk))
-        self.click_card_dropdown("Stratis pool", "Delete")
+        b.wait_visible(self.card_row("Encrypted Stratis pool", name=disk))
+        self.click_card_dropdown("Encrypted Stratis pool", "Delete")
         self.confirm()
         m.execute("! findmnt --fstab -n /sysroot/var")
 


### PR DESCRIPTION
When creating an encrypted Stratis pool in Anaconda mode, the passphrase was not stored in sessionStorage via cockpit_passphrases, so Anaconda could not retrieve it. This was already working for LUKS devices but missing for Stratis.

Call remember_passphrase for each block device used in the pool after successful encrypted pool creation, and update the integration test to create an encrypted pool and verify the passphrase is exported.

-----

This is part of Stratis support in Anaconda which is currently [proposed change for Fedora 45](https://fedoraproject.org/wiki/Changes/StratisAnacondaSupport).