### PR TITLE
[rhel9.8] sosreport: Provide encryption pass via an env variable

### DIFF
--- a/pkg/lib/cockpit.d.ts
+++ b/pkg/lib/cockpit.d.ts
@@ -264,7 +264,7 @@ declare module 'cockpit' {
                 path_namespace?: string,
                 interface?: string,
                 member?: string,
-                arg?: string
+                arg0?: string
             },
             callback: (path: string, iface: string, signal: string, args: unknown[]) => void,
             rule?: boolean,

--- a/pkg/networkmanager/firewall-client.js
+++ b/pkg/networkmanager/firewall-client.js
@@ -42,10 +42,11 @@ function debug() {
 }
 
 firewall.debouncedGetZones = debounce(300, () => {
-    getZones()
-            .then(() => getServices())
-            .then(() => firewall.debouncedEvent('changed'))
-            .catch(error => console.warn(error));
+    if (firewalld_dbus)
+        getZones()
+                .then(() => getServices())
+                .then(() => firewall.debouncedEvent('changed'))
+                .catch(error => console.warn(error));
 });
 
 /* As certain dbus signal callbacks might change the firewall frequently
@@ -59,38 +60,23 @@ firewall.debouncedGetServices = debounce(300, () => {
     getServices().then(() => firewall.debouncedEvent('changed'));
 });
 
-function initFirewalldDbus() {
-    debug("initializing D-Bus connection");
-    if (firewalld_dbus)
-        firewalld_dbus.close();
+function initFirewalldDbus(owner) {
+    debug("initializing D-Bus connection", owner);
+    firewall.owner = owner;
+    firewall.enabled = !!owner;
 
-    firewalld_dbus = cockpit.dbus('org.fedoraproject.FirewallD1', { superuser: "try" });
+    firewall.zones = {};
+    firewall.activeZones = new Set();
+    firewall.services = {};
+    firewall.enabledServices = new Set();
 
-    firewalld_dbus.addEventListener('owner', (event, owner) => {
-        if (firewall.owner === owner)
-            return;
-        debug("owner changed:", JSON.stringify(owner));
+    if (!firewall.enabled) {
+        firewall.ready = true;
+        firewall.dispatchEvent('changed');
+        return;
+    }
 
-        firewall.owner = owner;
-        firewall.enabled = !!owner;
-
-        firewall.zones = {};
-        firewall.activeZones = new Set();
-        firewall.services = {};
-        firewall.enabledServices = new Set();
-
-        if (!firewall.enabled) {
-            firewall.ready = true;
-            firewall.dispatchEvent('changed');
-            return;
-        }
-
-        getZones()
-                .then(() => getServices())
-                .catch(error => console.warn(error))
-                .then(() => { firewall.ready = true })
-                .then(() => firewall.debouncedEvent('changed'));
-    });
+    firewalld_dbus = cockpit.dbus(owner, { superuser: "try", track: true });
 
     firewalld_dbus.subscribe({
         interface: 'org.fedoraproject.FirewallD1.zone',
@@ -186,6 +172,12 @@ function initFirewalldDbus() {
         path: '/org/fedoraproject/FirewallD1',
         member: 'SourceRemoved'
     }, () => firewall.debouncedGetZones());
+
+    getZones()
+            .then(() => getServices())
+            .catch(error => console.warn(error))
+            .then(() => { firewall.ready = true })
+            .then(() => firewall.debouncedEvent('changed'));
 }
 
 firewalld_service.addEventListener('changed', () => {
@@ -200,13 +192,6 @@ firewalld_service.addEventListener('changed', () => {
 
     debug("systemd service changed: exists", firewalld_service.exists, "state", firewalld_service.state,
           "firewall.enabled:", JSON.stringify(firewall.enabled));
-
-    /* HACK: cockpit.dbus() remains dead for non-activatable names, so reinitialize it if the service gets enabled and started
-     * See https://github.com/cockpit-project/cockpit/pull/9125 */
-    if (!firewall.enabled && is_running) {
-        debug("reinitializing D-Bus connection after unit got started");
-        initFirewalldDbus();
-    }
 
     firewall.dispatchEvent('changed');
 });
@@ -333,7 +318,57 @@ function fetchZoneInfos(zones) {
     }));
 }
 
-initFirewalldDbus();
+/* We watch the name owner explicitly.
+
+   The org.fedoraproject.FirewallD service might appear on D-Bus only
+   some time after the firewalld.service is active and thus we want to
+   only try connecting to it once we know that it is definitely there.
+   However, while cockpit.dbus() does work with services that
+   disappear and then reappear on the bus while the channel is open,
+   it doesn't work with names that are not present when the channel is
+   initially opened (see
+   https://github.com/cockpit-project/cockpit/pull/9125).
+
+   Thus, we track the name explicitly via the org.freedesktop.DBus
+   API.
+ */
+
+function dbus_watch_name_owner(name, owner_callback) {
+    const bus = cockpit.dbus('org.freedesktop.DBus', { superuser: "try" });
+    let owner = null;
+
+    function owner_changed(new_owner) {
+        if (new_owner != owner) {
+            owner = new_owner;
+            owner_callback(owner);
+        }
+    }
+
+    bus.subscribe({
+        path: "/org/freedesktop/DBus",
+        interface: "org.freedesktop.DBus",
+        member: "NameOwnerChanged",
+        arg0: name,
+    }, (_path, _iface, _member, [_name, _old_owner, new_owner]) => {
+        owner_changed(new_owner);
+    });
+
+    bus.call(
+        "/org/freedesktop/DBus", "org.freedesktop.DBus", "GetNameOwner",
+        [name]
+    )
+            .then(([owner]) => {
+                owner_changed(owner);
+            })
+            .catch(ex => {
+                if (ex.name == "org.freedesktop.DBus.Error.NameHasNoOwner")
+                    owner_changed("");
+                else
+                    throw ex;
+            });
+}
+
+dbus_watch_name_owner('org.fedoraproject.FirewallD1', initFirewalldDbus);
 
 cockpit.spawn(['sh', '-c', 'pkcheck --action-id org.fedoraproject.FirewallD1.all --process $$ --allow-user-interaction 2>&1'], { superuser: "try" })
         .then(() => {

--- a/pkg/sosreport/sosreport.jsx
+++ b/pkg/sosreport/sosreport.jsx
@@ -132,7 +132,7 @@ function sosLister() {
     return self;
 }
 
-function sosCreate(args, setProgress, setError, setErrorDetail) {
+function sosCreate(args, setProgress, setError, setErrorDetail, options) {
     let output = "";
     let plugins_count = 0;
     const progress_regex = /Running ([0-9]+)\/([0-9]+):/; // Only for sos < 3.6
@@ -141,7 +141,7 @@ function sosCreate(args, setProgress, setError, setErrorDetail) {
 
     // TODO - Use a real API instead of scraping stdout once such an API exists
     const task = cockpit.spawn(["sos", "report", "--batch"].concat(args),
-                               { superuser: "require", err: "out", pty: true });
+                               { superuser: "require", err: "out", pty: true, ...options });
 
     task.stream(text => {
         let p = 0;
@@ -243,6 +243,7 @@ const SOSDialog = () => {
         setProgress(null);
 
         const args = [];
+        const options = {};
 
         if (label) {
             args.push("--label");
@@ -250,8 +251,8 @@ const SOSDialog = () => {
         }
 
         if (passphrase) {
-            args.push("--encrypt-pass");
-            args.push(passphrase);
+            args.push("--encrypt");
+            options.environ = ["SOSENCRYPTPASS=" + passphrase];
         }
 
         if (obfuscate) {
@@ -263,7 +264,7 @@ const SOSDialog = () => {
         }
 
         const task = sosCreate(args, setProgress, err => { if (err == "cancelled") Dialogs.close(); else setError(err); },
-                               setErrorDetail);
+                               setErrorDetail, options);
         setTask(task);
         task.then(Dialogs.close);
         task.finally(() => setTask(null));

--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -66,6 +66,8 @@ echo core > /proc/sys/kernel/core_pattern
 
 # make sure that we can access cockpit through the firewall
 systemctl start firewalld
+# wait for d-bus service to be accessible
+while ! firewall-cmd --state; do sleep 1; done
 firewall-cmd --add-service=cockpit --permanent
 firewall-cmd --add-service=cockpit
 

--- a/test/common/netlib.py
+++ b/test/common/netlib.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 
-import re
 import subprocess
 from collections.abc import Sequence, Set
 
@@ -112,14 +111,6 @@ class NetworkCase(NetworkHelpers):
                   'systemctl try-restart libvirtd.service')
         if 'default' in m.execute("virsh net-list --name || true"):
             m.execute("virsh net-autostart --disable default; virsh net-destroy default")
-
-        ver = self.machine.execute(
-            "busctl --system get-property org.freedesktop.NetworkManager /org/freedesktop/NetworkManager org.freedesktop.NetworkManager Version || true")
-        ver_match = re.match(r's "(.*)"', ver)
-        if ver_match:
-            self.networkmanager_version = [int(x) for x in ver_match.group(1).split(".")]
-        else:
-            self.networkmanager_version = [0]
 
         # Something unknown sometimes goes wrong with PCP, see #15625
         self.allow_journal_messages("pcp-archive: no such metric: network.interface.* Unknown metric name",

--- a/test/verify/check-networkmanager-checkpoints
+++ b/test/verify/check-networkmanager-checkpoints
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 
+import re
+
 import netlib
 import testlib
 
@@ -151,7 +153,7 @@ class TestNetworkingCheckpoints(netlib.NetworkCase):
             lines = m.execute("journalctl -u NetworkManager | grep op=").split("\n")
             last_checkpoint = None
             for line in lines:
-                match = netlib.re.search('op="checkpoint-create" arg="([^"]*)"', line)
+                match = re.search(r'op="checkpoint-create" arg="([^"]*)"', line)
                 if match:
                     last_checkpoint = match[1]
             if last_checkpoint:

--- a/test/verify/check-networkmanager-firewall
+++ b/test/verify/check-networkmanager-firewall
@@ -43,6 +43,8 @@ class TestFirewall(netlib.NetworkCase):
         self.restore_dir("/etc/firewalld", restart_unit="firewalld")
 
         m.execute("systemctl restart firewalld")
+        testlib.wait(lambda: m.execute("firewall-cmd --state"))
+
         self.btn_danger = "pf-m-danger"
         self.btn_primary = "pf-m-primary"
         self.default_zone = "Public zone"
@@ -56,6 +58,7 @@ class TestFirewall(netlib.NetworkCase):
         m = self.machine
 
         def get_num_zones():
+            testlib.wait(lambda: m.execute("firewall-cmd --state"))
             return int(m.execute("firewall-cmd --get-active-zones | grep --count '^[a-zA-Z]'").strip())
 
         self.login_and_go("/network", superuser=False)

--- a/test/verify/check-networkmanager-mac
+++ b/test/verify/check-networkmanager-mac
@@ -68,20 +68,16 @@ class TestNetworkingMAC(netlib.NetworkCase):
         mac = m.execute("cat /sys/class/net/tbond/address").strip()
         b.wait_text("#network-interface-mac", mac.upper())
 
-        if self.networkmanager_version >= [1, 6, 0]:
-            new_mac = self.network.interface()["mac"]
-            b.click("#network-interface-mac button")
-            b.wait_visible("#network-mac-settings-dialog")
-            b.set_input_text('#network-mac-settings-mac-input input', new_mac)
-            b.click(".pf-v6-c-menu ul > li > button")
-            b.click("#network-mac-settings-save")
-            b.wait_not_present("#network-mac-settings-dialog")
+        new_mac = self.network.interface()["mac"]
+        b.click("#network-interface-mac button")
+        b.wait_visible("#network-mac-settings-dialog")
+        b.set_input_text('#network-mac-settings-mac-input input', new_mac)
+        b.click(".pf-v6-c-menu ul > li > button")
+        b.click("#network-mac-settings-save")
+        b.wait_not_present("#network-mac-settings-dialog")
 
-            b.wait_text("#network-interface-mac", new_mac.upper())
-            self.assertIn(new_mac.lower(), m.execute("ip link show tbond"))
-
-        else:
-            b.wait_not_present("#network-interface-mac button")
+        b.wait_text("#network-interface-mac", new_mac.upper())
+        self.assertIn(new_mac.lower(), m.execute("ip link show tbond"))
 
 
 if __name__ == '__main__':

--- a/tools/urls-check
+++ b/tools/urls-check
@@ -14,12 +14,14 @@ import time
 import urllib
 from urllib.request import Request, urlopen
 
-from lib import task
+from lib.github import GitHub
 
 BASE_DIR = os.path.realpath(f'{__file__}/../..')
 
 DAYS = 7
 TASK_NAME = "Validate all URLs"
+
+github = GitHub()
 
 USER_AGENT = "Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:90.0) Gecko/20100101 Firefox/90.0"
 
@@ -47,8 +49,6 @@ def main():
                         help="Only show urls")
     opts = parser.parse_args()
 
-    task.verbose = opts.verbose
-
     if opts.dry_run:
         (success, err) = check_urls(opts.verbose)
         print(err)
@@ -58,12 +58,12 @@ def main():
     since = time.time() - (DAYS * 86400)
 
     # When there is an open issue, don't do anything
-    issues = task.api.issues(state="open")
+    issues = github.issues(state="open")
     issues = [i for i in issues if i["title"] == TASK_NAME]
     if issues:
         return
 
-    issues = task.api.issues(state="closed", since=since)
+    issues = github.issues(state="closed", since=since)
     issues = [i for i in issues if i["title"] == TASK_NAME]
 
     # If related issue was not modified in last n-DAYS, then do your thing
@@ -76,24 +76,24 @@ def main():
                 "body": err,
                 "labels": ["bot"]
             }
-            task.api.post("issues", data)
+            github.post("issues", data)
         else:
             # Try to comment on the last issue (look in the last 4*DAYS)
             # If there is not issue to be found, then just open a new one and close it
             success = success or "Task hasn't produced any output"
             since = time.time() - (DAYS * 4 * 86400)
-            issues = task.api.issues(state="closed", since=since)
+            issues = github.issues(state="closed", since=since)
             issues = [i for i in issues if i["title"] == TASK_NAME]
             if issues:
-                task.comment(issues[0], success)
+                github.comment(issues[0]["number"], success)
             else:
                 data = {
                     "title": TASK_NAME,
                     "body": success,
                     "labels": ["bot"]
                 }
-                new_issue = task.api.post("issues", data)
-                task.api.post("issues/{0}".format(new_issue["number"]), {"state": "closed"})
+                new_issue = github.post("issues", data)
+                github.patch(f"issues/{new_issue['number']}", {"state": "closed"})
 
 
 def check_urls(verbose):


### PR DESCRIPTION
Passing it via the command line allows it to be leaked via `ps aux`. Providing the password via an environment variable isn't ideal either but a normal user can't read read /proc/pid/environ of a root process.

Ideally we would use `--encrypt` and pass the passphrase via stdin but that can't be used in combination with `--batch` which we need to enable non-interactive mode.

Backported from main commit dd6615c70b10d24b3760dc94dd197ff628f6bae3