### PR TITLE
test: drop comments in initiatorname.iscsi file

### DIFF
--- a/test/verify/check-storage-iscsi
+++ b/test/verify/check-storage-iscsi
@@ -56,11 +56,11 @@ class TestStorageISCSI(storagelib.StorageCase):
         self.login_and_go("/storage")
 
         # Set initiator IQN
-        orig_iqn = m.execute("sed </etc/iscsi/initiatorname.iscsi -e 's/^.*=//'").rstrip()
+        orig_iqn = m.execute("sed </etc/iscsi/initiatorname.iscsi -e '/^#/d' -e 's/^.*=//'").rstrip()
         self.click_dropdown(self.card_header("Storage"), "Change iSCSI initiator name")
         self.dialog(expect={"name": orig_iqn},
                     values={"name": initiator_iqn})
-        new_iqn = m.execute("sed </etc/iscsi/initiatorname.iscsi -e 's/^.*=//'").rstrip()
+        new_iqn = m.execute("sed </etc/iscsi/initiatorname.iscsi -e '/^#/d' -e 's/^.*=//'").rstrip()
         self.assertEqual(new_iqn, initiator_iqn)
 
         # Access the target


### PR DESCRIPTION
Related: https://github.com/cockpit-project/bots/pull/9283

On new rhel-9-9 image refresh this file now contains comments at the start. So drop them because we don't care about it.