### PR TITLE
common: Fix ignored memfd name and out-of-range ctype arguments

### DIFF
--- a/src/common/cockpitauthorize.c
+++ b/src/common/cockpitauthorize.c
@@ -160,7 +160,7 @@ cockpit_authorize_type (const char *challenge,
           return NULL;
         }
       for (i = 0; i < len; i++)
-        (*type)[i] = tolower ((*type)[i]);
+        (*type)[i] = tolower ((unsigned char) (*type)[i]);
     }
 
   if (challenge[len])

--- a/src/common/cockpitconf.c
+++ b/src/common/cockpitconf.c
@@ -331,7 +331,8 @@ cockpit_conf_strv (const char *section,
     {
       /* strip off trailing whitespace (leading whitespace is already stripped by regexp) */
       entry->strv_value = strdupx (entry->value);
-      for (char *c = entry->strv_value + strlen (entry->strv_value) - 1; c >= entry->strv_value && isspace (*c); --c)
+      for (char *c = entry->strv_value + strlen (entry->strv_value) - 1;
+           c >= entry->strv_value && isspace ((unsigned char) *c); --c)
         *c = '\0';
       entry->strv_cache = strsplit (entry->strv_value, delimiter);
       entry->strv_delimiter = delimiter;

--- a/src/common/cockpitjsonprint.c
+++ b/src/common/cockpitjsonprint.c
@@ -172,11 +172,11 @@ cockpit_json_print_open_memfd (const char *name,
   int fd;
   /* current kernels moan about not specifying exec mode */
 #ifdef MFD_NOEXEC_SEAL
-  fd = memfd_create ("cockpit login messages", MFD_ALLOW_SEALING | MFD_CLOEXEC | MFD_NOEXEC_SEAL);
+  fd = memfd_create (name, MFD_ALLOW_SEALING | MFD_CLOEXEC | MFD_NOEXEC_SEAL);
   /* fallback for older kernels */
   if (fd == -1 && errno == EINVAL)
 #endif
-    fd = memfd_create ("cockpit login messages", MFD_ALLOW_SEALING | MFD_CLOEXEC);
+    fd = memfd_create (name, MFD_ALLOW_SEALING | MFD_CLOEXEC);
   assert (fd != -1);
 
   FILE *stream = fdopen (fd, "w");


### PR DESCRIPTION
Three defects in the shared code under src/common/:

cockpit_json_print_open_memfd() documents its @name parameter as being "passed to memfd_create, gets displayed in /proc/.../fd", but the parameter is unused: both memfd_create() calls hardcode "cockpit login messages".  So the memfd that cockpit-tls creates for its connection metadata — src/tls/connection.c passes "cockpit-tls metadata" — shows up in /proc as "cockpit login messages", which is actively misleading when inspecting a running system.  Pass @name through.

cockpit_authorize_type() and cockpit_conf_strv() pass a plain `char` to tolower() and isspace().  C requires the argument of the <ctype.h> functions to be representable as unsigned char or equal to EOF; where char is signed, any byte >= 0x80 is passed as a negative value, which is undefined behaviour (on implementations that index a table directly it is an out-of-bounds read).

Both are reachable with attacker- or admin-supplied bytes: cockpit_authorize_type() parses the "authorize" challenge, which comes straight from the HTTP Authorization header, and cockpit_conf_strv() trims values read from cockpit.conf.  For "Négotiate ..." the parser calls tolower(-61) and tolower(-87).

Cast to unsigned char, the way cockpitbase64.c already does.