### PR TITLE
ws: Fix memory leak of the CockpitLang cookie value in the login page

### DIFF
--- a/src/ws/cockpithandlers.c
+++ b/src/ws/cockpithandlers.c
@@ -399,7 +399,10 @@ send_login_html (CockpitWebResponse *response,
   gchar *cookie_line = NULL;
   gchar *base;
 
-  gchar *language = NULL;
+  /* "language" is a borrowed pointer, owned by either "language_cookie"
+   * or "languages" below */
+  const gchar *language = NULL;
+  g_autofree gchar *language_cookie = NULL;
   gchar **languages = NULL;
   GBytes *po_bytes;
   CockpitWebFilter *filter3 = NULL;
@@ -426,8 +429,12 @@ send_login_html (CockpitWebResponse *response,
 
   if (ws->login_po_js)
     {
-      language = cockpit_web_server_parse_cookie (headers, "CockpitLang");
-      if (!language)
+      language_cookie = cockpit_web_server_parse_cookie (headers, "CockpitLang");
+      if (language_cookie)
+        {
+          language = language_cookie;
+        }
+      else
         {
           accept = g_hash_table_lookup (headers, "Accept-Language");
           languages = cockpit_web_server_parse_accept_list (accept, NULL);


### PR DESCRIPTION
send_login_html() takes the language from the "CockpitLang" cookie, which cockpit_web_server_parse_cookie() returns as a newly allocated string.  That string was never freed: the function only releases "languages", the string vector used for the "Accept-Language" fallback path.

Every unauthenticated request that carries a CockpitLang cookie (a plain GET / on the login page is enough) therefore leaks one heap allocation whose size is attacker controlled, up to the request header size limit.  A remote unauthenticated attacker can repeat this to exhaust the memory of the host and cause a denial of service.

Keep "language" a borrowed pointer and give the cookie value an owner: "language_cookie" for the cookie path, "languages" for the Accept-Language path, so both are released on return.

The leak was introduced in 5516e7af3 ("ws: Translate login page").

Fixes: CVE-2026-76235