### PR TITLE
Group dependabot updates, update them monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -62,7 +62,7 @@ updates:
     labels:
       - "no-test"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
       actions:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,3 +63,7 @@ updates:
       - "no-test"
     schedule:
       interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Recently codeql started updating weekly for all our projects which is (7 projects in total) and a lot of manual churn. See how often codeql is [updated in cockpit-files](https://github.com/cockpit-project/cockpit-files/pulls?q=is%3Apr++is%3Aclosed+author%3Aapp%2Fdependabot+).

---

Once accepted here, will roll out everywhere.