### PR TITLE
test: Don't replace package archive files with pipes

### DIFF
--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -339,40 +339,7 @@ echo -e "Loaded patch modules:\nkpatch_3_10_0_1062_1_1 [enabled]\n\nInstalled pa
         # should only have one button (no security updates)
         self.assertEqual(b.text("#available-updates button#install-all"), "Install all updates")
 
-        if m.image in ["fedora-44"]:
-            # dnf5backend only makes it until "Initializing..." and doesn't show a Cancel button.
-            pass
-        else:
-            # stall the download of chocolate by replacing the package with a pipe, so that we can test cancelling
-            chocolate = m.execute(f"""set -ux;
-                p=$(ls {self.vm_tmpdir}/repo/chocolate*2.0*2*)
-                f={self.vm_tmpdir}/fifo
-                mkfifo $f
-                mount -o bind $f $p
-                echo $p""").strip()
-            try:
-                b.click("#available-updates button#install-all")
-
-                # applying updates panel present
-                b.wait_visible("#app div.pf-v6-c-progress__bar")
-
-                # cancel the installation
-                b.wait_in_text(".progress-main-view button.pf-m-secondary", "Cancel")
-                b.click(".progress-main-view button.pf-m-secondary")
-                # abort the current download, so that read calls don't hang indefinitely
-                m.spawn(f"echo > {self.vm_tmpdir}/fifo", "fifo")
-
-                # going back to overview, nothing happened just yet
-                b.wait_not_present(".progress-main-view")
-                self.assertEqual(b.text("#available-updates button#install-all"), "Install all updates")
-                self.assertFalse(b.is_present("table.updates-history"))
-                m.execute("test -f /stamp-vanilla-1.0-1; test -f /stamp-chocolate-2.0-1")
-            finally:
-                # avoid keeping the rpm file busy
-                m.execute("systemctl stop packagekit")
-                m.execute(f"umount {chocolate}")
-
-        # update again; Cancel button should eventually disappear, on some OSes
+        # update; Cancel button should eventually disappear, on some OSes
         b.click("#available-updates button#install-all")
         b.wait_visible(".progress-main-view")
         if m.image in ["fedora-44"]:


### PR DESCRIPTION
This is asking for trouble, and the test has indeed started to fail with

  Cannot seek to the begin of the file. lseek(13, 0, SEEK_SET) error: Illegal seek

on rhel-8-10.