### PR TITLE
Fix skipping Anaconda Storage tests on RHEL/CentOS

### DIFF
--- a/test/verify/check-storage-anaconda
+++ b/test/verify/check-storage-anaconda
@@ -14,7 +14,7 @@ import testlib
 
 @testlib.nondestructive
 @testlib.skipOstree("No /sysroot and directory cannot be created on read-only filesystem")
-@testlib.skipImage("Not relevant for Anaconda", "debian-*", "ubuntu-*", "arch", "rhel-8", "rhel-9")
+@testlib.skipImage("Not relevant for Anaconda", "debian-*", "ubuntu-*", "arch", "rhel-8-10", "rhel-9-*")
 class TestStorageAnaconda(storagelib.StorageCase):
 
     def enterAnacondaMode(self, config):

--- a/test/verify/check-storage-anaconda
+++ b/test/verify/check-storage-anaconda
@@ -14,7 +14,7 @@ import testlib
 
 @testlib.nondestructive
 @testlib.skipOstree("No /sysroot and directory cannot be created on read-only filesystem")
-@testlib.skipImage("Not relevant for Anaconda", "debian-*", "ubuntu-*", "arch", "rhel-8-10", "rhel-9-*")
+@testlib.skipImage("Not relevant for Anaconda", "debian-*", "ubuntu-*", "arch", "rhel-8-10", "rhel-9-*", "rhel-10-*", "centos-9-*", "centos-10")
 class TestStorageAnaconda(storagelib.StorageCase):
 
     def enterAnacondaMode(self, config):


### PR DESCRIPTION
| context                        | total time (sec) | base time (sec) | diff (sec) | tests | nd tests |
| ------------------------------ | ---------------- | --------------- | ---------- | ----- | -------- |
| arch/storage                   | 704              | 846             | -142       | 32    | 88       |
| centos-10/storage              | 736              | 1060            | -324       | 32    | 88       |
| centos-9-bootc/storage         | 663              | 801             | -138       | 32    | 88       |
| debian-testing/storage         | 724              | 851             | -127       | 32    | 88       |
| debian-trixie/storage          | 713              | 890             | -177       | 32    | 88       |
| fedora-43/storage              | 910              | 1210            | -300       | 32    | 88       |
| fedora-44/firefox-storage      | 935              | 1204            | -269       | 32    | 88       |
| fedora-44/storage              | 940              | 1188            | -248       | 32    | 88       |
| rhel-10-3/storage              | 735              | 984             | -249       | 32    | 88       |
| rhel-8-10/ws-container-storage | 668              | 850             | -182       | 32    | 88       |
| rhel-9-9/storage               | 715              | 903             | -188       | 32    | 88       |
| ubuntu-2604/storage            | 753              | 925             | -172       | 32    | 88       |
| ubuntu-stable/storage          | 753              | 850             | -97        | 32    | 88       |

Average difference: -201s across 13 contexts
