### PR TITLE
packagekit: Implement PackageManager.get_running_updates()

### DIFF
--- a/pkg/lib/_internal/dnf5daemon.ts
+++ b/pkg/lib/_internal/dnf5daemon.ts
@@ -5,7 +5,7 @@
 
 import cockpit from "cockpit";
 import { superuser } from 'superuser';
-import { InstallProgressCB, MissingPackages, PackageManager, ProgressCB, ResolveError, InstallProgressType, UpdateDetail, Update, Severity, History, UpdateWatchHandlers } from './packagemanager-abstract';
+import { InstallProgressCB, MissingPackages, PackageManager, ProgressCB, ResolveError, InstallProgressType, UpdateDetail, Update, Severity, History, UpdateWatchHandlers, TransactionExitStatus } from './packagemanager-abstract';
 
 let _dbus_client: cockpit.DBusClient | null = null;
 
@@ -604,7 +604,7 @@ export class Dnf5DaemonManager implements PackageManager {
         return Array.from(update_map.values()) as T extends true ? UpdateDetail[] : Update[];
     }
 
-    async update_packages(updates: Update[] | UpdateDetail[], progress_cb?: ProgressCB, _transaction_path?: string): Promise<void> {
+    async update_packages(updates: Update[] | UpdateDetail[], handlers: UpdateWatchHandlers): Promise<void> {
         const pkgnames = updates.map(update => update.id);
         let last_progress = 0;
         let total_packages: number;
@@ -621,28 +621,31 @@ export class Dnf5DaemonManager implements PackageManager {
             }
             }
 
-            if (progress_cb) {
-                progress_cb({
-                    waiting: false,
-                    percentage: last_progress,
-                    cancel: null,
-                });
-            }
+            handlers.on_notify({
+                Percentage: last_progress,
+                cancel: null,
+            });
         }
 
-        await this.with_session(async (session) => {
-            await call(session, "org.rpm.dnf.v0.rpm.Rpm", "upgrade", [pkgnames, {}]);
-            const [_transaction_items, result] = await call(session, "org.rpm.dnf.v0.Goal", "resolve", [{}]) as UpgradeResolveResult;
-            if (result !== 0) {
-                const [problem] = await call(session, "org.rpm.dnf.v0.Goal", "get_transaction_problems_string", []);
-                throw new ResolveError(`Resolving upgrade failed with result=${result}. ${problem}`);
-            }
-            await call(session, "org.rpm.dnf.v0.Goal", "do_transaction", [{}]);
-        }, signal_emitted);
+        try {
+            await this.with_session(async (session) => {
+                await call(session, "org.rpm.dnf.v0.rpm.Rpm", "upgrade", [pkgnames, {}]);
+                const [_transaction_items, result] = await call(session, "org.rpm.dnf.v0.Goal", "resolve", [{}]) as UpgradeResolveResult;
+                if (result !== 0) {
+                    const [problem] = await call(session, "org.rpm.dnf.v0.Goal", "get_transaction_problems_string", []);
+                    throw new ResolveError(`Resolving upgrade failed with result=${result}. ${problem}`);
+                }
+                await call(session, "org.rpm.dnf.v0.Goal", "do_transaction", [{}]);
+            }, signal_emitted);
+            handlers.on_finished(TransactionExitStatus.SUCCESS);
+        } catch (ex) {
+            handlers.on_error((ex as Error).message);
+            handlers.on_finished(TransactionExitStatus.FAILED);
+        }
     }
 
-    async get_running_update(_handlers: UpdateWatchHandlers): Promise<string | null> {
-        return null;
+    async get_running_update(_handlers: UpdateWatchHandlers): Promise<boolean> {
+        return false;
     }
 
     async get_backend(): Promise<string> {

--- a/pkg/lib/_internal/dnf5daemon.ts
+++ b/pkg/lib/_internal/dnf5daemon.ts
@@ -5,7 +5,7 @@
 
 import cockpit from "cockpit";
 import { superuser } from 'superuser';
-import { InstallProgressCB, MissingPackages, PackageManager, ProgressCB, ResolveError, InstallProgressType, UpdateDetail, Update, Severity, History } from './packagemanager-abstract';
+import { InstallProgressCB, MissingPackages, PackageManager, ProgressCB, ResolveError, InstallProgressType, UpdateDetail, Update, Severity, History, UpdateWatchHandlers } from './packagemanager-abstract';
 
 let _dbus_client: cockpit.DBusClient | null = null;
 
@@ -639,6 +639,10 @@ export class Dnf5DaemonManager implements PackageManager {
             }
             await call(session, "org.rpm.dnf.v0.Goal", "do_transaction", [{}]);
         }, signal_emitted);
+    }
+
+    async get_running_update(_handlers: UpdateWatchHandlers): Promise<string | null> {
+        return null;
     }
 
     async get_backend(): Promise<string> {

--- a/pkg/lib/_internal/packagekit.ts
+++ b/pkg/lib/_internal/packagekit.ts
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
-import { InstallProgressCB, MissingPackages, PackageManager, ProgressCB, InstallProgressType, UpdateDetail, Update, ProgressData, History } from './packagemanager-abstract';
+import cockpit from "cockpit";
+import { InstallProgressCB, MissingPackages, PackageManager, ProgressCB, InstallProgressType, UpdateDetail, Update, ProgressData, History, UpdateWatchHandlers, TransactionExitStatus } from './packagemanager-abstract';
 import * as PK from "packagekit.js";
 
 const InstallProgressMap = {
@@ -242,6 +243,45 @@ export class PackageKitManager implements PackageManager {
 
     async update_packages(updates: Update[] | UpdateDetail[], progress_cb?: ProgressCB, transaction_path?: string): Promise<void> {
         return PK.update_packages(updates, progress_cb, transaction_path);
+    }
+
+    async get_running_update(handlers: UpdateWatchHandlers): Promise<string | null> {
+        let transactions: string[];
+        let roles: unknown[];
+
+        try {
+            [transactions] = await PK.call("/org/freedesktop/PackageKit", "org.freedesktop.PackageKit", "GetTransactionList", []);
+            roles = await Promise.all(transactions.map(path => PK.call(path, "org.freedesktop.DBus.Properties", "Get", [PK.transactionInterface, "Role"])));
+        } catch (ex) {
+            console.warn("GetTransactionList: failed to read PackageKit transaction roles:", (ex as Error).message);
+            return null;
+        }
+        for (let idx = 0; idx < roles.length; ++idx) {
+            if ((roles[idx] as [{ v: number }])[0].v === PK.Enum.ROLE_UPDATE_PACKAGES) {
+                const transactionPath = transactions[idx];
+                PK.watchTransaction(transactionPath,
+                                    {
+                                        ErrorCode: (_code: string, details: string) => handlers.on_error(details),
+                                        Finished: (exit: number) => {
+                                            if (exit === PK.Enum.EXIT_SUCCESS) {
+                                                handlers.on_finished(TransactionExitStatus.SUCCESS);
+                                            } else if (exit === PK.Enum.EXIT_CANCELLED) {
+                                                handlers.on_finished(TransactionExitStatus.CANCELLED);
+                                            } else {
+                                                if (exit !== PK.Enum.EXIT_FAILED)
+                                                    handlers.on_error(cockpit.format(cockpit.gettext("PackageKit reported error code $0"), exit));
+                                                handlers.on_finished(TransactionExitStatus.FAILED);
+                                            }
+                                        },
+                                        Package: (status: number, packageId: string) => handlers.on_package(status, packageId),
+                                    },
+                                    (notify: Record<string, unknown>) => handlers.on_notify(notify),
+                );
+                return transactionPath;
+            }
+        }
+
+        return null;
     }
 
     async get_backend(): Promise<string> {

--- a/pkg/lib/_internal/packagekit.ts
+++ b/pkg/lib/_internal/packagekit.ts
@@ -4,8 +4,16 @@
  */
 
 import cockpit from "cockpit";
-import { InstallProgressCB, MissingPackages, PackageManager, ProgressCB, InstallProgressType, UpdateDetail, Update, ProgressData, History, UpdateWatchHandlers, TransactionExitStatus } from './packagemanager-abstract';
+import { InstallProgressCB, MissingPackages, PackageManager, ProgressCB, InstallProgressType, UpdateProgressType, UpdateDetail, Update, ProgressData, History, UpdateWatchHandlers, TransactionExitStatus } from './packagemanager-abstract';
 import * as PK from "packagekit.js";
+
+const UpdateProgressMap: Record<number, UpdateProgressType> = {
+    [PK.Enum.STATUS_DOWNLOAD]: UpdateProgressType.DOWNLOADING,
+    [PK.Enum.STATUS_INSTALL]: UpdateProgressType.INSTALLING,
+    [PK.Enum.STATUS_UPDATE]: UpdateProgressType.UPDATING,
+    [PK.Enum.STATUS_CLEANUP]: UpdateProgressType.CLEANUP,
+    [PK.Enum.STATUS_SIGCHECK]: UpdateProgressType.SIGCHECK,
+};
 
 const InstallProgressMap = {
     [PK.Enum.INFO_DOWNLOADING]: InstallProgressType.DOWNLOADING,
@@ -241,11 +249,40 @@ export class PackageKitManager implements PackageManager {
         return updates as unknown as T extends true ? UpdateDetail[] : Update[];
     }
 
-    async update_packages(updates: Update[] | UpdateDetail[], progress_cb?: ProgressCB, transaction_path?: string): Promise<void> {
-        return PK.update_packages(updates, progress_cb, transaction_path);
+    async update_packages(updates: Update[] | UpdateDetail[], handlers: UpdateWatchHandlers): Promise<void> {
+        const update_ids = updates.map(u => u.id);
+        let transactionPath: string | null = null;
+
+        await PK.transaction("UpdatePackages", [0, update_ids],
+                             {
+                                 ErrorCode: (_code: string, details: string) => handlers.on_error(details),
+                                 Finished: (exit: number) => {
+                                     if (exit === PK.Enum.EXIT_SUCCESS) {
+                                         handlers.on_finished(TransactionExitStatus.SUCCESS);
+                                     } else if (exit === PK.Enum.EXIT_CANCELLED) {
+                                         handlers.on_finished(TransactionExitStatus.CANCELLED);
+                                     } else {
+                                         if (exit !== PK.Enum.EXIT_FAILED)
+                                             handlers.on_error(cockpit.format(cockpit.gettext("PackageKit reported error code $0"), exit));
+                                         handlers.on_finished(TransactionExitStatus.FAILED);
+                                     }
+                                 },
+                                 Package: (status: number, packageId: string) => {
+                                     if (status in UpdateProgressMap)
+                                         handlers.on_package(UpdateProgressMap[status], packageId);
+                                 },
+                             },
+                             (notify: Record<string, unknown>, path: string) => {
+                                 transactionPath = path;
+                                 const cancel = notify.AllowCancel
+                                     ? () => PK.call(transactionPath!, PK.transactionInterface, "Cancel", [])
+                                     : null;
+                                 handlers.on_notify({ ...notify, cancel });
+                             },
+        );
     }
 
-    async get_running_update(handlers: UpdateWatchHandlers): Promise<string | null> {
+    async get_running_update(handlers: UpdateWatchHandlers): Promise<boolean> {
         let transactions: string[];
         let roles: unknown[];
 
@@ -254,7 +291,7 @@ export class PackageKitManager implements PackageManager {
             roles = await Promise.all(transactions.map(path => PK.call(path, "org.freedesktop.DBus.Properties", "Get", [PK.transactionInterface, "Role"])));
         } catch (ex) {
             console.warn("GetTransactionList: failed to read PackageKit transaction roles:", (ex as Error).message);
-            return null;
+            return false;
         }
         for (let idx = 0; idx < roles.length; ++idx) {
             if ((roles[idx] as [{ v: number }])[0].v === PK.Enum.ROLE_UPDATE_PACKAGES) {
@@ -273,15 +310,23 @@ export class PackageKitManager implements PackageManager {
                                                 handlers.on_finished(TransactionExitStatus.FAILED);
                                             }
                                         },
-                                        Package: (status: number, packageId: string) => handlers.on_package(status, packageId),
+                                        Package: (status: number, packageId: string) => {
+                                            if (status in UpdateProgressMap)
+                                                handlers.on_package(UpdateProgressMap[status], packageId);
+                                        },
                                     },
-                                    (notify: Record<string, unknown>) => handlers.on_notify(notify),
+                                    (notify: Record<string, unknown>) => {
+                                        const cancel = notify.AllowCancel
+                                            ? () => PK.call(transactionPath, PK.transactionInterface, "Cancel", [])
+                                            : null;
+                                        handlers.on_notify({ ...notify, cancel });
+                                    },
                 );
-                return transactionPath;
+                return true;
             }
         }
 
-        return null;
+        return false;
     }
 
     async get_backend(): Promise<string> {

--- a/pkg/lib/_internal/packagemanager-abstract.ts
+++ b/pkg/lib/_internal/packagemanager-abstract.ts
@@ -80,6 +80,19 @@ export interface History {
     packages: Record<string, string>
 }
 
+export enum TransactionExitStatus {
+  SUCCESS = "success",
+  CANCELLED = "cancelled",
+  FAILED = "failed",
+}
+
+export interface UpdateWatchHandlers {
+  on_error: (message: string) => void;
+  on_finished: (status: TransactionExitStatus) => void;
+  on_package: (status: number, packageId: string) => void;
+  on_notify: (props: Record<string, unknown>) => void;
+}
+
 export interface PackageManager {
   name: string
   check_missing_packages(pkgnames: string[], progress_cb?: ProgressCB): Promise<MissingPackages>;
@@ -91,6 +104,7 @@ export interface PackageManager {
   find_file_packages(files: string[], progress_cb?: ProgressCB): Promise<string[]>;
   get_updates<T extends boolean>(detail: T, progress_cb?: ProgressCB): Promise<T extends true ? UpdateDetail[] : Update[]>;
   update_packages(updates: Update[] | UpdateDetail[], progress_cb?: ProgressCB, transaction_path?: string): Promise<void>;
+  get_running_update(handlers: UpdateWatchHandlers): Promise<string | null>;
   get_backend(): Promise<string>;
   get_last_refresh_time(): Promise<number>;
   get_history(): Promise<History[]>;

--- a/pkg/lib/_internal/packagemanager-abstract.ts
+++ b/pkg/lib/_internal/packagemanager-abstract.ts
@@ -80,6 +80,14 @@ export interface History {
     packages: Record<string, string>
 }
 
+export enum UpdateProgressType {
+    DOWNLOADING,
+    INSTALLING,
+    UPDATING,
+    CLEANUP,
+    SIGCHECK,
+}
+
 export enum TransactionExitStatus {
   SUCCESS = "success",
   CANCELLED = "cancelled",
@@ -89,7 +97,7 @@ export enum TransactionExitStatus {
 export interface UpdateWatchHandlers {
   on_error: (message: string) => void;
   on_finished: (status: TransactionExitStatus) => void;
-  on_package: (status: number, packageId: string) => void;
+  on_package: (status: UpdateProgressType, packageId: string) => void;
   on_notify: (props: Record<string, unknown>) => void;
 }
 
@@ -103,8 +111,8 @@ export interface PackageManager {
   remove_packages(pkgnames: string[], progress_cb?: ProgressCB): Promise<void>;
   find_file_packages(files: string[], progress_cb?: ProgressCB): Promise<string[]>;
   get_updates<T extends boolean>(detail: T, progress_cb?: ProgressCB): Promise<T extends true ? UpdateDetail[] : Update[]>;
-  update_packages(updates: Update[] | UpdateDetail[], progress_cb?: ProgressCB, transaction_path?: string): Promise<void>;
-  get_running_update(handlers: UpdateWatchHandlers): Promise<string | null>;
+  update_packages(updates: Update[] | UpdateDetail[], handlers: UpdateWatchHandlers): Promise<void>;
+  get_running_update(handlers: UpdateWatchHandlers): Promise<boolean>;
   get_backend(): Promise<string>;
   get_last_refresh_time(): Promise<number>;
   get_history(): Promise<History[]>;

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -55,7 +55,6 @@ import { ShutdownModal } from 'cockpit-components-shutdown.jsx';
 import { WithDialogs } from "dialogs.jsx";
 
 import { superuser } from 'superuser';
-import * as PK from "packagekit.js";
 import * as python from "python.js";
 import * as timeformat from "timeformat";
 
@@ -65,7 +64,7 @@ import callTracerScript from './callTracer.py';
 
 import "./updates.scss";
 import { Truncate } from '@patternfly/react-core/dist/esm/components/Truncate/index.js';
-import { Severity, TransactionExitStatus } from '_internal/packagemanager-abstract';
+import { Severity, TransactionExitStatus, UpdateProgressType } from '_internal/packagemanager-abstract';
 import { getPackageManager } from 'packagemanager';
 import { Icon } from '@patternfly/react-core/dist/esm/components/Icon/index.js';
 
@@ -73,8 +72,8 @@ const _ = cockpit.gettext;
 
 // "available" heading is built dynamically
 const STATE_HEADINGS = {};
-const PK_STATUS_STRINGS = {};
-const PK_STATUS_LOG_STRINGS = {};
+const STATUS_STRINGS = {};
+const STATUS_LOG_STRINGS = {};
 
 const UPDATES = {
     ALL: 0,
@@ -91,17 +90,17 @@ function init() {
     STATE_HEADINGS.updateError = _("Applying updates failed");
     STATE_HEADINGS.loadError = _("Loading available updates failed");
 
-    PK_STATUS_STRINGS[PK.Enum.STATUS_DOWNLOAD] = _("Downloading");
-    PK_STATUS_STRINGS[PK.Enum.STATUS_INSTALL] = _("Installing");
-    PK_STATUS_STRINGS[PK.Enum.STATUS_UPDATE] = _("Updating");
-    PK_STATUS_STRINGS[PK.Enum.STATUS_CLEANUP] = _("Setting up");
-    PK_STATUS_STRINGS[PK.Enum.STATUS_SIGCHECK] = _("Verifying");
+    STATUS_STRINGS[UpdateProgressType.DOWNLOADING] = _("Downloading");
+    STATUS_STRINGS[UpdateProgressType.INSTALLING] = _("Installing");
+    STATUS_STRINGS[UpdateProgressType.UPDATING] = _("Updating");
+    STATUS_STRINGS[UpdateProgressType.CLEANUP] = _("Setting up");
+    STATUS_STRINGS[UpdateProgressType.SIGCHECK] = _("Verifying");
 
-    PK_STATUS_LOG_STRINGS[PK.Enum.STATUS_DOWNLOAD] = _("Downloaded");
-    PK_STATUS_LOG_STRINGS[PK.Enum.STATUS_INSTALL] = _("Installed");
-    PK_STATUS_LOG_STRINGS[PK.Enum.STATUS_UPDATE] = _("Updated");
-    PK_STATUS_LOG_STRINGS[PK.Enum.STATUS_CLEANUP] = _("Set up");
-    PK_STATUS_LOG_STRINGS[PK.Enum.STATUS_SIGCHECK] = _("Verified");
+    STATUS_LOG_STRINGS[UpdateProgressType.DOWNLOADING] = _("Downloaded");
+    STATUS_LOG_STRINGS[UpdateProgressType.INSTALLING] = _("Installed");
+    STATUS_LOG_STRINGS[UpdateProgressType.UPDATING] = _("Updated");
+    STATUS_LOG_STRINGS[UpdateProgressType.CLEANUP] = _("Set up");
+    STATUS_LOG_STRINGS[UpdateProgressType.SIGCHECK] = _("Verified");
 }
 
 function deduplicate(list) {
@@ -426,8 +425,8 @@ const formatPackageId = packageId => {
 };
 
 // actions is a chronological list of { status, packageId } events that happen during applying updates
-// status: see PK_STATUS_* at https://github.com/PackageKit/PackageKit/blob/main/lib/packagekit-glib2/pk-enum.h
-const ApplyUpdates = ({ transactionProps, actions, onCancel, rebootAfter, setRebootAfter }) => {
+// status: see STATUS_STRINGS
+const ApplyUpdates = ({ transactionProps, actions, rebootAfter, setRebootAfter }) => {
     const remain = transactionProps.RemainingTime
         ? timeformat.distanceToNow(new Date().valueOf() + transactionProps.RemainingTime * 1000)
         : null;
@@ -444,8 +443,8 @@ const ApplyUpdates = ({ transactionProps, actions, onCancel, rebootAfter, setReb
             log.scrollTop = log.scrollHeight;
     }
 
-    const cancelButton = transactionProps.AllowCancel
-        ? <Button variant="secondary" onClick={onCancel} size="sm">{_("Cancel")}</Button>
+    const cancelButton = transactionProps.cancel
+        ? <Button variant="secondary" onClick={transactionProps.cancel} size="sm">{_("Cancel")}</Button>
         : null;
 
     if (actions.length === 0 && percentage === 0) {
@@ -465,7 +464,7 @@ const ApplyUpdates = ({ transactionProps, actions, onCancel, rebootAfter, setReb
                 <GridItem span={12}>
                     <div className="progress-description pf-v6-u-display-flex">
                         <Spinner size="md" isInline />
-                        <strong>{PK_STATUS_STRINGS[lastAction?.status] || PK_STATUS_STRINGS[PK.Enum.STATUS_UPDATE]}</strong>
+                        <strong>{STATUS_STRINGS[lastAction?.status] || STATUS_STRINGS[UpdateProgressType.UPDATING]}</strong>
                         &nbsp;
                         <Truncate content={curPackage} />
                     </div>
@@ -495,7 +494,7 @@ const ApplyUpdates = ({ transactionProps, actions, onCancel, rebootAfter, setReb
                                 <tbody>
                                     { actions.slice(0, -1).map((action, i) => (
                                         <tr key={action.packageId + i}>
-                                            <th>{PK_STATUS_LOG_STRINGS[action.status] || PK_STATUS_LOG_STRINGS[PK.Enum.STATUS_UPDATE]}</th>
+                                            <th>{STATUS_LOG_STRINGS[action.status] || STATUS_LOG_STRINGS[UpdateProgressType.UPDATING]}</th>
                                             <td>{formatPackageId(action.packageId)}</td>
                                         </tr>)) }
                                 </tbody>
@@ -835,7 +834,6 @@ class OsUpdates extends React.Component {
             loadPercent: null,
             cockpitUpdate: false,
             haveOsRepo: null,
-            applyTransaction: null,
             applyTransactionProps: {},
             applyActions: [],
             history: [],
@@ -875,10 +873,10 @@ class OsUpdates extends React.Component {
 
         // check if there is an upgrade in progress already; if so, switch to "applying" state right away
         try {
-            const transaction_path = await packageManager.get_running_update({
+            const running_update = await packageManager.get_running_update({
                 on_error: (message) => this.setState(prevState => ({ errorMessages: [...prevState.errorMessages, message] })),
                 on_finished: (status) => {
-                    this.setState({ applyTransaction: null, applyTransactionProps: {}, applyActions: [] });
+                    this.setState({ applyTransactionProps: {}, applyActions: [] });
 
                     if (status === TransactionExitStatus.SUCCESS) {
                         this.setState({ state: "loading", loadPercent: null });
@@ -911,8 +909,8 @@ class OsUpdates extends React.Component {
             if (!this._mounted)
                 return;
 
-            if (transaction_path) {
-                this.setState({ state: "applying", applyTransaction: transaction_path, applyTransactionProps: {}, applyActions: [] });
+            if (running_update) {
+                this.setState({ state: "applying", applyTransactionProps: {}, applyActions: [] });
             } else {
                 // no running updates found, proceed to showing available updates
                 this.initialLoadOrRefresh();
@@ -1120,57 +1118,6 @@ class OsUpdates extends React.Component {
         }
     }
 
-    watchUpdates(transactionPath) {
-        this.setState({ state: "applying", applyTransaction: transactionPath, applyTransactionProps: {}, applyActions: [] });
-
-        return PK.watchTransaction(transactionPath,
-                                   {
-                                       ErrorCode: (code, details) => this.setState(prevState => ({ errorMessages: [...prevState.errorMessages, details] })),
-
-                                       Finished: exit => {
-                                           this.setState({ applyTransaction: null, applyTransactionProps: {}, applyActions: [] });
-
-                                           if (exit === PK.Enum.EXIT_SUCCESS) {
-                                               this.setState({ state: "loading", loadPercent: null });
-                                               this.loadHistory().then(() => {
-                                                   if (this.state.checkRestartAvailable) {
-                                                       this.checkNeedsRestart()
-                                                               .finally(() => this.setState({ state: "updateSuccess" }));
-                                                   } else {
-                                                       this.setState({ state: "updateSuccess", loadPercent: null });
-                                                   }
-                                               });
-                                           } else if (exit === PK.Enum.EXIT_CANCELLED) {
-                                               if (this.state.checkRestartAvailable) {
-                                                   this.setState({ state: "loading", loadPercent: null });
-                                                   this.checkNeedsRestart();
-                                               }
-                                               this.loadUpdates();
-                                           } else {
-                                               // normally we get FAILED here with ErrorCodes; handle unexpected errors to allow for some debugging
-                                               if (exit !== PK.Enum.EXIT_FAILED)
-                                                   this.setState(prevState => ({ errorMessages: [...prevState.errorMessages, cockpit.format(_("PackageKit reported error code $0"), exit)] }));
-                                               this.setState({ state: "updateError" });
-                                           }
-                                       },
-
-                                       // not working/being used in at least Fedora
-                                       RequireRestart: (type, packageId) => console.log("update RequireRestart", type, packageId),
-
-                                       Package: (status, packageId) => this.setState(old =>
-                                           ({ applyActions: [...old.applyActions, { status, packageId }] })
-                                       ),
-                                   },
-
-                                   notify => this.setState(old =>
-                                       ({ applyTransactionProps: { ...old.applyTransactionProps, ...notify } })
-                                   )
-        )
-                .catch(ex => {
-                    this.setState(prevState => ({ errorMessages: [...prevState.errorMessages, ex], state: "updateError" }));
-                });
-    }
-
     applyUpdates(type) {
         let updates = [...this.state.updates];
         if (type === UPDATES.SECURITY)
@@ -1179,23 +1126,47 @@ class OsUpdates extends React.Component {
             updates = updates.filter(update => isKpatchPackage(update.name));
         }
 
-        PK.transaction()
-                .then(transactionPath => {
-                    this.watchUpdates(transactionPath)
-                            .then(() => {
-                                PK.update_packages(updates, null, transactionPath)
-                                        .catch(ex => {
-                                            // We get more useful error messages through ErrorCode or "PackageKit has crashed", so only
-                                            // show this if we don't have anything else
-                                            this.setState(prevState => ({
-                                                errorMessages: prevState.errorMessages.length === 0 ? [ex.message] : prevState.errorMessages,
-                                                state: "updateError",
-                                            }));
-                                        });
-                            });
-                })
+        this.setState({ state: "applying", applyTransactionProps: {}, applyActions: [] });
+
+        this.state.packageManager.update_packages(updates, {
+            on_error: (message) => this.setState(prevState => ({ errorMessages: [...prevState.errorMessages, message] })),
+            on_finished: (status) => {
+                this.setState({ applyTransactionProps: {}, applyActions: [] });
+
+                if (status === TransactionExitStatus.SUCCESS) {
+                    this.setState({ state: "loading", loadPercent: null });
+                    this.loadHistory().then(() => {
+                        if (this.state.checkRestartAvailable) {
+                            this.checkNeedsRestart()
+                                    .finally(() => this.setState({ state: "updateSuccess" }));
+                        } else {
+                            this.setState({ state: "updateSuccess", loadPercent: null });
+                        }
+                    });
+                } else if (status === TransactionExitStatus.CANCELLED) {
+                    if (this.state.checkRestartAvailable) {
+                        this.setState({ state: "loading", loadPercent: null });
+                        this.checkNeedsRestart();
+                    }
+                    this.loadUpdates();
+                } else {
+                    this.setState({ state: "updateError" });
+                }
+            },
+            on_package: (status, packageId) => this.setState(prevState =>
+                ({ applyActions: [...prevState.applyActions, { status, packageId }] })
+            ),
+            on_notify: (notify) => this.setState(prevState =>
+                ({ applyTransactionProps: { ...prevState.applyTransactionProps, ...notify } })
+            ),
+        })
                 .catch(ex => {
-                    this.setState(prevState => ({ errorMessages: [...prevState.errorMessages, ex.message], state: "updateError" }));
+                    // We get more useful error messages through on_error, so only
+                    // show this if we don't have anything else
+                    this.setState(prevState => ({
+                        errorMessages: prevState.errorMessages.length === 0 ? [ex.message] : prevState.errorMessages,
+                        state: "updateError",
+                    }));
                 });
     }
 
@@ -1353,7 +1324,6 @@ class OsUpdates extends React.Component {
             page_status.set_own(null);
             return <ApplyUpdates transactionProps={this.state.applyTransactionProps}
                                  actions={this.state.applyActions}
-                                 onCancel={ () => PK.call(this.state.applyTransaction, PK.transactionInterface, "Cancel", []) }
                                  rebootAfter={this.state.rebootAfterSuccess}
                                  setRebootAfter={ (_event, enabled) => this.setState({ rebootAfterSuccess: enabled }) }
             />;

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -65,7 +65,7 @@ import callTracerScript from './callTracer.py';
 
 import "./updates.scss";
 import { Truncate } from '@patternfly/react-core/dist/esm/components/Truncate/index.js';
-import { Severity } from '_internal/packagemanager-abstract';
+import { Severity, TransactionExitStatus } from '_internal/packagemanager-abstract';
 import { getPackageManager } from 'packagemanager';
 import { Icon } from '@patternfly/react-core/dist/esm/components/Icon/index.js';
 
@@ -874,34 +874,52 @@ class OsUpdates extends React.Component {
         this.setState({ packageManager, backend });
 
         // check if there is an upgrade in progress already; if so, switch to "applying" state right away
-        PK.call("/org/freedesktop/PackageKit", "org.freedesktop.PackageKit", "GetTransactionList", [])
-                .then(([transactions]) => {
-                    if (!this._mounted)
-                        return;
+        try {
+            const transaction_path = await packageManager.get_running_update({
+                on_error: (message) => this.setState(prevState => ({ errorMessages: [...prevState.errorMessages, message] })),
+                on_finished: (status) => {
+                    this.setState({ applyTransaction: null, applyTransactionProps: {}, applyActions: [] });
 
-                    const promises = transactions.map(transactionPath => PK.call(
-                        transactionPath, "org.freedesktop.DBus.Properties", "Get", [PK.transactionInterface, "Role"]));
+                    if (status === TransactionExitStatus.SUCCESS) {
+                        this.setState({ state: "loading", loadPercent: null });
+                        this.loadHistory().then(() => {
+                            if (this.state.checkRestartAvailable) {
+                                this.checkNeedsRestart()
+                                        .finally(() => this.setState({ state: "updateSuccess" }));
+                            } else {
+                                this.setState({ state: "updateSuccess", loadPercent: null });
+                            }
+                        });
+                    } else if (status === TransactionExitStatus.CANCELLED) {
+                        if (this.state.checkRestartAvailable) {
+                            this.setState({ state: "loading", loadPercent: null });
+                            this.checkNeedsRestart();
+                        }
+                        this.loadUpdates();
+                    } else {
+                        this.setState({ state: "updateError" });
+                    }
+                },
+                on_package: (status, packageId) => this.setState(prevState =>
+                    ({ applyActions: [...prevState.applyActions, { status, packageId }] })
+                ),
+                on_notify: (notify) => this.setState(prevState =>
+                    ({ applyTransactionProps: { ...prevState.applyTransactionProps, ...notify } })
+                ),
+            });
 
-                    Promise.all(promises)
-                            .then(roles => {
-                                // any transaction with UPDATE_PACKAGES role?
-                                for (let idx = 0; idx < roles.length; ++idx) {
-                                    if (roles[idx][0].v === PK.Enum.ROLE_UPDATE_PACKAGES) {
-                                        this.watchUpdates(transactions[idx]);
-                                        return;
-                                    }
-                                }
+            if (!this._mounted)
+                return;
 
-                                // no running updates found, proceed to showing available updates
-                                this.initialLoadOrRefresh();
-                            })
-                            .catch(ex => {
-                                console.warn("GetTransactionList: failed to read PackageKit transaction roles:", ex.message);
-                                // be robust, try to continue with loading updates anyway
-                                this.initialLoadOrRefresh();
-                            });
-                })
-                .catch(this.handleLoadError);
+            if (transaction_path) {
+                this.setState({ state: "applying", applyTransaction: transaction_path, applyTransactionProps: {}, applyActions: [] });
+            } else {
+                // no running updates found, proceed to showing available updates
+                this.initialLoadOrRefresh();
+            }
+        } catch (err) {
+            this.handleLoadError(err);
+        }
     }
 
     componentWillUnmount() {


### PR DESCRIPTION
Move the initial watching of updates to a new method which can be implemented by PackageKit or DNF5Daemon. The current implementation still returns a transaction_path which is PackageKit specific but for now this is temporary until the next commit moves update_packages over to the PackageManager API.

The DNF5Daemon implementation will have to wait until we have update_packages() available.