### PR TITLE
workflows: Add a new workflow to sync our Containerfile

### DIFF
--- a/.github/workflows/cockpit-container-update.yml
+++ b/.github/workflows/cockpit-container-update.yml
@@ -1,0 +1,28 @@
+name: cockpit-container-update
+on:
+  schedule:
+    - cron: '0 4 * * 1'
+  # can be run manually on https://github.com/cockpit-project/cockpit/actions
+  workflow_dispatch:
+jobs:
+  cockpit-lib-update:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/cockpit-project/tasks
+      options: --user root
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - name: Set up configuration and secrets
+        run: |
+          printf '[user]\n\tname = Cockpit Project\n\temail=cockpituous@gmail.com\n' > ~/.gitconfig
+          echo '${{ secrets.GITHUB_TOKEN }}' > ~/.config/github-token
+
+      - name: Clone repository
+        uses: actions/checkout@v7
+
+      - name: Run cockpit-lib-update
+        run: |
+          make bots
+          bots/cockpit-container-update containers/ws/Containerfile


### PR DESCRIPTION
This workflow updates the Containerfile of cockpit-ws to the latest stable Fedora release, so we no longer need to do this manually. This runs on a weekly schedule.

---

Successful run here https://github.com/jelly/cockpit/actions/runs/35359076579