### PR TITLE
shell: Use FileChooser for SSH keys

### DIFF
--- a/pkg/lib/cockpit/react/FileChooser.tsx
+++ b/pkg/lib/cockpit/react/FileChooser.tsx
@@ -356,6 +356,14 @@ interface FileChooserValues {
     showHidden: boolean;
 }
 
+const HideOnWide = ({ children } : { children: React.ReactNode }) => {
+    return (
+        <div className="file-chooser-hide-on-wide">
+            {children}
+        </div>
+    );
+};
+
 export const FileChooser = ({
     title,
     shortcuts = [],
@@ -558,25 +566,27 @@ export const FileChooser = ({
 
         function shortcut(sc: FileChooserShortcut) {
             return (
-                <DropdownItem
-                    key={sc.label}
-                    onClick={() => setPath(dlg, sc.path)}
-                    className="file-chooser-hide-on-wide"
-                >
-                    {sc.label}
-                </DropdownItem>
+                <HideOnWide>
+                    <DropdownItem
+                        key={sc.label}
+                        onClick={() => setPath(dlg, sc.path)}
+                    >
+                        {sc.label}
+                    </DropdownItem>
+                </HideOnWide>
             );
         }
 
         function collection(cl: FileChooserCollection) {
             return (
-                <DropdownItem
-                    key={cl.label}
-                    onClick={() => setCollection(dlg, cl)}
-                    className="file-chooser-hide-on-wide"
-                >
-                    {cl.label}
-                </DropdownItem>
+                <HideOnWide>
+                    <DropdownItem
+                        key={cl.label}
+                        onClick={() => setCollection(dlg, cl)}
+                    >
+                        {cl.label}
+                    </DropdownItem>
+                </HideOnWide>
             );
         }
 

--- a/pkg/shell/credentials.tsx
+++ b/pkg/shell/credentials.tsx
@@ -10,7 +10,6 @@ import { ClipboardCopy, ClipboardCopyVariant } from "@patternfly/react-core/dist
 import { DescriptionList, DescriptionListDescription, DescriptionListGroup, DescriptionListTerm } from "@patternfly/react-core/dist/esm/components/DescriptionList/index.js";
 import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex/index.js";
 import { ActionGroup, Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form/index.js";
-import { Grid, GridItem } from "@patternfly/react-core/dist/esm/layouts/Grid/index.js";
 import { HelperText, HelperTextItem } from "@patternfly/react-core/dist/esm/components/HelperText/index.js";
 import {
     Modal, ModalBody, ModalFooter, ModalHeader
@@ -22,65 +21,16 @@ import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput/
 import { InfoCircleIcon } from '@patternfly/react-icons';
 
 import * as credentials from "credentials";
-import { FileAutoComplete } from "cockpit-components-file-autocomplete.jsx";
 import { ListingPanel } from 'cockpit-components-listing-panel.jsx';
 import { ListingTable } from 'cockpit-components-table.jsx';
 import { ModalError } from 'cockpit-components-inline-notification.jsx';
 import { useEvent, useObject } from 'hooks';
-import { DialogResult } from "dialogs";
+import { WithDialogs, useDialogs, DialogResult } from "dialogs";
+import { FileChooser } from "cockpit/react/FileChooser";
 
 import "./credentials.scss";
 
 const _ = cockpit.gettext;
-
-const AddNewKey = ({
-    keys,
-    unlockKey,
-    onClose
-} : {
-    keys: credentials.Keys,
-    unlockKey: (name: string) => void,
-    onClose: () => void
-}) => {
-    const [addNewKeyLoading, setAddNewKeyLoading] = useState(false);
-    const [newKeyPath, setNewKeyPath] = useState("");
-    const [newKeyPathError, setNewKeyPathError] = useState("");
-
-    const addCustomKey = () => {
-        setAddNewKeyLoading(true);
-        keys.load(newKeyPath, "")
-                .then(onClose)
-                .catch(ex => {
-                    if (!(ex instanceof credentials.KeyLoadError) || !ex.sent_password)
-                        setNewKeyPathError(ex.message);
-                    else
-                        unlockKey(newKeyPath);
-                })
-                .finally(() => setAddNewKeyLoading(false));
-    };
-
-    return (
-        <Grid hasGutter>
-            <GridItem span={9} id="ssh-file-add-key">
-                <FileAutoComplete onChange={setNewKeyPath}
-                                  placeholder={_("Path to file")}
-                                  superuser="try" />
-                {newKeyPathError && <HelperText className="pf-v6-c-form__helper-text">
-                    <HelperTextItem variant="error">{newKeyPathError}</HelperTextItem>
-                </HelperText>}
-            </GridItem>
-            <GridItem span={1}>
-                <Button id="ssh-file-add"
-                        isDisabled={addNewKeyLoading || !newKeyPath}
-                        isLoading={addNewKeyLoading}
-                        onClick={addCustomKey}
-                        variant="secondary">
-                    {_("Add")}
-                </Button>
-            </GridItem>
-        </Grid>
-    );
-};
 
 const KeyDetails = ({ currentKey } : { currentKey: credentials.Key }) => {
     return (
@@ -232,13 +182,42 @@ const UnlockKey = ({
     );
 };
 
+const AddKeyButton = ({
+    callback
+} : {
+    callback: (path: string) => Promise<void>,
+}) => {
+    const Dialogs = useDialogs();
+
+    return (
+        <Button
+            variant='secondary'
+            id="ssh-file-add-custom"
+            onClick={
+                async () => {
+                    const user = await cockpit.user();
+                    Dialogs.show(
+                        <FileChooser
+                            title={_("Add private SSH key")}
+                            action={callback}
+                            actionLabel={_("Add key")}
+                            path={user.home + "/.ssh"}
+                        />
+                    );
+                }
+            }
+        >
+            {_("Add key")}
+        </Button>
+    );
+};
+
 export const CredentialsModal = ({
     dialogResult
 } : {
     dialogResult: DialogResult<void>
 }) => {
     const keys = useObject(() => credentials.keys_instance(), null, []);
-    const [addNewKey, setAddNewKey] = useState(false);
     const [dialogError, setDialogError] = useState();
     const [unlockKey, setUnlockKey] = useState<string | undefined>();
 
@@ -262,6 +241,17 @@ export const CredentialsModal = ({
         }
     }
 
+    const addCustomKey = async (newKeyPath: string): Promise<void> => {
+        try {
+            await keys.load(newKeyPath, "");
+        } catch (ex) {
+            if (!(ex instanceof credentials.KeyLoadError) || !ex.sent_password)
+                throw ex;
+            else
+                setUnlockKey(newKeyPath);
+        }
+    };
+
     return (
         <>
             <Modal isOpen position="top" variant="medium"
@@ -274,13 +264,10 @@ export const CredentialsModal = ({
                         {dialogError && <ModalError dialogError={dialogError} />}
                         <Flex justifyContent={{ default: 'justifyContentSpaceBetween' }}>
                             <FlexItem>{_("Use the following keys to authenticate against other systems")}</FlexItem>
-                            <Button variant='secondary'
-                                    id="ssh-file-add-custom"
-                                    onClick={() => setAddNewKey(true)}>
-                                {_("Add key")}
-                            </Button>
+                            <WithDialogs>
+                                <AddKeyButton callback={addCustomKey} />
+                            </WithDialogs>
                         </Flex>
-                        {addNewKey && <AddNewKey keys={keys} unlockKey={setUnlockKey} onClose={() => setAddNewKey(false)} />}
                         <ListingTable
                             aria-label={ _("SSH keys") }
                             gridBreakPoint=''
@@ -339,7 +326,7 @@ export const CredentialsModal = ({
                     <Button variant='secondary' onClick={() => dialogResult.resolve()}>{_("Close")}</Button>
                 </ModalFooter>
             </Modal>
-            {unlockKey && <UnlockKey keyName={unlockKey} keys={keys} onClose={() => { setUnlockKey(undefined); setAddNewKey(false) }} />}
+            {unlockKey && <UnlockKey keyName={unlockKey} keys={keys} onClose={() => setUnlockKey(undefined)} />}
         </>
     );
 };

--- a/test/common/dialoglib.py
+++ b/test/common/dialoglib.py
@@ -159,3 +159,24 @@ class DialogHelpers:
 
     def set_FileChooserInput(self, path: str, val: str) -> None:
         self.browser.set_input_text(self.field(path) + " input", val)
+
+
+class FileChooserHelpers(DialogHelpers):
+
+    def file(self, name: str) -> str:
+        return f"{self.dialogSelector} .file-chooser-listing-body tr[data-name='{name}']"
+
+    def sidebar(self, name: str) -> str:
+        return f"{self.dialogSelector} .file-chooser-sidebar tr:contains('{name}')"
+
+    def wait_path(self, path: str) -> None:
+        self.browser.wait_js_func(
+            "((sel, path) => ph_select(sel).map(e => e.textContent).join('/') === path)",
+            f"{self.dialogSelector} .file-chooser-listing-breadcrumbs li a", path)
+
+    def set_path(self, path: str) -> None:
+        for p in path.split("/"):
+            if p == "":
+                self.browser.click(self.sidebar("Filesystem"))
+            else:
+                self.browser.mouse(self.file(p), "dblclick")

--- a/test/verify/check-dialog
+++ b/test/verify/check-dialog
@@ -362,7 +362,7 @@ class TestDialog(testlib.MachineCase):
         b = self.browser
         m = self.machine
         d = dialoglib.DialogHelpers(b, "#dialog")
-        df = dialoglib.DialogHelpers(b, ".file-chooser")
+        fc = dialoglib.FileChooserHelpers(b, ".file-chooser")
 
         # Inject a mock xdg-user-dir utility.
 
@@ -409,24 +409,19 @@ echo $HOME/Downloads
         d.set_FileChooserInput("file", test_files)
         b.wait_in_text(d.helper_text("file"), "directory")
 
-        def file(name):
-            return f".file-chooser-listing-body tr[data-name='{name}']"
-
         # Navigate to empty directory
 
         b.click(d.field("file") + " .pf-v6-c-text-input-group__utilities button")
         b.wait_visible(".file-chooser")
-        b.mouse(file("cockpittest"), "dblclick")
-        b.mouse(file("file-chooser-test"), "dblclick")
-        b.mouse(file("empty"), "dblclick")
+        fc.set_path("cockpittest/file-chooser-test/empty")
         b.wait_in_text(".file-chooser-listing-body", "Directory is empty")
 
         # Go up and choose tmpdir/file-chooser-test/foo
 
         b.click(".file-chooser-listing-breadcrumbs a:contains('file-chooser-test')")
         b.assert_pixels(".file-chooser", "basic")
-        b.mouse(file("foo"), "click")
-        b.click(df.apply_button())
+        b.mouse(fc.file("foo"), "click")
+        b.click(fc.apply_button())
 
         d.wait_FileChooserInput("file", test_files + "/file-chooser-test/foo")
         b.wait_in_text(d.helper_text("file"), "ASCII text")
@@ -435,13 +430,13 @@ echo $HOME/Downloads
 
         b.click(d.field("file") + " .pf-v6-c-text-input-group__utilities button")
         b.wait_visible(".file-chooser-listing-breadcrumbs nav")
-        b.wait_visible(file("foo"))
-        b.click(".file-chooser-sidebar tr:contains('Recent')")
+        b.wait_visible(fc.file("foo"))
+        b.click(fc.sidebar("Recent"))
         b.wait_not_present(".file-chooser-listing-breadcrumbs nav")
-        b.wait_visible(file("foo"))
-        b.wait_in_text(file("foo"), test_files + "/file-chooser-test")
-        b.mouse(file("foo"), "click")
-        b.click(df.apply_button())
+        b.wait_visible(fc.file("foo"))
+        b.wait_in_text(fc.file("foo"), test_files + "/file-chooser-test")
+        b.mouse(fc.file("foo"), "click")
+        b.click(fc.apply_button())
         d.wait_FileChooserInput("file", test_files + "/file-chooser-test/foo")
         b.wait_in_text(d.helper_text("file"), "ASCII text")
 
@@ -450,18 +445,18 @@ echo $HOME/Downloads
         m.execute("echo hi > ~admin/.dot-file")
 
         b.click(d.field("file") + " .pf-v6-c-text-input-group__utilities button")
-        b.click(".file-chooser-sidebar tr:contains('Home')")
+        b.click(fc.sidebar("Home"))
         # home can be /home/admin or /var/home/admin.
         home = m.execute("echo -n ~admin")
         b.wait_text(".file-chooser-listing-breadcrumbs", home.replace("/", ""))
         b.click(".file-chooser-listing-breadcrumbs a:contains('home')")
-        b.mouse(file("admin"), "dblclick")
+        b.mouse(fc.file("admin"), "dblclick")
         b.wait_in_text(".file-chooser-listing-body", "This directory contains only hidden files")
         b.click(".file-chooser-listing-body button:contains('Show hidden files')")
-        b.wait_visible(file(".ssh"))
+        b.wait_visible(fc.file(".ssh"))
         b.click(".file-chooser-listing-header button:contains('All files')")
-        b.click(file(".dot-file"))
-        b.click(df.apply_button())
+        b.click(fc.file(".dot-file"))
+        b.click(fc.apply_button())
 
         d.wait_FileChooserInput("file", f"{home}/.dot-file")
         b.wait_in_text(d.helper_text("file"), "ASCII text")
@@ -475,8 +470,7 @@ echo $HOME/Downloads
 
         # Check that we can't read /root
 
-        b.click(".file-chooser-sidebar tr:contains('Filesystem')")
-        b.mouse(file("root"), "dblclick")
+        fc.set_path("/root")
         b.wait_in_text(".file-chooser-listing-body", "Permission denied")
         b.assert_pixels(".file-chooser", "denied")
         b.click(".file-chooser .pf-v6-c-modal-box__close button")
@@ -486,31 +480,31 @@ echo $HOME/Downloads
 
         d.set_FileChooserInput("file", "")
         b.click(d.field("file") + " .pf-v6-c-text-input-group__utilities button")
-        b.click(".file-chooser-sidebar tr:contains('Test files')")
-        b.mouse(file("file-chooser-test"), "dblclick")
+        b.click(fc.sidebar("Test files"))
+        fc.set_path("file-chooser-test")
 
-        b.wait_visible(file("bar"))
-        b.wait_visible(file("foo"))
-        b.wait_visible(file("foobar"))
+        b.wait_visible(fc.file("bar"))
+        b.wait_visible(fc.file("foo"))
+        b.wait_visible(fc.file("foobar"))
 
         b.set_input_text(".file-chooser-listing-header input", "fo")
-        b.wait_visible(file("foo"))
-        b.wait_not_present(file("bar"))
-        b.wait_visible(file("foobar"))
+        b.wait_visible(fc.file("foo"))
+        b.wait_not_present(fc.file("bar"))
+        b.wait_visible(fc.file("foobar"))
         b.assert_pixels(".file-chooser", "filtered")
 
         b.set_input_text(".file-chooser-listing-header input", "ba")
-        b.wait_not_present(file("foo"))
-        b.wait_visible(file("bar"))
-        b.wait_visible(file("foobar"))
+        b.wait_not_present(fc.file("foo"))
+        b.wait_visible(fc.file("bar"))
+        b.wait_visible(fc.file("foobar"))
 
         b.set_input_text(".file-chooser-listing-header input", "xxx")
         b.wait_in_text(".file-chooser-listing-body", "No matching results")
         b.click(".file-chooser-listing-body button:contains('Clear filters')")
 
-        b.wait_visible(file("bar"))
-        b.wait_visible(file("foo"))
-        b.wait_visible(file("foobar"))
+        b.wait_visible(fc.file("bar"))
+        b.wait_visible(fc.file("foo"))
+        b.wait_visible(fc.file("foobar"))
 
         # Prepared filtering.
 
@@ -519,15 +513,15 @@ echo $HOME/Downloads
 
         b.click(".file-chooser-listing-header button:contains('All files')")
 
-        b.wait_visible(file("bar"))
-        b.wait_visible(file("foo"))
-        b.wait_visible(file("foobar"))
-        b.wait_visible(file("dots.txt"))
-        b.wait_visible(file("only.dots"))
+        b.wait_visible(fc.file("bar"))
+        b.wait_visible(fc.file("foo"))
+        b.wait_visible(fc.file("foobar"))
+        b.wait_visible(fc.file("dots.txt"))
+        b.wait_visible(fc.file("only.dots"))
 
-        b.mouse(file("only.dots"), "dblclick")
-        b.wait_visible(file("one.dot"))
-        b.wait_visible(file("two.dots"))
+        b.mouse(fc.file("only.dots"), "dblclick")
+        b.wait_visible(fc.file("one.dot"))
+        b.wait_visible(fc.file("two.dots"))
 
         b.click(".file-chooser-listing-header button:contains('No dots')")
 
@@ -538,8 +532,8 @@ echo $HOME/Downloads
 
         b.click(".file-chooser-listing-body button:contains('Clear filters')")
 
-        b.wait_visible(file("one.dot"))
-        b.wait_visible(file("two.dots"))
+        b.wait_visible(fc.file("one.dot"))
+        b.wait_visible(fc.file("two.dots"))
 
         b.click(".file-chooser .pf-v6-c-modal-box__close button")
         b.wait_not_present(".file-chooser")
@@ -547,14 +541,14 @@ echo $HOME/Downloads
         # Test the collection
 
         b.click(d.field("file") + " .pf-v6-c-text-input-group__utilities button")
-        b.click(".file-chooser-sidebar tr:contains('Some files')")
-        b.wait_visible(file("foo"))
-        b.wait_not_present(file("dots.txt"))
+        b.click(fc.sidebar("Some files"))
+        b.wait_visible(fc.file("foo"))
+        b.wait_not_present(fc.file("dots.txt"))
         b.click(".file-chooser-listing-header button:contains('All files')")
-        b.wait_visible(file("foo"))
-        b.wait_visible(file("dots.txt"))
-        b.click(file("dots.txt"))
-        b.click(df.apply_button())
+        b.wait_visible(fc.file("foo"))
+        b.wait_visible(fc.file("dots.txt"))
+        b.click(fc.file("dots.txt"))
+        b.click(fc.apply_button())
 
         d.wait_FileChooserInput("file", "/var/lib/cockpittest/file-chooser-test/dots.txt")
         b.wait_in_text(d.helper_text("file"), "ASCII text")
@@ -566,10 +560,8 @@ echo $HOME/Downloads
         b.become_superuser()
 
         b.click(d.field("file") + " .pf-v6-c-text-input-group__utilities button")
-        b.click(".file-chooser-sidebar tr:contains('Filesystem')")
-        b.mouse(file("root"), "dblclick")
-        b.mouse(file("hello"), "click")
-        b.click(df.apply_button())
+        fc.set_path("/root/hello")
+        b.click(fc.apply_button())
         d.wait_FileChooserInput("file", "/root/hello")
         b.wait_in_text(d.helper_text("file"), "ASCII text")
 
@@ -579,20 +571,20 @@ echo $HOME/Downloads
         b.click(d.field("dir") + " .pf-v6-c-text-input-group__utilities button")
 
         b.wait_in_text(".file-chooser-listing-body", "No recent directories")
-        b.click(".file-chooser-sidebar tr:contains('Test files')")
-        b.click(file("file-chooser-test"))
-        b.click(df.apply_button())
+        b.click(fc.sidebar("Test files"))
+        b.click(fc.file("file-chooser-test"))
+        b.click(fc.apply_button())
 
         d.wait_FileChooserInput("dir", test_files + "/file-chooser-test")
 
         b.click(d.field("dir") + " .pf-v6-c-text-input-group__utilities button")
-        b.wait_visible(file("only.dots"))
-        b.click(".file-chooser-sidebar tr:contains('Recent')")
-        b.wait_visible(file("file-chooser-test"))
-        b.wait_not_present(file("foo"))
-        b.wait_in_text(file("file-chooser-test"), test_files)
+        b.wait_visible(fc.file("only.dots"))
+        b.click(fc.sidebar("Recent"))
+        b.wait_visible(fc.file("file-chooser-test"))
+        b.wait_not_present(fc.file("foo"))
+        b.wait_in_text(fc.file("file-chooser-test"), test_files)
 
-        b.wait_visible(df.apply_button() + ":disabled")
+        b.wait_visible(fc.apply_button() + ":disabled")
         b.click(".file-chooser .pf-v6-c-modal-box__close button")
         b.wait_not_present(".file-chooser")
 
@@ -605,8 +597,8 @@ echo $HOME/Downloads
         b.wait_visible(".file-chooser-kebab")
 
         b.select_PF(".file-chooser-kebab", "Test files")
-        b.mouse(file("file-chooser-test"), "dblclick")
-        b.wait_visible(file("empty"))
+        b.mouse(fc.file("file-chooser-test"), "dblclick")
+        b.wait_visible(fc.file("empty"))
 
         b.click(".file-chooser .pf-v6-c-modal-box__close button")
         b.wait_not_present(".file-chooser")
@@ -617,26 +609,25 @@ echo $HOME/Downloads
 
         b.click("#open-file-chooser")
         b.wait_visible(".file-chooser")
-        b.click(".file-chooser-sidebar tr:contains('Some TXT files')")
-        b.wait_visible(file("foo.txt"))
-        b.wait_not_present(file("no-such-file.txt"))
-        b.click(file("foo.txt"))
-        b.wait_text(df.apply_button(), "Load")
-        b.click(df.apply_button())
+        b.click(fc.sidebar("Some TXT files"))
+        b.wait_visible(fc.file("foo.txt"))
+        b.wait_not_present(fc.file("no-such-file.txt"))
+        b.click(fc.file("foo.txt"))
+        b.wait_text(fc.apply_button(), "Load")
+        b.click(fc.apply_button())
         b.wait_not_present(".file-chooser")
 
         b.click("#open-file-chooser")
         b.wait_visible(".file-chooser")
-        b.click(".file-chooser-sidebar tr:contains('Test files')")
-        b.mouse(file("file-chooser-test"), "dblclick")
-        b.mouse(file("text"), "dblclick")
-        b.wait_visible(file("foo.txt"))
-        b.wait_visible(file("bar.txt"))
-        b.click(file("bar.txt"))
-        b.click(df.apply_button())
-        b.wait_in_text(df.error(), "Does not start with \"foo\"")
-        b.click(file("foo.txt"))
-        b.click(df.apply_button())
+        b.click(fc.sidebar("Test files"))
+        fc.set_path("file-chooser-test/text")
+        b.wait_visible(fc.file("foo.txt"))
+        b.wait_visible(fc.file("bar.txt"))
+        b.click(fc.file("bar.txt"))
+        b.click(fc.apply_button())
+        b.wait_in_text(fc.error(), "Does not start with \"foo\"")
+        b.click(fc.file("foo.txt"))
+        b.click(fc.apply_button())
         b.wait_not_present(".file-chooser")
 
 

--- a/test/verify/check-shell-keys
+++ b/test/verify/check-shell-keys
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 
+import dialoglib
 import testlib
 
 FP_SHA256 = "SHA256:iyVAl4Z8riL9Jg4fV9Wv/6cbqebdDtsBEMkojNLLYX8"
@@ -295,21 +296,22 @@ session    optional     pam_ssh_add.so
         b.wait_visible("#credential-keys")
         b.wait_not_present("#ssh-file-add")
         b.click("#ssh-file-add-custom")
-        b.set_file_autocomplete_val("#ssh-file-add-key", "/etc/")
-        b.click("#ssh-file-add")
-        b.wait_text("#credentials-modal .pf-m-error > .pf-v6-c-helper-text__item-text", "Not a valid private key")
 
-        b.set_input_text("#credentials-modal .pf-v6-c-menu-toggle input", "/var/test/")
-        b.wait_in_text(".pf-v6-c-menu__list-item.pf-m-aria-disabled", "No such file or directory")
-        b.focus("#credentials-modal .pf-v6-c-menu-toggle input")
-        b.key("Backspace", 5)
-        b.wait_visible(".pf-v6-c-menu__list-item.directory:contains('/var/lib/')")
-        b.click("#credentials-modal .pf-v6-c-menu-toggle button[aria-label='Clear input value']")
-        b.wait_val("#credentials-modal .pf-v6-c-menu-toggle input", "")
+        fc = dialoglib.FileChooserHelpers(b, ".file-chooser")
 
-        b.set_file_autocomplete_val("#ssh-file-add-key", "/tmp/new.rsa")
-        b.click("#ssh-file-add")
-        b.wait_not_present("#ssh-file-add")
+        # Should open in ~admin/.ssh
+        ssh_dir = m.execute("echo -n ~admin/.ssh")
+        fc.wait_path(ssh_dir)
+
+        # Select something that is not a private key
+        fc.set_path("id_rsa.pub")
+        b.click(fc.apply_button())
+        b.wait_in_text(fc.error(), "Not a valid private key")
+
+        # Select /tmp/new.rsa
+        fc.set_path("/tmp/new.rsa")
+        b.click(fc.apply_button())
+
         # OpenSSH 7.8 and up has a new default key format where
         # keys are marked as "agent_only", thereby limiting functionality
         keys = list_keys()
@@ -338,15 +340,14 @@ session    optional     pam_ssh_add.so
         m.execute("chown admin:admin /tmp/new_with_passphrase.rsa")
         m.execute("rm /tmp/new_with_passphrase.rsa.pub")
 
-        b.wait_not_present("#ssh-file-add")
         b.click("#ssh-file-add-custom")
-        b.set_file_autocomplete_val("#ssh-file-add-key", "/tmp/new_with_passphrase.rsa")
-        b.click("#ssh-file-add")
+        fc.set_path("/tmp/new_with_passphrase.rsa")
+        b.click(fc.apply_button())
+
         b.wait_visible("h1:contains('Unlock key /tmp/new_with_passphrase.rsa')")
         b.set_input_text("#\\/tmp\\/new_with_passphrase\\.rsa-password", "foobar")
         b.click("button:contains('Unlock')")
         b.wait_not_present("h1:contains('Unlock key /tmp/new_with_passphrase.rsa')")
-        b.wait_not_present("#ssh-file-add")
         b.wait_count("#credential-keys tbody", 4)
 
         b.click("#credentials-modal button[aria-label=Close]")


### PR DESCRIPTION
Demo: https://youtu.be/5YccZ_m3i6s

----------------

shell: SSH keys are now added with a new file chooser dialog

We are going to replace many of the old uses of the FileAutoComplete component with a new file chooser dialog. This is the first instance. Please try it out and give feedback!

<img width="1438" height="732" alt="image" src="https://github.com/user-attachments/assets/88e96f92-c970-42fe-90b5-a0cf7e872042" />
