### PR TITLE
test: Show setup/image-prepare timings in CI

### DIFF
--- a/test/run
+++ b/test/run
@@ -17,6 +17,10 @@
 
 set -eu
 
+if [ -n "${TEST_REVISION:-}" ]; then
+    START_TIME=$SECONDS
+fi
+
 test/common/make-bots
 if [ "$(cat test/reference-image)" = "$TEST_OS" ]; then
     test/common/pixel-tests pull
@@ -79,6 +83,13 @@ if [ -n "$TEST_SCENARIO" ] && [ -z "$RUN_OPTS" ]; then
     echo "Unknown test scenario: $TEST_SCENARIO"
     exit 1
 fi
+if [ -n "${TEST_REVISION:-}" ]; then
+    echo "SETUP DONE $((SECONDS - START_TIME))s"
+    PREPARE_START=$SECONDS
+fi
 
 test/image-prepare --verbose ${PREPARE_OPTS} "$TEST_OS"
+if [ -n "${TEST_REVISION:-}" ]; then
+    echo "PREPARE DONE $((SECONDS - PREPARE_START))s"
+fi
 test/common/run-tests --test-dir test/verify --track-naughties ${RUN_OPTS}


### PR DESCRIPTION
Our log viewer shows how long every test takes, but the "initialization" step has no timing information. To make better guesses on what to optimize add two timings for the "setup" step which pulls bots and pixels, and for image-prepare itself.

The idea is that the logs viewer would maybe show these steps as sections with timing information.

---

This is inspired by the recent performance improvements work. This would also help with benchmarking changes, see https://github.com/jelly/bots/commit/ad94a1f62802659cd78ee6d19485cc3af4a38b21 for example for a script which could compare two logs with some more changes and output a markdown table with changes.