### PR TITLE
test: Drop Ubuntu 24.04 workarounds

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1863,11 +1863,10 @@ class MachineCase(unittest.TestCase):
         self.restart_sshd = f'systemctl try-restart {self.sshd_service}'
 
         # only enabled by default on released OSes; see pkg/shell/manifest.json
-        self.multihost_enabled = image.startswith(("rhel-9", "centos-9")) or image in [
-                "ubuntu-2404"]
+        self.multihost_enabled = image.startswith(("rhel-9", "centos-9"))
 
         # sudo-rs behaves quite differently, tests need to adapt
-        self.has_sudo_rs = image.startswith("ubuntu") and image not in ["ubuntu-2404", "ubuntu-stable"]
+        self.has_sudo_rs = image.startswith("ubuntu") and image not in ["ubuntu-stable"]
 
     def nonDestructiveSetup(self) -> None:
         """generic setUp/tearDown for @nondestructive tests"""

--- a/test/image-prepare
+++ b/test/image-prepare
@@ -125,7 +125,7 @@ def build_install_package(dist_tars: list[str], image: str, *, quick: bool) -> l
         args.append("--run-command")
         suppress = {'initial-upload-closes-no-bugs', 'newer-standards-version'}
         # older OSes don't yet know about watch format v5; drop ubuntu-stable once that moves to lintian 2.127.0
-        if image in ["debian-trixie", "ubuntu-2404", "ubuntu-stable"]:
+        if image in ["debian-trixie", "ubuntu-stable"]:
             suppress.add("missing-debian-watch-file-standard")
 
         args.append(fr"""

--- a/test/pytest/conftest.py
+++ b/test/pytest/conftest.py
@@ -2,12 +2,10 @@ import asyncio
 import os
 import subprocess
 import sys
-from importlib.metadata import version
 from typing import AsyncGenerator
 
 import pytest
 import pytest_asyncio
-from packaging.specifiers import SpecifierSet
 
 from cockpit._vendor.systemd_ctypes import EventLoopPolicy
 
@@ -42,14 +40,6 @@ else:
 # AbstractEventLoopPolicy is deprecated in 3.14 and will be removed in 3.16
 def event_loop_policy() -> asyncio.AbstractEventLoopPolicy:  # type: ignore[name-defined]
     return EventLoopPolicy()
-
-
-# if m.image in ['ubuntu-2404', '🙃']:
-if version("pytest-asyncio") not in SpecifierSet(">=0.22"):
-    # Compatibility with pre-`event_loop_policy` versions of pytest-asyncio
-    @pytest.fixture(autouse=True)
-    def event_loop() -> asyncio.AbstractEventLoop:
-        return EventLoopPolicy().new_event_loop()
 
 
 @pytest_asyncio.fixture(autouse=True)

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -507,10 +507,6 @@ class TestHistoryMetrics(testlib.MachineCase):
         except AssertionError:
             self.assertIn(f"until=2021-3-8%2010%3A{load_minute + 1}%3A", url)
 
-        # Workaround journald crash? on ubuntu 2404.
-        if m.image == "ubuntu-2404":
-            b.logout()
-
     @testlib.nondestructive
     def testNoDataEnable(self):
         b = self.browser

--- a/test/verify/check-sosreport
+++ b/test/verify/check-sosreport
@@ -24,7 +24,7 @@ class TestSOS(testlib.MachineCase):
         # Older Debian and Ubuntu systems have sosreport in /tmp
         # Newer versions of sosreport changed to /var/tmp
         # https://github.com/sosreport/sos/pull/4090
-        if m.image in ["debian-trixie", "ubuntu-2404"]:
+        if m.image in ["debian-trixie"]:
             self.report_dir = "/tmp"
         else:
             self.report_dir = "/var/tmp"

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -1419,7 +1419,7 @@ WantedBy=multi-user.target
         m.execute("systemctl stop test.service")
         self.check_service_details(["Read-only", "Disabled"], [], enabled=False, onoff=False, kebab=False)
 
-    @testlib.skipImage("no quadlet (pod) support", "ubuntu-2404", "rhel-8-10")
+    @testlib.skipImage("no quadlet (pod) support", "rhel-8-10")
     @testlib.nondestructive
     def testQuadlets(self):
         m = self.machine


### PR DESCRIPTION
Cockpit no longer tests on Ubuntu 24.04