### PR TITLE
weblate: Add screenshot references

### DIFF
--- a/.github/workflows/weblate-sync-pot.yml
+++ b/.github/workflows/weblate-sync-pot.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Commit .pot to weblate repo
         run: |
           cp src/po/cockpit.pot weblate/cockpit.pot
+          cp src/test/reference/*medium-pixels.png weblate/reference
           git config --global user.name "GitHub Workflow"
           git config --global user.email "cockpituous@cockpit-project.org"
           git -C weblate commit -m "Update source file" -- cockpit.pot


### PR DESCRIPTION
Adds our screenshots dir to Weblate repo so we can keep screenshots on Weblate up to date as well as provide context for translators to know where translation strings are.

Only medium-sized images are included as we do not need all images included.

Fixes: https://github.com/cockpit-project/cockpit/issues/23744
Related-to: https://docs.weblate.org/en/weblate-2026.6.1/admin/translating.html#managing-screenshots-from-the-repository