### PR TITLE
systemd: Make chrony sources drop-in world-readable

### DIFF
--- a/pkg/lib/serverTime.js
+++ b/pkg/lib/serverTime.js
@@ -336,7 +336,7 @@ export function ServerTime() {
                 });
     }
 
-    function set_custom_ntp_chronyd(config) {
+    async function set_custom_ntp_chronyd(config) {
         const enabled_file = cockpit.file(chronyd_sources_enabled, { superuser: "require" });
         const disabled_file = cockpit.file(chronyd_sources_disabled, { superuser: "require" });
 
@@ -353,13 +353,20 @@ export function ServerTime() {
             return cockpit.file("/etc/chrony.conf", { superuser: "require" }).modify(add_sourcedir);
         }
 
-        return cockpit.spawn(["mkdir", "-p", chronyd_sourcedir], { superuser: "require" })
-                .then(() => {
-                    if (config.enabled)
-                        return enabled_file.replace(text).then(() => disabled_file.replace(null)).then(ensure_sourcedir);
-                    else
-                        return disabled_file.replace(text).then(() => enabled_file.replace(null));
-                });
+        // chronyd runs as unprivileged chrony user; must be readable with tight umask
+        await cockpit.spawn(["mkdir", "-p", "-m755", chronyd_sourcedir], { superuser: "require" });
+        await cockpit.spawn(["chmod", "755", "/etc/chrony", chronyd_sourcedir], { superuser: "require" });
+
+        if (config.enabled) {
+            await enabled_file.replace(text);
+            await disabled_file.replace(null);
+            await cockpit.spawn(["chmod", "644", chronyd_sources_enabled], { superuser: "require" });
+            await ensure_sourcedir();
+        } else {
+            await disabled_file.replace(text);
+            await enabled_file.replace(null);
+            await cockpit.spawn(["chmod", "644", chronyd_sources_disabled], { superuser: "require" });
+        }
     }
 
     self.get_custom_ntp = function () {

--- a/pkg/lib/serverTime.js
+++ b/pkg/lib/serverTime.js
@@ -353,9 +353,9 @@ export function ServerTime() {
             return cockpit.file("/etc/chrony.conf", { superuser: "require" }).modify(add_sourcedir);
         }
 
-        // chronyd runs as unprivileged chrony user; must be readable with tight umask
+        // chronyd runs as unprivileged chrony user; must be readable with tight umask.
+        // mkdir -p -m755 sets mode on newly created dirs (existing ones keep their mode).
         await cockpit.spawn(["mkdir", "-p", "-m755", chronyd_sourcedir], { superuser: "require" });
-        await cockpit.spawn(["chmod", "755", "/etc/chrony", chronyd_sourcedir], { superuser: "require" });
 
         if (config.enabled) {
             await enabled_file.replace(text);

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -1035,6 +1035,9 @@ class TestSystemInfoTime(packagelib.PackageCase):
         m = self.machine
         b = self.browser
 
+        # run this test with a tight umask to check proper file permissions (chronyd runs as non-root)
+        self.sed_file(r"/^UMASK/ s/0../077/", "/etc/login.defs")
+
         enabled_conf = "/etc/chrony/sources.d/cockpit.sources"
         disabled_conf = "/etc/chrony/sources.d/cockpit.disabled"
 
@@ -1073,6 +1076,9 @@ class TestSystemInfoTime(packagelib.PackageCase):
         m.execute(f"grep 0.ntp.example.com {enabled_conf}")
         m.execute(f"grep 1.ntp.example.com {enabled_conf}")
         m.execute(f"! test -f {disabled_conf}")
+        # Cockpit created the file with the correct permissions
+        self.assertEqual(m.execute(f"stat --format '%a' {enabled_conf}").strip(), "644")
+        self.assertEqual(m.execute("stat --format '%a' /etc/chrony /etc/chrony/sources.d").strip(), "755\n755")
 
         # restarts chronyd to pick up the new config
         testlib.wait(lambda: get_chronyd_start() > prev_chronyd_start, delay=0.2)


### PR DESCRIPTION
chronyd runs as `chrony:chrony`. On CIS hosts with umask 0027, Cockpit creates:

- `/etc/chrony` 750 root:root
- `/etc/chrony/sources.d` 750 root:root
- `/etc/chrony/sources.d/cockpit.sources` 640 root:root

so chronyd cannot load the NTP servers set in the UI.

This is the chrony equivalent of #21381 / issue #21364 (timesyncd). Use `mkdir -p -m755` and `chmod 644` so the drop-in is readable regardless of session umask.

RHEL: https://issues.redhat.com/browse/RHEL-253609

Made with [Cursor](https://cursor.com)