### PR TITLE
packages: Only strip a literal ".gz" suffix from file names

### DIFF
--- a/src/cockpit/packages.py
+++ b/src/cockpit/packages.py
@@ -335,7 +335,7 @@ class Package:
                 self.translations[f'{basename}.js'][lower_locale] = name
             else:
                 # strip out trailing '.gz' components
-                basename = re.sub(r'.gz$', '', name)
+                basename = re.sub(r'\.gz$', '', name)
                 logger.debug('Adding content %r -> %r', basename, name)
                 self.files[basename] = name
 

--- a/test/pytest/test_packages.py
+++ b/test/pytest/test_packages.py
@@ -346,6 +346,26 @@ def test_filename_mangling(pkgdir: Path) -> None:
     assert encodings == {None, 'gzip'}  # make sure we saw both compressed and uncompressed
 
 
+def test_filename_gz_suffix_only(pkgdir: Path) -> None:
+    """Only a literal '.gz' suffix may be stripped, not any character + 'gz'."""
+    make_package(pkgdir, 'one')
+
+    (pkgdir / 'one' / 'data.tgz').write_bytes(b'a tarball')
+    (pkgdir / 'one' / 'logo.svgz').write_bytes(b'a compressed svg')
+
+    packages = Packages()
+
+    # these must be served under their own names, unmodified
+    assert packages.load_path('/one/data.tgz', {}).data.read() == b'a tarball'
+    assert packages.load_path('/one/logo.svgz', {}).data.read() == b'a compressed svg'
+
+    # ... and must not have been registered under a truncated name
+    with pytest.raises(KeyError):
+        packages.load_path('/one/data.', {})
+    with pytest.raises(KeyError):
+        packages.load_path('/one/logo.s', {})
+
+
 def test_overlapping_minified(pkgdir: Path) -> None:
     make_package(pkgdir, 'one')
     (pkgdir / 'one' / 'one.min.js').write_text('min')


### PR DESCRIPTION
The regular expression used to strip the compression suffix while scanning a package directory is `r'.gz$'`.  The dot is unescaped, so it matches *any* character followed by "gz" at the end of the name.

Files whose name ends in "gz" without being gzip-compressed are therefore registered under a truncated name:

    data.tgz   ->  "data."
    logo.svgz  ->  "logo.s"

Requesting such a file under its real name is then a KeyError, ie. a
404.

Escape the dot and add a regression test.