### PR TITLE
test: Split uptime test out of TestSystemInfo.testBasic

### DIFF
--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -190,7 +190,16 @@ class TestSystemInfo(testlib.MachineCase):
         mid = m.execute("cat /etc/machine-id")
         b.wait_text('#system_machine_id', mid)
 
-        # uptime (introduced in PR #13885)
+        self.allow_journal_messages("error loading contents of os-release: .*",  # C bridge
+                                    ".* Neither /etc/os-release nor /usr/lib/os-release exists",  # py bridge
+                                    "sudo: unable to resolve host host1.cockpit.lan: .*")
+
+    @testlib.nondestructive
+    def testUptime(self):
+        m = self.machine
+        b = self.browser
+
+        self.login_and_go("/system")
         b.wait_text_not("#system_uptime", "")
         # replace it with a known value, it should automatically update every minute
         m.write("/tmp/fake_uptime", "2000.12 12345.30\n")
@@ -202,10 +211,6 @@ class TestSystemInfo(testlib.MachineCase):
         m.write("/tmp/fake_uptime", "10370000 12345.30\n")
         with b.wait_timeout(70):
             b.wait_text("#system_uptime", "4 months ago")
-
-        self.allow_journal_messages("error loading contents of os-release: .*",  # C bridge
-                                    ".* Neither /etc/os-release nor /usr/lib/os-release exists",  # py bridge
-                                    "sudo: unable to resolve host host1.cockpit.lan: .*")
 
     @testlib.nondestructive
     @testlib.skipImage("TODO: fix for OpenSUSE", "opensuse-tumbleweed")


### PR DESCRIPTION
The new AWS infrastructure runs more tests in parallel so converting a long test in two and making it non destructive should help with that added parallelism. Additionally it benefits developers running `TestSystemInfo.testBasic` locally without having to wait for 147 seconds for it to complete, it now takes 22 seconds in a X1 carbon (2025 model).

---

Compare with https://github.com/cockpit-project/cockpit/pull/23685 with as sneaky commit https://github.com/cockpit-project/cockpit/pull/23688/commits/55076d1c256781e73cf00fab735d02908a85f9e2 which skips retries so the comparison is fair :)

Since we have launch_runner we can easily benchmark things now with two sha commits (main/your branch) plus a script to compare the log results https://github.com/jelly/bots/commit/ad94a1f62802659cd78ee6d19485cc3af4a38b21
 
| image | old (seconds) | new | diff | after making testlib CoreOS only | diff | 
|--------- | ------ | ----- | ----- | ----- |  --- |
|fedora-44/other                |                    1144s|   1014s  |  -130s | 939s | -75 |
|rhel-10-3/other                   |                 1123s|  978s |  -145s |  928s  | -50 |
|fedora-44/firefox-other       |                     1123s|  1038s | -85s      | 924s |  -114 |
|fedora-43/other                    |                1118s|    1003s |  -115s | 923s |  -80 |
|centos-10/other                    |                1108s|  968s     | -140s | 918s  | -50 |
|ubuntu-stable/other            |                    1104s|   1089s   | -15s | 929s |  -160 |
|rhel-9-9/other                          |           1098s|        1013s | -85s | 918s |  -113 |
|ubuntu-2604/other                |                  1093s|  978s     |  -115s | 938s | -40 |
|fedora-coreos/other               |                 1068s|   963s | -105s | 1083s | +120 |
|debian-testing/other             |                  1058s|   938s        |  -120s|  878s | -60 |
|arch/other                             |            1058s|  928s   | -130s | 868s | -60 |
|debian-trixie/other             |                   1053s|   938s    |  -115s | 888s | -50 |
|rhel-8-10/ws-container-other   |                    1028s|    908s    | -120s | 838s | -70 |
|centos-9-bootc/other                   |             999s|  873s   | -126s | 814s | -59 |
|opensuse-tumbleweed/other         |                  983s|  858s |  -125s |  783s | -75 |

Results seem very good, on Debian it shaves off a complete 2 minutes. On average 111 seconds saved.

The testlib changes shave off an additional average 60 seconds.