### PR TITLE
workflows: Auto-add new issues to GH project

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,7 @@ updates:
       prefix: "[no-test]"
     labels:
       - "node_modules"
+      - "bot"
     groups:
       eslint:
         patterns:
@@ -61,5 +62,6 @@ updates:
     open-pull-requests-limit: 3
     labels:
       - "no-test"
+      - "bot"
     schedule:
       interval: "weekly"

--- a/.github/workflows/gh-project-add-issues.yml
+++ b/.github/workflows/gh-project-add-issues.yml
@@ -1,0 +1,18 @@
+name: Add new issues to Cockpit GitHub Project
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  # Needs repo and project scopes in a PAT token in the org
+  # https://github.com/actions/add-to-project#creating-a-pat-and-adding-it-to-your-repository
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v2
+        with:
+          project-url: https://github.com/orgs/cockpit-project/projects/10
+          github-token: ${{ secrets.GH_PROJECTS }}

--- a/.github/workflows/gh-project-add-prs.yml
+++ b/.github/workflows/gh-project-add-prs.yml
@@ -1,0 +1,20 @@
+name: Add bot PRs to Cockpit GitHub Project
+
+on:
+  pull_request:
+    types:
+      # We only need to add to a project
+      - labeled
+
+jobs:
+  # Needs repo and project scopes in a PAT token in the org
+  # https://github.com/actions/add-to-project#creating-a-pat-and-adding-it-to-your-repository
+  add-to-project:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'bot') }}
+    name: Add bot PR to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v2
+        with:
+          project-url: https://github.com/orgs/cockpit-project/projects/10
+          github-token: ${{ secrets.GH_PROJECTS }}


### PR DESCRIPTION
Adds all new issues to GH project as-is. Any filtering that needs to be done should be done so through labels that are added to issues or their linked PRs.