### PR TITLE
test: Allow installing updates from a vendor

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -43,7 +43,7 @@ fi
 main_builds_repo="$(ls /etc/yum.repos.d/*cockpit*main-builds* 2>/dev/null || true)"
 if [ -n "$main_builds_repo" ]; then
     echo 'priority=0' >> "$main_builds_repo"
-    dnf distro-sync -y 'cockpit*'
+    dnf distro-sync --setopt=allow_vendor_change=1 -y 'cockpit*'
 fi
 
 #HACK: unbreak RHEL 9's default choice of 999999999 rounds, see https://bugzilla.redhat.com/show_bug.cgi?id=1993919


### PR DESCRIPTION
New DNF5 policy does not allow switching vendors if in our example a COPR repository offers a newer version of cockpit. We want to override this behaviour and in reverse dependency testing install the latest version of cockpit (provided by @cockpit/main-builds).

https://fedoraproject.org/wiki/Changes/DisableVendorChangeByDefault