### PR TITLE
storaged: Disable Stratis Tang encryption in Anaconda mode

### DIFF
--- a/pkg/storaged/stratis/create-dialog.jsx
+++ b/pkg/storaged/stratis/create-dialog.jsx
@@ -117,6 +117,7 @@ export function create_stratis_pool() {
                        }),
             CheckBoxes("encrypt_tang", "",
                        {
+                           visible: () => !client.in_anaconda_mode(),
                            fields: [
                                { tag: "on", title: _("Encrypt data with a Tang keyserver") }
                            ],

--- a/pkg/storaged/stratis/pool.jsx
+++ b/pkg/storaged/stratis/pool.jsx
@@ -705,6 +705,7 @@ const StratisV1TokenDescriptions = ({
                     }
                 </Flex>
             </StorageDescription>
+            { (clevis_infos.length > 0 || !client.in_anaconda_mode()) &&
             <StorageDescription title={_("Keyserver")}>
                 <Flex>
                     { clevis_infos.length == 0
@@ -735,7 +736,7 @@ const StratisV1TokenDescriptions = ({
                         )
                     }
                 </Flex>
-            </StorageDescription>
+            </StorageDescription>}
         </>
     );
 };
@@ -822,12 +823,14 @@ const StratisV2TokenTable = ({
             action: add_passphrase,
             excuse: add_excuse
         },
-        {
+    ];
+
+    if (!client.in_anaconda_mode())
+        actions.push({
             title: _("Add keyserver"),
             action: add_tang,
             excuse: add_excuse
-        },
-    ];
+        });
 
     const v2_table = (
         <Table variant="compact">

--- a/test/verify/check-storage-anaconda
+++ b/test/verify/check-storage-anaconda
@@ -192,6 +192,9 @@ class TestStorageAnaconda(storagelib.StorageCase):
         self.click_devices_dropdown("Create Stratis pool")
         self.dialog_wait_open()
         b.wait_count("#dialog .select-space-name", 1)
+        # Passphrase encryption is available, but Tang/clevis is hidden in Anaconda mode
+        b.wait_visible(self.dialog_field("encrypt_pass.on"))
+        b.wait_not_present(self.dialog_field("encrypt_tang.on"))
         self.dialog_set_val("disks", {disk: True})
         self.dialog_set_val("encrypt_pass.on", val=True)
         self.dialog_set_val("passphrase", "vainu-reku-toma-rolle-kaja")
@@ -251,6 +254,9 @@ class TestStorageAnaconda(storagelib.StorageCase):
         # Check and delete pool
         b.click(self.card_parent_link())
         b.wait_visible(self.card_row("Encrypted Stratis pool", name=disk))
+        # Managing passphrases is allowed, but adding a Tang keyserver is hidden in Anaconda mode
+        b.wait_visible(self.card("Encryption tokens"))
+        self.assertNotIn("keyserver", b.text(self.card("Encryption tokens")).lower())
         self.click_card_dropdown("Encrypted Stratis pool", "Delete")
         self.confirm()
         m.execute("! findmnt --fstab -n /sysroot/var")


### PR DESCRIPTION
Anaconda and Blivet currently don't support using Clevis/Tang encryption with Stratis so we shouldn't allow users creating Stratis pools with Clevis encryption.