### PR TITLE
workflows: Disable the nightly testing scenario

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,4 +19,4 @@ jobs:
           mkdir -p ~/.config/cockpit-dev
           echo "${{ github.token }}" >> ~/.config/cockpit-dev/github-token
           TEST_OS=$(PYTHONPATH=bots python3 -c 'from lib.constants import TEST_OS_DEFAULT; print(TEST_OS_DEFAULT)')
-          bots/tests-trigger --force "-" "${TEST_OS}/updates-testing" "${TEST_OS}/daily"
+          bots/tests-trigger --force "-" "${TEST_OS}/updates-testing"


### PR DESCRIPTION
This disables the nightly scenario, we recently haven't had any issues with dnf/udisks for a while now.