### PR TITLE
packages: Ignore override files with invalid JSON

### DIFF
--- a/src/cockpit/packages.py
+++ b/src/cockpit/packages.py
@@ -439,8 +439,9 @@ class PackagesLoader:
             except FileNotFoundError:
                 continue
             except json.JSONDecodeError as exc:
-                # User input error: report a warning
+                # User input error: report a warning and ignore this file.
                 logger.warning('%s: %s', override_file, exc)
+                continue
 
             if not isinstance(override, dict):
                 logger.warning('%s: override file is not a dictionary', override_file)

--- a/test/pytest/test_packages.py
+++ b/test/pytest/test_packages.py
@@ -89,6 +89,33 @@ def test_override_etc(pkgdir: Path, confdir: Path) -> None:
     }
 
 
+def test_override_invalid_json(pkgdir: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """An override file with broken JSON must be ignored, not crash the bridge."""
+    (pkgdir / 'basic' / 'override.json').write_text('{ "priority": 5,, }')
+
+    packages = Packages()
+    assert len(packages.packages) == 1
+    # the broken override is ignored, the manifest is untouched
+    assert packages.packages['basic'].manifest['description'] == 'standard package'
+    assert packages.packages['basic'].priority == 1
+    assert 'override.json' in caplog.text
+
+
+def test_override_invalid_json_does_not_hide_later_ones(
+    pkgdir: Path, confdir: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A broken override file must not stop the remaining ones from being applied."""
+    # first candidate: broken
+    (pkgdir / 'basic' / 'override.json').write_text('not json at all')
+    # second candidate: fine
+    (confdir / 'basic.override.json').write_text('{"priority": 5}')
+
+    packages = Packages()
+    assert len(packages.packages) == 1
+    assert packages.packages['basic'].priority == 5
+    assert 'override.json' in caplog.text
+
+
 def test_priority(pkgdir: Path) -> None:
     make_package(pkgdir, 'vip', name='basic', description='VIP', priority=100)
     make_package(pkgdir, 'guest', description='Guest')


### PR DESCRIPTION
The JSONDecodeError handler in PackagesLoader.patch_manifest() logs a warning but then falls through into the code that applies the override, because it is missing a `continue`.

That has two consequences:

 * If the *first* override file we try is invalid JSON, `override` was never assigned, and the following `isinstance(override, dict)` check raises UnboundLocalError.  This propagates out of load_manifests() and aborts loading of all packages — a single typo in a hand-written override.json takes the whole bridge down instead of just being reported as a warning.

 * If a *later* override file is invalid, `override` still holds the value parsed from a previous iteration, so that earlier override gets merged into the manifest a second time.

Add the missing `continue` and cover both cases with regression tests.