### PR TITLE
Fix a misspelled error message and a grammar typo in a comment

### DIFF
--- a/files.js
+++ b/files.js
@@ -159,7 +159,7 @@ const nodedir = path.relative(process.cwd(), path.resolve(srcdir, "node_modules"
 
 export const all_subdirs = Array.from(new Set(info.entries.map(key => key.split('/')[0])));
 
-// This are the fonts we used up until migrating to Patternfly v6
+// These are the fonts we used up until migrating to Patternfly v6
 // It is kept here to make sure all dependencies of the fonts works like in
 // third-party plugins etc.
 

--- a/pkg/lib/long-running-process.js
+++ b/pkg/lib/long-running-process.js
@@ -92,7 +92,7 @@ export class LongRunningProcess {
         if (this.state === ProcessState.FAILED)
             this.systemdClient.call(O_SD_OBJ, I_SD_MGR, "ResetFailedUnit", [this.serviceName], { type: "s" });
         else
-            throw new Error(`cannot reset LongRuningProcess in state ${this.state}`);
+            throw new Error(`cannot reset LongRunningProcess in state ${this.state}`);
     }
     /*
      * below are internal private methods


### PR DESCRIPTION
## Summary

Two small text fixes, one commit each (per HACKING.md's "one single logical simple reviewable change" guidance):

**`pkg/lib/long-running-process.js`** — `reset()` throws ``cannot reset LongRuningProcess in state ${this.state}`` with a single `n` in "Runing". The two sibling errors in the same class spell it correctly (`cannot start LongRunningProcess` in `run()`, `cannot terminate LongRunningProcess` in `terminate()`), as does the class declaration itself, so this is the only occurrence in the tree. `codespell` does not catch it because `pyproject.toml` excludes `./pkg` from the scan.

This one is a change to a runtime error string rather than a comment, so it is worth a second look — but nothing in the repository asserts on the old text (checked with a full-tree grep for `cannot reset`), and the only other match is the throw site itself.

**`files.js`** — `// This are the fonts we used up until migrating to Patternfly v6` -> `// These are the fonts ...`. Comment only.

### Deliberately not changed

The scan that produced these also flagged the three `Patternfly` spellings in `files.js` as needing to be `PatternFly`. They are left alone: the tree currently has 19 `PatternFly` and 10 `Patternfly`, spread over `testlib.py`, `.github/dependabot.yml`, `pkg/lib/dialogs.tsx`, `pkg/lib/cockpit-components-truncate.tsx`, `pkg/lib/_global-variables.scss` and `pkg/lib/patternfly/patternfly-6-overrides.scss` as well as `files.js`. Normalising three of them in one file would be arbitrary, and normalising all ten is a separate, opinionated change that belongs to the maintainers.