### PR TITLE
test: Start journald explicitly again after stopping it

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -469,7 +469,8 @@ class TestHistoryMetrics(testlib.MachineCase):
         m.execute("""gunzip /tmp/journal.journal.gz
                      systemctl stop systemd-journald
                      rm /var/log/journal/*/*.journal
-                     cp /tmp/journal.journal /var/log/journal/*/""")
+                     cp /tmp/journal.journal /var/log/journal/*/
+                     systemctl start systemd-journald""")
         b.reload()
         b.enter_page("/metrics")
 


### PR DESCRIPTION
The journald service should auto-start, but something goes wrong on recent ubuntu-2604 images where TestHistoryMetrics.testEvents ultimately fails when running "journalctl --sync" during teardown. The error is:

    Failed to connect to Varlink socket: Connection refused

So maybe there something broken about varlink auto-activation. Starting it explicitly works around this problem.