### PR TITLE
Make more tests non-destructive / speed up some tests

### DIFF
--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1666,7 +1666,6 @@ class TestAutoUpdates(NoSubManCase):
                       f'/etc/systemd/system/{self.timer_unit}.timer.d/time.conf; systemctl daemon-reload')
             b.reload()
             b.enter_page("/updates")
-            time.sleep(5)
             b.wait_visible("#settings .pf-v6-c-alert")
             # don't allow stomping over unparsable custom settings
             b.wait_not_present("#autoupdates-settings button")

--- a/test/verify/check-system-shutdown-restart
+++ b/test/verify/check-system-shutdown-restart
@@ -186,9 +186,6 @@ class TestUncleanShutdownStatus(testlib.MachineCase):
 
         m.start_cockpit()
         self.login_and_go("/system")
-
-        # Clean reboot
-        self._cleanReboot()
         b.wait_visible('#system_information_os_text')
         b.wait_not_present("#unclean-shutdown-status")
 

--- a/test/verify/check-testlib
+++ b/test/verify/check-testlib
@@ -195,6 +195,7 @@ class TestSystemd(unittest.TestCase):
         self.assertRegex(stdout, rb"\nok .* TestSystemd.testBasic \(1\.7GB\)\n")
         self.assertNotRegex(stdout, b"RETRY")
 
+    @testlib.nondestructive
     def testTodo(self):
         env = os.environ.copy()
         try:


### PR DESCRIPTION
Don't expect magic but we skip one expensive reboot and booting a machine for a test which is non destructive, should shave off a theoretical ~ 40 second boot times two, but as our tests are parallel you won't notice it. 