### PR TITLE
tmt: reboot machine after installing kernel-modules-internal

### DIFF
--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -144,6 +144,13 @@ if [ "$PLAN" = "main" ]; then
               TestUpdates.testFailServiceRestart
               TestUpdates.testKpatch
               "
+
+    # FIXME: TestingFarm will fix their auto-reboot ansible
+    # https://gitlab.com/testing-farm/profiles/-/merge_requests/92
+    EXCLUDES="$EXCLUDES
+              TestNetworkingWifi.testHidden
+              TestNetworkingWifi.testWifi
+              "
 fi
 
 if [ "$PLAN" = "storage-basic" ]; then


### PR DESCRIPTION
This can also pull in newer kernel since TF targets latest repositories, reboot the machine after installation.