### PR TITLE
WIP! apps: Migrate to AppStream API

### DIFF
--- a/pkg/apps/application-list.jsx
+++ b/pkg/apps/application-list.jsx
@@ -26,6 +26,24 @@ import { Title, TitleSizes } from "@patternfly/react-core/dist/esm/components/Ti
 
 const _ = cockpit.gettext;
 
+
+/**
+ * @typedef {import("_internal/packagemanager-abstract").ProgressCB} ProgressCB
+ */
+
+/**
+ * Checks if packages are installed on the system.
+ * @param {string[]} pkgnames Package names to check.
+ * @param {ProgressCB} progress_cb Callback function to indicate the progress of checking if a package is installed.
+ * @returns {Promise<string[]>} List of installed packages
+ */
+async function get_installed_packages(pkgnames, progress_cb) {
+    const packagemanager = await getPackageManager();
+    const data = await packagemanager.check_missing_packages(pkgnames, progress_cb);
+    return pkgnames.filter(pkgname => !data.missing_names.includes(pkgname))
+}
+
+
 async function refresh_appstream_metadata(origin_files, config_packages, data_packages, progress_cb) {
     /* In addition to refreshing the repository metadata, we also
      * update all packages that contain AppStream collection metadata.
@@ -82,7 +100,7 @@ async function refresh_appstream_metadata(origin_files, config_packages, data_pa
     }
 }
 
-const ApplicationRow = ({ comp, progress, progress_title, action }) => {
+const ApplicationRow = ({ comp, progress, progress_title, action, isInstalled }) => {
     const [error, setError] = useState();
 
     const name = (
@@ -131,7 +149,7 @@ const ApplicationRow = ({ comp, progress, progress_title, action }) => {
                     ]}
                 />
                 <DataListAction aria-labelledby={comp.name} aria-label={_("Actions")}>
-                    <ActionButton comp={comp} progress={progress} action={action} />
+                    <ActionButton comp={comp} isInstalled={isInstalled} progress={progress} action={action} />
                 </DataListAction>
             </DataListItemRow>
         </DataListItem>
@@ -141,7 +159,9 @@ const ApplicationRow = ({ comp, progress, progress_title, action }) => {
 export const ApplicationList = ({ metainfo_db, appProgress, appProgressTitle, action }) => {
     const [progress, setProgress] = useState(false);
     const [dataPackagesInstalled, setDataPackagesInstalled] = useState(null);
+    const [componentsInstalled, setComponentsInstalled] = useState(null);
     const comps = [];
+
     for (const id in metainfo_db.components)
         comps.push(metainfo_db.components[id]);
     comps.sort((a, b) => a.name.localeCompare(b.name));
@@ -167,6 +187,11 @@ export const ApplicationList = ({ metainfo_db, appProgress, appProgressTitle, ac
     useInit(async () => {
         const [config, data] = await get_packages();
         await check_missing_data([...config, ...data]);
+        if (comps.length > 0) {
+            const packageNames = comps.map(c => c.pkgname).filter(pkgname => pkgname);
+            const packages = await get_installed_packages(packageNames, setProgress);
+            setComponentsInstalled(packages);
+        }
     });
 
     async function refresh() {
@@ -199,6 +224,7 @@ export const ApplicationList = ({ metainfo_db, appProgress, appProgressTitle, ac
 
     if (comps.length) {
         tbody = comps.map(c => <ApplicationRow comp={c} key={c.id}
+                                               isInstalled={componentsInstalled?.includes(c.pkgname) ?? false}
                                                progress={appProgress[c.id]}
                                                progress_title={appProgressTitle[c.id]}
                                                action={action} />);

--- a/pkg/apps/application.jsx
+++ b/pkg/apps/application.jsx
@@ -85,15 +85,8 @@ export const Application = ({ metainfo_db, id, progress, action }) => {
         if (!description)
             return <p>{_("No description provided.")}</p>;
 
-        return description.map((paragraph, index) => {
-            if (paragraph.tag == 'ul') {
-                return <ul key={`paragraph-${index}`}>{paragraph.items.map(item => <li key={item}>{item}</li>)}</ul>;
-            } else if (paragraph.tag == 'ol') {
-                return <ol key={`paragraph-${index}`}>{paragraph.items.map(item => <li key={item}>{item}</li>)}</ol>;
-            } else {
-                return <p key={`paragraph-${index}`}>{paragraph}</p>;
-            }
-        });
+        // TODO: Fix
+        return <p>{description}</p>;
     }
 
     // Render the icon, name, homepage link, summary, description, and screenshots of the component,

--- a/pkg/apps/application.jsx
+++ b/pkg/apps/application.jsx
@@ -20,6 +20,26 @@ import { getPackageManager } from "packagemanager.js";
 
 const _ = cockpit.gettext;
 
+/**
+ * @typedef {import("_internal/packagemanager-abstract").ProgressCB} ProgressCB
+ */
+
+/**
+ * Checks if the package is installed on the system.
+ * @param {string} pkgname Package name to check.
+ * @returns {Promise<boolean>} true if installed, otherwise false
+ */
+async function is_installed(pkgname) {
+    const packagemanager = await getPackageManager();
+    return packagemanager.is_installed([pkgname])
+}
+
+/**
+ * Installs a package.
+ * @param {string} pkgname Package name to install.
+ * @param {ProgressCB} progress_cb Callback function to indicate the progress of checking if a package is installed.
+ * @returns {Promise<void>}
+ */
 async function install_package(pkgname, progress_cb) {
     const packagemanager = await getPackageManager();
     await packagemanager.install_packages([pkgname], progress_cb);
@@ -36,7 +56,7 @@ async function remove_package(filename, progress_cb) {
     await reload_bridge_packages();
 }
 
-export const ActionButton = ({ comp, progress, action }) => {
+export const ActionButton = ({ comp, progress, action, isInstalled=false }) => {
     function install(comp) {
         action(install_package, comp.pkgname, _("Installing"), comp.id);
     }
@@ -47,7 +67,7 @@ export const ActionButton = ({ comp, progress, action }) => {
 
     if (progress) {
         return <CancelButton data={progress} />;
-    } else if (comp.installed) {
+    } else if (isInstalled) {
         return <Button variant="danger" onClick={() => remove(comp)}>{_("Remove")}</Button>;
     } else {
         return <Button variant="secondary" onClick={() => install(comp)}>{_("Install")}</Button>;
@@ -59,6 +79,10 @@ export const Application = ({ metainfo_db, id, progress, action }) => {
         return null;
 
     const comp = metainfo_db.components[id];
+    let isInstalled = false
+    if (comp) {
+        isInstalled = is_installed(comp.name)
+    }
 
     function render_homepage_link(urls) {
         return urls.map((url, index) => {
@@ -85,15 +109,8 @@ export const Application = ({ metainfo_db, id, progress, action }) => {
         if (!description)
             return <p>{_("No description provided.")}</p>;
 
-        return description.map((paragraph, index) => {
-            if (paragraph.tag == 'ul') {
-                return <ul key={`paragraph-${index}`}>{paragraph.items.map(item => <li key={item}>{item}</li>)}</ul>;
-            } else if (paragraph.tag == 'ol') {
-                return <ol key={`paragraph-${index}`}>{paragraph.items.map(item => <li key={item}>{item}</li>)}</ol>;
-            } else {
-                return <p key={`paragraph-${index}`}>{paragraph}</p>;
-            }
-        });
+        // TODO: Fix
+        return <p>{description}</p>;
     }
 
     // Render the icon, name, homepage link, summary, description, and screenshots of the component,

--- a/pkg/apps/appstream.js
+++ b/pkg/apps/appstream.js
@@ -8,7 +8,7 @@ import * as python from "python.js";
 import inotify_py from "inotify.py";
 
 import { debug } from "./utils";
-import watch_appstream_py from "./watch-appstream.py";
+import watch_appstream_gobject from "./watch_appstream_gobject.py";
 
 let metainfo_db = null;
 
@@ -21,7 +21,7 @@ export function get_metainfo_db() {
         });
 
         let buf = "";
-        python.spawn([inotify_py, watch_appstream_py], [],
+        python.spawn([inotify_py, watch_appstream_gobject], [],
                      { environ: ["LANGUAGE=" + (cockpit.language || "en")] })
                 .stream(function (data) {
                     buf += data;
@@ -29,8 +29,7 @@ export function get_metainfo_db() {
                     buf = lines[lines.length - 1];
                     if (lines.length >= 2) {
                         const metadata = JSON.parse(lines[lines.length - 2]);
-                        metainfo_db.components = metadata.components;
-                        metainfo_db.origin_files = metadata.origin_files;
+                        metainfo_db.components = metadata;
                         metainfo_db.ready = true;
                         metainfo_db.dispatchEvent("changed");
                         debug("read metainfo_db:", metainfo_db);

--- a/pkg/apps/old_output.json
+++ b/pkg/apps/old_output.json
@@ -1,0 +1,349 @@
+{
+    "components": {
+        "org.cockpit_project.cockpit_networkmanager": {
+            "id": "org.cockpit_project.cockpit_networkmanager",
+            "pkgname": "cockpit-networkmanager",
+            "name": "Networking",
+            "summary": "Cockpit configuration of NetworkManager and Firewalld",
+            "description": [
+                "\n    \tThis tool manages networking such as bonds, bridges, teams, VLANs\n    \tand firewalls using NetworkManager and Firewalld.\n        NetworkManager is incompatible with Ubuntu's default systemd-networkd and\n\tDebian's ifupdown scripts.\n    "
+            ],
+            "icon": null,
+            "screenshots": [],
+            "launchables": [
+                {
+                    "name": "network",
+                    "type": "cockpit-manifest"
+                }
+            ],
+            "urls": [
+                {
+                    "type": "homepage",
+                    "link": "https://cockpit-project.org/"
+                }
+            ],
+            "installed": true,
+            "file": "/usr/share/metainfo/org.cockpit_project.cockpit_networkmanager.metainfo.xml"
+        },
+        "org.cockpit_project.cockpit_storaged": {
+            "id": "org.cockpit_project.cockpit_storaged",
+            "pkgname": "cockpit-storaged",
+            "name": "Storage",
+            "summary": "Manage storage",
+            "description": [
+                "\n      This tool manages local storage, such as filesystems, LVM2\n      volume groups, and NFS mounts.\n    "
+            ],
+            "icon": null,
+            "screenshots": [],
+            "launchables": [
+                {
+                    "name": "storage",
+                    "type": "cockpit-manifest"
+                }
+            ],
+            "urls": [
+                {
+                    "type": "homepage",
+                    "link": "https://cockpit-project.org/"
+                }
+            ],
+            "installed": true,
+            "file": "/usr/share/metainfo/org.cockpit_project.cockpit_storaged.metainfo.xml"
+        },
+        "org.cockpit_project.cockpit_kdump": {
+            "id": "org.cockpit_project.cockpit_kdump",
+            "pkgname": "cockpit-kdump",
+            "name": "Kernel dump",
+            "summary": "Collect kernel crash dumps",
+            "description": [
+                "\n      This tool configures the system to write kernel crash dumps. It supports\n      the \"local\" (disk), \"ssh\", and \"nfs\" dump targets.\n    "
+            ],
+            "icon": null,
+            "screenshots": [],
+            "launchables": [
+                {
+                    "name": "kdump",
+                    "type": "cockpit-manifest"
+                }
+            ],
+            "urls": [
+                {
+                    "type": "homepage",
+                    "link": "https://cockpit-project.org/"
+                }
+            ],
+            "installed": true,
+            "file": "/usr/share/metainfo/org.cockpit_project.cockpit_kdump.metainfo.xml"
+        },
+        "org.cockpit_project.cockpit_selinux": {
+            "id": "org.cockpit_project.cockpit_selinux",
+            "pkgname": "cockpit-selinux",
+            "name": "SELinux",
+            "summary": "Security Enhanced Linux configuration and troubleshooting",
+            "description": [
+                "\n      This tool configures the SELinux policy and can help with\n      understanding and resolving policy violations.\n    "
+            ],
+            "icon": null,
+            "screenshots": [],
+            "launchables": [
+                {
+                    "name": "selinux",
+                    "type": "cockpit-manifest"
+                }
+            ],
+            "urls": [
+                {
+                    "type": "homepage",
+                    "link": "https://cockpit-project.org/"
+                }
+            ],
+            "installed": true,
+            "file": "/usr/share/metainfo/org.cockpit_project.cockpit_selinux.metainfo.xml"
+        },
+        "org.cockpit_project.cockpit_sosreport": {
+            "id": "org.cockpit_project.cockpit_sosreport",
+            "pkgname": "cockpit-sosreport",
+            "name": "Diagnostic reports",
+            "summary": "Collect and package diagnostic and support data",
+            "description": [
+                "\n      This tool generates an archive of configuration and diagnostic\n      information from the running system. The archive may be stored\n      locally or centrally for recording or tracking purposes or may\n      be sent to technical support representatives, developers or\n      system administrators to assist with technical fault-finding and\n      debugging.\n    "
+            ],
+            "icon": "/usr/share/icons/hicolor/64x64/apps/cockpit-sosreport.png",
+            "screenshots": [],
+            "launchables": [
+                {
+                    "name": "sosreport",
+                    "type": "cockpit-manifest"
+                }
+            ],
+            "urls": [
+                {
+                    "type": "homepage",
+                    "link": "https://cockpit-project.org/"
+                }
+            ],
+            "installed": true,
+            "file": "/usr/share/metainfo/org.cockpit_project.cockpit_sosreport.metainfo.xml"
+        },
+        "org.candlepinproject.subscription_manager": {
+            "id": "org.candlepinproject.subscription_manager",
+            "pkgname": "subscription-manager-cockpit",
+            "name": "Subscription Manager",
+            "summary": "Subscription Manager in Cockpit",
+            "description": [
+                "Manage subscriptions to a Candlepin backend, such as for Red Hat products."
+            ],
+            "icon": null,
+            "screenshots": [],
+            "launchables": [
+                {
+                    "name": "subscriptions",
+                    "type": "cockpit-manifest"
+                }
+            ],
+            "urls": [
+                {
+                    "type": "homepage",
+                    "link": "https://candlepinproject.org/"
+                }
+            ]
+        },
+        "org.clusterlabs.cockpit_pcs_web_ui": {
+            "id": "org.clusterlabs.cockpit_pcs_web_ui",
+            "pkgname": "cockpit-ha-cluster",
+            "name": "HA Cluster Management",
+            "summary": "Manage Pacemaker based clusters",
+            "description": [
+                "Application for managing Pacemaker based clusters. Uses Pacemaker/Corosync Configuration System (pcs) in the background."
+            ],
+            "icon": null,
+            "screenshots": [],
+            "launchables": [
+                {
+                    "name": "ha-cluster",
+                    "type": "cockpit-manifest"
+                }
+            ],
+            "urls": [
+                {
+                    "type": "homepage",
+                    "link": "https://github.com/ClusterLabs/pcs-web-ui"
+                }
+            ]
+        },
+        "org.cockpit_project.files": {
+            "id": "org.cockpit_project.files",
+            "pkgname": "cockpit-files",
+            "name": "Files",
+            "summary": "Manage your files",
+            "description": [
+                "A file system UI for Cockpit.\n\nYou can browse directories, upload and download files, and change their properties. It also includes a simple file editor."
+            ],
+            "icon": null,
+            "screenshots": [],
+            "launchables": [
+                {
+                    "name": "files",
+                    "type": "cockpit-manifest"
+                }
+            ],
+            "urls": [
+                {
+                    "type": "bugtracker",
+                    "link": "https://github.com/cockpit-project/cockpit-files/issues"
+                },
+                {
+                    "type": "homepage",
+                    "link": "https://github.com/cockpit-project/cockpit-files"
+                }
+            ]
+        },
+        "org.cockpit_project.machines": {
+            "id": "org.cockpit_project.machines",
+            "pkgname": "cockpit-machines",
+            "name": "Machines",
+            "summary": "Manage your virtual machines",
+            "description": [
+                "This tool manages virtual machines.  With it, you can create, monitor, and control the virtual machines of the libvirt subsystem."
+            ],
+            "icon": null,
+            "screenshots": [],
+            "launchables": [
+                {
+                    "name": "machines",
+                    "type": "cockpit-manifest"
+                }
+            ],
+            "urls": [
+                {
+                    "type": "homepage",
+                    "link": "https://cockpit-project.org/"
+                }
+            ]
+        },
+        "org.cockpit_project.podman": {
+            "id": "org.cockpit_project.podman",
+            "pkgname": "cockpit-podman",
+            "name": "Podman",
+            "summary": "Cockpit component for Podman containers",
+            "description": [
+                "The Cockpit user interface for Podman containers.\n\npodman (Pod Manager) is a fully featured daemon-less engine for OCI containers, pods (groups of containers), and container images. It is CLI, API, and functionally compatible with Docker."
+            ],
+            "icon": null,
+            "screenshots": [],
+            "launchables": [
+                {
+                    "name": "podman",
+                    "type": "cockpit-manifest"
+                }
+            ],
+            "urls": [
+                {
+                    "type": "homepage",
+                    "link": "https://cockpit-project.org/"
+                }
+            ]
+        },
+        "org.cockpit_project.session-recording": {
+            "id": "org.cockpit_project.session-recording",
+            "pkgname": "cockpit-session-recording",
+            "name": "Session Recording",
+            "summary": "Session Recording module for Cockpit",
+            "description": [
+                "Provides Session Recording module for Cockpit. Provides list of recorded by tlog terminal sessions from Journal. Allows to play them in a player with various controls. Shows correlated logs which happened during session."
+            ],
+            "icon": null,
+            "screenshots": [],
+            "launchables": [
+                {
+                    "name": "session-recording",
+                    "type": "cockpit-manifest"
+                }
+            ],
+            "urls": [
+                {
+                    "type": "bugtracker",
+                    "link": "https://github.com/Scribery/cockpit-session-recording/issues"
+                },
+                {
+                    "type": "homepage",
+                    "link": "https://github.com/Scribery/cockpit-session-recording"
+                }
+            ]
+        },
+        "org.image-builder.cockpit-composer": {
+            "id": "org.image-builder.cockpit-composer",
+            "pkgname": "cockpit-composer",
+            "name": "Image Builder",
+            "summary": "Build customized operating system images",
+            "description": [
+                "Image Builder (Composer) can generate custom images suitable for deploying systems, or as images ready to upload to the cloud."
+            ],
+            "icon": null,
+            "screenshots": [],
+            "launchables": [
+                {
+                    "name": "composer",
+                    "type": "cockpit-manifest"
+                }
+            ],
+            "urls": [
+                {
+                    "type": "homepage",
+                    "link": "https://github.com/osbuild/cockpit-composer/"
+                }
+            ]
+        },
+        "org.image-builder.cockpit-image-builder": {
+            "id": "org.image-builder.cockpit-image-builder",
+            "pkgname": "cockpit-image-builder",
+            "name": "Image Builder",
+            "summary": "Build customized operating system images",
+            "description": [
+                "Image Builder can generate custom images suitable for deploying systems, or as images ready to upload to the cloud."
+            ],
+            "icon": null,
+            "screenshots": [],
+            "launchables": [
+                {
+                    "name": "cockpit-image-builder",
+                    "type": "cockpit-manifest"
+                }
+            ],
+            "urls": [
+                {
+                    "type": "homepage",
+                    "link": "https://github.com/osbuild/image-builder-frontend/"
+                }
+            ]
+        },
+        "org.port389.cockpit_console": {
+            "id": "org.port389.cockpit_console",
+            "pkgname": "cockpit-389-ds",
+            "name": "389 Directory Server",
+            "summary": "389 Directory Server Management",
+            "description": [
+                "389 Directory Server is a highly usable, fully featured, reliable and secure LDAP server implementation. It handles many of the largest LDAP deployments in the world."
+            ],
+            "icon": null,
+            "screenshots": [],
+            "launchables": [
+                {
+                    "name": "cockpit-389-console",
+                    "type": "cockpit-manifest"
+                }
+            ],
+            "urls": [
+                {
+                    "type": "homepage",
+                    "link": "https://www.port389.org/"
+                }
+            ]
+        }
+    },
+    "origin_files": [
+        "/usr/share/swcatalog/xml/fedora.xml.gz",
+        "/usr/share/swcatalog/xml/gstreamer-non-free.xml",
+        "/usr/share/swcatalog/xml/other-repos.xml"
+    ]
+}

--- a/pkg/apps/watch_appstream_gobject.py
+++ b/pkg/apps/watch_appstream_gobject.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import json
+import os
+import sys
+from typing import Dict, List, Optional
+
+import gi
+
+gi.require_version('AppStream', '1.0')
+from gi.repository import AppStream, Gio, GLib
+
+loop = GLib.MainLoop()
+
+
+def convert_stock_icon(icon_name: str):
+    def try_size(size: str, extension: str):
+        path = os.path.join("/usr/share/icons/hicolor", size, "apps", f"{icon_name}.{extension}")
+        return path if os.path.exists(path) else None
+
+    return (
+        try_size("64x64", "svg")
+        or try_size("64x64", "png")
+        or try_size("128x128", "svg")
+        or try_size("128x128", "png")
+    )
+
+
+def find_and_convert_icon(icon: AppStream.Icon) -> str:
+    if icon is None:
+        return None
+    kind = icon.get_kind()
+    if kind in [AppStream.IconKind.CACHED, AppStream.IconKind.LOCAL]:
+        return icon.get_filename()
+    elif kind == AppStream.IconKind.REMOTE:
+        return icon.get_url()
+    elif kind == AppStream.IconKind.STOCK:
+        return convert_stock_icon(icon.get_name())
+    return "foo"
+
+
+def convert_screenshotshots(screenshots: List[AppStream.Screenshot]) -> List[str]:
+    images = []
+    for screenshot in screenshots:
+        kind = screenshot.get_kind()
+        if kind == AppStream.ScreenshotKind.UNKNOWN:
+            continue
+        for image in screenshot.get_images():
+            if image.get_kind() != AppStream.ImageKind.SOURCE:
+                continue
+            url = image.get_url()
+            if kind == AppStream.ScreenshotKind.DEFAULT:
+                images.insert(0, url)
+            elif not images and kind == AppStream.ScreenshotKind.EXTRA:
+                images.append(url)
+    return images
+
+
+def convert_launchables(launchables: List[AppStream.Launchable]) -> List:
+    ables = []
+
+    for launchable in launchables:
+        if launchable.get_kind() != AppStream.LaunchableKind.COCKPIT_MANIFEST:
+            continue
+        ables = ables + launchable.get_entries()
+
+    return ables
+
+
+def convert_urls(component: AppStream.Component) -> List[Dict]:
+    # There is no get_urls for AppStream so we need to
+    # actively check each type
+    urls = []
+    for kind in AppStream.UrlKind:
+        c_url = component.get_url(kind)
+        if c_url:
+            urls.append({'type': kind.to_string(), 'link': c_url})
+    return urls
+
+
+def on_pool_changed(pool: AppStream.Pool) -> None:
+    # NOTE: Don't use get_components() unless you absolutely have to, it's a
+    # very expensive operation. This is just for testing!
+    # You will definitely want to do something else here...
+    components = {}
+    # box = pool.get_components()
+    box = pool.get_components_by_extends("org.cockpit_project.cockpit")
+    for c in box.as_array():
+        c_id = c.get_id()
+        icon = find_and_convert_icon(c.get_icon_stock())
+        components[c_id] = {
+            'id': c_id,
+            'pkgname': c.get_pkgname(),
+            "name": c.get_name(),
+            'summary': c.get_summary(),
+            'description': c.get_description(),
+            'icon': icon,
+            'screenshots': convert_screenshotshots(c.get_screenshots_all()),
+            'launchables': convert_launchables(c.get_launchables()),
+            'urls': convert_urls(c)
+        }
+    sys.stdout.write(json.dumps(components) + '\n')
+    sys.stdout.flush()
+
+pool = AppStream.Pool()
+if os.environ.get('LANGUAGE'):
+    pool.set_locale(os.environ.get('LANGUAGE'))
+pool.add_flags(AppStream.PoolFlags.MONITOR)
+pool.remove_flags(AppStream.PoolFlags.LOAD_FLATPAK)
+
+# Connect signal before loading, so you can observe changes during/after load.
+pool.connect("changed", on_pool_changed)
+
+# Async loading, but if sync loading is okay, just running pool.load() means
+# you could skip all MainLoop() stuff
+pool.load()
+on_pool_changed(pool)
+# box = pool.get_components_by_extends("org.cockpit_project.cockpit").get_size()
+
+# for component in box.as_array():
+#     print(component.get_name())
+#     print(component.get_summary())
+#     print(component.get_id())
+
+# wait for on_load_done to be called
+loop.run()
+
+# for cpt in pool.search("cockpit").as_array():
+#     print(cpt.get_id())
+
+# pool.load()
+# box = pool.get_components_by_extends("org.cockpit_project.cockpit")
+# pool.clear()
+
+# for component in box.as_array():
+#     print(component.get_name())
+#     print(component.get_summary())
+#     print(component.get_id())

--- a/pkg/apps/watch_appstream_gobject.py
+++ b/pkg/apps/watch_appstream_gobject.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import json
+import os
+import sys
+from typing import Dict, List
+
+import gi
+
+gi.require_version('AppStream', '1.0')
+from gi.repository import AppStream, GLib
+
+loop = GLib.MainLoop()
+
+
+def convert_stock_icon(icon_name: str):
+    def try_size(size: str, extension: str):
+        path = os.path.join("/usr/share/icons/hicolor", size, "apps", f"{icon_name}.{extension}")
+        return path if os.path.exists(path) else None
+
+    return (
+        try_size("64x64", "svg")
+        or try_size("64x64", "png")
+        or try_size("128x128", "svg")
+        or try_size("128x128", "png")
+    )
+
+
+def find_and_convert_icon(icon: AppStream.Icon) -> str:
+    if icon is None:
+        return None
+    kind = icon.get_kind()
+    if kind in [AppStream.IconKind.CACHED, AppStream.IconKind.LOCAL]:
+        return icon.get_filename()
+    elif kind == AppStream.IconKind.REMOTE:
+        return icon.get_url()
+    elif kind == AppStream.IconKind.STOCK:
+        return convert_stock_icon(icon.get_name())
+    return "foo"
+
+
+def convert_screenshotshots(screenshots: List[AppStream.Screenshot]) -> List[str]:
+    images = []
+    for screenshot in screenshots:
+        kind = screenshot.get_kind()
+        if kind == AppStream.ScreenshotKind.UNKNOWN:
+            continue
+        for image in screenshot.get_images():
+            if image.get_kind() != AppStream.ImageKind.SOURCE:
+                continue
+            url = image.get_url()
+            if kind == AppStream.ScreenshotKind.DEFAULT:
+                images.insert(0, url)
+            elif not images and kind == AppStream.ScreenshotKind.EXTRA:
+                images.append(url)
+    return images
+
+
+def convert_launchables(launchables: List[AppStream.Launchable]) -> List:
+    ables = []
+
+    for launchable in launchables:
+        if launchable.get_kind() != AppStream.LaunchableKind.COCKPIT_MANIFEST:
+            continue
+        ables = ables + launchable.get_entries()
+
+    return ables
+
+
+def convert_urls(component: AppStream.Component) -> List[Dict]:
+    # There is no get_urls for AppStream so we need to
+    # actively check each type
+    urls = []
+    for kind in range(10):
+        url_kind = AppStream.UrlKind(kind)
+        c_url = component.get_url(url_kind)
+        if c_url:
+            urls.append({'type': url_kind.value_nick, 'link': c_url})
+    return urls
+
+
+def on_pool_changed(pool: AppStream.Pool) -> None:
+    # NOTE: Don't use get_components() unless you absolutely have to, it's a
+    # very expensive operation. This is just for testing!
+    # You will definitely want to do something else here...
+    components = {}
+    # box = pool.get_components()
+    box = pool.get_components_by_extends("org.cockpit_project.cockpit")
+    for c in box.as_array():
+        c_id = c.get_id()
+        icon = find_and_convert_icon(c.get_icon_stock())
+        components[c_id] = {
+            'id': c_id,
+            'pkgname': c.get_pkgname(),
+            "name": c.get_name(),
+            'summary': c.get_summary(),
+            'description': c.get_description(),
+            'icon': icon,
+            'screenshots': convert_screenshotshots(c.get_screenshots_all()),
+            'launchables': convert_launchables(c.get_launchables()),
+            'urls': convert_urls(c)
+        }
+    sys.stdout.write(json.dumps(components) + '\n')
+    sys.stdout.flush()
+
+pool = AppStream.Pool()
+if os.environ.get('LANGUAGE'):
+    pool.set_locale(os.environ.get('LANGUAGE'))
+pool.add_flags(AppStream.PoolFlags.MONITOR)
+pool.remove_flags(AppStream.PoolFlags.LOAD_FLATPAK)
+
+# Connect signal before loading, so you can observe changes during/after load.
+pool.connect("changed", on_pool_changed)
+
+# Async loading, but if sync loading is okay, just running pool.load() means
+# you could skip all MainLoop() stuff
+pool.load()
+on_pool_changed(pool)
+# box = pool.get_components_by_extends("org.cockpit_project.cockpit").get_size()
+
+# for component in box.as_array():
+#     print(component.get_name())
+#     print(component.get_summary())
+#     print(component.get_id())
+
+# wait for on_load_done to be called
+loop.run()
+
+# for cpt in pool.search("cockpit").as_array():
+#     print(cpt.get_id())
+
+# pool.load()
+# box = pool.get_components_by_extends("org.cockpit_project.cockpit")
+# pool.clear()
+
+# for component in box.as_array():
+#     print(component.get_name())
+#     print(component.get_summary())
+#     print(component.get_id())

--- a/pkg/lib/_internal/dnf5daemon.ts
+++ b/pkg/lib/_internal/dnf5daemon.ts
@@ -242,6 +242,12 @@ export class Dnf5DaemonManager implements PackageManager {
             await call(session, "org.rpm.dnf.v0.rpm.Rpm", "install", [pkgnames, {}]);
             const [transaction_items, result] = await call(session, "org.rpm.dnf.v0.Goal", "resolve", [{}]) as InstallResolveResult;
             if (result !== 0) {
+                const [problems] = await call(session, "org.rpm.dnf.v0.Goal", "get_transaction_problems", []) as TransactionProblem[][];
+                if (problems.every((p: TransactionProblem) => p.problem.v === GoalProblem.ALREADY_INSTALLED)) {
+                    await call(session, "org.rpm.dnf.v0.Goal", "reset", []);
+                    return;
+                }
+
                 const [problem] = await call(session, "org.rpm.dnf.v0.Goal", "get_transaction_problems_string", []);
                 throw new ResolveError(`Resolving install failed with result=${result}. ${problem}`);
             }


### PR DESCRIPTION
Checking for XML files and managing the AppStream packages isn't ideal and doesn't work at all for Debian and Ubuntu distros as they utilize Yaml based files instead for AppStream.

The AppStream project does have a stable API with GObject that works fine that we can use instead.

WIP! Todo
- [ ] Support showing installed or not
- [ ] Change structure of front-end parsing of JSON
- [ ] Fix debian not allowing AppStream.UrlKind to be serialized