### PR TITLE
testlib: Add `only_when_changed` testlib decorator

### DIFF
--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -430,6 +430,11 @@ def detect_tests(
                 test_timeout = testlib.get_decorator(test_method, test, "timeout", 600)
                 nd = testlib.get_decorator(test_method, test, "nondestructive")
                 rwa = not testlib.get_decorator(test_method, test, "no_retry_when_changed")
+                only_when_changed = testlib.get_decorator(test_method, test, "only_when_changed")
+                if only_when_changed and opts.base:
+                    diff_out = subprocess.check_output(["git", "diff", "--name-only", f"origin/{opts.base}", "--", *only_when_changed])
+                    if not diff_out.strip():
+                        unittest.skip(f"no changes in {', '.join(only_when_changed)}")(test_method)
                 todo = testlib.get_decorator(test_method, test, "todo")
 
                 # Calculate test's RAM requirement (VM memory + browser)

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -2686,6 +2686,18 @@ def no_retry_when_changed(testEntity: _T) -> _T:
     return testEntity
 
 
+def only_when_changed(*paths: str) -> Callable[[_T], _T]:
+    """Only run this test when the given paths have changes.
+
+    Only run these tests when affected code has been changed, for example only
+    run the testlib tests when anything in test/common was changed.
+    """
+    def wrapper(testEntity: _T) -> _T:
+        setattr(testEntity, '_testlib__only_when_changed', paths)
+        return testEntity
+    return wrapper
+
+
 def todo(reason: str = '') -> Callable[[_T], _T]:
     """Tests decorated with @todo are expected to fail.
 

--- a/test/verify/check-testlib
+++ b/test/verify/check-testlib
@@ -19,6 +19,7 @@ VERIFY_DIR = os.path.join(testlib.TEST_DIR, "verify")
 ROOT_DIR = os.path.dirname(testlib.TEST_DIR)
 
 
+@testlib.only_when_changed("test/common")
 class TestRunTestListing(unittest.TestCase):
 
     def testBasic(self):
@@ -60,7 +61,7 @@ class TestRunTestListing(unittest.TestCase):
 
 # This can't be @nondestructive, as we run our own @nondestructive test nested inside this test. This will already call the
 # cleanup handlers, and the outside cleanup would then fail to do that again.
-@testlib.onlyImage("Only run on the required image", "fedora-coreos")
+@testlib.only_when_changed("test/common")
 class TestRunTest(testlib.MachineCase):
     def testExistingMachine(self):
         env = os.environ.copy()


### PR DESCRIPTION
This decorator skips tests when the given paths in the decorator have not changed. For example `TestRunTest.testExistingMachine` only runs when something in test/common has changed.

The goal is to avoid running expensive tests when the affected code did not change and this saving time spend on CI.