### PR TITLE
test: Drop storaged_version < 2.8.0 checks

### DIFF
--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -6,7 +6,6 @@
 
 
 import os
-import unittest
 
 import storagelib
 import testlib
@@ -136,10 +135,6 @@ class TestStorageResize(storagelib.StorageCase):
         m = self.machine
         b = self.browser
 
-        if self.storaged_version < [2, 7, 6]:
-            # No Filesystem.Size property
-            raise unittest.SkipTest("UDisks2 too old")
-
         self.login_and_go("/storage")
         disk = m.add_disk("500M", serial="DISK1")
         b.wait_visible(self.card_row("Storage", name=f"/dev/{disk['dev']}"))
@@ -192,10 +187,6 @@ class TestStorageResize(storagelib.StorageCase):
     def testGrowShrinkEncryptedHelp(self):
         m = self.machine
         b = self.browser
-
-        if self.storaged_version < [2, 8, 0]:
-            # No Encrypted.MetadataSize property
-            raise unittest.SkipTest("UDisks2 too old")
 
         self.login_and_go("/storage")
         disk = m.add_disk("500M", serial="DISK1")

--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -33,7 +33,7 @@ class TestStorageResize(storagelib.StorageCase):
         disk = m.add_disk("500M", serial="DISK1")
         b.wait_visible(self.card_row("Storage", name=f"/dev/{disk['dev']}"))
 
-        m.execute("vgcreate TEST /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_DISK1")
+        m.execute("vgcreate TEST /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_DISK1; udevadm trigger")
         b.wait_visible(self.card_row("Storage", name="TEST"))
 
         m.execute("lvcreate TEST -n vol -L 320m")  # minimum xfs size is ~300MB


### PR DESCRIPTION
RHEL 8.10 ships with UDisks 2.9.0 and that is our oldest image.

---

For Ubuntu flakes see the weather report links:

https://cockpit-ci-logs.s3.us-east-1.amazonaws.com/pull-23700-a4eb8953-20260908-083931-ubuntu-stable-storage/log.html
https://cockpit-ci-logs.s3.us-east-1.amazonaws.com/pull-23698-8962e445-20260907-174551-ubuntu-stable-storage/log.html
https://cockpit-ci-logs.s3.us-east-1.amazonaws.com/pull-23676-3e2b7220-20260908-082008-ubuntu-2604-storage/log.html